### PR TITLE
Refactor `SoilCO2ModelParameters` constructor

### DIFF
--- a/docs/src/standalone/apps/hetero_resp.jl
+++ b/docs/src/standalone/apps/hetero_resp.jl
@@ -21,19 +21,7 @@ function ParamViz.parameterisation(
     D_oa,
 ) # constants
 
-    params = SoilCO2ModelParameters{FT}(;
-        ν = ν,
-        θ_a100 = θ_a100,
-        D_liq = D_liq,
-        α_sx = α_sx,
-        Ea_sx = Ea_sx,
-        kM_sx = kM_sx,
-        kM_o2 = kM_O₂,
-        O2_a = O₂_a,
-        D_oa = D_oa,
-        p_sx = p_sx,
-        earth_param_set = earth_param_set,
-    )
+    params = SoilCO2ModelParameters(FT; ν)
     # θ has to be lower than porosity
     if θ > ν
         θ = ν

--- a/docs/tutorials/integrated/soil_canopy_tutorial.jl
+++ b/docs/tutorials/integrated/soil_canopy_tutorial.jl
@@ -172,36 +172,9 @@ soil_model_type = Soil.EnergyHydrology{FT}
 # [documentation](https://clima.github.io/ClimaLand.jl/previews/PR214/dynamicdocs/pages/soil_biogeochemistry/microbial_respiration/)
 # to understand the parameterisation.
 # The domain is defined similarly to the soil domain described above.
-ν = soil_ν # defined above
-θ_a100 = FT(0.1816)
-D_ref = FT(1.39e-5)
-b = FT(4.547)
-D_liq = FT(3.17)
-α_sx = FT(194e3)
-Ea_sx = FT(61e3)
-kM_sx = FT(5e-3)
-kM_o2 = FT(0.004)
-O2_a = FT(0.209)
-D_oa = FT(1.67)
-p_sx = FT(0.024)
-
 soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
 
-soilco2_ps = SoilCO2ModelParameters{FT}(;
-    ν = soil_ν,
-    θ_a100 = θ_a100,
-    D_ref = D_ref,
-    b = b,
-    D_liq = D_liq,
-    α_sx = α_sx,
-    Ea_sx = Ea_sx,
-    kM_sx = kM_sx,
-    kM_o2 = kM_o2,
-    O2_a = O2_a,
-    D_oa = D_oa,
-    p_sx = p_sx,
-    earth_param_set = earth_param_set,
-);
+soilco2_ps = SoilCO2ModelParameters(FT; ν = soil_ν);
 
 # soil microbes args
 Csom = (z, t) -> eltype(z)(5); # kg C m⁻³, this is a guess, not measured at the site

--- a/experiments/integrated/fluxnet/US-Ha1/US-Ha1_parameters.jl
+++ b/experiments/integrated/fluxnet/US-Ha1/US-Ha1_parameters.jl
@@ -15,21 +15,6 @@ long = FT(-72.1715) # degree
 atmos_h = FT(30)
 # https://atmos.seas.harvard.edu/research-harvard_forest-instrumentation
 
-## LAI data from MODIS
-# Heterotrophic respiration parameters
-θ_a100 = FT(0.1816)
-D_ref = FT(1.39e-5)
-b = FT(4.547)
-D_liq = FT(3.17)
-# DAMM
-α_sx = FT(194e3)
-Ea_sx = FT(61e3)
-kM_sx = FT(5e-3)
-kM_o2 = FT(0.004)
-O2_a = FT(0.209)
-D_oa = FT(1.67)
-p_sx = FT(0.024)
-
 # Soil parameters
 soil_ν = FT(0.5) # m3/m3
 soil_K_sat = FT(4e-7) # m/s, matches Natan

--- a/experiments/integrated/fluxnet/US-MOz/US-MOz_parameters.jl
+++ b/experiments/integrated/fluxnet/US-MOz/US-MOz_parameters.jl
@@ -14,20 +14,6 @@ atmos_h = FT(32)
 lat = FT(38.7441) # degree
 long = FT(-92.2000) # degree
 
-# Heterotrophic respiration parameters
-θ_a100 = FT(0.1816)
-D_ref = FT(1.39e-5)
-b = FT(4.547)
-D_liq = FT(3.17)
-# DAMM
-α_sx = FT(194e3)
-Ea_sx = FT(61e3)
-kM_sx = FT(5e-3)
-kM_o2 = FT(0.004)
-O2_a = FT(0.209)
-D_oa = FT(1.67)
-p_sx = FT(0.024)
-
 # Soil parameters
 soil_ν = FT(0.5) # m3/m3
 soil_K_sat = FT(4e-7) # m/s, matches Natan

--- a/experiments/integrated/fluxnet/US-NR1/US-NR1_parameters.jl
+++ b/experiments/integrated/fluxnet/US-NR1/US-NR1_parameters.jl
@@ -18,21 +18,6 @@ atmos_h = FT(21.5)
 # gas analyzer sampling system for measuring eddy covariance fluxes of H2O and
 # CO2. Atmospheric Measurement Techniques. 9. 1341-1359. 10.5194/amt-9-1341-2016. 
 
-## LAI data from MODIS
-# Heterotrophic respiration parameters
-θ_a100 = FT(0.1816)
-D_ref = FT(1.39e-5)
-b = FT(4.547)
-D_liq = FT(3.17)
-# DAMM
-α_sx = FT(194e3)
-Ea_sx = FT(61e3)
-kM_sx = FT(5e-3)
-kM_o2 = FT(0.004)
-O2_a = FT(0.209)
-D_oa = FT(1.67)
-p_sx = FT(0.024)
-
 # Soil parameters
 soil_ν = FT(0.45) # m3/m3
 soil_K_sat = FT(4e-7) # m/s, matches Natan

--- a/experiments/integrated/fluxnet/US-Var/US-Var_parameters.jl
+++ b/experiments/integrated/fluxnet/US-Var/US-Var_parameters.jl
@@ -23,20 +23,6 @@ time_offset = 8
 lat = FT(38.4133) # degree
 long = FT(-120.9508) # degree
 
-# Heterotrophic respiration parameters
-θ_a100 = FT(0.1816)
-D_ref = FT(1.39e-5)
-b = FT(4.547)
-D_liq = FT(3.17)
-# DAMM
-α_sx = FT(194e3)
-Ea_sx = FT(61e3)
-kM_sx = FT(5e-3)
-kM_o2 = FT(0.004)
-O2_a = FT(0.209)
-D_oa = FT(1.67)
-p_sx = FT(0.024)
-
 # Soil parameters
 soil_ν = FT(0.45) # m3/m3
 soil_K_sat = FT(0.45 / 3600 / 100) # m/s,

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -132,21 +132,9 @@ soil_model_type = Soil.EnergyHydrology{FT}
 # Soil microbes model
 soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
 
-soilco2_ps = SoilCO2ModelParameters{FT}(;
+soilco2_ps = SoilCO2ModelParameters(
+    FT;
     ν = soil_ν, # same as soil
-    θ_a100 = θ_a100,
-    D_ref = D_ref,
-    b = b,
-    D_liq = D_liq,
-    # DAMM
-    α_sx = α_sx,
-    Ea_sx = Ea_sx,
-    kM_sx = kM_sx,
-    kM_o2 = kM_o2,
-    O2_a = O2_a,
-    D_oa = D_oa,
-    p_sx = p_sx,
-    earth_param_set = earth_param_set,
 )
 
 # soil microbes args

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -92,21 +92,9 @@ soil_model_type = Soil.EnergyHydrology{FT}
 # Soil microbes model
 soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
 
-soilco2_ps = SoilCO2ModelParameters{FT}(;
+soilco2_ps = SoilCO2ModelParameters(
+    FT;
     ν = soil_ν, # same as soil
-    θ_a100 = θ_a100,
-    D_ref = D_ref,
-    b = b,
-    D_liq = D_liq,
-    # DAMM
-    α_sx = α_sx,
-    Ea_sx = Ea_sx,
-    kM_sx = kM_sx,
-    kM_o2 = kM_o2,
-    O2_a = O2_a,
-    D_oa = D_oa,
-    p_sx = p_sx,
-    earth_param_set = earth_param_set,
 )
 
 # soil microbes args

--- a/experiments/integrated/ozark/conservation/ozark_conservation.jl
+++ b/experiments/integrated/ozark/conservation/ozark_conservation.jl
@@ -93,22 +93,7 @@ for float_type in (Float32, Float64)
     # Soil microbes model
     soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
 
-    soilco2_ps = SoilCO2ModelParameters{FT}(;
-        ν = soil_ν,
-        θ_a100 = θ_a100,
-        D_ref = D_ref,
-        b = b,
-        D_liq = D_liq,
-        # DAMM
-        α_sx = α_sx,
-        Ea_sx = Ea_sx,
-        kM_sx = kM_sx,
-        kM_o2 = kM_o2,
-        O2_a = O2_a,
-        D_oa = D_oa,
-        p_sx = p_sx,
-        earth_param_set = earth_param_set,
-    )
+    soilco2_ps = SoilCO2ModelParameters(FT; ν = soil_ν)
 
     # soil microbes args
     Csom = (z, t) -> eltype(z)(5.0)

--- a/experiments/standalone/Biogeochemistry/experiment.jl
+++ b/experiments/standalone/Biogeochemistry/experiment.jl
@@ -70,9 +70,7 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
     # Make biogeochemistry model args
     Csom = (z, t) -> eltype(z)(5.0)
 
-    co2_parameters = Soil.Biogeochemistry.SoilCO2ModelParameters{FT}(;
-        earth_param_set = earth_param_set,
-    )
+    co2_parameters = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
     C = FT(100)
 
     co2_top_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> 0.0)

--- a/experiments/standalone/Biogeochemistry/experiment.jl
+++ b/experiments/standalone/Biogeochemistry/experiment.jl
@@ -70,7 +70,7 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
     # Make biogeochemistry model args
     Csom = (z, t) -> eltype(z)(5.0)
 
-    co2_parameters = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
+    co2_parameters = Soil.Biogeochemistry.SoilCO2ModelParameters(FT; ν = 0.556)
     C = FT(100)
 
     co2_top_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> 0.0)

--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -468,7 +468,6 @@ SoilCO2ModelParameters(::Type{FT}; kwargs...) where {FT <: AbstractFloat} =
 
 function SoilCO2ModelParameters(toml_dict::CP.AbstractTOMLDict; kwargs...)
     # These parameters have defaults that should not go in ClimaParams
-    ν = 0.556
     θ_a100 = 0.1816
     b = 4.547
 
@@ -488,7 +487,6 @@ function SoilCO2ModelParameters(toml_dict::CP.AbstractTOMLDict; kwargs...)
     earth_param_set = LP.LandParameters(toml_dict)
     return SoilCO2ModelParameters{FT, typeof(earth_param_set)}(;
         earth_param_set,
-        ν,
         θ_a100,
         b,
         parameters...,

--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -442,7 +442,7 @@ function BucketModelParameters(
     parameters = CP.get_parameter_values(toml_dict, name_map, "Land")
 
     AAM = typeof(albedo)
-    earth_param_set = LandParameters(toml_dict)
+    earth_param_set = LP.LandParameters(toml_dict)
     PSE = typeof(earth_param_set)
     FT = CP.float_type(toml_dict)
     BucketModelParameters{FT, AAM, PSE}(;
@@ -485,7 +485,7 @@ function SoilCO2ModelParameters(toml_dict::CP.AbstractTOMLDict; kwargs...)
     )
     parameters = CP.get_parameter_values(toml_dict, name_map, "Land")
     FT = CP.float_type(toml_dict)
-    earth_param_set = LandParameters(toml_dict)
+    earth_param_set = LP.LandParameters(toml_dict)
     return SoilCO2ModelParameters{FT, typeof(earth_param_set)}(;
         earth_param_set,
         ν,

--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -8,15 +8,15 @@ import SurfaceFluxes.UniversalFunctions as UF
 import ClimaParams as CP
 
 import ClimaLand
-import ClimaLand.Parameters.LandParameters
+import ClimaLand.Soil
+# Parameter structs
+import ClimaLand.Parameters as LP
+import ClimaLand.Soil.EnergyHydrologyParameters
 import ClimaLand.Canopy.AutotrophicRespirationParameters
 import ClimaLand.Canopy.FarquharParameters
 import ClimaLand.Canopy.OptimalityFarquharParameters
 import ClimaLand.Bucket.BucketModelParameters
-
-import ClimaLand.Soil
-import ClimaLand.Parameters as LP
-import ClimaLand.Soil.EnergyHydrologyParameters
+import ClimaLand.Soil.Biogeochemistry.SoilCO2ModelParameters
 
 LP.LandParameters(::Type{FT}) where {FT <: AbstractFloat} =
     LP.LandParameters(CP.create_toml_dict(FT))
@@ -456,5 +456,44 @@ function BucketModelParameters(
     )
 end
 
+"""
+    SoilCO2ModelParameters(FT; kwargs...)
+    SoilCO2ModelParameters(toml_dict; kwargs...)
+
+SoilCO2ModelParameters has two constructors: float-type and toml dict based.
+Keywords arguments can be used to directly override any parameters.
+"""
+SoilCO2ModelParameters(::Type{FT}; kwargs...) where {FT <: AbstractFloat} =
+    SoilCO2ModelParameters(CP.create_toml_dict(FT); kwargs...)
+
+function SoilCO2ModelParameters(toml_dict::CP.AbstractTOMLDict; kwargs...)
+    # These parameters have defaults that should not go in ClimaParams
+    ν = 0.556
+    θ_a100 = 0.1816
+    b = 4.547
+
+    name_map = (;
+        :CO2_diffusion_coefficient => :D_ref,
+        :soil_C_substrate_diffusivity => :D_liq,
+        :soilCO2_pre_expontential_factor => :α_sx,
+        :soilCO2_activation_energy => :Ea_sx,
+        :michaelis_constant => :kM_sx,
+        :O2_michaelis_constant => :kM_o2,
+        :O2_volume_fraction => :O2_a,
+        :oxygen_diffusion_coefficient => :D_oa,
+        :soluble_soil_carbon_fraction => :p_sx,
+    )
+    parameters = CP.get_parameter_values(toml_dict, name_map, "Land")
+    FT = CP.float_type(toml_dict)
+    earth_param_set = LandParameters(toml_dict)
+    return SoilCO2ModelParameters{FT, typeof(earth_param_set)}(;
+        earth_param_set,
+        ν,
+        θ_a100,
+        b,
+        parameters...,
+        kwargs...,
+    )
+end
 
 end

--- a/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
@@ -44,7 +44,8 @@ function run_fluxnet(
     # Soil microbes model
     soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
 
-    soilco2_ps = SoilCO2ModelParameters{FT}(;
+    soilco2_ps = SoilCO2ModelParameters(
+        FT;
         ν = params.soil.ν,
         θ_a100 = params.hetero_resp.θ_a100,
         D_ref = params.hetero_resp.D_ref,

--- a/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
+++ b/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
@@ -41,7 +41,7 @@ export SoilCO2ModelParameters,
 A struct for storing parameters of the `SoilCO2Model`.
 $(DocStringExtensions.FIELDS)
 """
-struct SoilCO2ModelParameters{FT <: AbstractFloat, PSE}
+Base.@kwdef struct SoilCO2ModelParameters{FT <: AbstractFloat, PSE}
     "Soil porosity (m³ m⁻³)"
     ν::FT
     "Air-filled porosity at soil water potential of -100 cm H₂O (~ 10 Pa)"
@@ -69,62 +69,6 @@ struct SoilCO2ModelParameters{FT <: AbstractFloat, PSE}
     p_sx::FT
     "Physical constants used Clima-wide"
     earth_param_set::PSE
-end
-
-"""
-    SoilCO2ModelParameters{FT}(;
-                                ν = FT(0.556),
-                                θ_a100 = FT(0.1816),
-                                D_ref = FT(1.39e-5),
-                                b = FT(4.547),
-                                D_liq = FT(3.17),
-                                # DAMM
-                                α_sx = FT(194e3),
-                                Ea_sx = FT(61e3),
-                                kM_sx = FT(5e-3),
-                                kM_o2 = FT(0.004),
-                                O2_a = FT(0.209),
-                                D_oa = FT(1.67),
-                                p_sx = FT(0.024),
-                                earth_param_set::PSE
-                               ) where {FT, PSE}
-
-
-An outer constructor for creating the parameter struct of the `SoilCO2Model`,
-    based on keyword arguments.
-"""
-function SoilCO2ModelParameters{FT}(;
-    ν = FT(0.556),
-    θ_a100 = FT(0.1816),
-    D_ref = FT(1.39e-5),
-    b = FT(4.547),
-    D_liq = FT(3.17),
-    # DAMM
-    α_sx = FT(194e3), # kgC m⁻³ s⁻¹
-    Ea_sx = FT(61e3), # J mol⁻¹
-    kM_sx = FT(5e-3), # kgC m⁻³
-    kM_o2 = FT(0.004), # L L⁻¹
-    O2_a = FT(0.209),
-    D_oa = FT(1.67),
-    p_sx = FT(0.024),
-    earth_param_set::PSE,
-) where {FT, PSE}
-    return SoilCO2ModelParameters{FT, PSE}(
-        ν,
-        θ_a100,
-        D_ref,
-        b,
-        D_liq,
-        # DAMM
-        α_sx,
-        Ea_sx,
-        kM_sx,
-        kM_o2,
-        O2_a,
-        D_oa,
-        p_sx,
-        earth_param_set,
-    )
 end
 
 """

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -63,7 +63,8 @@ for FT in (Float32, Float64)
         # Make biogeochemistry model args
         Csom = (z, t) -> eltype(z)(5.0)
 
-        co2_parameters = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
+        co2_parameters =
+            Soil.Biogeochemistry.SoilCO2ModelParameters(FT; ν = 0.556)
         C = FT(4)
         co2_top_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> C)
         co2_bot_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> C)

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -7,6 +7,7 @@ using ClimaLand.Soil
 using ClimaLand.Soil.Biogeochemistry
 using Dates
 
+import CLIMAParameters
 import ClimaLand.Parameters as LP
 
 for FT in (Float32, Float64)
@@ -62,9 +63,7 @@ for FT in (Float32, Float64)
         # Make biogeochemistry model args
         Csom = (z, t) -> eltype(z)(5.0)
 
-        co2_parameters = Soil.Biogeochemistry.SoilCO2ModelParameters{FT}(;
-            earth_param_set = earth_param_set,
-        )
+        co2_parameters = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
         C = FT(4)
         co2_top_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> C)
         co2_bot_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> C)
@@ -164,10 +163,8 @@ for FT in (Float32, Float64)
         )
 
         try
-            co2_parameters = Soil.Biogeochemistry.SoilCO2ModelParameters{FT}(;
-                ν = FT(0.2),
-                earth_param_set = earth_param_set,
-            )
+            co2_parameters =
+                Soil.Biogeochemistry.SoilCO2ModelParameters(FT; ν = 0.2)
             soil_drivers = Soil.Biogeochemistry.SoilDrivers(
                 Soil.Biogeochemistry.PrognosticMet{FT}(),
                 Soil.Biogeochemistry.PrescribedSOC{FT}(Csom),

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -7,7 +7,7 @@ using ClimaLand.Soil
 using ClimaLand.Soil.Biogeochemistry
 using Dates
 
-import CLIMAParameters
+import ClimaParams
 import ClimaLand.Parameters as LP
 
 for FT in (Float32, Float64)

--- a/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
+++ b/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
@@ -17,7 +17,7 @@ for FT in (Float32, Float64)
         θ_i = (z, t) -> eltype(z)(0)
         Csom = (z, t) -> eltype(z)(5.0) # 3 [kg C m-3] soil organic C content at depth z
         D_ref = FT(0.0)
-        parameters = SoilCO2ModelParameters(FT; D_ref)
+        parameters = SoilCO2ModelParameters(FT; ν = 0.556, D_ref)
 
         nelems = 50 # number of layers in the vertical
         zmin = FT(-1) # 0 to 1 m depth
@@ -85,7 +85,7 @@ for FT in (Float32, Float64)
         θ_i = (z, t) -> eltype(z)(0.0)
         Csom = (z, t) -> eltype(z)(5.0) # 3 [kg C m-3] soil organic C content at depth z
 
-        parameters = SoilCO2ModelParameters(FT)
+        parameters = SoilCO2ModelParameters(FT; ν = 0.556)
         C = FT(4)
         nelems = 50 # number of layers in the vertical
         zmin = FT(-1) # 0 to 1 m depth

--- a/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
+++ b/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
@@ -10,7 +10,6 @@ import ClimaLand.Parameters as LP
 
 for FT in (Float32, Float64)
     @testset "Soil co2 biogeochemistry sources, FT = $FT" begin
-        earth_param_set = LP.LandParameters(FT)
         # Prognostic variables
         P_sfc = (t) -> 101e3
         T_soil = (z, t) -> eltype(z)(t)
@@ -18,10 +17,7 @@ for FT in (Float32, Float64)
         θ_i = (z, t) -> eltype(z)(0)
         Csom = (z, t) -> eltype(z)(5.0) # 3 [kg C m-3] soil organic C content at depth z
         D_ref = FT(0.0)
-        parameters = SoilCO2ModelParameters{FT}(;
-            D_ref = D_ref,
-            earth_param_set = earth_param_set,
-        )
+        parameters = SoilCO2ModelParameters(FT; D_ref)
 
         nelems = 50 # number of layers in the vertical
         zmin = FT(-1) # 0 to 1 m depth
@@ -82,7 +78,6 @@ for FT in (Float32, Float64)
 
 
     @testset "Soil co2 biogeochemistry diffusion, FT = $FT" begin
-        earth_param_set = LP.LandParameters(FT)
         # Prognostic variables
         P_sfc = (t) -> 101e3
         T_soil = (z, t) -> eltype(z)(303)
@@ -90,8 +85,7 @@ for FT in (Float32, Float64)
         θ_i = (z, t) -> eltype(z)(0.0)
         Csom = (z, t) -> eltype(z)(5.0) # 3 [kg C m-3] soil organic C content at depth z
 
-        parameters =
-            SoilCO2ModelParameters{FT}(; earth_param_set = earth_param_set)
+        parameters = SoilCO2ModelParameters(FT)
         C = FT(4)
         nelems = 50 # number of layers in the vertical
         zmin = FT(-1) # 0 to 1 m depth

--- a/test/standalone/Soil/Biogeochemistry/co2_parameterizations.jl
+++ b/test/standalone/Soil/Biogeochemistry/co2_parameterizations.jl
@@ -9,18 +9,7 @@ for FT in (Float32, Float64)
     @testset "Soil CO2 production and transport, FT = $FT" begin
         earth_param_set = LP.LandParameters(FT)
         # Parameters should be supplied in m/kg/s (Pa... etc)
-        D_liq = FT(3.17)
         ν = FT(0.556)
-        θ_a100 = FT(0.1846)
-        D_ref = FT(1.39e-5)
-        b = FT(4.547)
-        α_sx = FT(194e3)
-        Ea_sx = FT(61e3)
-        kM_sx = FT(5e-3)
-        kM_o2 = FT(0.004)
-        O2_a = FT(0.209)
-        D_oa = FT(1.67)
-        p_sx = FT(0.024)
         # Prognostic variables
         P_sfc = FT(101e3)
         T_soil = FT(303)
@@ -31,14 +20,7 @@ for FT in (Float32, Float64)
         T_ref = FT(LP.T_0(earth_param_set))
         R = FT(LP.gas_constant(earth_param_set))
 
-        parameters = SoilCO2ModelParameters{FT}(;
-            D_liq = D_liq,
-            ν = ν,
-            θ_a100 = θ_a100,
-            D_ref = D_ref,
-            b = b,
-            earth_param_set = earth_param_set,
-        )
+        parameters = SoilCO2ModelParameters(FT; ν)
 
         # Test that parameterizations functions are working properly
         θ_a = volumetric_air_content(θ_w, parameters)

--- a/test/standalone/Soil/Biogeochemistry/co2_parameterizations.jl
+++ b/test/standalone/Soil/Biogeochemistry/co2_parameterizations.jl
@@ -40,6 +40,7 @@ for FT in (Float32, Float64)
 
         ms = microbe_source(T_soil, θ_l, Csom, parameters)
         # check that the value is correct
+        (; p_sx, D_liq, kM_o2, D_oa, kM_sx, O2_a, α_sx, Ea_sx) = parameters
         MM_sx =
             p_sx * Csom * D_liq * θ_l^3 / (kM_sx + p_sx * Csom * D_liq * θ_l^3)
         MM_o2 =


### PR DESCRIPTION
This PR uses ClimaParams for `SoilCO2ModelParameters`.

As before, the new constructors are:
```julia
import ClimaLand
import ClimaParams as CP
toml_dict= CP.create_toml_dict(Float32)

ClimaLand.Soil.Biogeochemistry.SoilCO2ModelParameters(Float64)
ClimaLand.Soil.Biogeochemistry.SoilCO2ModelParameters(Float64; ν = 99999)
ClimaLand.Soil.Biogeochemistry.SoilCO2ModelParameters(toml_dict)
ClimaLand.Soil.Biogeochemistry.SoilCO2ModelParameters(toml_dict; ν = 99999)
```