### PR TITLE
Refactor AutotrophicRespirationParameters to use ClimaParameters

### DIFF
--- a/docs/tutorials/integrated/soil_canopy_tutorial.jl
+++ b/docs/tutorials/integrated/soil_canopy_tutorial.jl
@@ -248,17 +248,8 @@ canopy_component_types = (;
 # Then provide arguments to the canopy radiative transfer, stomatal conductance,
 # and photosynthesis models as was done in the previous tutorial.
 
-autotrophic_respiration_args = (;
-    parameters = AutotrophicRespirationParameters{FT}(;
-        ne = FT(8 * 1e-4),
-        ηsl = FT(0.01),
-        σl = FT(0.05),
-        μr = FT(1.0),
-        μs = FT(0.1),
-        f1 = FT(0.012),
-        f2 = FT(0.25),
-    )
-)
+autotrophic_respiration_args =
+    (; parameters = AutotrophicRespirationParameters(FT))
 
 radiative_transfer_args = (;
     parameters = TwoStreamParameters{FT}(;

--- a/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -203,7 +203,7 @@ photo_params = FarquharParameters{FT}(
 photosynthesis_model = FarquharModel{FT}(photo_params);
 
 # Arguments for autotrophic respiration model:
-AR_params = AutotrophicRespirationParameters{FT}()
+AR_params = AutotrophicRespirationParameters(FT)
 AR_model = AutotrophicRespirationModel{FT}(AR_params);
 
 # Arguments for plant hydraulics model are more complicated.

--- a/experiments/integrated/fluxnet/US-Ha1/US-Ha1_parameters.jl
+++ b/experiments/integrated/fluxnet/US-Ha1/US-Ha1_parameters.jl
@@ -30,15 +30,6 @@ O2_a = FT(0.209)
 D_oa = FT(1.67)
 p_sx = FT(0.024)
 
-# Autotrophic respiration parameters
-ne = FT(8 * 1e-4)
-ηsl = FT(0.01)
-σl = FT(0.05)
-μr = FT(1.0)
-μs = FT(0.1)
-f1 = FT(0.012)
-f2 = FT(0.25)
-
 # Soil parameters
 soil_ν = FT(0.5) # m3/m3
 soil_K_sat = FT(4e-7) # m/s, matches Natan

--- a/experiments/integrated/fluxnet/US-MOz/US-MOz_parameters.jl
+++ b/experiments/integrated/fluxnet/US-MOz/US-MOz_parameters.jl
@@ -28,15 +28,6 @@ O2_a = FT(0.209)
 D_oa = FT(1.67)
 p_sx = FT(0.024)
 
-# Autotrophic respiration parameters
-ne = FT(8 * 1e-4)
-ηsl = FT(0.01)
-σl = FT(0.05)
-μr = FT(1.0)
-μs = FT(0.1)
-f1 = FT(0.012)
-f2 = FT(0.25)
-
 # Soil parameters
 soil_ν = FT(0.5) # m3/m3
 soil_K_sat = FT(4e-7) # m/s, matches Natan

--- a/experiments/integrated/fluxnet/US-NR1/US-NR1_parameters.jl
+++ b/experiments/integrated/fluxnet/US-NR1/US-NR1_parameters.jl
@@ -33,15 +33,6 @@ O2_a = FT(0.209)
 D_oa = FT(1.67)
 p_sx = FT(0.024)
 
-# Autotrophic respiration parameters
-ne = FT(8 * 1e-4)
-ηsl = FT(0.01)
-σl = FT(0.05)
-μr = FT(1.0)
-μs = FT(0.1)
-f1 = FT(0.012)
-f2 = FT(0.25)
-
 # Soil parameters
 soil_ν = FT(0.45) # m3/m3
 soil_K_sat = FT(4e-7) # m/s, matches Natan

--- a/experiments/integrated/fluxnet/US-Var/US-Var_parameters.jl
+++ b/experiments/integrated/fluxnet/US-Var/US-Var_parameters.jl
@@ -37,15 +37,6 @@ O2_a = FT(0.209)
 D_oa = FT(1.67)
 p_sx = FT(0.024)
 
-# Autotrophic respiration parameters
-ne = FT(8 * 1e-4)
-ηsl = FT(0.01)
-σl = FT(0.05)
-μr = FT(1.0)
-μs = FT(0.1)
-f1 = FT(0.012)
-f2 = FT(0.25)
-
 # Soil parameters
 soil_ν = FT(0.45) # m3/m3
 soil_K_sat = FT(0.45 / 3600 / 100) # m/s,

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -146,17 +146,8 @@ canopy_component_types = (;
 )
 # Individual Component arguments
 # Set up autotrophic respiration
-autotrophic_respiration_args = (;
-    parameters = AutotrophicRespirationParameters{FT}(;
-        ne = ne,
-        ηsl = ηsl,
-        σl = σl,
-        μr = μr,
-        μs = μs,
-        f1 = f1,
-        f2 = f2,
-    )
-)
+autotrophic_respiration_args =
+    (; parameters = AutotrophicRespirationParameters(FT))
 # Set up radiative transfer
 radiative_transfer_args = (;
     parameters = TwoStreamParameters{FT}(;

--- a/experiments/integrated/ozark/conservation/ozark_conservation.jl
+++ b/experiments/integrated/ozark/conservation/ozark_conservation.jl
@@ -149,17 +149,8 @@ for float_type in (Float32, Float64)
     energy_args = (parameters = Canopy.BigLeafEnergyParameters{FT}(ac_canopy),)
 
     # Set up autotrophic respiration
-    autotrophic_respiration_args = (;
-        parameters = AutotrophicRespirationParameters{FT}(;
-            ne = ne,
-            ηsl = ηsl,
-            σl = σl,
-            μr = μr,
-            μs = μs,
-            f1 = f1,
-            f2 = f2,
-        )
-    )
+    autotrophic_respiration_args =
+        (; parameters = AutotrophicRespirationParameters(FT))
     # Set up radiative transfer
     radiative_transfer_args = (;
         parameters = TwoStreamParameters{FT}(;

--- a/src/standalone/Vegetation/autotrophic_respiration.jl
+++ b/src/standalone/Vegetation/autotrophic_respiration.jl
@@ -9,7 +9,7 @@ abstract type AbstractAutotrophicRespirationModel{FT} <:
 The required parameters for the autrophic respiration model.
 $(DocStringExtensions.FIELDS)
 """
-struct AutotrophicRespirationParameters{FT <: AbstractFloat}
+Base.@kwdef struct AutotrophicRespirationParameters{FT <: AbstractFloat}
     "Vcmax25 to N factor (mol CO2 m-2 s-1 kg C (kg C)-1)"
     ne::FT
     "Live stem wood coefficient (kg C m-3)"
@@ -24,31 +24,6 @@ struct AutotrophicRespirationParameters{FT <: AbstractFloat}
     f1::FT
     "Factor of relative contribution or Rgrowth (-)"
     f2::FT
-end
-
-"""
-    function AutotrophicRespirationParameters{FT}(;
-        ne = FT(8 * 1e-4),
-        ηsl = FT(0.01),
-        σl = FT(0.05),
-        μr = FT(1.0),
-        μs = FT(0.1),
-        f1 = FT(0.012), 
-        f2 = FT(0.25)        
-) where {FT}
-
-A constructor supplying default values for the AutotrophicRespirationParameters struct.
-"""
-function AutotrophicRespirationParameters{FT}(;
-    ne = FT(8 * 1e-4),
-    ηsl = FT(0.01),
-    σl = FT(0.05),
-    μr = FT(1.0),
-    μs = FT(0.1),
-    f1 = FT(0.012),
-    f2 = FT(0.25),
-) where {FT}
-    return AutotrophicRespirationParameters{FT}(ne, ηsl, σl, μr, μs, f1, f2)
 end
 
 Base.eltype(::AutotrophicRespirationParameters{FT}) where {FT} = FT

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -1,5 +1,5 @@
 using Test
-import CLIMAParameters as CP
+import CLIMAParameters
 using ClimaCore
 using Thermodynamics
 using Dates
@@ -19,7 +19,7 @@ for FT in (Float32, Float64)
     @testset "Canopy software pipes, FT = $FT" begin
         domain = Point(; z_sfc = FT(0.0))
 
-        AR_params = AutotrophicRespirationParameters{FT}()
+        AR_params = AutotrophicRespirationParameters(FT)
         RTparams = BeerLambertParameters{FT}()
         photosynthesis_params = FarquharParameters{FT}(C3();)
         stomatal_g_params = MedlynConductanceParameters{FT}()
@@ -641,12 +641,9 @@ for FT in (Float32, Float64)
             compartment_surfaces = compartment_faces,
             compartment_midpoints = compartment_centers,
         )
-        autotrophic_parameters =
-            ClimaLand.Canopy.AutotrophicRespirationParameters{FT}()
+        autotrophic_parameters = AutotrophicRespirationParameters(FT)
         autotrophic_respiration_model =
-            ClimaLand.Canopy.AutotrophicRespirationModel{FT}(
-                autotrophic_parameters,
-            )
+            AutotrophicRespirationModel{FT}(autotrophic_parameters)
 
         canopy = ClimaLand.Canopy.CanopyModel{FT}(;
             parameters = shared_params,

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -2,7 +2,7 @@ using Test
 using Statistics
 using NLsolve
 using ClimaCore
-import CLIMAParameters as CP
+import CLIMAParameters
 using ClimaLand
 using ClimaLand.Domains: Point, Plane
 using ClimaLand.Canopy
@@ -111,7 +111,7 @@ for FT in (Float32, Float64)
             ),
         ]
 
-        AR_params = AutotrophicRespirationParameters{FT}()
+        AR_params = AutotrophicRespirationParameters(FT)
         RTparams = BeerLambertParameters{FT}()
         photosynthesis_params = FarquharParameters{FT}(C3();)
         stomatal_g_params = MedlynConductanceParameters{FT}()
@@ -263,12 +263,9 @@ for FT in (Float32, Float64)
             compartment_surfaces = compartment_surfaces,
             compartment_midpoints = compartment_midpoints,
         )
-        autotrophic_parameters =
-            ClimaLand.Canopy.AutotrophicRespirationParameters{FT}()
+        autotrophic_parameters = AutotrophicRespirationParameters(FT)
         autotrophic_respiration_model =
-            ClimaLand.Canopy.AutotrophicRespirationModel{FT}(
-                autotrophic_parameters,
-            )
+            AutotrophicRespirationModel{FT}(autotrophic_parameters)
         for domain in domains
             model = ClimaLand.Canopy.CanopyModel{FT}(;
                 parameters = shared_params,
@@ -407,7 +404,7 @@ for FT in (Float32, Float64)
     @testset "No plant, FT = $FT" begin
         domain = Point(; z_sfc = FT(0.0))
 
-        AR_params = AutotrophicRespirationParameters{FT}()
+        AR_params = AutotrophicRespirationParameters(FT)
         RTparams = BeerLambertParameters{FT}()
         photosynthesis_params = FarquharParameters{FT}(C3();)
         stomatal_g_params = MedlynConductanceParameters{FT}()
@@ -545,10 +542,9 @@ for FT in (Float32, Float64)
             compartment_midpoints = compartment_midpoints,
         )
 
-        autotrophic_parameters =
-            ClimaLand.Canopy.AutotrophicRespirationParameters{FT}()
+        autotrophic_parameters = AutotrophicRespirationParameters(FT)
         autotrophic_respiration_model =
-            ClimaLand.Canopy.AutotrophicRespirationModel(autotrophic_parameters)
+            AutotrophicRespirationModel(autotrophic_parameters)
 
         model = ClimaLand.Canopy.CanopyModel{FT}(;
             parameters = shared_params,

--- a/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
+++ b/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
@@ -71,7 +71,7 @@ for FT in (Float32, Float64)
     @testset "Big Leaf Parameterizations, FT = $FT" begin
         earth_param_set = LP.LandParameters(FT)
         # Test with defaults
-        ARparams = AutotrophicRespirationParameters{FT}()
+        ARparams = AutotrophicRespirationParameters(FT)
         RTparams = BeerLambertParameters{FT}()
         RT = BeerLambertModel{FT}(RTparams)
         photosynthesisparams = FarquharParameters{FT}(C3();)


### PR DESCRIPTION
This is the first in a series of PRs changing the parameter constructors to use ClimaParameters.


### Content 
The changes here are straightforward, since the values for `AutotrophicRespirationParameters` never change.
The core changes are in `src/standalone/Vegetation/autotrophic_respiration.jl`
The former `AutotrophicRespirationParameters` constructor has been removed and replaced by two constructors. For both constructors, parameters can be passed in via kwargs.
1. `AutotrophicRespirationParameters(FT; kwargs...)` takes a float type and uses the param values found in the default climaparameters toml dict.
2. `AutotrophicRespirationParameters(toml_dict; kwargs...)` takes a toml dictionary, and populates the struct from the dict.

Since all of the struct values are constant, I have replaced calls to the old constructor with the new `AutotrophicRespirationParameters(FT)` constructor.