### PR TITLE
ClimaLandSimulations make all figures of experiments

### DIFF
--- a/.github/workflows/ClimaLandSimulations.yml
+++ b/.github/workflows/ClimaLandSimulations.yml
@@ -1,0 +1,31 @@
+name: ClimaLandSimulations CI
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  lib-climalandsimulations:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: '1.10'
+      - uses: julia-actions/cache@v1
+      - name: Install Julia dependencies
+        run: >
+          julia --project= -e 'using Pkg; Pkg.develop(path="$(pwd())"); Pkg.develop(path="$(pwd())/lib/ClimaLandSimulations")'
+      - name: Run the tests
+        continue-on-error: true
+        env:
+            CI_OUTPUT_DIR: output
+        run: >
+          julia --project= -e 'using Pkg; Pkg.test("ClimaLandSimulations")'

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,8 @@ v0.11.1
 -------
 - ![][badge-✨feature] Add option to profile albedo job. PR
   [#505](https://github.com/CliMA/ClimaLand.jl/pull/551)
+- ![][badge-✨feature] ClimaLandSimulations: better plots (legend and style tweaks, added cumulative ET and P), unit tests, start and end time as an optional argument. PR [#494](https://github.com/CliMA/ClimaLand.jl/pull/494)
+- ![][badge-🐛bugfix] ClimaLandSimulations: installation readme. PR [#494](https://github.com/CliMA/ClimaLand.jl/pull/494)
 
 v0.11.0
 -------

--- a/lib/ClimaLandSimulations/README.md
+++ b/lib/ClimaLandSimulations/README.md
@@ -1,16 +1,27 @@
 # ClimaLandSimulations
 
 A library of methods to run ClimaLand:
-- at single sites, such as FLUXNET
+- at single sites 
 - globally (WIP)
 
 ## Installation
 
 ```jl
 julia> ] # to go into pkg mode
-pkg> add https://github.com/CliMA/ClimaLand.jl/tree/main/lib/ClimaLandSimulations # because unregistered for now
+pkg> add https://github.com/CliMA/ClimaLand.jl:lib/ClimaLandSimulations # because unregistered for now
 pkg> *backspace* # press backspace button to go back into julia mode
 julia> using ClimaLandSimulations
 ```
 
 For examples, see the [experiments](https://github.com/CliMA/ClimaLand.jl/lib/ClimaLandSimulations/experiments) folder
+
+### Development of the `ClimaLandSimulations` subpackage
+
+    cd ClimaCore/lib/ClimaLandSimulations
+
+    # Add ClimaCore to subpackage environment
+    julia --project -e 'using Pkg; Pkg.develop(path="../../")'
+
+    # Instantiate ClimaCoreMakie project environment
+    julia --project -e 'using Pkg; Pkg.instantiate()'
+    julia --project -e 'using Pkg; Pkg.test()'

--- a/lib/ClimaLandSimulations/experiments/ozark.jl
+++ b/lib/ClimaLandSimulations/experiments/ozark.jl
@@ -7,12 +7,20 @@ sv_test, sol_test, Y_test, p_test = run_fluxnet(
     params = ozark_default_params(; hetero_resp = hetero_resp_ozark(; b = 2)),
 )
 
+# defaults, except start time
+sv, sol, Y, p = run_fluxnet(
+    "US-MOz";
+    setup = make_setup(;
+        ozark_default_args(; t0 = Float64(125 * 3600 * 24))...,
+    ),
+)
+
 # default parameters
 sv, sol, Y, p = run_fluxnet("US-MOz")
 
 # DataFrame for input and output
 inputs, inputs_SI, inputs_commonly_used = make_inputs_df("US-MOz")
-simulation_output = make_output_df(sv, inputs)
+simulation_output = make_output_df("US-MOz", sv, inputs)
 
 # Will save figures in current repo /figures
 make_plots(inputs, simulation_output)

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Ha1/US-Ha1_config.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Ha1/US-Ha1_config.jl
@@ -1,19 +1,36 @@
 export harvard_default_configs
 
 """
-    harvard_default_configs = (
-        data_link = "https://caltech.box.com/shared/static/xixaod6511cutz51ag81k1mtvy05hbol.csv",
-        local_to_UTC = 5,
-        lat = FT(42.5378), # degree
-        long = FT(-72.1715), # degree
-        atmos_h = FT(30),
+	function harvard_default_configs(;
+		data_link = "https://caltech.box.com/shared/static/xixaod6511cutz51ag81k1mtvy05hbol.csv",
+		local_to_UTC = 5,
+		lat = FT(42.5378), # degree
+		long = FT(-72.1715), # degree
+		atmos_h = FT(30),
+		)
+		return (
+			data_link = data_link,
+			local_to_UTC = local_to_UTC,
+			atmos_h = atmos_h,
+			lat = lat,
+			long = long,	
+		)
+	end
 
 Named Tuple containing default configurations for the Harvard site. 
 """
-harvard_default_configs = (
+function harvard_default_configs(;
     data_link = "https://caltech.box.com/shared/static/xixaod6511cutz51ag81k1mtvy05hbol.csv",
     local_to_UTC = 5,
     lat = FT(42.5378), # degree
     long = FT(-72.1715), # degree
     atmos_h = FT(30),
 )
+    return (
+        data_link = data_link,
+        local_to_UTC = local_to_UTC,
+        atmos_h = atmos_h,
+        lat = lat,
+        long = long,
+    )
+end

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Ha1/US-Ha1_simulation.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Ha1/US-Ha1_simulation.jl
@@ -1,21 +1,33 @@
 export harvard_default_args
 
 """
-    harvard_default_args = (
-        dz_bottom = FT(1.5),
-        dz_top = FT(0.025),
-        n_stem = Int64(1),
-        n_leaf = Int64(1),
-        h_leaf = FT(12), # m
-        h_stem = FT(14), # m
-        t0 = Float64(120 * 3600 * 24),
-        dt = Float64(40),
-        n = 45,
-        )
+	function harvard_default_args(;
+		dz_bottom = FT(1.5),
+		dz_top = FT(0.025),
+		n_stem = Int64(1),
+		n_leaf = Int64(1),
+		h_leaf = FT(12), # m
+		h_stem = FT(14), # m
+		t0 = Float64(120 * 3600 * 24),
+		dt = Float64(40),
+		n = 45,
+		)
+		return (
+			dz_bottom = dz_bottom,
+			dz_top = dz_top,
+			n_stem = n_stem,
+			n_leaf = n_leaf,
+			h_stem = h_stem,
+			h_leaf = h_leaf,
+			t0 = t0,
+			dt = dt,
+			n = n,	
+		)
+	end
 
 Named Tuple containing default simulation parameter for the Harvard site. 
 """
-harvard_default_args = (
+function harvard_default_args(;
     dz_bottom = FT(1.5),
     dz_top = FT(0.025),
     n_stem = Int64(1),
@@ -26,3 +38,15 @@ harvard_default_args = (
     dt = Float64(40),
     n = 45,
 )
+    return (
+        dz_bottom = dz_bottom,
+        dz_top = dz_top,
+        n_stem = n_stem,
+        n_leaf = n_leaf,
+        h_stem = h_stem,
+        h_leaf = h_leaf,
+        t0 = t0,
+        dt = dt,
+        n = n,
+    )
+end

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-MOz/US-MOz_config.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-MOz/US-MOz_config.jl
@@ -1,20 +1,36 @@
 export ozark_default_configs
 
 """
-    ozark_default_configs = (
-        data_link = "https://caltech.box.com/shared/static/7r0ci9pacsnwyo0o9c25mhhcjhsu6d72.csv",
-        local_to_UTC = 7,
-        atmos_h = FT(32),
-        lat = FT(38.7441), 
-        long = FT(-92.2000)
-        )
+	function ozark_default_configs(;
+		data_link = "https://caltech.box.com/shared/static/7r0ci9pacsnwyo0o9c25mhhcjhsu6d72.csv",
+		local_to_UTC = 7,
+		atmos_h = FT(32),
+		lat = FT(38.7441),
+		long = FT(-92.2000),
+		)
+		return (
+			data_link = data_link,
+			local_to_UTC = local_to_UTC,
+			atmos_h = atmos_h,
+			lat = lat,
+			long = long,
+		)
+	end
 
 Named Tuple containing default configurations for the Ozark site. 
 """
-ozark_default_configs = (
+function ozark_default_configs(;
     data_link = "https://caltech.box.com/shared/static/7r0ci9pacsnwyo0o9c25mhhcjhsu6d72.csv",
     local_to_UTC = 7,
     atmos_h = FT(32),
     lat = FT(38.7441),
     long = FT(-92.2000),
 )
+    return (
+        data_link = data_link,
+        local_to_UTC = local_to_UTC,
+        atmos_h = atmos_h,
+        lat = lat,
+        long = long,
+    )
+end

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-MOz/US-MOz_simulation.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-MOz/US-MOz_simulation.jl
@@ -1,21 +1,33 @@
 export ozark_default_args
 
 """
-    ozark_default_args = (
-    dz_bottom = FT(1.5),
-    dz_top = FT(0.025),
-    n_stem = Int64(1),
-    n_leaf = Int64(1),
-    h_stem = FT(9),
-    h_leaf = FT(9.5),
-    t0 = Float64(120 * 3600 * 24), 
-    dt = Float64(120),
-    n = 15
-   )
+	function ozark_default_args(;
+		dz_bottom = FT(1.5),
+		dz_top = FT(0.025),
+		n_stem = Int64(1),
+		n_leaf = Int64(1),
+		h_stem = FT(9),
+		h_leaf = FT(9.5),
+		t0 = Float64(120 * 3600 * 24),
+		dt = Float64(120),
+		n = 15,
+		)
+		return (
+			dz_bottom = dz_bottom,
+			dz_top = dz_top,
+			n_stem = n_stem,
+			n_leaf = n_leaf,
+			h_stem = h_stem,
+			h_leaf = h_leaf,
+			t0 = t0,
+			dt = dt,
+			n = n,
+		)
+	end
 
 Named Tuple containing default simulation parameter for the Ozark site. 
 """
-ozark_default_args = (
+function ozark_default_args(;
     dz_bottom = FT(1.5),
     dz_top = FT(0.025),
     n_stem = Int64(1),
@@ -26,3 +38,15 @@ ozark_default_args = (
     dt = Float64(120),
     n = 15,
 )
+    return (
+        dz_bottom = dz_bottom,
+        dz_top = dz_top,
+        n_stem = n_stem,
+        n_leaf = n_leaf,
+        h_stem = h_stem,
+        h_leaf = h_leaf,
+        t0 = t0,
+        dt = dt,
+        n = n,
+    )
+end

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-NR1/US-NR1_config.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-NR1/US-NR1_config.jl
@@ -1,20 +1,36 @@
 export niwotridge_default_configs
 
 """
-    niwot_default_configs = (
-        data_link = "https://caltech.box.com/shared/static/r6gvldgabk3mvtx53gevnlaq1ztsk41i.csv",
-        local_to_UTC = 7,
-        lat = FT(40.0329), # degree,
-        long = FT(-105.5464), # degree,
-        atmos_h = FT(21.5),
-    )
+	function niwotridge_default_configs(;
+		data_link = "https://caltech.box.com/shared/static/r6gvldgabk3mvtx53gevnlaq1ztsk41i.csv",
+		local_to_UTC = 7,
+		lat = FT(40.0329), # degree,
+		long = FT(-105.5464), # degree,
+		atmos_h = FT(21.5),
+		)
+		return (
+			data_link = data_link,
+			local_to_UTC = local_to_UTC,
+			atmos_h = atmos_h,
+			lat = lat,
+			long = long,	
+		)
+	end
 
 Named Tuple containing default configurations for the Niwot Ridge site. 
 """
-niwotridge_default_configs = (
+function niwotridge_default_configs(;
     data_link = "https://caltech.box.com/shared/static/r6gvldgabk3mvtx53gevnlaq1ztsk41i.csv",
     local_to_UTC = 7,
     lat = FT(40.0329), # degree,
     long = FT(-105.5464), # degree,
     atmos_h = FT(21.5),
 )
+    return (
+        data_link = data_link,
+        local_to_UTC = local_to_UTC,
+        atmos_h = atmos_h,
+        lat = lat,
+        long = long,
+    )
+end

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-NR1/US-NR1_simulation.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-NR1/US-NR1_simulation.jl
@@ -1,21 +1,33 @@
 export niwotridge_default_args
 
 """
-    niwotridge_default_args = (
-        dz_bottom = FT(1.25),
-        dz_top = FT(0.05),
-        n_stem = Int64(1),
-        n_leaf = Int64(1),
-        h_leaf = FT(6.5), # m,
-        h_stem = FT(7.5), # m,
-        t0 = Float64(120 * 3600 * 24), # start mid year to avoid snow,
-        dt = Float64(40),
-        n = 45,
-    )
+	function niwotridge_default_args(;
+		dz_bottom = FT(1.25),
+		dz_top = FT(0.05),
+		n_stem = Int64(1),
+		n_leaf = Int64(1),
+		h_leaf = FT(6.5), # m,
+		h_stem = FT(7.5), # m,
+		t0 = Float64(120 * 3600 * 24), # start mid year to avoid snow,
+		dt = Float64(40),
+		n = 45,
+		)
+		return (
+			dz_bottom = dz_bottom,
+			dz_top = dz_top,
+			n_stem = n_stem,
+			n_leaf = n_leaf,
+			h_stem = h_stem,
+			h_leaf = h_leaf,
+			t0 = t0,
+			dt = dt,
+			n = n,	
+		)
+	end
 
 Named Tuple containing default simulation parameter for the Niwot Ridge site. 
 """
-niwotridge_default_args = (
+function niwotridge_default_args(;
     dz_bottom = FT(1.25),
     dz_top = FT(0.05),
     n_stem = Int64(1),
@@ -26,3 +38,15 @@ niwotridge_default_args = (
     dt = Float64(40),
     n = 45,
 )
+    return (
+        dz_bottom = dz_bottom,
+        dz_top = dz_top,
+        n_stem = n_stem,
+        n_leaf = n_leaf,
+        h_stem = h_stem,
+        h_leaf = h_leaf,
+        t0 = t0,
+        dt = dt,
+        n = n,
+    )
+end

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Var/US-Var_config.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Var/US-Var_config.jl
@@ -1,18 +1,27 @@
 export vairaranch_default_configs
 
 """
-    vairaranch_default_configs = (
-        data_link = "https://caltech.box.com/shared/static/dx0p5idbsbrdebsda10t9pfv2lbdaz95.csv",
-        LAI_link = "https://caltech.box.com/shared/static/y5vf8s9qkoogglc1bc2eyu1k95sbjsc3.csv",
-        atmos_h = FT(2),
-        local_to_UTC = 8,
-        lat = FT(38.4133), # degree
-        long = FT(-120.9508), # degree
-    )
+function vairaranch_default_configs(;
+    data_link = "https://caltech.box.com/shared/static/dx0p5idbsbrdebsda10t9pfv2lbdaz95.csv",
+    LAI_link = "https://caltech.box.com/shared/static/y5vf8s9qkoogglc1bc2eyu1k95sbjsc3.csv",
+    atmos_h = FT(2),
+    local_to_UTC = 8,
+    lat = FT(38.4133), # degree
+    long = FT(-120.9508), # degree
+	)
+	return (
+	    data_link = data_link,
+		LAI_link = LAI_link,
+        local_to_UTC = local_to_UTC,
+        atmos_h = atmos_h,
+        lat = lat,
+        long = long,	
+	)
+end
 
 Named Tuple containing default configurations for the Vaira Ranch site. 
 """
-vairaranch_default_configs = (
+function vairaranch_default_configs(;
     data_link = "https://caltech.box.com/shared/static/dx0p5idbsbrdebsda10t9pfv2lbdaz95.csv",
     LAI_link = "https://caltech.box.com/shared/static/y5vf8s9qkoogglc1bc2eyu1k95sbjsc3.csv",
     atmos_h = FT(2),
@@ -20,3 +29,12 @@ vairaranch_default_configs = (
     lat = FT(38.4133), # degree
     long = FT(-120.9508), # degree
 )
+    return (
+        data_link = data_link,
+        LAI_link = LAI_link,
+        local_to_UTC = local_to_UTC,
+        atmos_h = atmos_h,
+        lat = lat,
+        long = long,
+    )
+end

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Var/US-Var_simulation.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Var/US-Var_simulation.jl
@@ -1,21 +1,33 @@
 export vairaranch_default_args
 
 """
-    vairaranch_default_args = (
-        dz_bottom = FT(1.0),
-        dz_top = FT(0.05),
-        n_stem = Int64(0),
-        n_leaf = Int64(1),
-        h_leaf = FT(0.7), # m,
-        h_stem = FT(0), # m,
-        t0 = Float64(21 * 3600 * 24), # start day 21 of the year,
-        dt = Float64(40),
-        n = 45,
-    )
+	function vairaranch_default_args(;
+		dz_bottom = FT(1.0),
+		dz_top = FT(0.05),
+		n_stem = Int64(0),
+		n_leaf = Int64(1),
+		h_leaf = FT(0.7), # m,
+		h_stem = FT(0), # m,
+		t0 = Float64(21 * 3600 * 24), # start day 21 of the year,
+		dt = Float64(40),
+		n = 45,
+		)
+		return (
+			dz_bottom = dz_bottom,
+			dz_top = dz_top,
+			n_stem = n_stem,
+			n_leaf = n_leaf,
+			h_stem = h_stem,
+			h_leaf = h_leaf,
+			t0 = t0,
+			dt = dt,
+			n = n,	
+		)
+	end
 
 Named Tuple containing default simulation parameter for the Vaira Ranch site. 
 """
-vairaranch_default_args = (
+function vairaranch_default_args(;
     dz_bottom = FT(1.0),
     dz_top = FT(0.05),
     n_stem = Int64(0),
@@ -26,3 +38,15 @@ vairaranch_default_args = (
     dt = Float64(40),
     n = 45,
 )
+    return (
+        dz_bottom = dz_bottom,
+        dz_top = dz_top,
+        n_stem = n_stem,
+        n_leaf = n_leaf,
+        h_stem = h_stem,
+        h_leaf = h_leaf,
+        t0 = t0,
+        dt = dt,
+        n = n,
+    )
+end

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_utilities/make_config.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_utilities/make_config.jl
@@ -22,10 +22,10 @@ end
 
 function make_config(site_ID)
     default_configs = Dict(
-        "US-MOz" => ozark_default_configs,
-        "US-Ha1" => harvard_default_configs,
-        "US-NR1" => niwotridge_default_configs,
-        "US-Var" => vairaranch_default_configs,
+        "US-MOz" => ozark_default_configs(),
+        "US-Ha1" => harvard_default_configs(),
+        "US-NR1" => niwotridge_default_configs(),
+        "US-Var" => vairaranch_default_configs(),
     )
 
     if haskey(default_configs, site_ID)

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_utilities/make_setup.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_utilities/make_setup.jl
@@ -40,10 +40,10 @@ end
 
 function make_setup(site_ID)
     default_args = Dict(
-        "US-MOz" => ozark_default_args,
-        "US-Ha1" => harvard_default_args,
-        "US-NR1" => niwotridge_default_args,
-        "US-Var" => vairaranch_default_args,
+        "US-MOz" => ozark_default_args(),
+        "US-Ha1" => harvard_default_args(),
+        "US-NR1" => niwotridge_default_args(),
+        "US-Var" => vairaranch_default_args(),
     )
 
     if haskey(default_args, site_ID)

--- a/lib/ClimaLandSimulations/src/utilities/climaland_output_dataframe.jl
+++ b/lib/ClimaLandSimulations/src/utilities/climaland_output_dataframe.jl
@@ -1,63 +1,85 @@
 export getoutput, make_output_df
 
 """
-    getoutput(variable::Symbol, variables::Symbol...; result = sv.saveval, depth = 1)
+    getoutput(sv, variable::Symbol, variables::Symbol...; result = sv.saveval, depth = 1)
 
 Return a vector of FT corresponding to the variable of interest at all times.
 By default, get output from sv.saveval, but user can specify e.g., result = sol.u
 By default, get surface value, but user can specify depth for e.g., soil temperature
+
+example 1: 
+julia> getoutput(sv, 1, :SW_out)
+
+example 2: 
+julia> getoutput(sv, 1, :canopy, :conductance, :gs)
+
+example 3: 
+julia> getoutput(sol, 1, :soil, :ϑ_l; result = sol.u)
 """
 function getoutput(
-    sv,
+    sv, # or sol for prognostic variables
+    depth, # 1 is surface
     variable::Symbol,
     variables::Symbol...;
-    result = sv.saveval,
-    depth = 1,
+    result = sv.saveval, # or sol.u for prognostic variables
 )
     for v in (variable, variables...)
         result = getproperty.(result, v)
     end
     return [parent(r)[depth] for r in result]
 end
-# example: getoutput(:SW_out)
-# example 2: getoutput(:canopy, :conductance, :gs)
-# example 3: getoutput(:soil, :T; result = sol.u, depth = 2)
 
 """
     make_output_df(sv, inputs)
 
 Return a dataframe containing climaland outputs
 """
-function make_output_df(sv, inputs; N_days = 60, N_spinup_days = 30)
+function make_output_df(
+    site_ID,
+    sv,
+    inputs;
+    setup = make_setup(site_ID),
+    timestepper = make_timestepper(setup),
+)
     # List of output that we want
-    output_list = (
-        (:SW_out,),
-        (:LW_out,),
-        (:canopy, :conductance, :gs),
-        (:canopy, :conductance, :transpiration),
-        (:canopy, :autotrophic_respiration, :Ra),
-        (:canopy, :photosynthesis, :GPP),
-        (:canopy, :hydraulics, :β),
-        (:canopy, :hydraulics, :area_index, :leaf),
-        (:canopy, :energy, :lhf),
-        (:soil, :turbulent_fluxes, :shf),
-        (:soil, :turbulent_fluxes, :lhf),
-        (:soil, :T),
-        (:soil, :θ_l),
-        (:soil, :turbulent_fluxes, :vapor_flux),
+    output_list = vcat(
+        (1, :SW_out),
+        (1, :LW_out),
+        (1, :canopy, :conductance, :gs),
+        (1, :canopy, :conductance, :transpiration),
+        (1, :canopy, :autotrophic_respiration, :Ra),
+        (1, :canopy, :photosynthesis, :GPP),
+        (1, :canopy, :hydraulics, :β),
+        (1, :canopy, :hydraulics, :area_index, :leaf),
+        (1, :canopy, :energy, :lhf),
+        (1, :soil, :turbulent_fluxes, :shf),
+        (1, :soil, :turbulent_fluxes, :lhf),
+        collect(map(i -> (i, :soil, :T), 1:20)), # 20 shouldn't be hard-coded, but an arg, equal to n layers
+        collect(map(i -> (i, :soil, :θ_l), 1:20)),
+        (1, :soil, :turbulent_fluxes, :vapor_flux),
     )
 
     output_vectors = [getoutput(sv, args...) for args in output_list]
     # Extract the last symbol from each tuple for column names
-    column_names = [names[end] for names in output_list]
+    column_names =
+        [Symbol(names[end], "_depth_", names[1]) for names in output_list]
+    # remove "_1"
+    for i in 1:length(column_names)
+        name = string(column_names[i])
+        if endswith(name, "_1")
+            column_names[i] = Symbol(chop(name, tail = 8))
+        end
+    end
     # Create a dictionary with simplified column names and corresponding vectors
     data_dict = Dict(zip(column_names, output_vectors))
     # Create a DataFrame from the dictionary
     climaland = DataFrame(data_dict)
     # now if I want for example GPP, I can just do df.GPP
 
-    index_t_start = 120 * 48 # we shouldn't hardcode that 120 in ozark_simulation.jl
-    index_t_end = 120 * 48 + (N_days - N_spinup_days) * 48
+    index_t_start = Int(setup.t0 / (3600 * 24) * 48)
+    index_t_end = Int(
+        index_t_start + (timestepper.N_days - timestepper.N_spinup_days) * 48,
+    )
     model_dt = inputs.DateTime[index_t_start:index_t_end]
 
     insertcols!(climaland, 1, :DateTime => model_dt)

--- a/lib/ClimaLandSimulations/src/utilities/make_timestepper.jl
+++ b/lib/ClimaLandSimulations/src/utilities/make_timestepper.jl
@@ -30,5 +30,6 @@ function make_timestepper(
         saveat = saveat,
         timestepper = timestepper,
         ode_algo = ode_algo,
+        N_spinup_days = N_spinup_days,
     )
 end

--- a/lib/ClimaLandSimulations/test/Project.toml
+++ b/lib/ClimaLandSimulations/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+ClimaLandSimulations = "348a0bd3-1299-4261-8002-d2cd97df6055"

--- a/lib/ClimaLandSimulations/test/runtests.jl
+++ b/lib/ClimaLandSimulations/test/runtests.jl
@@ -1,3 +1,31 @@
-using ClimaLand # rename to ClimaLand WIP
-using ClimaLandSite
 using Test
+using ClimaLandSimulations
+using ClimaLandSimulations.Fluxnet
+
+@testset "Fluxnet single site" begin
+    sv, sol, Y, p = run_fluxnet("US-MOz")
+    @test typeof(sv) ==
+          @NamedTuple{t::Vector{Float64}, saveval::Vector{NamedTuple}}
+end
+
+@testset "Fluxnet single site, custom param" begin
+    sv, sol, Y, p = run_fluxnet(
+        "US-MOz";
+        params = ozark_default_params(;
+            hetero_resp = hetero_resp_ozark(; b = 2),
+        ),
+    )
+    @test typeof(sv) ==
+          @NamedTuple{t::Vector{Float64}, saveval::Vector{NamedTuple}}
+end
+
+@testset "Fluxnet single site, custom start time" begin
+    sv, sol, Y, p = run_fluxnet(
+        "US-MOz";
+        setup = make_setup(;
+            ozark_default_args(; t0 = Float64(125 * 3600 * 24))...,
+        ),
+    )
+    @test typeof(sv) ==
+          @NamedTuple{t::Vector{Float64}, saveval::Vector{NamedTuple}}
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR main goal is to be up to date with experiments/integrated/fluxnet, meaning it will make all the same figures, and ensure they are doing exactly the same thing. 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- [x] Fixed README link to install unregistered package ClimaLandSimulations
- [x] Climaland_output_dataframe.jl - output by layers
- [x] Diurnals: better legend subplot 1, GPP, ER, AR, HR?
- [x] Plot cumulative P and ET
- [x] Index_t_start and index_t_start removed from Makie plot args
- [x] Model start and end is set in make_setup() which gets site default values (which can be modified), e.g., ozark_default_args 
- [x] CI workflow (.yml) for ClimaLandSimulation test
- [x] Test: ozark, default args
- [x] Test: ozark, change default start time (t0) 
- [x] Test: ozark, change default parameters 
- [x] Site default as function returning tuples instead of tuple, for more user flexibility
- [x] Timeseries: lines instead of scatter
- [x] WIP: added more fingerplots
- [ ] Test: all sites, default args
- [ ] Makie_plots.jl, make sure to use inputs and outputs in units that we want, instead of hard-coding conversion factors which can be confusing (currently error in cumulative water units and timeseries water units)
- [ ] In experiments/integrated/fluxnet, we compare model to data only when driver observation are available (not gap-filled), but we don't filter for gap-filled NEE / GPP / Reco. We should do so here.
- [ ] Use FLUXNET2015 datasets, drivers gapfilled with ERA
- [ ] climaland_output_dataframe.jl don't hardcode 20 (n layers)
- [ ] Inputs_dataframe.jl -> make a function to convert units (from, to) of a DataFrame, which can be called on input and output dataframe
- [ ] Flux timeseries: better legend radiation, SW_in LW_in, LW_out, G...
- [ ] Plot: only when met data was available (don't use gapfilled index) 
- [ ] Add widget to plot timeseries or diurnal etc. of use chosen variable 
- [ ] (!high prio) make all plots that /experiment/integrated makes, and make sure they are the same
- [ ] (!high prio) docstrings for all struct/functions
- [ ] (!high prio) better README.md
- [ ] (!high prio) docs (ClimaLandSimulation page in ClimaLand docs)
- [ ] (!high prio) move earth_param_set out of module
- [ ] (!high prio) move const FT = FLoat64 out of module
- [ ] use our src constructor for parameters (still need to fix hetero_resp and plant_hydraulics)
- [ ] less functions or clearer names (make_config(), make_setup()...) make_domain and make_timestepper can live in the same file (maybe setup_utils.jl) 
- [ ] modules as an arg (e.g., photosynthesis = Farquhar or photosynthesis = optimality)
- [ ] no hard-coded values 
- [ ] shorter list of params (use more defaults or constants)
- [ ] lib/ClimaLandSimulations/src/fluxnet_simulation.jl around line 266, why the +40? (this is in experiment/integrated as well)
- [ ] Should LAI, RAI, plant_\nu be in met_drivers?
- [ ] lib/ClimaLandSimulations/src/utilities/inputs_dataframe.jl do we always have all variables from fluxnet input files? (note: I think so, even if there are -9999 they should be there - if not we can create it)
- [ ] add else case for if haskey(...) in make_config
- [ ] rename LAIfunction to allow for other types of LAI input (e.g. netcdf)
- [ ] add PFTs functionality 
- [ ] Add Mitra gap-filling code in data_tools.jl (or another gap-filling method, maybe use ERA from FLUXNET)
- [ ] Experiment: all sites, not just Ozark

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
