### PR TITLE
Update (Optimality)FarquharParameters to use ClimaParameters

### DIFF
--- a/docs/tutorials/integrated/soil_canopy_tutorial.jl
+++ b/docs/tutorials/integrated/soil_canopy_tutorial.jl
@@ -272,28 +272,8 @@ conductance_args = (;
     )
 )
 
-photosynthesis_args = (;
-    parameters = FarquharParameters{FT}(
-        Canopy.C3();
-        oi = FT(0.209),
-        ϕ = FT(0.6),
-        θj = FT(0.9),
-        f = FT(0.015),
-        sc = FT(5e-6),
-        pc = FT(-2e5),
-        Vcmax25 = FT(5e-5),
-        Γstar25 = FT(4.275e-5),
-        Kc25 = FT(4.049e-4),
-        Ko25 = FT(0.2874),
-        To = FT(298.15),
-        ΔHkc = FT(79430),
-        ΔHko = FT(36380),
-        ΔHVcmax = FT(58520),
-        ΔHΓstar = FT(37830),
-        ΔHJmax = FT(43540),
-        ΔHRd = FT(46390),
-    )
-);
+photosynthesis_args =
+    (; parameters = FarquharParameters(FT, Canopy.C3(); Vcmax25 = FT(5e-5)));
 
 K_sat_plant = FT(1.8e-8)
 RAI = (SAI + maxLAI) * f_root_to_shoot;

--- a/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -179,26 +179,7 @@ stomatal_model = MedlynConductanceModel{FT}(cond_params);
 
 # Arguments for photosynthesis model:
 
-photo_params = FarquharParameters{FT}(
-    Canopy.C3();
-    oi = FT(0.209),
-    ϕ = FT(0.6),
-    θj = FT(0.9),
-    f = FT(0.015),
-    sc = FT(5e-6),
-    pc = FT(-2e5),
-    Vcmax25 = FT(5e-5),
-    Γstar25 = FT(4.275e-5),
-    Kc25 = FT(4.049e-4),
-    Ko25 = FT(0.2874),
-    To = FT(298.15),
-    ΔHkc = FT(79430),
-    ΔHko = FT(36380),
-    ΔHVcmax = FT(58520),
-    ΔHΓstar = FT(37830),
-    ΔHJmax = FT(43540),
-    ΔHRd = FT(46390),
-)
+photo_params = FarquharParameters(FT, Canopy.C3(); Vcmax25 = FT(5e-5))
 
 photosynthesis_model = FarquharModel{FT}(photo_params);
 

--- a/experiments/integrated/fluxnet/US-Ha1/US-Ha1_parameters.jl
+++ b/experiments/integrated/fluxnet/US-Ha1/US-Ha1_parameters.jl
@@ -68,23 +68,7 @@ Drel = FT(1.6)
 g0 = FT(1e-4)
 
 #Photosynthesis model
-oi = FT(0.209)
-ϕ = FT(0.6)
-θj = FT(0.9)
-f = FT(0.015)
-sc = FT(2e-6) # Bonan's book: range of 2-5e-6
-pc = FT(-2e6) # Bonan's book: -2e6
 Vcmax25 = FT(9e-5) # from Yujie's paper 4.5e-5 , Natan used 9e-5
-Γstar25 = FT(4.275e-5)
-Kc25 = FT(4.049e-4)
-Ko25 = FT(0.2874)
-To = FT(298.15)
-ΔHkc = FT(79430)
-ΔHko = FT(36380)
-ΔHVcmax = FT(58520)
-ΔHΓstar = FT(37830)
-ΔHJmax = FT(43540)
-ΔHRd = FT(46390)
 
 # Plant Hydraulics and general plant parameters
 SAI = FT(1.0) # m2/m2 or: estimated from Wang et al, FT(0.00242) ?

--- a/experiments/integrated/fluxnet/US-MOz/US-MOz_parameters.jl
+++ b/experiments/integrated/fluxnet/US-MOz/US-MOz_parameters.jl
@@ -66,23 +66,7 @@ Drel = FT(1.6)
 g0 = FT(1e-4)
 
 #Photosynthesis model
-oi = FT(0.209)
-ϕ = FT(0.6)
-θj = FT(0.9)
-f = FT(0.015)
-sc = FT(2e-6) # Bonan's book: range of 2-5e-6
-pc = FT(-2e6) # Bonan's book: -2e6
 Vcmax25 = FT(9e-5) # from Yujie's paper 4.5e-5 , Natan used 9e-5
-Γstar25 = FT(4.275e-5)
-Kc25 = FT(4.049e-4)
-Ko25 = FT(0.2874)
-To = FT(298.15)
-ΔHkc = FT(79430)
-ΔHko = FT(36380)
-ΔHVcmax = FT(58520)
-ΔHΓstar = FT(37830)
-ΔHJmax = FT(43540)
-ΔHRd = FT(46390)
 
 # Plant Hydraulics and general plant parameters
 SAI = FT(1.0) # m2/m2 or: estimated from Wang et al, FT(0.00242) ?

--- a/experiments/integrated/fluxnet/US-NR1/US-NR1_parameters.jl
+++ b/experiments/integrated/fluxnet/US-NR1/US-NR1_parameters.jl
@@ -71,23 +71,7 @@ Drel = FT(1.6)
 g0 = FT(1e-4)
 
 #Photosynthesis model
-oi = FT(0.209)
-ϕ = FT(0.6)
-θj = FT(0.9)
-f = FT(0.015)
-sc = FT(2e-6) # Bonan's book: range of 2-5e-6
-pc = FT(-2e6) # Bonan's book: -2e6
 Vcmax25 = FT(9e-5) # from Yujie's paper 4.5e-5 , Natan used 9e-5
-Γstar25 = FT(4.275e-5)
-Kc25 = FT(4.049e-4)
-Ko25 = FT(0.2874)
-To = FT(298.15)
-ΔHkc = FT(79430)
-ΔHko = FT(36380)
-ΔHVcmax = FT(58520)
-ΔHΓstar = FT(37830)
-ΔHJmax = FT(43540)
-ΔHRd = FT(46390)
 
 # Plant Hydraulics and general plant parameters
 SAI = FT(1.0) # m2/m2 or: estimated from Wang et al, FT(0.00242) ?

--- a/experiments/integrated/fluxnet/US-Var/US-Var_parameters.jl
+++ b/experiments/integrated/fluxnet/US-Var/US-Var_parameters.jl
@@ -72,23 +72,7 @@ Drel = FT(1.6)
 g0 = FT(1e-4)
 
 #Photosynthesis model
-oi = FT(0.209)
-ϕ = FT(0.6)
-θj = FT(0.9)
-f = FT(0.015)
-sc = FT(2e-6) # Bonan's book: range of 2-5e-6
-pc = FT(-2e6) # Bonan's book: -2e6
 Vcmax25 = FT(4.225e-5) # CLM C3 grass, Slevin et al. 2015
-Γstar25 = FT(4.275e-5)
-Kc25 = FT(4.049e-4)
-Ko25 = FT(0.2874)
-To = FT(298.15)
-ΔHkc = FT(79430)
-ΔHko = FT(36380)
-ΔHVcmax = FT(58520)
-ΔHΓstar = FT(37830)
-ΔHJmax = FT(43540)
-ΔHRd = FT(46390)
 
 # Energy Balance model
 ac_canopy = FT(745)

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -171,28 +171,8 @@ conductance_args = (;
     )
 )
 # Set up photosynthesis
-photosynthesis_args = (;
-    parameters = FarquharParameters{FT}(
-        Canopy.C3();
-        oi = oi,
-        ϕ = ϕ,
-        θj = θj,
-        f = f,
-        sc = sc,
-        pc = pc,
-        Vcmax25 = Vcmax25,
-        Γstar25 = Γstar25,
-        Kc25 = Kc25,
-        Ko25 = Ko25,
-        To = To,
-        ΔHkc = ΔHkc,
-        ΔHko = ΔHko,
-        ΔHVcmax = ΔHVcmax,
-        ΔHΓstar = ΔHΓstar,
-        ΔHJmax = ΔHJmax,
-        ΔHRd = ΔHRd,
-    )
-)
+photosynthesis_args =
+    (; parameters = FarquharParameters(FT, Canopy.C3(); Vcmax25 = Vcmax25))
 # Set up plant hydraulics
 ai_parameterization = PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
 

--- a/experiments/integrated/ozark/conservation/ozark_conservation.jl
+++ b/experiments/integrated/ozark/conservation/ozark_conservation.jl
@@ -173,28 +173,8 @@ for float_type in (Float32, Float64)
         )
     )
     # Set up photosynthesis
-    photosynthesis_args = (;
-        parameters = FarquharParameters{FT}(
-            Canopy.C3();
-            oi = oi,
-            ϕ = ϕ,
-            θj = θj,
-            f = f,
-            sc = sc,
-            pc = pc,
-            Vcmax25 = Vcmax25,
-            Γstar25 = Γstar25,
-            Kc25 = Kc25,
-            Ko25 = Ko25,
-            To = To,
-            ΔHkc = ΔHkc,
-            ΔHko = ΔHko,
-            ΔHVcmax = ΔHVcmax,
-            ΔHΓstar = ΔHΓstar,
-            ΔHJmax = ΔHJmax,
-            ΔHRd = ΔHRd,
-        )
-    )
+    photosynthesis_args =
+        (; parameters = FarquharParameters(FT, Canopy.C3(); Vcmax25 = Vcmax25))
     # Set up plant hydraulics
     ai_parameterization = PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
 

--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -6,9 +6,11 @@ import SurfaceFluxes.Parameters.SurfaceFluxesParameters
 import SurfaceFluxes.UniversalFunctions as UF
 import CLIMAParameters as CP
 
-# Parameter structs to override
+import ClimaLand
 import ClimaLand.Parameters.LandParameters
 import ClimaLand.Canopy.AutotrophicRespirationParameters
+import ClimaLand.Canopy.FarquharParameters
+import ClimaLand.Canopy.OptimalityFarquharParameters
 
 LandParameters(::Type{FT}) where {FT <: AbstractFloat} =
     LandParameters(CP.create_toml_dict(FT))
@@ -89,6 +91,133 @@ function AutotrophicRespirationParameters(
     parameters = CP.get_parameter_values(toml_dict, name_map, "Land")
     FT = CP.float_type(toml_dict)
     AutotrophicRespirationParameters{FT}(; parameters..., kwargs...)
+end
+
+"""
+    function FarquharParameters(
+        FT, 
+        mechanism::AbstractPhotosynthesisMechanism;
+        Vcmax25 = FT(5e-5),
+        kwargs...  # For individual parameter overrides
+    )
+
+    function FarquharParameters(
+        toml_dict::CP.AbstractTOMLDict, 
+        mechanism::AbstractPhotosynthesisMechanism;
+        Vcmax25 = FT(5e-5),
+        kwargs...  # For individual parameter overrides
+    )
+    
+Constructors for the FarquharParameters struct. Two variants:
+1. Pass in the float-type and retrieve parameter values from the default TOML dict.
+2. Pass in a TOML dictionary to retrieve parameter values.Possible calls:
+```julia
+ClimaLand.Canopy.FarquharParameters(Float64, ClimaLand.Canopy.C3())
+# Kwarg overrides
+ClimaLand.Canopy.FarquharParameters(Float64, ClimaLand.Canopy.C3(); Vcmax25 = 99999999, pc = 444444444)
+# TOML Dictionary:
+import CLIMAParameters as CP
+toml_dict = CP.create_toml_dict(Float32);
+ClimaLand.Canopy.FarquharParameters(toml_dict, ClimaLand.Canopy.C3(); Vcmax25 = 99999999, pc = 444444444)
+```
+"""
+FarquharParameters(
+    ::Type{FT},
+    mechanism;
+    kwargs...,
+) where {FT <: AbstractFloat} =
+    FarquharParameters(CP.create_toml_dict(FT), mechanism; kwargs...)
+
+function FarquharParameters(
+    toml_dict::CP.AbstractTOMLDict,
+    mechanism;
+    Vcmax25 = 5e-5,
+    kwargs...,
+)
+    name_map = (;
+        :Jmax_activation_energy => :ΔHJmax,
+        :intercellular_O2_concentration => :oi,
+        :CO2_compensation_point_25c => :Γstar25,
+        :Farquhar_curvature_parameter => :θj,
+        :kelvin_25C => :To,
+        :photosystem_II_quantum_yield => :ϕ,
+        :O2_michaelis_menten => :Ko25,
+        :CO2_michaelis_menten => :Kc25,
+        :dark_respiration_factor => :f,
+        :O2_activation_energy => :ΔHko,
+        :low_water_pressure_sensitivity => :sc,
+        :Rd_activation_energy => :ΔHRd,
+        :Vcmax_activation_energy => :ΔHVcmax,
+        :Γstar_activation_energy => :ΔHΓstar,
+        :CO2_activation_energy => :ΔHkc,
+        :moisture_stress_ref_water_pressure => :pc,
+    )
+    parameters = CP.get_parameter_values(toml_dict, name_map, "Land")
+    FT = CP.float_type(toml_dict)
+    MECH = typeof(mechanism)
+    return FarquharParameters{FT, MECH}(;
+        mechanism,
+        Vcmax25,
+        parameters...,
+        kwargs...,
+    )
+end
+
+"""
+    function OptimalityFarquharParameters(
+        FT,
+        kwargs...  # For individual parameter overrides
+    )
+
+    function OptimalityFarquharParameters(
+        toml_dict::CP.AbstractTOMLDict, 
+        kwargs...  # For individual parameter overrides
+    )
+
+Constructors for the OptimalityFarquharParameters struct. Two variants:
+1. Pass in the float-type and retrieve parameter values from the default TOML dict.
+2. Pass in a TOML dictionary to retrieve parameter values.Possible calls:
+```julia
+ClimaLand.Canopy.OptimalityFarquharParameters(Float64)
+# Kwarg overrides
+ClimaLand.Canopy.OptimalityFarquharParameters(Float64; pc = 444444444)
+# Toml Dictionary:
+import CLIMAParameters as CP
+toml_dict = CP.create_toml_dict(Float32);
+ClimaLand.Canopy.OptimalityFarquharParameters(toml_dict; pc = 444444444)
+```
+"""
+OptimalityFarquharParameters(
+    ::Type{FT};
+    kwargs...,
+) where {FT <: AbstractFloat} =
+    OptimalityFarquharParameters(CP.create_toml_dict(FT); kwargs...)
+
+function OptimalityFarquharParameters(toml_dict; kwargs...)
+    name_map = (;
+        :Jmax_activation_energy => :ΔHJmax,
+        :intercellular_O2_concentration => :oi,
+        :CO2_compensation_point_25c => :Γstar25,
+        :Farquhar_curvature_parameter => :θj,
+        :kelvin_25C => :To,
+        :photosystem_II_quantum_yield => :ϕ,
+        :O2_michaelis_menten => :Ko25,
+        :CO2_michaelis_menten => :Kc25,
+        :dark_respiration_factor => :f,
+        :O2_activation_energy => :ΔHko,
+        :low_water_pressure_sensitivity => :sc,
+        :Rd_activation_energy => :ΔHRd,
+        :Vcmax_activation_energy => :ΔHVcmax,
+        :electron_transport_maintenance => :c,
+        :Γstar_activation_energy => :ΔHΓstar,
+        :CO2_activation_energy => :ΔHkc,
+        :moisture_stress_ref_water_pressure => :pc,
+    )
+
+    params = CP.get_parameter_values(toml_dict, name_map, "Land")
+    FT = CP.float_type(toml_dict)
+    mechanism = ClimaLand.Canopy.C3()
+    return OptimalityFarquharParameters{FT}(; params..., kwargs..., mechanism)
 end
 
 end

--- a/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
@@ -133,7 +133,8 @@ function run_fluxnet(
     )
     # Set up photosynthesis
     photosynthesis_args = (;
-        parameters = FarquharParameters{FT}(
+        parameters = FarquharParameters(
+            FT,
             Canopy.C3();
             oi = params.photosynthesis.oi,
             ϕ = params.photosynthesis.ϕ,

--- a/src/standalone/Vegetation/optimality_farquhar.jl
+++ b/src/standalone/Vegetation/optimality_farquhar.jl
@@ -8,7 +8,7 @@ The required parameters for the optimality Farquhar photosynthesis model.
 Currently, only C3 photosynthesis is supported.
 $(DocStringExtensions.FIELDS)
 """
-struct OptimalityFarquharParameters{FT <: AbstractFloat}
+Base.@kwdef struct OptimalityFarquharParameters{FT <: AbstractFloat}
     "Photosynthesis mechanism: C3 only"
     mechanism::C3
     "Γstar at 25 °C (mol/mol)"
@@ -48,70 +48,6 @@ struct OptimalityFarquharParameters{FT <: AbstractFloat}
 end
 
 Base.eltype(::OptimalityFarquharParameters{FT}) where {FT} = FT
-
-"""
-    function OptimalityFarquharParameters{FT}(
-        oi = FT(0.209),
-        ϕ = FT(0.6),
-        θj = FT(0.9),
-        f = FT(0.015),
-        sc = FT(5e-6),
-        pc = FT(-2e6),
-        Γstar25 = FT(4.275e-5),
-        Kc25 = FT(4.049e-4),
-        Ko25 = FT(0.2874),
-        To = FT(298.15),
-        ΔHkc = FT(79430),
-        ΔHko = FT(36380),
-        ΔHVcmax = FT(58520),
-        ΔHΓstar = FT(37830),
-        ΔHJmax = FT(43540),
-        ΔHRd = FT(46390),
-        c = FT(0.05336251)
-    )
-A constructor supplying default values for the FarquharParameters struct.
-"""
-function OptimalityFarquharParameters{FT}(;
-    oi = FT(0.209),
-    ϕ = FT(0.6),
-    θj = FT(0.9),
-    f = FT(0.015),
-    sc = FT(5e-6),
-    pc = FT(-2e6),
-    Γstar25 = FT(4.275e-5),
-    Kc25 = FT(4.049e-4),
-    Ko25 = FT(0.2874),
-    To = FT(298.15),
-    ΔHkc = FT(79430),
-    ΔHko = FT(36380),
-    ΔHVcmax = FT(58520),
-    ΔHΓstar = FT(37830),
-    ΔHJmax = FT(43540),
-    ΔHRd = FT(46390),
-    c = FT(0.05336251),
-) where {FT}
-    mechanism = C3()
-    return OptimalityFarquharParameters{FT}(
-        mechanism,
-        Γstar25,
-        Kc25,
-        Ko25,
-        ΔHkc,
-        ΔHko,
-        ΔHVcmax,
-        ΔHΓstar,
-        ΔHJmax,
-        ΔHRd,
-        To,
-        oi,
-        ϕ,
-        θj,
-        f,
-        sc,
-        pc,
-        c,
-    )
-end
 
 """
     OptimalityFarquharModel{FT,

--- a/src/standalone/Vegetation/photosynthesis.jl
+++ b/src/standalone/Vegetation/photosynthesis.jl
@@ -22,7 +22,7 @@ abstract type AbstractPhotosynthesisModel{FT} <: AbstractCanopyComponent{FT} end
 The required parameters for the Farquhar photosynthesis model.
 $(DocStringExtensions.FIELDS)
 """
-struct FarquharParameters{
+Base.@kwdef struct FarquharParameters{
     FT <: AbstractFloat,
     MECH <: AbstractPhotosynthesisMechanism,
 }
@@ -62,71 +62,6 @@ struct FarquharParameters{
     pc::FT
     "Photosynthesis mechanism: C3 or C4"
     mechanism::MECH
-end
-
-"""
-    function FarquharParameters{FT}(mechanism::AbstractPhotosynthesisMechanism;
-        oi = FT(0.209),# mol/mol
-        ϕ = FT(0.6), # unitless
-        θj = FT(0.9), # unitless
-        f = FT(0.015), # unitless
-        sc = FT(5e-6),# Pa
-        pc = FT(-2e6), # Pa
-        Vcmax25 = FT(5e-5), # converted from 50 μmol/mol CO2/m^2/s to mol/m^2/s
-        Γstar25 = FT(4.275e-5),  # converted from 42.75 μmol/mol to mol/mol
-        Kc25 = FT(4.049e-4), # converted from 404.9 μmol/mol to mol/mol
-        Ko25 = FT(0.2874), # converted from 278.4 mmol/mol to mol/mol
-        To = FT(298.15), # 25 C
-        ΔHkc = FT(79430), #J/mol, Table 11.2 Bonan
-        ΔHko = FT(36380), #J/mol, Table 11.2 Bonan
-        ΔHVcmax = FT(58520), #J/mol, Table 11.2 Bonan
-        ΔHΓstar = FT(37830), #J/mol, 11.2 Bonan
-        ΔHJmax = FT(43540), # J/mol, 11.2 Bonan
-        ΔHRd = FT(43390), # J/mol, 11.2 Bonan
-        ) where {FT}
-
-A constructor supplying default values for the FarquharParameters struct.
-"""
-function FarquharParameters{FT}(
-    mechanism::AbstractPhotosynthesisMechanism;
-    oi = FT(0.209),
-    ϕ = FT(0.6),
-    θj = FT(0.9),
-    f = FT(0.015),
-    sc = FT(5e-6),
-    pc = FT(-2e6),
-    Vcmax25 = FT(5e-5),
-    Γstar25 = FT(4.275e-5),
-    Kc25 = FT(4.049e-4),
-    Ko25 = FT(0.2874),
-    To = FT(298.15),
-    ΔHkc = FT(79430),
-    ΔHko = FT(36380),
-    ΔHVcmax = FT(58520),
-    ΔHΓstar = FT(37830),
-    ΔHJmax = FT(43540),
-    ΔHRd = FT(46390),
-) where {FT}
-    return FarquharParameters{FT, typeof(mechanism)}(
-        Vcmax25,
-        Γstar25,
-        Kc25,
-        Ko25,
-        ΔHkc,
-        ΔHko,
-        ΔHVcmax,
-        ΔHΓstar,
-        ΔHJmax,
-        ΔHRd,
-        To,
-        oi,
-        ϕ,
-        θj,
-        f,
-        sc,
-        pc,
-        mechanism,
-    )
 end
 
 Base.eltype(::FarquharParameters{FT}) where {FT} = FT

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -21,7 +21,7 @@ for FT in (Float32, Float64)
 
         AR_params = AutotrophicRespirationParameters(FT)
         RTparams = BeerLambertParameters{FT}()
-        photosynthesis_params = FarquharParameters{FT}(C3();)
+        photosynthesis_params = FarquharParameters(FT, C3())
         stomatal_g_params = MedlynConductanceParameters{FT}()
 
         AR_model = AutotrophicRespirationModel{FT}(AR_params)
@@ -482,7 +482,7 @@ for FT in (Float32, Float64)
         domain = Point(; z_sfc = FT(0.0))
 
         RTparams = BeerLambertParameters{FT}()
-        photosynthesis_params = FarquharParameters{FT}(C3();)
+        photosynthesis_params = FarquharParameters(FT, C3())
         stomatal_g_params = MedlynConductanceParameters{FT}()
 
         stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -113,7 +113,7 @@ for FT in (Float32, Float64)
 
         AR_params = AutotrophicRespirationParameters(FT)
         RTparams = BeerLambertParameters{FT}()
-        photosynthesis_params = FarquharParameters{FT}(C3();)
+        photosynthesis_params = FarquharParameters(FT, C3())
         stomatal_g_params = MedlynConductanceParameters{FT}()
 
         AR_model = AutotrophicRespirationModel{FT}(AR_params)
@@ -406,7 +406,7 @@ for FT in (Float32, Float64)
 
         AR_params = AutotrophicRespirationParameters(FT)
         RTparams = BeerLambertParameters{FT}()
-        photosynthesis_params = FarquharParameters{FT}(C3();)
+        photosynthesis_params = FarquharParameters(FT, C3())
         stomatal_g_params = MedlynConductanceParameters{FT}()
 
         AR_model = AutotrophicRespirationModel{FT}(AR_params)

--- a/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
+++ b/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
@@ -36,7 +36,7 @@ for FT in (Float32, Float64)
         @test abs(Vcmax - FT(1.8572441998848603e-7)) < 1e-10
         @test typeof(Jmax) == FT
         @test typeof(Vcmax) == FT
-        params = OptimalityFarquharParameters{FT}()
+        params = OptimalityFarquharParameters(FT)
         @test params.mechanism == C3()
         model = OptimalityFarquharModel(params)
         @test ClimaLand.auxiliary_vars(model) == (:An, :GPP, :Rd, :Vcmax25)
@@ -74,7 +74,7 @@ for FT in (Float32, Float64)
         ARparams = AutotrophicRespirationParameters(FT)
         RTparams = BeerLambertParameters{FT}()
         RT = BeerLambertModel{FT}(RTparams)
-        photosynthesisparams = FarquharParameters{FT}(C3();)
+        photosynthesisparams = FarquharParameters(FT, C3())
         stomatal_g_params = MedlynConductanceParameters{FT}()
 
         LAI = FT(5.0) # m2 (leaf) m-2 (ground)


### PR DESCRIPTION
Similar to #480.

Core changes are to the constructors in `src/standalone/Vegetation/photosynthesis.jl` and `src/standalone/Vegetation/optimality_farquhar.jl`.
The other changes are to update to the new constructors. 
I have removed all of the calls that explicitly pass in values because they only pass in default values (see `docs/tutorials/standalone/Canopy/canopy_tutorial.jl`), but overriding the default parameters via kwargs is still possible.

New constructors:
```

import ClimaLand
import CLIMAParameters as CP
toml_dict= CP.create_toml_dict(Float32)

ClimaLand.Canopy.FarquharParameters(Float64, ClimaLand.Canopy.C3())
ClimaLand.Canopy.FarquharParameters(Float64, ClimaLand.Canopy.C3(); Vcmax25 = 99999)
ClimaLand.Canopy.FarquharParameters(toml_dict, ClimaLand.Canopy.C3(); Vcmax25 = 99999999, pc = 444444444)
```