### PR TITLE
Clarify role of n_layers in radiative transfer

### DIFF
--- a/docs/tutorials/integrated/soil_canopy_tutorial.jl
+++ b/docs/tutorials/integrated/soil_canopy_tutorial.jl
@@ -287,7 +287,6 @@ radiative_transfer_args = (;
         Ω = FT(0.69),
         λ_γ_PAR = FT(5e-7),
         λ_γ_NIR = FT(1.65e-6),
-        n_layers = UInt64(20),
     )
 )
 

--- a/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -164,7 +164,6 @@ rt_params = TwoStreamParameters{FT}(;
     Ω = FT(0.69),
     λ_γ_PAR = FT(5e-7),
     λ_γ_NIR = FT(1.65e-6),
-    n_layers = UInt64(20),
 )
 
 rt_model = TwoStreamModel{FT}(rt_params);

--- a/experiments/integrated/fluxnet/US-Ha1/US-Ha1_parameters.jl
+++ b/experiments/integrated/fluxnet/US-Ha1/US-Ha1_parameters.jl
@@ -78,7 +78,6 @@ ld = FT(0.5)
 τ_PAR_leaf = FT(0.05)
 α_NIR_leaf = FT(0.45)
 τ_NIR_leaf = FT(0.25)
-n_layers = UInt64(20)
 ϵ_canopy = FT(0.97)
 
 # Energy Balance model

--- a/experiments/integrated/fluxnet/US-MOz/US-MOz_parameters.jl
+++ b/experiments/integrated/fluxnet/US-MOz/US-MOz_parameters.jl
@@ -76,7 +76,6 @@ ld = FT(0.5)
 τ_PAR_leaf = FT(0.05)
 α_NIR_leaf = FT(0.45)
 τ_NIR_leaf = FT(0.25)
-n_layers = UInt64(20)
 ϵ_canopy = FT(0.97)
 
 # Energy Balance model

--- a/experiments/integrated/fluxnet/US-NR1/US-NR1_parameters.jl
+++ b/experiments/integrated/fluxnet/US-NR1/US-NR1_parameters.jl
@@ -81,7 +81,6 @@ ld = FT(0.5)
 τ_PAR_leaf = FT(0.05)
 α_NIR_leaf = FT(0.35)
 τ_NIR_leaf = FT(0.25)
-n_layers = UInt64(20)
 ϵ_canopy = FT(0.97)
 
 # Energy Balance model

--- a/experiments/integrated/fluxnet/US-Var/US-Var_parameters.jl
+++ b/experiments/integrated/fluxnet/US-Var/US-Var_parameters.jl
@@ -85,7 +85,6 @@ ld = FT(0.5)
 τ_PAR_leaf = FT(0.05)
 α_NIR_leaf = FT(0.35)
 τ_NIR_leaf = FT(0.34)
-n_layers = UInt64(20)
 ϵ_canopy = FT(0.97)
 
 # Conductance Model

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -173,7 +173,6 @@ radiative_transfer_args = (;
         τ_PAR_leaf = τ_PAR_leaf,
         α_NIR_leaf = α_NIR_leaf,
         τ_NIR_leaf = τ_NIR_leaf,
-        n_layers = n_layers,
         ϵ_canopy = ϵ_canopy,
     )
 )

--- a/experiments/integrated/ozark/conservation/ozark_conservation.jl
+++ b/experiments/integrated/ozark/conservation/ozark_conservation.jl
@@ -175,7 +175,6 @@ for float_type in (Float32, Float64)
             τ_PAR_leaf = τ_PAR_leaf,
             α_NIR_leaf = α_NIR_leaf,
             τ_NIR_leaf = τ_NIR_leaf,
-            n_layers = n_layers,
         )
     )
     # Set up conductance

--- a/lib/ClimaLandSimulations/src/fluxnet/US-Ha1/US-Ha1_parameters.jl
+++ b/lib/ClimaLandSimulations/src/fluxnet/US-Ha1/US-Ha1_parameters.jl
@@ -78,7 +78,6 @@ ld = FT(0.5)
 τ_PAR_leaf = FT(0.05)
 α_NIR_leaf = FT(0.45)
 τ_NIR_leaf = FT(0.25)
-n_layers = UInt64(20)
 ϵ_canopy = FT(0.97)
 
 # Energy Balance model

--- a/lib/ClimaLandSimulations/src/fluxnet/US-MOz/US-MOz_parameters.jl
+++ b/lib/ClimaLandSimulations/src/fluxnet/US-MOz/US-MOz_parameters.jl
@@ -76,7 +76,6 @@ ld = FT(0.5)
 τ_PAR_leaf = FT(0.05)
 α_NIR_leaf = FT(0.45)
 τ_NIR_leaf = FT(0.25)
-n_layers = UInt64(20)
 ϵ_canopy = FT(0.97)
 
 # Energy Balance model

--- a/lib/ClimaLandSimulations/src/fluxnet/US-NR1/US-NR1_parameters.jl
+++ b/lib/ClimaLandSimulations/src/fluxnet/US-NR1/US-NR1_parameters.jl
@@ -81,7 +81,6 @@ ld = FT(0.5)
 τ_PAR_leaf = FT(0.05)
 α_NIR_leaf = FT(0.35)
 τ_NIR_leaf = FT(0.25)
-n_layers = UInt64(20)
 ϵ_canopy = FT(0.97)
 
 # Energy Balance model

--- a/lib/ClimaLandSimulations/src/fluxnet/US-Var/US-Var_parameters.jl
+++ b/lib/ClimaLandSimulations/src/fluxnet/US-Var/US-Var_parameters.jl
@@ -85,7 +85,6 @@ ld = FT(0.5)
 τ_PAR_leaf = FT(0.05)
 α_NIR_leaf = FT(0.35)
 τ_NIR_leaf = FT(0.34)
-n_layers = UInt64(20)
 ϵ_canopy = FT(0.97)
 
 # Conductance Model

--- a/lib/ClimaLandSimulations/src/fluxnet_simulation.jl
+++ b/lib/ClimaLandSimulations/src/fluxnet_simulation.jl
@@ -156,7 +156,6 @@ function fluxnet_simulation(
             τ_PAR_leaf = τ_PAR_leaf,
             α_NIR_leaf = α_NIR_leaf,
             τ_NIR_leaf = τ_NIR_leaf,
-            n_layers = n_layers,
             ϵ_canopy = ϵ_canopy,
         )
     )

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -96,13 +96,16 @@ struct TwoStreamParameters{FT <: AbstractFloat}
     τ_NIR_leaf::FT
     "Emissivity of the canopy"
     ϵ_canopy::FT
-    "Clumping index following Braghiere (2021) (unitless)"
+    "Clumping index following Braghiere 2021 (unitless)"
     Ω::FT
     "Typical wavelength per PAR photon (m)"
     λ_γ_PAR::FT
     "Typical wavelength per NIR photon (m)"
     λ_γ_NIR::FT
-    "number of layers to simulate radiative transfer through"
+    "Number of layers to partition the canopy into when integrating the
+    absorption over the canopy vertically. Unrelated to the number of layers in 
+    the vertical discretization of the canopy for the plant hydraulics model.
+    (Constant, and should eventually move to ClimaParameters)"
     n_layers::UInt64
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR clarifies the role of `n_layers` in the `TwoStream` radiative transfer model and differentiates it from the vertical discretization of the canopy. Will close #270

In the TwoStream model, total absorbed radiation is computed by integrating over the total LAI in the canopy in vertical layers. The `n_layers` parameter specifies the size of the partition for integrating. Without a vertical profile for LAI, this is just a simple constant whose value beyond 20 layers doesn't change the resulting value very much. This is therefore unrelated to the number of vertical layers in the canopy discretization used in the hydraulics model.

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
 - Remove `n_layers` from any places where parameters are specified -> it should be constant everywhere
 - Clarify the purpose of `n_layers` in the `TwoStreamParameters` documentation

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
