### PR TITLE
store bareground albedo

### DIFF
--- a/docs/src/APIs/Bucket.md
+++ b/docs/src/APIs/Bucket.md
@@ -23,7 +23,6 @@ ClimaLand.Bucket.beta_factor
 ## Methods for handling parameters read in from NetCDF files
 
 ```@docs
-ClimaLand.Bucket.set_initial_parameter_field!
 ClimaLand.Bucket.update_soil_albedo
 ```
 

--- a/docs/src/APIs/Bucket.md
+++ b/docs/src/APIs/Bucket.md
@@ -20,12 +20,6 @@ ClimaLand.Bucket.surface_albedo
 ClimaLand.Bucket.beta_factor
 ```
 
-## Methods for handling parameters read in from NetCDF files
-
-```@docs
-ClimaLand.Bucket.update_soil_albedo
-```
-
 ## Artifact Path Functions
 
 ```@docs

--- a/docs/tutorials/standalone/Bucket/bucket_tutorial.jl
+++ b/docs/tutorials/standalone/Bucket/bucket_tutorial.jl
@@ -83,7 +83,7 @@
 # equation, since we neglect the sensible heat contribution and only track the
 # latent heat contribution. We neglect the energy in liquid precipitation.
 
-# Finally, we have `α_sfc(lat, lon)` the
+# Finally, we have `α_bareground_func(lat, lon)` the
 # (snow-free) surface albedo, `ρc` the volumetric
 # heat capacity of the land, `σ_SB` the Stefan-Boltzmann constant,  and `κ_soil` the thermal
 # conductivity. The albedo is a linear interpolation between the albedo of surface and
@@ -179,15 +179,16 @@ soil_depth = FT(3.5);
 bucket_domain = Column(; zlim = (-soil_depth, FT(0.0)), nelements = 10);
 surface_space = bucket_domain.space.surface
 
-# Define our `BulkAlbedoFunction` model using a constant surface and snow albedo:
-# The surface albedo is a function of coordinates, which would be
+# Define our `BulkAlbedoFunction` model using a constant bareground surface and
+# snow albedo:
+# The bareground albedo is a function of coordinates, which would be
 # (x,y) on a plane, and (lat,lon) on a sphere. Another albedo
 # option is to specify a `BulkAlbedoStatic` or `BulkAlbedoFunction`,
-# which uses a NetCDF file to read in surface albedo.
+# which uses a NetCDF file to read in bareground albedo.
 # These options only applies when coordinates are (lat,lon).
-α_sfc = (coordinate_point) -> 0.2;
+α_bareground_func = (coordinate_point) -> 0.2;
 α_snow = FT(0.8);
-albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc, surface_space);
+albedo = BulkAlbedoFunction{FT}(α_snow, α_bareground_func, surface_space);
 # The critical snow level setting the scale for when we interpolate between
 # snow and surface albedo
 σS_c = FT(0.2);

--- a/experiments/standalone/Bucket/compare_gpu_cpu_output.jl
+++ b/experiments/standalone/Bucket/compare_gpu_cpu_output.jl
@@ -6,4 +6,4 @@ cpu_state = readdlm(joinpath(outdir, "tf_state_cpu.txt"), ',')
 gpu_state = readdlm(joinpath(outdir, "tf_state_gpu.txt"), ',')
 @show mean(cpu_state .- gpu_state)
 @show eps(Float64)
-@assert mean(cpu_state .- gpu_state) < eps(Float64) * 100
+@assert mean(cpu_state .- gpu_state) < eps(Float64) * 5e2

--- a/experiments/standalone/Bucket/global_bucket.jl
+++ b/experiments/standalone/Bucket/global_bucket.jl
@@ -54,9 +54,9 @@ bucket_domain = ClimaLand.Domains.SphericalShell(;
 surface_space = bucket_domain.space.surface
 
 # Set up parameters
-α_sfc = (coordinate_point) -> 0.2;
+α_bareground_func = (coordinate_point) -> 0.2;
 α_snow = FT(0.8);
-albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc, surface_space);
+albedo = BulkAlbedoFunction{FT}(α_snow, α_bareground_func, surface_space);
 σS_c = FT(0.2);
 W_f = FT(0.15);
 z_0m = FT(1e-2);

--- a/experiments/standalone/Bucket/global_bucket.jl
+++ b/experiments/standalone/Bucket/global_bucket.jl
@@ -41,9 +41,22 @@ context = ClimaComms.context()
 earth_param_set = create_lsm_parameters(FT);
 outdir = joinpath(pkgdir(ClimaLand), "experiments/standalone/Bucket/artifacts")
 !ispath(outdir) && mkpath(outdir)
+
+# Construct simulation domain
+soil_depth = FT(3.5);
+bucket_domain = ClimaLand.Domains.SphericalShell(;
+    radius = FT(6.3781e6),
+    depth = soil_depth,
+    nelements = (10, 10),
+    npolynomial = 1,
+    dz_tuple = FT.((1.0, 0.05)),
+);
+surface_space = bucket_domain.space.surface
+
+# Set up parameters
 α_sfc = (coordinate_point) -> 0.2;
 α_snow = FT(0.8);
-albedo = BulkAlbedoFunction(α_snow, α_sfc);
+albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc, surface_space);
 σS_c = FT(0.2);
 W_f = FT(0.15);
 z_0m = FT(1e-2);
@@ -65,15 +78,6 @@ bucket_parameters = BucketModelParameters(
     z_0b,
     τc,
     earth_param_set,
-);
-
-soil_depth = FT(3.5);
-bucket_domain = ClimaLand.Domains.SphericalShell(;
-    radius = FT(6.3781e6),
-    depth = soil_depth,
-    nelements = (10, 10),
-    npolynomial = 1,
-    dz_tuple = FT.((1.0, 0.05)),
 );
 ref_time = DateTime(2005);
 

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -564,7 +564,7 @@ end
     surface_albedo(model::AbstractModel, Y, p)
 
 A helper function which returns the surface albedo
- for a given model, needed because different models compute and store α_sfc in
+for a given model, needed because different models compute and store α_sfc in
 different ways and places.
 
 Extending this function for your model is only necessary if you need to

--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -89,11 +89,11 @@ end
 
 function BulkAlbedoFunction{FT}(
     α_snow::FT,
-    α_sfc::Function,
+    α_bareground_func::Function,
     space,
 ) where {FT <: AbstractFloat}
     surface_coords = ClimaCore.Fields.coordinate_field(space)
-    α_bareground = FT.(α_sfc.(surface_coords))
+    α_bareground = FT.(α_bareground_func.(surface_coords))
     args = (α_snow, α_bareground)
     BulkAlbedoFunction{typeof.(args)...}(args...)
 end
@@ -149,7 +149,7 @@ function BulkAlbedoStatic{FT}(
     if surface_space isa ClimaCore.Spaces.PointSpace
         error("Using an albedo map requires a global run.")
     end
-    α_sfc = PrescribedDataStatic{FT}(
+    α_bareground_data = PrescribedDataStatic{FT}(
         get_infile,
         regrid_dirpath,
         varnames,
@@ -158,7 +158,8 @@ function BulkAlbedoStatic{FT}(
 
     # Albedo file only has one variable, so access first `varname`
     varname = varnames[1]
-    α_bareground = FT.(get_data_at_date(α_sfc, surface_space, varname))
+    α_bareground =
+        FT.(get_data_at_date(α_bareground_data, surface_space, varname))
     return BulkAlbedoStatic(α_snow, α_bareground)
 end
 

--- a/test/standalone/Bucket/albedo_types.jl
+++ b/test/standalone/Bucket/albedo_types.jl
@@ -18,7 +18,6 @@ using ClimaLand.Bucket:
     BulkAlbedoTemporal,
     bareground_albedo_dataset_path,
     cesm2_albedo_dataset_path,
-    set_initial_parameter_field!,
     next_albedo
 using ClimaLand.Domains: coordinates, Column, SphericalShell
 using ClimaLand:
@@ -63,23 +62,6 @@ regrid_dir_static = joinpath(pkgdir(ClimaLand), "test", "static")
 regrid_dir_temporal = joinpath(pkgdir(ClimaLand), "test", "temporal")
 isdir(regrid_dir_static) ? nothing : mkpath(regrid_dir_static)
 isdir(regrid_dir_temporal) ? nothing : mkpath(regrid_dir_temporal)
-
-@testset "Test set_initial_parameter_field for BulkAlbedoFunction, FT = $FT" begin
-    # set up for function call
-    α_sfc = (coord_point) -> sin(coord_point.lat + coord_point.long)
-    α_snow = FT(0.8)
-    domain = create_domain_2d(FT)
-    space = domain.space.surface
-    albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc, space)
-
-    p = (; bucket = (; α_sfc = Fields.zeros(space)))
-    surface_coords = Fields.coordinate_field(space)
-
-    set_initial_parameter_field!(albedo, p, surface_coords)
-
-    # compare calculated result to manually applied albedo function
-    @test p.bucket.α_sfc == α_sfc.(surface_coords)
-end
 
 @testset "Test next_albedo for BulkAlbedoFunction, FT = $FT" begin
     # set up each argument for function call
@@ -131,7 +113,6 @@ if !Sys.iswindows()
         parameters = (; σS_c = σS_c)
 
         p = (; bucket = (; α_sfc = Fields.zeros(space)))
-        set_initial_parameter_field!(albedo, p, surface_coords)
 
         σS = FT(0.1)
         Y = (; bucket = (; σS = σS))
@@ -148,64 +129,6 @@ if !Sys.iswindows()
         )
 
         @test next_albedo(albedo, parameters, Y, p, FT(0)) == next_alb_manual
-    end
-
-    @testset "Test set_initial_parameter_field for BulkAlbedoStatic, FT = $FT" begin
-        # set up for function call
-        domain = create_domain_2d(FT)
-        space = domain.space.surface
-        p = (; bucket = (; α_sfc = Fields.zeros(space)))
-        surface_coords = Fields.coordinate_field(space)
-
-        albedo = BulkAlbedoStatic{FT}(regrid_dir_static, space)
-        set_initial_parameter_field!(albedo, p, surface_coords)
-
-        # read data manually
-        varname = "sw_alb"
-        outfile_root = "static_data_cgll"
-        comms_ctx = ClimaComms.context(space)
-        field = read_from_hdf5(
-            regrid_dir_static,
-            outfile_root,
-            Dates.DateTime(0), # dummy date
-            varname,
-            comms_ctx,
-        )
-        data_manual = nans_to_zero.(field)
-
-        @test p.bucket.α_sfc == data_manual
-    end
-
-    @testset "Test set_initial_parameter_field for BulkAlbedoTemporal, FT = $FT" begin
-        # set up for function call
-        t_start = Float64(0)
-        domain = create_domain_2d(FT)
-        space = domain.space.surface
-
-        infile_path = cesm2_albedo_dataset_path()
-        date_ref = to_datetime(NCDataset(infile_path, "r") do ds
-            ds["time"][1]
-        end)
-
-        albedo = BulkAlbedoTemporal{FT}(
-            regrid_dir_temporal,
-            date_ref,
-            t_start,
-            space,
-        )
-        p = (; bucket = (; α_sfc = Fields.zeros(space)))
-        surface_coords = Fields.coordinate_field(space)
-
-        set_initial_parameter_field!(albedo, p, surface_coords)
-
-        # set up for manual data reading
-        infile_path = bareground_albedo_dataset_path()
-        varname = "sw_alb"
-
-        data_manual =
-            get_data_at_date(albedo.albedo_info, space, varname, date_ref)
-
-        @test nans_to_zero.(p.bucket.α_sfc) == nans_to_zero.(data_manual)
     end
 
     @testset "Test next_albedo for BulkAlbedoTemporal, FT = $FT" begin
@@ -229,9 +152,6 @@ if !Sys.iswindows()
 
         Y = (; bucket = (; W = Fields.zeros(space)))
         p = (; bucket = (; α_sfc = Fields.zeros(space)))
-
-        # initialize data fields
-        set_initial_parameter_field!(albedo, p, surface_coords)
 
         # set up for manual data reading
         varname = "sw_alb"

--- a/test/standalone/Bucket/snow_bucket_tests.jl
+++ b/test/standalone/Bucket/snow_bucket_tests.jl
@@ -26,7 +26,7 @@ include(joinpath(pkgdir(ClimaLand), "parameters", "create_parameters.jl"))
 
 for FT in (Float32, Float64)
     earth_param_set = create_lsm_parameters(FT)
-    α_sfc = (coordinate_point) -> 0.2 # surface albedo, spatially constant
+    α_bareground_func = (coordinate_point) -> 0.2 # surface albedo, spatially constant
     α_snow = FT(0.8) # snow albedo
     σS_c = FT(0.2)
     W_f = FT(0.15)
@@ -88,7 +88,8 @@ for FT in (Float32, Float64)
 
             τc = FT(10.0)
             surface_space = bucket_domains[i].space.surface
-            albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc, surface_space)
+            albedo =
+                BulkAlbedoFunction{FT}(α_snow, α_bareground_func, surface_space)
             bucket_parameters = BucketModelParameters(
                 κ_soil,
                 ρc_soil,
@@ -206,7 +207,8 @@ for FT in (Float32, Float64)
 
             τc = FT(10.0)
             surface_space = bucket_domains[i].space.surface
-            albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc, surface_space)
+            albedo =
+                BulkAlbedoFunction{FT}(α_snow, α_bareground_func, surface_space)
             bucket_parameters = BucketModelParameters(
                 κ_soil,
                 ρc_soil,
@@ -324,7 +326,8 @@ for FT in (Float32, Float64)
 
         τc = FT(10.0)
         surface_space = bucket_domains[i].space.surface
-        albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc, surface_space)
+        albedo =
+            BulkAlbedoFunction{FT}(α_snow, α_bareground_func, surface_space)
         bucket_parameters = BucketModelParameters(
             κ_soil,
             ρc_soil,

--- a/test/standalone/Bucket/snow_bucket_tests.jl
+++ b/test/standalone/Bucket/snow_bucket_tests.jl
@@ -28,7 +28,6 @@ for FT in (Float32, Float64)
     earth_param_set = create_lsm_parameters(FT)
     α_sfc = (coordinate_point) -> 0.2 # surface albedo, spatially constant
     α_snow = FT(0.8) # snow albedo
-    albedo = BulkAlbedoFunction(α_snow, α_sfc)
     σS_c = FT(0.2)
     W_f = FT(0.15)
     z_0m = FT(1e-2)
@@ -86,7 +85,10 @@ for FT in (Float32, Float64)
                 ref_time,
                 h_atmos,
             )
+
             τc = FT(10.0)
+            surface_space = bucket_domains[i].space.surface
+            albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc, surface_space)
             bucket_parameters = BucketModelParameters(
                 κ_soil,
                 ρc_soil,
@@ -201,7 +203,10 @@ for FT in (Float32, Float64)
                 ref_time,
                 h_atmos,
             )
+
             τc = FT(10.0)
+            surface_space = bucket_domains[i].space.surface
+            albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc, surface_space)
             bucket_parameters = BucketModelParameters(
                 κ_soil,
                 ρc_soil,
@@ -316,7 +321,10 @@ for FT in (Float32, Float64)
             ref_time,
             h_atmos,
         )
+
         τc = FT(10.0)
+        surface_space = bucket_domains[i].space.surface
+        albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc, surface_space)
         bucket_parameters = BucketModelParameters(
             κ_soil,
             ρc_soil,

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -23,7 +23,6 @@ for FT in (Float32, Float64)
     earth_param_set = create_lsm_parameters(FT)
     α_sfc = (coordinate_point) -> 0.2 # surface albedo, spatially constant
     α_snow = FT(0.8) # snow albedo
-    albedo = BulkAlbedoFunction(α_snow, α_sfc)
     σS_c = FT(0.2)
     W_f = FT(0.15)
     z_0m = FT(1e-2)
@@ -51,6 +50,9 @@ for FT in (Float32, Float64)
     ]
     init_temp(z::FT, value::FT) where {FT} = FT(value)
     for bucket_domain in bucket_domains
+        surface_space = bucket_domain.space.surface
+        albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc, surface_space)
+
         @testset "Zero flux tendency, FT = $FT" begin
             # Radiation
             ref_time = DateTime(2005)

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -21,7 +21,7 @@ include(joinpath(pkgdir(ClimaLand), "parameters", "create_parameters.jl"))
 
 for FT in (Float32, Float64)
     earth_param_set = create_lsm_parameters(FT)
-    α_sfc = (coordinate_point) -> 0.2 # surface albedo, spatially constant
+    α_bareground_func = (coordinate_point) -> 0.2 # surface albedo, spatially constant
     α_snow = FT(0.8) # snow albedo
     σS_c = FT(0.2)
     W_f = FT(0.15)
@@ -51,7 +51,8 @@ for FT in (Float32, Float64)
     init_temp(z::FT, value::FT) where {FT} = FT(value)
     for bucket_domain in bucket_domains
         surface_space = bucket_domain.space.surface
-        albedo = BulkAlbedoFunction{FT}(α_snow, α_sfc, surface_space)
+        albedo =
+            BulkAlbedoFunction{FT}(α_snow, α_bareground_func, surface_space)
 
         @testset "Zero flux tendency, FT = $FT" begin
             # Radiation


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Store bareground albedo for albedo types that require bareground and snow albedo (`BulkAlbedoFunction` and `BulkAlbedoStatic`, but not `BulkAlbedoTemporal`). This allows us to remove the surface albedo that was previously stored in these two objects.

closes #472

## Content
- [x] add `\alpha_bareground` to `BulkAlbedoFunction/Static`
- [x] remove `\alpha_sfc` from `BulkAlbedoFunction/Static`
- [x] set `\alpha_bareground` (a Field) in albedo object constructor, using either function or input file
- [x] use `\alpha_bareground` to set `p.bucket.\alpha_sfc` in set_initial_parameter_field
- [x] use `\alpha_bareground` instead of `\alpha_sfc` in `next_albedo`
- [x] update for `BulkAlbedoFunction` constructor interface change (needs space now)
- [x] remove `set_initial_parameter_field` - calculations handled in `next_albedo`
- [x] update tests to check correct snow fraction update


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
