### PR TITLE
fix Bucket snow/soil warnings

### DIFF
--- a/test/standalone/Bucket/snow_bucket_tests.jl
+++ b/test/standalone/Bucket/snow_bucket_tests.jl
@@ -57,8 +57,7 @@ for FT in (Float32, Float64)
     init_temp(z::FT, value::FT) where {FT} = FT(value)
     for i in 1:3
         @testset "Conservation of water and energy I (snow present), FT = $FT" begin
-            "Radiation"
-
+            # Radiation
             ref_time = DateTime(2005)
             SW_d = (t) -> 20
             LW_d = (t) -> 20
@@ -68,7 +67,7 @@ for FT in (Float32, Float64)
                 TimeVaryingInput(LW_d),
                 ref_time,
             )
-            "Atmos"
+            # Atmos
             liquid_precip = (t) -> -1e-8 # precipitation
             snow_precip = (t) -> -1e-7 # precipitation
 
@@ -173,7 +172,7 @@ for FT in (Float32, Float64)
 
     for i in 1:3
         @testset "Conservation of water and energy II (no snow to start), FT = $FT" begin
-            "Radiation"
+            # Radiation
             ref_time = DateTime(2005)
             SW_d = (t) -> 20
             LW_d = (t) -> 20
@@ -183,7 +182,7 @@ for FT in (Float32, Float64)
                 TimeVaryingInput(LW_d),
                 ref_time,
             )
-            "Atmos"
+            # Atmos
             liquid_precip = (t) -> -1e-8 # precipitation
             snow_precip = (t) -> -1e-7 # precipitation
 
@@ -288,7 +287,7 @@ for FT in (Float32, Float64)
 
     @testset "Conservation of water and energy - nonuniform evaporation, FT = $FT" begin
         i = 3
-        "Radiation"
+        # Radiation
         ref_time = DateTime(2005)
         SW_d = (t) -> 20
         LW_d = (t) -> 20
@@ -298,7 +297,7 @@ for FT in (Float32, Float64)
             TimeVaryingInput(LW_d),
             ref_time,
         )
-        "Atmos"
+        # Atmos
         liquid_precip = (t) -> -1e-8 # precipitation
         snow_precip = (t) -> -1e-7 # precipitation
 

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -149,7 +149,7 @@ for FT in (Float32, Float64)
 
 
         @testset "Energy + Moisture Conservation, FT = $FT" begin
-            "Radiation"
+            # Radiation
             ref_time = DateTime(2005)
             SW_d = (t) -> 10
             LW_d = (t) -> 300
@@ -159,7 +159,7 @@ for FT in (Float32, Float64)
                 TimeVaryingInput(LW_d),
                 ref_time,
             )
-            "Atmos"
+            # Atmos
             precip = (t) -> -1e-6
             precip_snow = (t) -> 0
             T_atmos = (t) -> 298


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
I noticed that we're getting a bunch of warnings in the Bucket snow and soil tests that look like this:

> ┌ Warning: Replacing docs for `Main.var"##Bucket soil tests#507".ref_time :: Union{}` in module `Main.var"##Bucket soil tests#507"`
└ @ Base.Docs docs/Docs.jl:243
┌ Warning: Replacing docs for `Main.var"##Bucket soil tests#507".precip :: Union{}` in module `Main.var"##Bucket soil tests#507"`
└ @ Base.Docs docs/Docs.jl:243

(see GHA run [here](https://github.com/CliMA/ClimaLand.jl/actions/runs/7747825838/job/21129149749))
I think this is because we had some lines containing `"Atmos"` or `"Radiation"`, which seem like they were meant to be comments but are being interpreted by Julia as docstrings. This PR changes them to comments, which removes all the warnings from those tests.
