### PR TITLE
SpaceVaryingInput

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,6 +22,7 @@ tutorials = [
             "Richards Equation" => "standalone/Soil/richards_equation.jl",
             "Energy and Hydrology" => "standalone/Soil/soil_energy_hydrology.jl",
             "Phase Changes" => "standalone/Soil/freezing_front.jl",
+            "Layered Soil" => "standalone/Soil/layered_soil.jl",
         ],
         "Canopy modeling" => [
             "Standalone Canopy" => "standalone/Canopy/canopy_tutorial.jl",

--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -87,3 +87,8 @@ ClimaLand.make_update_drivers
 ClimaLand.TimeVaryingInput
 ClimaLand.evaluate!
 ```
+
+## SpaceVaryingInput
+```@docs
+ClimaLand.SpaceVaryingInput
+```

--- a/docs/tutorials/integrated/soil_canopy_tutorial.jl
+++ b/docs/tutorials/integrated/soil_canopy_tutorial.jl
@@ -152,7 +152,7 @@ soil_ps = Soil.EnergyHydrologyParameters{FT}(;
     ν_ss_om = ν_ss_om,
     ν_ss_quartz = ν_ss_quartz,
     ν_ss_gravel = ν_ss_gravel,
-    hydrology_cm = vanGenuchten(; α = soil_vg_α, n = soil_vg_n),
+    hydrology_cm = vanGenuchten{FT}(; α = soil_vg_α, n = soil_vg_n),
     K_sat = soil_K_sat,
     S_s = soil_S_s,
     θ_r = θ_r,

--- a/docs/tutorials/standalone/Soil/freezing_front.jl
+++ b/docs/tutorials/standalone/Soil/freezing_front.jl
@@ -100,7 +100,7 @@ K_sat = FT(3.2e-6) # m/s
 S_s = FT(1e-3) #inverse meters
 vg_n = FT(1.48)
 vg_α = FT(1.11) # inverse meters
-hcm = vanGenuchten(; α = vg_α, n = vg_n);
+hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n);
 # You could also try the Brooks and Corey model:
 #ψb = FT(-0.6)
 #c = FT(0.43)

--- a/docs/tutorials/standalone/Soil/layered_soil.jl
+++ b/docs/tutorials/standalone/Soil/layered_soil.jl
@@ -1,0 +1,172 @@
+# This shows how to run single colum soil model, in standalone mode
+# with spatially varying properties. We are mimicking the experiment
+# carried out in Huang et. al.
+# Can. J. Soil Sci. (2011) 91: 169183 doi:10.4141/CJSS09118,
+# which measured the infiltration of layered soil in Fort McMurray,
+# Alberta, Canada. We thank Mingbin Huang and S. Lee Barbour for
+# correspondence and support, including sharing of data, with us
+# Note that all data used in this tutorial is available in their
+# publication.
+
+using Plots
+import SciMLBase
+import ClimaTimeSteppers as CTS
+using ClimaCore
+import CLIMAParameters as CP
+using ArtifactWrappers
+using DelimitedFiles: readdlm
+
+using ClimaLand
+using ClimaLand.Domains: Column
+using ClimaLand.Soil
+import ClimaLand
+FT = Float64;
+
+# Define simulation times
+t0 = Float64(0)
+tf = Float64(60 * 60)
+dt = Float64(30);
+
+# Define the domain 
+zmax = FT(0)
+zmin = FT(-1.1)
+nelems = 75
+Δ = FT((zmax - zmin) / nelems / 2)
+soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems);
+
+# Download the parameter data. This has been obtained from
+# Table 1b of
+# Infiltration and drainage processes in multi-layered coarse soils
+# Mingbin Huang et. al.
+# Can. J. Soil Sci. (2011) 91: 169183 doi:10.4141/CJSS09118
+af = ArtifactFile(
+    url = "https://caltech.box.com/shared/static/qvbt37xkwz8gveyi6tzzbs0e18trpcsq.csv",
+    filename = "sv_62.csv",
+)
+dataset = ArtifactWrapper(@__DIR__, "sv62", ArtifactFile[af]);
+dataset_path = get_data_folder(dataset);
+data = joinpath(dataset_path, af.filename)
+parameter_data = readdlm(data, ',');
+# Our model treats z as increasing in the upwards direction.
+# Values below the surface are negative.
+# Because of this, we convert the (positive-valued) depth
+# of the data into a monotonically increasing z coordinate value.
+# using a negative sign and the reverse function.
+depth = reverse(-parameter_data[1, :] .* 0.01) # convert to m
+ksat = reverse(parameter_data[6, :] .* 1 / 100.0 / 60.0) # convert cm/min to m/s
+vgα = reverse(parameter_data[4, :] .* 100 * 2) # they report αᵈ; αʷ = 2αᵈ. This experiment is for infiltration (wetting).
+vgn = reverse(parameter_data[5, :])
+residual_frac = reverse(parameter_data[2, :])
+porosity = reverse(parameter_data[3, :]);
+
+# Create fields corresponding to the parameter
+ν = SpaceVaryingInput(depth, porosity, soil_domain.space.subsurface)
+K_sat = SpaceVaryingInput(depth, ksat, soil_domain.space.subsurface)
+θ_r = SpaceVaryingInput(depth, residual_frac, soil_domain.space.subsurface);
+# The specific storativity is not something we have data on, so we
+# approximate it as being constant in depth, and create the parameter field directly:
+S_s = ClimaCore.Fields.zeros(soil_domain.space.subsurface) .+ 1e-3;
+
+# The retention model is a vanGenuchten model with α and n as a function of
+# depth, read from the data:
+hcm = SpaceVaryingInput(
+    depth,
+    (; α = vgα, n = vgn),
+    soil_domain.space.subsurface,
+    vanGenuchten{FT},
+);
+
+# The parameter struct:
+params = ClimaLand.Soil.RichardsParameters(;
+    ν = ν,
+    hydrology_cm = hcm,
+    K_sat = K_sat,
+    S_s = S_s,
+    θ_r = θ_r,
+);
+
+# From here on out, everything should look familiar if you've already gone
+# through the other soil tutorials.
+# Set Boundary conditions:
+# At the top, we use the observed value of Ksat at the top of the domain.
+# Setting the flux to be -Ksat is approximating the top as saturated.
+function top_flux_function(p, t)
+    return -0.0001033
+end
+top_bc = ClimaLand.Soil.FluxBC(top_flux_function)
+bottom_bc = ClimaLand.Soil.FreeDrainage()
+boundary_fluxes = (; top = (water = top_bc,), bottom = (water = bottom_bc,))
+soil = Soil.RichardsModel{FT}(;
+    parameters = params,
+    domain = soil_domain,
+    boundary_conditions = boundary_fluxes,
+    sources = (),
+);
+
+# Initial the state vectors, and set initial conditions
+Y, p, cds = initialize(soil);
+
+# Initial conditions
+Y.soil.ϑ_l .= 0.0353; # read from Figure 4 of Huang et al. 
+
+# We also set the initial conditions of the auxiliary state here:
+set_initial_cache! = make_set_initial_cache(soil)
+set_initial_cache!(p, Y, t0);
+
+# Timestepping:
+stepper = CTS.ARS111()
+@assert FT in (Float32, Float64)
+err = (FT == Float64) ? 1e-8 : 1e-4
+convergence_cond = CTS.MaximumError(err)
+conv_checker = CTS.ConvergenceChecker(norm_condition = convergence_cond)
+ode_algo = CTS.IMEXAlgorithm(
+    stepper,
+    CTS.NewtonsMethod(
+        max_iters = 50,
+        update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
+        convergence_checker = conv_checker,
+    ),
+)
+exp_tendency! = make_exp_tendency(soil)
+imp_tendency! = make_imp_tendency(soil)
+update_jacobian! = make_update_jacobian(soil)
+jac_kwargs =
+    (; jac_prototype = RichardsTridiagonalW(Y), Wfact = update_jacobian!)
+prob = SciMLBase.ODEProblem(
+    CTS.ClimaODEFunction(
+        T_exp! = exp_tendency!,
+        T_imp! = SciMLBase.ODEFunction(imp_tendency!; jac_kwargs...),
+        dss! = ClimaLand.dss!,
+    ),
+    Y,
+    (t0, tf),
+    p,
+)
+saveat = [0.0, 8.0, 16.0, 24.0, 32.0, 40.0, 60.0] .* 60 # chosen to compare with data in plots in paper
+sol = SciMLBase.solve(prob, ode_algo; dt = dt, saveat = saveat);
+
+z = parent(ClimaCore.Fields.coordinate_field(soil_domain.space.subsurface).z)
+ϑ_l = [parent(sol.u[k].soil.ϑ_l) for k in 1:length(sol.t)]
+plot(ϑ_l[1], z, label = "initial", color = "grey", aspect_ratio = 0.8)
+plot!(ϑ_l[2], z, label = "8min", color = "orange")
+plot!(ϑ_l[3], z, label = "16min", color = "red")
+plot!(ϑ_l[4], z, label = "24min", color = "teal")
+plot!(ϑ_l[5], z, label = "32min", color = "blue")
+plot!(ϑ_l[6], z, label = "40min", color = "purple")
+plot!(ϑ_l[7], z, label = "60min", color = "green")
+scatter!(porosity, depth, label = "Porosity")
+plot!(legend = :bottomright)
+
+plot!(xlim = [0, 0.7])
+
+plot!(
+    ylim = [-1.1, 0],
+    yticks = [-1.1, -1, -0.9, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1],
+)
+
+plot!(ylabel = "Depth (m)")
+
+plot!(xlabel = "Volumeteric Water Content")
+
+savefig("./sv62_alpha_2_inf_updated_data_climaland.png")
+# ![](sv62_alpha_2_inf_updated_data_climaland.png)

--- a/docs/tutorials/standalone/Soil/richards_equation.jl
+++ b/docs/tutorials/standalone/Soil/richards_equation.jl
@@ -89,9 +89,9 @@ S_s = FT(1e-3)
 ν = FT(0.495)
 vg_α = FT(2.6)
 vg_n = FT(2)
-hcm = vanGenuchten(; α = vg_α, n = vg_n);
+hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n);
 θ_r = FT(0)
-params = Soil.RichardsParameters{FT, typeof(hcm)}(;
+params = Soil.RichardsParameters(;
     ν = ν,
     hydrology_cm = hcm,
     K_sat = K_sat,
@@ -109,7 +109,7 @@ soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems);
 # We also need to specify the boundary conditions. The user can specify two conditions,
 # either at the top or at the bottom, and they can either be either
 # on the state `ϑ_l` or on the flux  `-K∇h`. Flux boundary conditions
-# are passed as the (scalar) z-component of the flux `f`, i.e. F⃗ = f ẑ.
+# are passed as the (scalar) z-component of the flux `f`, i.e. F⃗ = f ẑ.
 # In either case, the user must pass a function of the auxiliary variables `p` and time `t`:
 
 surface_flux = Soil.FluxBC((p, t) -> 0.0)

--- a/docs/tutorials/standalone/Soil/soil_energy_hydrology.jl
+++ b/docs/tutorials/standalone/Soil/soil_energy_hydrology.jl
@@ -116,7 +116,7 @@ Ksat = FT(4.42 / 3600 / 100) # m/s
 S_s = FT(1e-3) #inverse meters
 vg_n = FT(1.89)
 vg_α = FT(7.5) # inverse meters
-hcm = vanGenuchten(; α = vg_α, n = vg_n);
+hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n);
 θ_r = FT(0.0);
 params = Soil.EnergyHydrologyParameters{FT}(;
     ν = ν,
@@ -141,7 +141,7 @@ soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems);
 # requires a boundary condition at the top and the bottom of the domain
 # for each equation being solved. These conditions can be on the state (`ϑ_l`
 # or `T`), or on the fluxes (`-K∇h` or `-κ∇T`). In the case of fluxes,
-# we return the magnitude of the flux, assumed to point along `ẑ`. And, in each case,
+# we return the magnitude of the flux, assumed to point along `ẑ`. And, in each case,
 # the boundary conditions are supplied in the form of a function of auxiliary variables
 # `p` and time `t`.
 

--- a/docs/tutorials/standalone/Usage/LSM_single_column_tutorial.jl
+++ b/docs/tutorials/standalone/Usage/LSM_single_column_tutorial.jl
@@ -75,9 +75,9 @@ K_sat = FT(0.0443 / 3600 / 100); # m/s
 S_s = FT(1e-3); #inverse meters
 vg_n = FT(2.0);
 vg_α = FT(2.6); # inverse meters
-hcm = vanGenuchten(; α = vg_α, n = vg_n);
+hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n);
 θ_r = FT(0);
-soil_ps = Soil.RichardsParameters{FT, typeof(hcm)}(;
+soil_ps = Soil.RichardsParameters(;
     ν = ν,
     hydrology_cm = hcm,
     K_sat = K_sat,

--- a/docs/tutorials/standalone/Usage/model_tutorial.jl
+++ b/docs/tutorials/standalone/Usage/model_tutorial.jl
@@ -307,7 +307,7 @@ end;
 # # Running a simulation
 # Create a model instance.
 FT = Float32
-vGmodel = ClimaLand.Soil.vanGenuchten(; α = 2.3f0, n = 2.0f0)
+vGmodel = ClimaLand.Soil.vanGenuchten{FT}(; α = 2.3f0, n = 2.0f0)
 Ksat = FT(4.0e-7)
 ν = 0.5f0
 θ_r = 0.0f0

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -74,7 +74,7 @@ soil_ps = Soil.EnergyHydrologyParameters{FT}(;
     ν_ss_om = ν_ss_om,
     ν_ss_quartz = ν_ss_quartz,
     ν_ss_gravel = ν_ss_gravel,
-    hydrology_cm = vanGenuchten(; α = soil_vg_α, n = soil_vg_n),
+    hydrology_cm = vanGenuchten{FT}(; α = soil_vg_α, n = soil_vg_n),
     K_sat = soil_K_sat,
     S_s = soil_S_s,
     θ_r = θ_r,

--- a/experiments/integrated/ozark/conservation/ozark_conservation.jl
+++ b/experiments/integrated/ozark/conservation/ozark_conservation.jl
@@ -75,7 +75,7 @@ for float_type in (Float32, Float64)
         ν_ss_om = ν_ss_om,
         ν_ss_quartz = ν_ss_quartz,
         ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = vanGenuchten(; α = soil_vg_α, n = soil_vg_n),
+        hydrology_cm = vanGenuchten{FT}(; α = soil_vg_α, n = soil_vg_n),
         K_sat = soil_K_sat,
         S_s = soil_S_s,
         θ_r = θ_r,

--- a/experiments/standalone/Biogeochemistry/experiment.jl
+++ b/experiments/standalone/Biogeochemistry/experiment.jl
@@ -25,7 +25,7 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
     S_s = FT(1e-3) #inverse meters
     vg_n = FT(2.0)
     vg_α = FT(2.6) # inverse meters
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
+    hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
     θ_r = FT(0.1)
     ν_ss_om = FT(0.0)
     ν_ss_quartz = FT(1.0)

--- a/experiments/standalone/Soil/evaporation.jl
+++ b/experiments/standalone/Soil/evaporation.jl
@@ -33,7 +33,7 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
     # n and alpha estimated by matching vG curve.
     vg_n = FT(10.0)
     vg_α = FT(6.0)
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
+    hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
     # Alternative parameters for Brooks Corey water retention model
     #ψb = FT(-0.14)
     #c = FT(5.5)

--- a/experiments/standalone/Soil/richards_comparison.jl
+++ b/experiments/standalone/Soil/richards_comparison.jl
@@ -45,7 +45,7 @@ bonan_sand_dataset = ArtifactWrapper(
         S_s = FT(1e-3) #inverse meters
         vg_n = FT(1.43)
         vg_α = FT(2.6) # inverse meters
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0.124)
         zmax = FT(0)
         zmin = FT(-1.5)
@@ -58,8 +58,13 @@ bonan_sand_dataset = ArtifactWrapper(
         sources = ()
         boundary_states =
             (; top = (water = top_state_bc,), bottom = (water = bot_flux_bc,))
-        params =
-            Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
+        params = Soil.RichardsParameters(;
+            ν = ν,
+            hydrology_cm = hcm,
+            K_sat = K_sat,
+            S_s = S_s,
+            θ_r = θ_r,
+        )
 
         soil = Soil.RichardsModel{FT}(;
             parameters = params,
@@ -145,7 +150,7 @@ end
         S_s = FT(1e-3) #inverse meters
         vg_n = FT(3.96)
         vg_α = FT(2.7) # inverse meters
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0.075)
         zmax = FT(0)
         zmin = FT(-1.5)

--- a/experiments/standalone/Soil/water_conservation.jl
+++ b/experiments/standalone/Soil/water_conservation.jl
@@ -66,13 +66,19 @@ for FT in (Float32, Float64)
     vg_α = FT(0.026 * 100) # inverse meters
     θ_r = FT(0.124)
     S_s = FT(1e-3) #inverse meters
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
+    hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
 
     zmax = FT(0)
     zmin = FT(-0.5)
     nelems = 50
 
-    params = Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
+    params = Soil.RichardsParameters(;
+        ν = ν,
+        hydrology_cm = hcm,
+        K_sat = K_sat,
+        S_s = S_s,
+        θ_r = θ_r,
+    )
     soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
     sources = ()
 

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Ha1/US-Ha1_parameters.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Ha1/US-Ha1_parameters.jl
@@ -86,7 +86,7 @@ function soil_harvard(;
     PAR_albedo = FT(0.2),
     NIR_albedo = FT(0.2),
 )
-    hydrology_cm = vanGenuchten(; α = vg_α, n = vg_n)
+    hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
     return EnergyHydrologyParameters{FT}(; # here, calls the src function, not the src struct    
         ν = ν,
         ν_ss_om = ν_ss_om,

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-MOz/US-MOz_parameters.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-MOz/US-MOz_parameters.jl
@@ -86,7 +86,7 @@ function soil_ozark(; # Function that returns the src function, but with ozark d
     PAR_albedo = FT(0.2),
     NIR_albedo = FT(0.2),
 )
-    hydrology_cm = vanGenuchten(; α = vg_α, n = vg_n)
+    hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
     return EnergyHydrologyParameters{FT}(; # here, calls the src function, not the src struct    
         ν = ν,
         ν_ss_om = ν_ss_om,

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-NR1/US-NR1_parameters.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-NR1/US-NR1_parameters.jl
@@ -86,7 +86,7 @@ function soil_niwotridge(;
     PAR_albedo = FT(0.2),
     NIR_albedo = FT(0.2),
 )
-    hydrology_cm = vanGenuchten(; α = vg_α, n = vg_n)
+    hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
     return EnergyHydrologyParameters{FT}(; # here, calls the src function, not the src struct    
         ν = ν,
         ν_ss_om = ν_ss_om,

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Var/US-Var_parameters.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Var/US-Var_parameters.jl
@@ -86,7 +86,7 @@ function soil_vairaranch(;
     PAR_albedo = FT(0.2),
     NIR_albedo = FT(0.2),
 )
-    hydrology_cm = vanGenuchten(; α = vg_α, n = vg_n)
+    hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
     return EnergyHydrologyParameters{FT}(; # here, calls the src function, not the src struct    
         ν = ν,
         ν_ss_om = ν_ss_om,

--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -11,10 +11,12 @@ include("shared_utilities/general_utils.jl")
 include("shared_utilities/TimeVaryingInputs.jl")
 using .TimeVaryingInputs
 export TimeVaryingInput, evaluate!
-
 include("shared_utilities/Regridder.jl")
 include("shared_utilities/Domains.jl")
 include("shared_utilities/FileReader.jl")
+include("shared_utilities/SpaceVaryingInputs.jl")
+using .SpaceVaryingInputs
+export SpaceVaryingInput
 using .Domains
 include("shared_utilities/utils.jl")
 include("shared_utilities/models.jl")

--- a/src/shared_utilities/SpaceVaryingInputs.jl
+++ b/src/shared_utilities/SpaceVaryingInputs.jl
@@ -1,0 +1,165 @@
+# SpaceVaryingInputs.jl
+#
+# This module contains methods to process external data, regrid it onto the
+# model grid, and return the corresponding fields for use in the simulation.
+# This module only concerns with external data which varies in space,
+# and not time. For temporally varying input, we refer you to `TimeVaryingInputs.jl`.
+
+# All spatially varying parameter fields are assumed to fit into memory,
+# and on GPU runs, they have underlying CuArrays on the GPU.
+
+# The planned parameter underlying arrays are:
+# - one-dimensional (values prescribed as a function of depth at a site),
+# - two-dimensional (values prescribed globally at each lat/lon),
+# - three-dimensional (values prescribed as a function of depth globally)
+# - analytic (functions of the coordinates of the space)
+
+module SpaceVaryingInputs
+using ClimaCore
+using ClimaComms
+using DocStringExtensions
+import ..searchsortednearest
+import ..linear_interpolation
+using ClimaLand.FileReader
+export SpaceVaryingInput
+
+# Analytic case
+"""
+    SpaceVaryingInput(data_function::Function, space::ClimaCore.Spaces.AbstractSpace) 
+  
+Returns the parameter field to be used in the model; appropriate when
+a parameter is defined using a function of the coordinates of the space.
+
+Pass the ``data" as a function `data_function` which takes coordinates as arguments, 
+and  the ClimaCore space of the model simulation.
+
+This returns a scalar field.
+Note that data_function is broadcasted over the coordinate field. Internally, inside
+your function, this must be unpacked (coords.lat, coords.lon, e.g.) for 
+use of the coordinate values directly.
+"""
+function SpaceVaryingInput(
+    data_function::Function,
+    space::ClimaCore.Spaces.AbstractSpace,
+)
+    model_value = ClimaCore.Fields.zeros(space)
+    coords = ClimaCore.Fields.coordinate_field(space)
+    return model_value .= data_function.(coords)
+end
+
+# 1-D Case
+"""
+    function SpaceVaryingInput(
+        data_z::AbstractArray,
+        data_values::AbstractArray,
+        space::S,
+    ) where {S <: ClimaCore.Spaces.CenterFiniteDifferenceSpace}
+
+Given a set of depths `data_z` and the observed values `data_values` 
+at those depths, create an interpolated field of values at each value
+of z in the model grid - defined implicitly by `space`.
+
+Returns a ClimaCore.Fields.Field of scalars.
+"""
+function SpaceVaryingInput(
+    data_z::AbstractArray,
+    data_values::AbstractArray,
+    space::S,
+) where {S <: ClimaCore.Spaces.CenterFiniteDifferenceSpace}
+    model_value = ClimaCore.Fields.zeros(space)
+    # convert the passed arrays to the appropriate type for the device
+    device = ClimaComms.device(space)
+    AT = ClimaComms.array_type(device)
+    data_values = AT(data_values)
+    data_z = AT(data_z)
+    zvalues = ClimaCore.Fields.coordinate_field(space).z
+    #now create the parameter field
+    model_value .= map(zvalues) do z
+        linear_interpolation(data_z, data_values, z)
+    end
+    return model_value
+end
+
+
+"""
+    SpaceVaryingInputs.SpaceVaryingInput(
+        data_z::AbstractArray,
+        data_values::NamedTuple,
+        space::S,
+        dest_type::Type{DT},
+    ) where {
+        S <: ClimaCore.Spaces.CenterFiniteDifferenceSpace,
+        DT,
+    }
+
+Returns a field of parameter structs to be used in the model; 
+appropriate when the parameter struct values vary in depth; 
+the `dest_type` argument is the struct type - we assumed that
+your struct as a constructor which accepts the values of its arguments
+by kwarg,
+- `data_z` is where the measured values were obtained,
+- `data_values` is a NamedTuple with keys equal to the argument names
+of the struct, and with values equal to an array of measured values,
+- `space` defines the model grid.
+
+As an example, we can create a field of vanGenuchten structs as follows. This struct
+requires two parameters, `α` and `n`. Let's assume that we have measurements of these
+as a function of depth at the locations given by `data_z`, called `data_α` and `data_n`.
+Then we can write
+`vG_field = SpaceVaryingInput(data_z, (;α = data_α, n = data_n), space, vanGenuchten{Float32})`.
+Under the hood, at each point in the model grid, we will create
+`vanGenuchten{Float32}(;α = interp_α, n = interp_n)`, where `interp` indicates
+the interpolated value at the model depth.
+
+Returns a ClimaCore.Fields.Field of type DT.
+
+"""
+function SpaceVaryingInput(
+    data_z::AbstractArray,
+    data_values::NamedTuple,
+    space::S,
+    dest_type::Type{DT},
+) where {S <: ClimaCore.Spaces.CenterFiniteDifferenceSpace, DT}
+    zvalues = ClimaCore.Fields.coordinate_field(space).z
+    # convert the passed arrays to the appropriate type for the device
+    device = ClimaComms.device(space)
+    AT = ClimaComms.array_type(device)
+    data_z = AT(data_z)
+    data_values_AT = map(AT, data_values)
+    # now create the field of structs
+    model_value = map(zvalues) do z
+        args = map(data_values_AT) do value
+            return linear_interpolation(data_z, value, z)
+        end
+        DT(; args...)
+    end
+    return model_value
+end
+
+"""
+    SpaceVaryingInput(data::PDS, varname::N; space::S) 
+    where {PDS <: FileReader.PrescribedDataStatic, N <: String, S <: ClimaCore.Spaces.SpectralElement2D}
+  
+Returns the parameter field to be used in the model; appropriate when
+a parameter is defined on the surface of the Earth.
+
+Pass the data as a `FileReader.PrescribedDataStatic` object
+as well as the variable name of the variable in the data file, and the ClimaCore space
+of the model simulation.
+
+Returns a ClimaCore.Fields.Field of scalars; analogous to the 1D case which also
+returns a ClimaCore.Fields.Field of scalars.
+"""
+function SpaceVaryingInput(
+    data::PDS,
+    varname::N,
+    space::S,
+) where {
+    PDS <: FileReader.PrescribedDataStatic,
+    N <: String,
+    S <: ClimaCore.Spaces.SpectralElementSpace2D,
+}
+    return FileReader.get_data_at_date(data, space, varname)
+end
+
+end

--- a/src/shared_utilities/TimeVaryingInputs.jl
+++ b/src/shared_utilities/TimeVaryingInputs.jl
@@ -31,6 +31,7 @@
 module TimeVaryingInputs
 
 import ..searchsortednearest
+import ..linear_interpolation
 
 import Adapt
 import CUDA

--- a/src/shared_utilities/general_utils.jl
+++ b/src/shared_utilities/general_utils.jl
@@ -16,3 +16,30 @@ function searchsortednearest(a, x)
         return abs(a[i] - x) < abs(a[i - 1] - x) ? i : i - 1
     end
 end
+
+
+"""
+    linear_interpolation(indep_vars, dep_vars, indep_value)
+
+Carries out linear interpolation to obtain a value at
+location `indep_value`, using a independent variable
+1-d vector `indep_vars` and a dependent variable 
+1-d vector `dep_vars`.
+
+If the `indep_value` is outside the range of `indep_vars`, this
+returns the endpoint value closest.
+"""
+function linear_interpolation(indep_vars, dep_vars, indep_value)
+    N = length(indep_vars)
+    id = searchsortedfirst(indep_vars, indep_value)
+    if id == 1
+        dep_vars[begin]
+    elseif id == N + 1
+        dep_vars[end]
+    else
+        id_prev = id - 1
+        x0, x1 = indep_vars[id_prev], indep_vars[id]
+        y0, y1 = dep_vars[id_prev], dep_vars[id]
+        y0 + (y1 - y0) / (x1 - x0) * (indep_value - x0)
+    end
+end

--- a/src/shared_utilities/interpolating_time_varying_input0d.jl
+++ b/src/shared_utilities/interpolating_time_varying_input0d.jl
@@ -152,17 +152,9 @@ function evaluate!(
     # case, we just return the value of vals[1] (we are on a node, no need for
     # interpolation).
 
-    index = searchsortedfirst(itp.times, time)
-    if index == 1
-        dest .= itp.vals[index]
-    else
-        index_prev = index - 1
-
-        t0, t1 = itp.times[index_prev], itp.times[index]
-        y0, y1 = itp.vals[index_prev], itp.vals[index]
-
-        dest .= y0 + (y1 - y0) / (t1 - t0) * (time - t0)
-    end
-
+    indep_vars = itp.times
+    indep_value = time
+    dep_vars = itp.vals
+    dest .= linear_interpolation(indep_vars, dep_vars, indep_value)
     return nothing
 end

--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -92,8 +92,7 @@ function BulkAlbedoFunction{FT}(
     α_bareground_func::Function,
     space,
 ) where {FT <: AbstractFloat}
-    surface_coords = ClimaCore.Fields.coordinate_field(space)
-    α_bareground = FT.(α_bareground_func.(surface_coords))
+    α_bareground = SpaceVaryingInput(α_bareground_func, space)
     args = (α_snow, α_bareground)
     BulkAlbedoFunction{typeof.(args)...}(args...)
 end
@@ -158,8 +157,7 @@ function BulkAlbedoStatic{FT}(
 
     # Albedo file only has one variable, so access first `varname`
     varname = varnames[1]
-    α_bareground =
-        FT.(get_data_at_date(α_bareground_data, surface_space, varname))
+    α_bareground = SpaceVaryingInput(α_bareground_data, varname, surface_space)
     return BulkAlbedoStatic(α_snow, α_bareground)
 end
 

--- a/src/standalone/Soil/retention_models.jl
+++ b/src/standalone/Soil/retention_models.jl
@@ -36,7 +36,7 @@ struct vanGenuchten{FT} <: AbstractSoilHydrologyClosure{FT}
     m::FT
     "A derived parameter: the critical saturation at which capillary flow no longer replenishes the surface"
     S_c::FT
-    function vanGenuchten(; α::FT, n::FT) where {FT}
+    function vanGenuchten{FT}(; α::FT, n::FT) where {FT}
         m = 1 - 1 / n
         S_c = (1 + ((n - 1) / n)^(1 - 2 * n))^(-m)
         return new{FT}(α, n, m, S_c)
@@ -61,7 +61,7 @@ struct BrooksCorey{FT} <: AbstractSoilHydrologyClosure{FT}
     ψb::FT
     "A derived parameter: the critical saturation at which capillary flow no longer replenishes the surface"
     S_c::FT
-    function BrooksCorey(; c::FT, ψb::FT) where {FT}
+    function BrooksCorey{FT}(; c::FT, ψb::FT) where {FT}
         S_c = (1 + 1 / c)^(-c)
         return new{FT}(c, ψb, S_c)
     end

--- a/src/standalone/Soil/rre.jl
+++ b/src/standalone/Soil/rre.jl
@@ -1,33 +1,33 @@
 """
-    RichardsParameters{FT <: AbstractFloat, C <: AbstractSoilHydrologyClosure}
+    RichardsParameters{F <: Union{<: AbstractFloat, ClimaCore.Fields.Field}, C <: AbstractSoilHydrologyClosure}
 
 A struct for storing parameters of the `RichardModel`.
 $(DocStringExtensions.FIELDS)
 """
 struct RichardsParameters{
-    FT <: AbstractFloat,
-    C <: AbstractSoilHydrologyClosure,
+    F <: Union{<:AbstractFloat, ClimaCore.Fields.Field},
+    C,
 }
     "The porosity of the soil (m^3/m^3)"
-    ν::FT
+    ν::F
     "The hydrology closure model: vanGenuchten or BrooksCorey"
     hydrology_cm::C
     "The saturated hydraulic conductivity (m/s)"
-    K_sat::FT
+    K_sat::F
     "The specific storativity (1/m)"
-    S_s::FT
+    S_s::F
     "The residual water fraction (m^3/m^3"
-    θ_r::FT
+    θ_r::F
 end
 
-function RichardsParameters{FT, C}(;
+function RichardsParameters(;
     hydrology_cm::C,
-    ν::FT,
-    K_sat::FT,
-    S_s::FT,
-    θ_r::FT,
-) where {FT, C}
-    return RichardsParameters{FT, typeof(hydrology_cm)}(
+    ν::F,
+    K_sat::F,
+    S_s::F,
+    θ_r::F,
+) where {F <: Union{<:AbstractFloat, ClimaCore.Fields.Field}, C}
+    return RichardsParameters{F, typeof(hydrology_cm)}(
         ν,
         hydrology_cm,
         K_sat,
@@ -68,7 +68,7 @@ end
 
 """
     RichardsModel{FT}(;
-        parameters::RichardsParameters{FT},
+        parameters::RichardsParameters,
         domain::D,
         boundary_conditions::NamedTuple,
         sources::Tuple,
@@ -79,7 +79,7 @@ A constructor for a `RichardsModel`, which sets the
 default value of `lateral_flow` to be true.
 """
 function RichardsModel{FT}(;
-    parameters::RichardsParameters{FT},
+    parameters::RichardsParameters,
     domain::D,
     boundary_conditions::NamedTuple,
     sources::Tuple,

--- a/test/integrated/pond_soil_lsm.jl
+++ b/test/integrated/pond_soil_lsm.jl
@@ -20,7 +20,7 @@ for FT in (Float32, Float64)
         S_s = FT(1e-3) #inverse meters
         vg_n = FT(2.0)
         vg_α = FT(2.6) # inverse meters
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0)
         zmax = FT(0)
         zmin = FT(-1)

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -17,7 +17,7 @@ for FT in (Float32, Float64)
         S_s = FT(1e-3) #inverse meters
         vg_n = FT(2.0)
         vg_α = FT(2.6) # inverse meters
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0.1)
         ν_ss_om = FT(0.0)
         ν_ss_quartz = FT(1.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,9 @@ end
 @safetestset "FileReader module tests" begin
     include("shared_utilities/file_reader.jl")
 end
+@safetestset "SpaceVaryingInput module tests" begin
+    include("shared_utilities/space_varying_inputs.jl")
+end
 @safetestset "TimeVaryingInput module tests" begin
     include("shared_utilities/time_varying_inputs.jl")
 end

--- a/test/shared_utilities/implicit_timestepping/richards_model.jl
+++ b/test/shared_utilities/implicit_timestepping/richards_model.jl
@@ -17,7 +17,7 @@ for FT in (Float32, Float64)
         S_s = FT(1e-3) #inverse meters
         vg_n = FT(1.43)
         vg_α = FT(2.6) # inverse meters
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0.124)
         zmax = FT(0)
         zmin = FT(-1.5)
@@ -37,8 +37,7 @@ for FT in (Float32, Float64)
         sources = ()
         boundary_states =
             (; top = (water = top_state_bc,), bottom = (water = bot_flux_bc,))
-        params =
-            Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
+        params = Soil.RichardsParameters(ν, hcm, K_sat, S_s, θ_r)
 
         for domain in soil_domains
             soil = Soil.RichardsModel{FT}(;
@@ -129,7 +128,7 @@ for FT in (Float32, Float64)
         S_s = FT(1e-3) #inverse meters
         vg_n = FT(1.43)
         vg_α = FT(2.6) # inverse meters
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0.124)
         zmax = FT(0)
         zmin = FT(-1.5)
@@ -149,8 +148,7 @@ for FT in (Float32, Float64)
         sources = ()
         boundary_states =
             (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
-        params =
-            Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
+        params = Soil.RichardsParameters(ν, hcm, K_sat, S_s, θ_r)
         for domain in soil_domains
             soil = Soil.RichardsModel{FT}(;
                 parameters = params,

--- a/test/shared_utilities/space_varying_inputs.jl
+++ b/test/shared_utilities/space_varying_inputs.jl
@@ -1,0 +1,79 @@
+using Test
+import ClimaLand
+using ClimaLand.SpaceVaryingInputs: SpaceVaryingInput
+using ClimaLand: Domains
+
+using ClimaCore: Fields
+using ClimaComms
+
+device = ClimaComms.device()
+context = ClimaComms.SingletonCommsContext(device)
+AT = ClimaComms.array_type(device)
+# This tests the analytic and 1d cases of the SpaceVaryingInput function
+@testset "SpaceVaryingInput" begin
+    FT = Float32
+    zmin = FT(-1.0)
+    zmax = FT(0.0)
+    xlim = FT.((0.0, 10.0))
+    ylim = FT.((0.0, 1.0))
+    zlim = FT.((zmin, zmax))
+    nelements = (1, 1, 10)
+    radius = FT(100)
+    depth = FT(30)
+    n_elements_sphere = (6, 20)
+    npoly_sphere = 3
+    shell = Domains.SphericalShell(;
+        radius = radius,
+        depth = depth,
+        nelements = n_elements_sphere,
+        npolynomial = npoly_sphere,
+    )
+
+    box = Domains.HybridBox(;
+        xlim = xlim,
+        ylim = ylim,
+        zlim = zlim,
+        nelements = nelements,
+        npolynomial = 0,
+    )
+
+    column = Domains.Column(; zlim = zlim, nelements = nelements[3])
+
+    domains = [shell, box, column]
+    analytic_func = (coords) -> 2.0
+    for domain in domains
+        for space in domain.space
+            coords = Fields.coordinate_field(space)
+            @test SpaceVaryingInput(analytic_func, space) ==
+                  FT.(analytic_func.(coords))
+        end
+    end
+
+    # 1D cases
+    data_z = collect(range(FT(-1.0), FT(0.0), 11))
+    data_value = data_z .* 2
+    space = column.space.subsurface
+    field = SpaceVaryingInput(data_z, data_value, space)
+    @test parent(field)[:] ≈ AT(collect(range(FT(-1.9), FT(-0.1), 10)))
+
+    struct Tmp{FT}
+        a::FT
+        b::FT
+        c::FT
+        function Tmp{FT}(; a::FT, c::FT) where {FT}
+            b = a * 2
+            new{FT}(a, b, c)
+        end
+    end
+    data_values = (; a = data_z .* 2, c = data_z .* 3)
+    field_of_structs = SpaceVaryingInput(data_z, data_values, space, Tmp{FT})
+    @test eltype(field_of_structs) == Tmp{FT}
+    @test field_of_structs.a == field
+    @test field_of_structs.b == 2 .* field_of_structs.a
+    @test parent(field_of_structs.c)[:] ≈
+          AT(collect(range(FT(-2.85), FT(-0.15), 10)))
+
+    # 2D SpaceVaryingInput
+    # the 2d from netcdf + regridding is tested now implicitly in the albedo_types test, since the BulkAlbedoStatic
+    # uses SpaceVaryingInput now. 
+end

--- a/test/standalone/Bucket/albedo_types.jl
+++ b/test/standalone/Bucket/albedo_types.jl
@@ -120,6 +120,7 @@ if !Sys.iswindows()
         param_σS_c = parameters.σS_c
         a_α_snow = albedo.α_snow
         a_α_bareground = albedo.α_bareground
+        @test eltype(a_α_bareground) == FT
 
         next_alb_manual = @. (
             (1 - Y_σS / (Y_σS + param_σS_c)) * a_α_bareground +

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -6,8 +6,8 @@ using ClimaLand
 using ClimaLand.Soil
 import ClimaLand
 import ClimaLand.Parameters as LP
-
 using Dates
+
 
 for FT in (Float32, Float64)
     @testset "Surface fluxes and radiation for soil, FT = $FT" begin
@@ -33,7 +33,7 @@ for FT in (Float32, Float64)
         vg_n = FT(2.0)
         vg_α = FT(2.6) # inverse meters
         vg_m = FT(1) - FT(1) / vg_n
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0.1)
         S_c = hcm.S_c
         @test Soil.dry_soil_layer_thickness(FT(1), S_c, FT(1)) == FT(0)

--- a/test/standalone/Soil/soil_bc.jl
+++ b/test/standalone/Soil/soil_bc.jl
@@ -97,7 +97,7 @@ for FT in (Float32, Float64)
         S_s = FT(1e-3) #inverse meters
         vg_n = FT(2.0)
         vg_α = FT(2.6) # inverse meters
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0)
         zmax = FT(0)
         zmin = FT(-10)
@@ -135,7 +135,7 @@ for FT in (Float32, Float64)
         S_s = FT(1e-3) #inverse meters
         vg_n = FT(2.0)
         vg_α = FT(2.6) # inverse meters
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0.1)
         ν_ss_om = FT(0.0)
         ν_ss_quartz = FT(1.0)
@@ -197,25 +197,25 @@ end
     S_s = FT(1e-3) #inverse meters
     vg_n = FT(2.0)
     vg_α = FT(2.6) # inverse meters
-    vg_m = FT(1) - FT(1) / vg_n
-    hcm = vanGenuchten(; α = vg_α, n = vg_n)
+    hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
     θ_r = FT(0.1)
     ν_ss_om = FT(0.0)
     ν_ss_quartz = FT(1.0)
     ν_ss_gravel = FT(0.0)
     κ_minerals = FT(2.5)
-    κ_om = FT(0.25)
-    κ_quartz = FT(8.0)
-    κ_air = FT(0.025)
-    κ_ice = FT(2.21)
-    κ_liq = FT(0.57)
     ρp = FT(2.66 / 1e3 * 1e6)
-    ρc_ds = FT(2e6 * (1.0 - ν))
-    κ_soil_solids =
-        Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
-    κ_dry_soil = Soil.κ_dry(ρp, ν, κ_soil_solids, κ_air)
-    κ_sat_ice = Soil.κ_sat_frozen(κ_soil_solids, ν, κ_ice)
-    κ_sat_liq = Soil.κ_sat_unfrozen(κ_soil_solids, ν, κ_liq)
+    ρc_ds = @. FT(2e6 * (1.0 - ν))
+    parameters = Soil.EnergyHydrologyParameters{FT}(;
+        ν = ν,
+        ν_ss_om = ν_ss_om,
+        ν_ss_quartz = ν_ss_quartz,
+        ν_ss_gravel = ν_ss_gravel,
+        hydrology_cm = hcm,
+        K_sat = K_sat,
+        S_s = S_s,
+        θ_r = θ_r,
+        earth_param_set = earth_param_set,
+    )
     zmax = FT(0)
     zmin = FT(-1)
     nelems = 200
@@ -285,7 +285,7 @@ end
     boundary_fluxes =
         (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
 
-    parameters = Soil.RichardsParameters{FT, typeof(hcm)}(;
+    parameters = Soil.RichardsParameters(;
         ν = ν,
         hydrology_cm = hcm,
         K_sat = FT(0),

--- a/test/standalone/Soil/soil_parameterizations.jl
+++ b/test/standalone/Soil/soil_parameterizations.jl
@@ -26,7 +26,7 @@ for FT in (Float32, Float64)
         θ_r = FT(0.1)
         vg_α = FT(2.0)
         vg_n = FT(1.4)
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         K_sat = FT(1e-5)
         ν_ss_om = FT(0.1)
         ν_ss_gravel = FT(0.1)
@@ -155,8 +155,6 @@ for FT in (Float32, Float64)
         @test Soil.κ_dry(ρp, ν, κ_solid_soil, κ_air) ==
               ((FT(0.053) * FT(κ_solid_soil) - κ_air) * FT(ρb) + κ_air * ρp) /
               (ρp - (FT(1.0) - FT(0.053)) * ρb)
-
-
         # Impedance factor
         @test impedance_factor(FT(1.0), parameters.Ω) ≈ 1e-7
 
@@ -186,7 +184,7 @@ for FT in (Float32, Float64)
     end
 
     @testset "Brooks and Corey closure, FT = $FT" begin
-        hcm = BrooksCorey(; ψb = FT(-0.09), c = FT(0.228))
+        hcm = BrooksCorey{FT}(; ψb = FT(-0.09), c = FT(0.228))
         # Test derived parameter
         @test hcm.S_c == (1 + 1 / FT(0.228))^(-FT(0.228))
 
@@ -226,10 +224,10 @@ for FT in (Float32, Float64)
         S_s = FT(1e-2)
         vg_α = FT(3.6)
         vg_n = FT(1.56)
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         K_sat = FT(2.9e-7)
         vg_m = FT(1.0 - 1.0 / vg_n)
-        richards_parameters = RichardsParameters{FT, typeof(hcm)}(;
+        richards_parameters = RichardsParameters(;
             ν = ν,
             hydrology_cm = hcm,
             K_sat = K_sat,
@@ -304,7 +302,7 @@ for FT in (Float32, Float64)
         θ_r = FT(0.1)
         vg_α = FT(2.0)
         vg_n = FT(1.4)
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
 
         K_sat = FT(1e-5)
         ν_ss_om = FT(0.1)

--- a/test/standalone/Soil/soil_test_3d.jl
+++ b/test/standalone/Soil/soil_test_3d.jl
@@ -11,12 +11,12 @@ import ClimaLand.Parameters as LP
 for FT in (Float32, Float64)
     @testset "Soil horizontal operators unit tests, FT = $FT" begin
         ν = FT(0.495)
-        K_sat = FT(1)#0.0443 / 3600 / 100); # m/s
-        S_s = FT(1)#e-3); #inverse meters
+        K_sat = FT(1)
+        S_s = FT(1)
         vg_n = FT(2.0)
         vg_α = FT(2.6) # inverse meters
         vg_m = 1 - 1 / vg_n
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0)
         zmax = FT(0)
         zmin = FT(-1)
@@ -33,8 +33,13 @@ for FT in (Float32, Float64)
         sources = ()
         boundary_fluxes =
             (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
-        params =
-            Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
+        params = Soil.RichardsParameters(;
+            ν = ν,
+            hydrology_cm = hcm,
+            K_sat = K_sat,
+            S_s = S_s,
+            θ_r = θ_r,
+        )
 
         soil = Soil.RichardsModel{FT}(;
             parameters = params,
@@ -235,7 +240,7 @@ for FT in (Float32, Float64)
         vg_n = FT(2.68)
         vg_α = FT(14.5) # inverse meters
         vg_m = 1 - 1 / vg_n
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0.045)
         ν_ss_om = FT(0.0)
         ν_ss_quartz = FT(1.0)
@@ -339,10 +344,9 @@ for FT in (Float32, Float64)
         vg_n = FT(2.68)
         vg_α = FT(14.5) # inverse meters
         vg_m = 1 - 1 / vg_n
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0.045)
-
-        parameters = Soil.RichardsParameters{FT, typeof(hcm)}(
+        parameters = Soil.RichardsParameters(;
             ν = ν,
             hydrology_cm = hcm,
             K_sat = K_sat,

--- a/test/standalone/Soil/soiltest.jl
+++ b/test/standalone/Soil/soiltest.jl
@@ -16,7 +16,7 @@ for FT in (Float32, Float64)
         S_s = FT(1e-3) #inverse meters
         vg_n = FT(2.0)
         vg_α = FT(2.6) # inverse meters
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0)
         zmax = FT(0)
         zmin = FT(-10)
@@ -28,8 +28,13 @@ for FT in (Float32, Float64)
         sources = ()
         boundary_fluxes =
             (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
-        params =
-            Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)
+        params = Soil.RichardsParameters(;
+            ν = ν,
+            hydrology_cm = hcm,
+            K_sat = K_sat,
+            S_s = S_s,
+            θ_r = θ_r,
+        )
 
         soil = Soil.RichardsModel{FT}(;
             parameters = params,
@@ -87,23 +92,13 @@ for FT in (Float32, Float64)
         vg_n = FT(2.0)
         vg_α = FT(2.6) # inverse meters
         vg_m = FT(1) - FT(1) / vg_n
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0.1)
         ν_ss_om = FT(0.0)
         ν_ss_quartz = FT(1.0)
         ν_ss_gravel = FT(0.0)
-        κ_minerals = FT(2.5)
-        κ_om = FT(0.25)
-        κ_quartz = FT(8.0)
-        κ_air = FT(0.025)
-        κ_ice = FT(2.21)
-        κ_liq = FT(0.57)
         ρp = FT(2.66 / 1e3 * 1e6)
         ρc_ds = FT(2e6 * (1.0 - ν))
-        κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
-        κ_dry = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
-        κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, ν, κ_ice)
-        κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, ν, κ_liq)
         zmax = FT(0)
         zmin = FT(-1)
         nelems = 200
@@ -187,6 +182,7 @@ for FT in (Float32, Float64)
         ### the thermal conductivities to zero, but at the expense of being unreadable.
         ### Because this is only for a test, we tolerate it :)
         hyd_on_en_off = Soil.EnergyHydrologyParameters{
+            FT,
             FT,
             typeof(hcm),
             typeof(earth_param_set),
@@ -359,6 +355,7 @@ for FT in (Float32, Float64)
         ### Because this is only for a test, we tolerate it :)
         hyd_off_en_off = Soil.EnergyHydrologyParameters{
             FT,
+            FT,
             typeof(hcm),
             typeof(earth_param_set),
         }(
@@ -373,7 +370,7 @@ for FT in (Float32, Float64)
             FT(0.24), #α
             FT(18.3), #β
             hcm,
-            FT(0), # ksat
+            FT(0), # K_sat
             S_s,
             θ_r,
             FT(7),#Ω
@@ -386,12 +383,6 @@ for FT in (Float32, Float64)
             FT(0.01), # z_0b
             FT(0.015), #d_ds
             earth_param_set,
-        )
-        soil_water_on = Soil.EnergyHydrology{FT}(;
-            parameters = hyd_on_en_off,
-            domain = soil_domain,
-            boundary_conditions = boundary_fluxes,
-            sources = sources,
         )
 
         soil_both_off = Soil.EnergyHydrology{FT}(;
@@ -557,23 +548,13 @@ for FT in (Float32, Float64)
         S_s = FT(1e-3) #inverse meters
         vg_n = FT(2.0)
         vg_α = FT(2.6) # inverse meters
-        hcm = vanGenuchten(; α = vg_α, n = vg_n)
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0.1)
         ν_ss_om = FT(0.0)
         ν_ss_quartz = FT(1.0)
         ν_ss_gravel = FT(0.0)
-        κ_minerals = FT(2.5)
-        κ_om = FT(0.25)
-        κ_quartz = FT(8.0)
-        κ_air = FT(0.025)
-        κ_ice = FT(2.21)
-        κ_liq = FT(0.57)
         ρp = FT(2.66 / 1e3 * 1e6)
         ρc_ds = FT(2e6 * (1.0 - ν))
-        κ_solid = Soil.κ_solid(ν_ss_om, ν_ss_quartz, κ_om, κ_quartz, κ_minerals)
-        κ_dry = Soil.κ_dry(ρp, ν, κ_solid, κ_air)
-        κ_sat_frozen = Soil.κ_sat_frozen(κ_solid, ν, κ_ice)
-        κ_sat_unfrozen = Soil.κ_sat_unfrozen(κ_solid, ν, κ_liq)
         zmax = FT(0)
         zmin = FT(-1)
         nelems = 200


### PR DESCRIPTION
## Purpose 
Adds a "SpaceVaryingInput" function which has the following methods
- 2D - returns a regridded field
- 1D - returns a regridded field
- 1D - returns a field of structs with the regridded values
- analytic. Takes in a function of (coords) and can return whatever you like

Future extensions could be for depth resolved global data (3D), or to extend the struct case to the 2D case if needed

For the struct case, this is because: some parameters get packaged into a struct which we then dispatch on. For example, the soil retention model (vanGenuchten, BrooksCorey). Each has a few parameters which will spatially vary. If we have a field of structs, we can still use dispatch +broadcasting. Im not sure if this is also needed for the BucketModel and for the Canopy Model subparameterizations. If it is very niche, we can put these methods in the Soil module. This may also lead to performance issues as per @Sbozzolo 

The goal is to unify the way we handle parameters for spatially varying parameters regardless of the simulation domain.  Note that non-spatially varying parameters are scalars and do not use the `SpaceVaryingInput` function.

## To-do
- Write more tests?
- see discussion point below
## Content
- add SpaceVaryingInputs module
- defined linear interpolation function, moved to `general_utilities`. Now Space and Time VaryingInputs share this. Slightly modified to account for edge case (double check if needed)
- generalize Richards and EnergyHydrology parameters struct to allow for FT or Fields as arguments
- BucketAlbedoStatic and Function use SpaceVaryingInput under the hood now.
- 1D case is in the layered soil tutorial experiment
- update soil boundary condition functions to use some helper functions (extract the top or bottom level of a center field, put onto the corresponding 2D face field). 
- extract the top or bottom level ^^ as described above for the parameters if they are fields vs scalars. *Discussion*: if they are passed into the constructor as scalars, should we create a field of constant value? then we would not need this if statement (or method).

Note that many files have changed for two reasons which are seemingly unrelated to this PR:
- `RichardsParameters{FT, typeof(hcm)}() -> RichardsParameters()`. Before we had scalars (FT) and a scalar struct (hcm). Now we can support scalars or fields. we could do `typeof(field_parameter), typeof(hcm)`, but Im not sure what we are gaining from this, so I ended up just removing it. We may want to do the same for other parameter structs. For EnergyHydrology, I kept the `{FT}`, since there are some default global scalar parameters in that struct. in the long term, I think this will need to update too. But im a little unsure on all of this. 
- I had to add in a parametric type to `vanGenuchten{FT}`'s inner constructor. Im not sure, but without it, the SpaceVaryingInput call in the 1D case does not have an inferrable eltype.
## Future PRs
1. simplify BulkAlbedoFunction and BulkAlbedoStatic to be PrescribedBaregroundAlbedo, and we can compute the bareground albedo in the driver using the "SpaceVaryingInput" function.
2. test 1D depth varying input with energy hydrology model - update parametric type in that model's parameter struct too
3. set up global soil run using mask + soil parameters from a file, add in 3D case
4. propagate to canopy..
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
