### PR TITLE
fix bugs for coupler; make release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaLand"
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
 authors = ["Clima Land Team"]
-version = "0.9.0"
+version = "0.10.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -293,7 +293,7 @@ version = "0.3.13"
 deps = ["Adapt", "ArtifactWrappers", "CFTime", "CSV", "CUDA", "ClimaComms", "ClimaCore", "ClimaCoreTempestRemap", "DataFrames", "Dates", "DocStringExtensions", "Flux", "HTTP", "Insolation", "IntervalSets", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "StatsBase", "SurfaceFluxes", "Thermodynamics", "cuDNN"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "0.9.0"
+version = "0.10.0"
 weakdeps = ["CLIMAParameters"]
 
     [deps.ClimaLand.extensions]

--- a/docs/src/APIs/Regridder.md
+++ b/docs/src/APIs/Regridder.md
@@ -8,4 +8,5 @@ CurrentModule = ClimaLand.Regridder
 
 ```@docs
 ClimaLand.Regridder.hdwrite_regridfile_rll_to_cgll
+ClimaLand.Regridder.swap_space
 ```

--- a/experiments/Manifest.toml
+++ b/experiments/Manifest.toml
@@ -350,7 +350,7 @@ version = "0.3.13"
 deps = ["Adapt", "ArtifactWrappers", "CFTime", "CSV", "CUDA", "ClimaComms", "ClimaCore", "ClimaCoreTempestRemap", "DataFrames", "Dates", "DocStringExtensions", "Flux", "HTTP", "Insolation", "IntervalSets", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "StatsBase", "SurfaceFluxes", "Thermodynamics", "cuDNN"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "0.9.0"
+version = "0.10.0"
 weakdeps = ["CLIMAParameters"]
 
     [deps.ClimaLand.extensions]

--- a/src/shared_utilities/FileReader.jl
+++ b/src/shared_utilities/FileReader.jl
@@ -345,7 +345,7 @@ function read_data_fields!(
                 outfile_root,
                 all_dates[Int(date_idx0)],
                 varname,
-                comms_ctx,
+                space,
             )
             file_state.data_fields[2] .= file_state.data_fields[1]
             file_state.segment_length .= 0
@@ -363,7 +363,7 @@ function read_data_fields!(
                 outfile_root,
                 all_dates[end],
                 varname,
-                comms_ctx,
+                space,
             )
             file_state.data_fields[2] .= file_state.data_fields[1]
             file_state.segment_length .= 0
@@ -390,14 +390,14 @@ function read_data_fields!(
                 outfile_root,
                 all_dates[Int(date_idx)],
                 varname,
-                comms_ctx,
+                space,
             )
             file_state.data_fields[2] .= Regridder.read_from_hdf5(
                 regrid_dirpath,
                 outfile_root,
                 all_dates[Int(date_idx + 1)],
                 varname,
-                comms_ctx,
+                space,
             )
         end
         # Case 4: Everything else
@@ -456,7 +456,7 @@ function get_data_at_date(
         outfile_root,
         Dates.DateTime(0), # dummy date
         varname,
-        comms_ctx,
+        space,
     )
     return nans_to_zero.(field)
 end

--- a/src/shared_utilities/FileReader.jl
+++ b/src/shared_utilities/FileReader.jl
@@ -458,7 +458,7 @@ function get_data_at_date(
         varname,
         space,
     )
-    return nans_to_zero.(field)
+    return field
 end
 
 """
@@ -510,7 +510,6 @@ function get_data_at_date(
     end
 end
 
-nans_to_zero(v::T) where {T} = isnan(v) ? T(0) : v
 
 """
     interpol(f1::FT, f2::FT, Δt_tt1::FT, Δt_t2t1::FT)

--- a/src/shared_utilities/Regridder.jl
+++ b/src/shared_utilities/Regridder.jl
@@ -54,11 +54,30 @@ function reshape_cgll_sparse_to_field!(
 end
 
 """
-    read_from_hdf5(REGIRD_DIR, hd_outfile_root, time, varname,
-        comms_ctx = ClimaComms.SingletonCommsContext())
+    swap_space(field, new_space)
 
-Read in a variable `varname` from an HDF5 file.
-If a CommsContext other than SingletonCommsContext is used for `comms_ctx`,
+Update the space of a ClimaCore.Fields.Field object. Returns a new Field
+object with the same values as the original field, but on the new space.
+This is needed to correctly read in regridded files that may be reused
+between simulations.
+
+# Arguments
+- `field`: The ClimaCore.Fields.Field object to swap the space of.
+- `new_space`: The new ClimaCore.Spaces.AbstractSpace to assign to the field.
+"""
+function swap_space(field, new_space)
+    return ClimaCore.Fields.Field(
+        ClimaCore.Fields.field_values(field),
+        new_space,
+    )
+end
+
+"""
+    read_from_hdf5(REGIRD_DIR, hd_outfile_root, time, varname,
+        space)
+
+Read in a variable `varname` from an HDF5 file onto the provided space.
+If a CommsContext other than SingletonCommsContext is used in the `space`,
 the input HDF5 file must be readable by multiple MPI processes.
 
 Code taken from ClimaCoupler.Regridder.
@@ -68,17 +87,12 @@ Code taken from ClimaCoupler.Regridder.
 - `hd_outfile_root`: [String] root of the output file name.
 - `time`: [Dates.DateTime] the timestamp of the data being written.
 - `varname`: [String] variable name of data.
-- `comms_ctx`: [ClimaComms.AbstractCommsContext] context used for this operation.
+- `space`: [ClimaCore.Spaces.AbstractSpace] to read the HDF5 file onto.
 # Returns
 - Field or FieldVector
 """
-function read_from_hdf5(
-    REGRID_DIR,
-    hd_outfile_root,
-    time,
-    varname,
-    comms_ctx = ClimaComms.SingletonCommsContext(),
-)
+function read_from_hdf5(REGRID_DIR, hd_outfile_root, time, varname, space)
+    comms_ctx = ClimaComms.context(space)
     # Include time component in HDF5 reader name if it's a valid date
     if !(time == Dates.DateTime(0))
         hdfreader_path = joinpath(
@@ -93,7 +107,10 @@ function read_from_hdf5(
 
     field = ClimaCore.InputOutput.read_field(hdfreader, varname)
     Base.close(hdfreader)
-    return field
+
+    # Ensure the field is on the correct space when reusing regridded files
+    #  between simulations
+    return swap_space(field, space)
 end
 
 

--- a/test/shared_utilities/file_reader.jl
+++ b/test/shared_utilities/file_reader.jl
@@ -485,7 +485,7 @@ if !Sys.iswindows()
                 outfile_root,
                 all_dates[i + 1],
                 varnames[1],
-                comms_ctx,
+                surface_space_t,
             )
             # Replace NaNs and missings for testing comparison
             replace_nan_missing!(data_manual[i])
@@ -665,7 +665,7 @@ if !Sys.iswindows()
                         outfile_root,
                         updating_dates[i],
                         varname,
-                        comms_ctx,
+                        surface_space_t,
                     ),
                 )
                 # Replace NaNs and missings for testing comparison

--- a/test/standalone/Bucket/albedo_types.jl
+++ b/test/standalone/Bucket/albedo_types.jl
@@ -270,7 +270,7 @@ if !Sys.iswindows()
                     outfile_root,
                     Dates.DateTime(0), # dummy date
                     varname,
-                    comms_ctx,
+                    surface_space,
                 )
                 data_manual = nans_to_zero.(field)
 

--- a/test/standalone/Bucket/albedo_types.jl
+++ b/test/standalone/Bucket/albedo_types.jl
@@ -8,8 +8,7 @@ import CLIMAParameters as CP
 using Dates
 using NCDatasets
 using ClimaLand.Regridder: read_from_hdf5
-using ClimaLand.FileReader:
-    next_date_in_file, to_datetime, nans_to_zero, get_data_at_date
+using ClimaLand.FileReader: next_date_in_file, to_datetime, get_data_at_date
 using ClimaLand.Bucket:
     BucketModel,
     BucketModelParameters,
@@ -272,7 +271,8 @@ if !Sys.iswindows()
                     varname,
                     surface_space,
                 )
-                data_manual = nans_to_zero.(field)
+                replace_nan_missing!(field)
+                data_manual = field
 
                 @test p.bucket.α_sfc == data_manual
             else
@@ -410,8 +410,9 @@ if !Sys.iswindows()
                     date_ref,
                 )
                 # If there are any NaNs in the input data, replace them so we can compare results
-                @test nans_to_zero.(p.bucket.α_sfc) ==
-                      nans_to_zero.(data_manual)
+                replace_nan_missing!(p.bucket.α_sfc)
+                replace_nan_missing!(data_manual)
+                @test p.bucket.α_sfc == data_manual
 
                 update_aux! = make_update_aux(model)
                 new_date = date_ref + Second(t_start)
@@ -426,8 +427,9 @@ if !Sys.iswindows()
                         varname,
                         file_dates[i],
                     )
-                    @test nans_to_zero.(p.bucket.α_sfc) ≈
-                          nans_to_zero.(data_manual)
+                    replace_nan_missing!(p.bucket.α_sfc)
+                    replace_nan_missing!(data_manual)
+                    @test p.bucket.α_sfc == data_manual
 
                     # Update manual date to match next date in file
                     dt = Second(file_dates[i + 1] - file_dates[i])


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Coupler runs are failing because spaces of fields (i.e. `alpha_bareground`) read from files (via `read_from_hdf5` after writing in `regrid_field_cgll_to_rll` regridding function) don't match the simulation space. I spent a long time debugging this and can't figure out how the spaces are actually different (it's something to do with the grids, but from all the inspection I've done they look to be the same, except `==` is evaluated as false)


## Content
- [x] add back `swap_space` to Regridder
  - tested from coupler - works in coupled simulations
  - allows us to re-use regridded files between simulations
- [x] tag new release v0.10.0 (missed last week's)


## Breaking changes in this release
- dependencies updated in #501
  - now require CLIMAParameters v0.9, ClimaCore v0.12, SurfaceFluxes v0.9, Thermodynamics v0.12
  - coordinated with ClimaAtmos v0.21
  - Thermodynamics has stricter FT type restrictions - may need to update in coupler

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
