### PR TITLE
Fix docs broken links

### DIFF
--- a/docs/src/folderstructure.md
+++ b/docs/src/folderstructure.md
@@ -2,7 +2,7 @@
 
 [ClimaLSM](https://github.com/CliMA/ClimaLSM.jl) home directory has 5 main folders:
 
-- docs: contains files to generate [the documentation website](clima.github.io/ClimaLSM.jl/).  
+- docs: contains files to generate [the documentation website](https://clima.github.io/ClimaLSM.jl/dev/).  
 - experiments: contains simple runs of `ClimaLSM` models. 
 - parameters: contains a file to retrieve constants such as avogadro's number, the speed of light, etc. 
 - src: contains the code of `ClimaLSM` models. 

--- a/docs/tutorials/Bucket/bucket_tutorial.jl
+++ b/docs/tutorials/Bucket/bucket_tutorial.jl
@@ -7,7 +7,7 @@
 # This tutorial explains in brief the core equations and the
 # necessary parameters of the bucket model, and shows how to set up a simulation in standalone
 # mode. More detail for coupled runs can be
-# found in the ClimaCoupler.jl [documentation](https://clima.github.io/ClimaCoupler.jl/dev/) and in the coupled simulation [tutorial](https://clima.github.io/ClimaLSM.jl/dev/generated/coupled_bucket/).
+# found in the ClimaCoupler.jl [documentation](https://clima.github.io/ClimaCoupler.jl/dev/) and in the coupled simulation [tutorial](https://clima.github.io/ClimaLSM.jl/dev/generated/Bucket/coupled_bucket/).
 
 # At each coordinate point on the surface, we solve ordinary differential
 # equations for the subsurface water storage

--- a/docs/tutorials/Bucket/coupled_bucket.jl
+++ b/docs/tutorials/Bucket/coupled_bucket.jl
@@ -5,7 +5,7 @@
 
 # This tutorial shows how to set up a simulation for a coupled simulation. More detail for coupled runs can be
 # found in the ClimaCoupler.jl [documentation](https://clima.github.io/ClimaCoupler.jl/dev/). In
-# preparation for understanding this tutorial, we recommend also reading the [intro to multi-component models tutorial](https://clima.github.io/ClimaLSM.jl/dev/generated/LSM_single_column_tutorial/) as well as being familiar
+# preparation for understanding this tutorial, we recommend also reading the [intro to multi-component models tutorial](https://clima.github.io/ClimaLSM.jl/dev/generated/Usage/LSM_single_column_tutorial/) as well as being familiar
 # with multiple dispatch programming in Julia.
 
 # # Background

--- a/docs/tutorials/Bucket/coupled_bucket.jl
+++ b/docs/tutorials/Bucket/coupled_bucket.jl
@@ -1,7 +1,7 @@
 # # Setting up a Coupled Simulation
 
 # For more information about the bucket model,
-# please see [the bucket model tutorial](https://clima.github.io/ClimaLSM.jl/dev/generated/bucket_tutorial/).
+# please see [the bucket model tutorial](https://clima.github.io/ClimaLSM.jl/dev/generated/Bucket/bucket_tutorial/).
 
 # This tutorial shows how to set up a simulation for a coupled simulation. More detail for coupled runs can be
 # found in the ClimaCoupler.jl [documentation](https://clima.github.io/ClimaCoupler.jl/dev/). In

--- a/docs/tutorials/Usage/LSM_single_column_tutorial.jl
+++ b/docs/tutorials/Usage/LSM_single_column_tutorial.jl
@@ -1,5 +1,5 @@
 # The `AbstractModel`
-# [tutorial](https://clima.github.io/ClimaLSM.jl/dev/generated/model_tutorial)
+# [tutorial](https://clima.github.io/ClimaLSM.jl/dev/generated/Usage/model_tutorial/)
 # describes how a user can run
 # simulations of a physical system governed by differential equations.
 # In this framework, the user must define a model type for their problem,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Fix broken (outdated) links in docs 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
Go through the docs, check all links, fix the ones that are broken

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
Fixed 1 link to start this PR

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
