### PR TITLE
Refactor EnergyHydrologyParameters

### DIFF
--- a/docs/tutorials/integrated/soil_canopy_tutorial.jl
+++ b/docs/tutorials/integrated/soil_canopy_tutorial.jl
@@ -147,7 +147,8 @@ soil_α_PAR = FT(0.2)
 soil_α_NIR = FT(0.4)
 
 soil_domain = land_domain
-soil_ps = Soil.EnergyHydrologyParameters{FT}(;
+soil_ps = Soil.EnergyHydrologyParameters(
+    FT;
     ν = soil_ν,
     ν_ss_om = ν_ss_om,
     ν_ss_quartz = ν_ss_quartz,

--- a/docs/tutorials/standalone/Soil/freezing_front.jl
+++ b/docs/tutorials/standalone/Soil/freezing_front.jl
@@ -88,11 +88,10 @@ using ClimaLand.Soil
 import ClimaLand
 import ClimaLand.Parameters as LP
 
-# # Preliminary set-up
+# Preliminary set-up
 
 # Choose a floating point precision, and get the parameter set, which holds constants used across CliMA models:
 FT = Float32
-earth_param_set = LP.LandParameters(FT);
 
 # Set the values of other parameters required by the model:
 ν = FT(0.535)
@@ -100,7 +99,7 @@ K_sat = FT(3.2e-6) # m/s
 S_s = FT(1e-3) #inverse meters
 vg_n = FT(1.48)
 vg_α = FT(1.11) # inverse meters
-hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n);
+hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n);
 # You could also try the Brooks and Corey model:
 #ψb = FT(-0.6)
 #c = FT(0.43)
@@ -109,16 +108,16 @@ hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n);
 ν_ss_om = FT(0.3)
 ν_ss_quartz = FT(0.7)
 ν_ss_gravel = FT(0.0)
-params = Soil.EnergyHydrologyParameters{FT}(;
-    ν = ν,
-    ν_ss_om = ν_ss_om,
-    ν_ss_quartz = ν_ss_quartz,
-    ν_ss_gravel = ν_ss_gravel,
-    hydrology_cm = hcm,
-    K_sat = K_sat,
-    S_s = S_s,
-    θ_r = θ_r,
-    earth_param_set = earth_param_set,
+params = Soil.EnergyHydrologyParameters(
+    FT;
+    ν,
+    ν_ss_om,
+    ν_ss_quartz,
+    ν_ss_gravel,
+    hydrology_cm,
+    K_sat,
+    S_s,
+    θ_r,
 );
 # Choose the domain and discretization:
 zmax = FT(0)

--- a/docs/tutorials/standalone/Soil/soil_energy_hydrology.jl
+++ b/docs/tutorials/standalone/Soil/soil_energy_hydrology.jl
@@ -100,14 +100,14 @@ earth_param_set = LP.LandParameters(FT);
 
 # # Create the model
 # Set the values of other parameters required by the model:
-ν = FT(0.395);
+ν = FT(0.395)
 # Soil solids
 # are the components of soil besides water, ice, gases, and air.
 # We specify the soil component fractions, relative to all soil solids.
 # These do not sum to unity; the remainder is ν_ss_minerals (=0.08, in this case).
 ν_ss_quartz = FT(0.92)
 ν_ss_om = FT(0.0)
-ν_ss_gravel = FT(0.0);
+ν_ss_gravel = FT(0.0)
 # Other parameters include the hydraulic conductivity at saturation, the specific
 # storage, and the van Genuchten parameters for sand.
 # We recommend Chapter 8 of Bonan (2019) for finding parameters
@@ -116,18 +116,18 @@ Ksat = FT(4.42 / 3600 / 100) # m/s
 S_s = FT(1e-3) #inverse meters
 vg_n = FT(1.89)
 vg_α = FT(7.5) # inverse meters
-hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n);
-θ_r = FT(0.0);
-params = Soil.EnergyHydrologyParameters{FT}(;
-    ν = ν,
-    ν_ss_om = ν_ss_om,
-    ν_ss_quartz = ν_ss_quartz,
-    ν_ss_gravel = ν_ss_gravel,
-    hydrology_cm = hcm,
+hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
+θ_r = FT(0.0)
+params = Soil.EnergyHydrologyParameters(
+    FT;
+    ν,
+    ν_ss_om,
+    ν_ss_quartz,
+    ν_ss_gravel,
+    hydrology_cm,
     K_sat = Ksat,
-    S_s = S_s,
-    θ_r = θ_r,
-    earth_param_set = earth_param_set,
+    S_s,
+    θ_r,
 );
 
 # We also need to pick a domain on which to solve the equations:

--- a/experiments/Manifest.toml
+++ b/experiments/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.1"
 manifest_format = "2.0"
-project_hash = "960bdc0a1ed4b3f2aee66ed2e0c02065769614a9"
+project_hash = "fa68ae5ff1b320df9bb9d1834d62589b82185252"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "41c37aa88889c171f1300ceac1313c06e891d245"

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -108,7 +108,8 @@ include(
 # Now we set up the model. For the soil model, we pick
 # a model type and model args:
 soil_domain = land_domain
-soil_ps = Soil.EnergyHydrologyParameters{FT}(;
+soil_ps = Soil.EnergyHydrologyParameters(
+    FT;
     ν = soil_ν,
     ν_ss_om = ν_ss_om,
     ν_ss_quartz = ν_ss_quartz,

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -69,16 +69,16 @@ include(
 # Now we set up the model. For the soil model, we pick
 # a model type and model args:
 soil_domain = land_domain
-soil_ps = Soil.EnergyHydrologyParameters{FT}(;
+soil_ps = Soil.EnergyHydrologyParameters(
+    FT;
     ν = soil_ν,
-    ν_ss_om = ν_ss_om,
-    ν_ss_quartz = ν_ss_quartz,
-    ν_ss_gravel = ν_ss_gravel,
+    ν_ss_om,
+    ν_ss_quartz,
+    ν_ss_gravel,
     hydrology_cm = vanGenuchten{FT}(; α = soil_vg_α, n = soil_vg_n),
     K_sat = soil_K_sat,
     S_s = soil_S_s,
-    θ_r = θ_r,
-    earth_param_set = earth_param_set,
+    θ_r,
     z_0m = z_0m_soil,
     z_0b = z_0b_soil,
     emissivity = soil_ϵ,

--- a/experiments/integrated/ozark/conservation/ozark_conservation.jl
+++ b/experiments/integrated/ozark/conservation/ozark_conservation.jl
@@ -70,16 +70,16 @@ for float_type in (Float32, Float64)
     # Now we set up the model. For the soil model, we pick
     # a model type and model args:
     soil_domain = land_domain
-    soil_ps = Soil.EnergyHydrologyParameters{FT}(;
+    soil_ps = Soil.EnergyHydrologyParameters(
+        FT;
         ν = soil_ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
+        ν_ss_om,
+        ν_ss_quartz,
+        ν_ss_gravel,
         hydrology_cm = vanGenuchten{FT}(; α = soil_vg_α, n = soil_vg_n),
         K_sat = soil_K_sat,
         S_s = soil_S_s,
-        θ_r = θ_r,
-        earth_param_set = earth_param_set,
+        θ_r,
         z_0m = z_0m_soil,
         z_0b = z_0b_soil,
         emissivity = soil_ϵ,

--- a/experiments/standalone/Biogeochemistry/experiment.jl
+++ b/experiments/standalone/Biogeochemistry/experiment.jl
@@ -25,21 +25,20 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
     S_s = FT(1e-3) #inverse meters
     vg_n = FT(2.0)
     vg_α = FT(2.6) # inverse meters
-    hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
     θ_r = FT(0.1)
     ν_ss_om = FT(0.0)
     ν_ss_quartz = FT(1.0)
     ν_ss_gravel = FT(0.0)
-    soil_ps = Soil.EnergyHydrologyParameters{FT}(;
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hcm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-        earth_param_set = earth_param_set,
+    soil_ps = Soil.EnergyHydrologyParameters(
+        FT;
+        ν,
+        ν_ss_om,
+        ν_ss_quartz,
+        ν_ss_gravel,
+        hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n),
+        K_sat,
+        S_s,
+        θ_r,
     )
 
     zmax = FT(0)

--- a/experiments/standalone/Soil/evaporation.jl
+++ b/experiments/standalone/Soil/evaporation.jl
@@ -95,22 +95,22 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
         top = top_bc,
         bottom = WaterHeatBC(; water = zero_water_flux, heat = zero_heat_flux),
     )
-    params = ClimaLand.Soil.EnergyHydrologyParameters{FT}(;
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
+    params = ClimaLand.Soil.EnergyHydrologyParameters(
+        FT;
+        ν,
+        ν_ss_om,
+        ν_ss_quartz,
+        ν_ss_gravel,
         hydrology_cm = hcm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-        PAR_albedo = PAR_albedo,
-        NIR_albedo = NIR_albedo,
-        emissivity = emissivity,
-        z_0m = z_0m,
-        z_0b = z_0b,
-        earth_param_set = earth_param_set,
-        d_ds = d_ds,
+        K_sat,
+        S_s,
+        θ_r,
+        PAR_albedo,
+        NIR_albedo,
+        emissivity,
+        z_0m,
+        z_0b,
+        d_ds,
     )
 
     #TODO: Run with higher resolution once we have the implicit stepper

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Ha1/US-Ha1_parameters.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Ha1/US-Ha1_parameters.jl
@@ -87,21 +87,21 @@ function soil_harvard(;
     NIR_albedo = FT(0.2),
 )
     hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
-    return EnergyHydrologyParameters{FT}(; # here, calls the src function, not the src struct    
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hydrology_cm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-        PAR_albedo = PAR_albedo,
-        NIR_albedo = NIR_albedo,
-        emissivity = emissivity,
-        z_0m = z_0m,
-        z_0b = z_0b,
-        earth_param_set = earth_param_set,
+    return EnergyHydrologyParameters(
+        FT;
+        ν,
+        ν_ss_om,
+        ν_ss_quartz,
+        ν_ss_gravel,
+        hydrology_cm,
+        K_sat,
+        S_s,
+        θ_r,
+        PAR_albedo,
+        NIR_albedo,
+        emissivity,
+        z_0m,
+        z_0b,
     )
 end
 

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-MOz/US-MOz_parameters.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-MOz/US-MOz_parameters.jl
@@ -87,21 +87,21 @@ function soil_ozark(; # Function that returns the src function, but with ozark d
     NIR_albedo = FT(0.2),
 )
     hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
-    return EnergyHydrologyParameters{FT}(; # here, calls the src function, not the src struct    
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hydrology_cm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-        PAR_albedo = PAR_albedo,
-        NIR_albedo = NIR_albedo,
-        emissivity = emissivity,
-        z_0m = z_0m,
-        z_0b = z_0b,
-        earth_param_set = earth_param_set,
+    return EnergyHydrologyParameters(
+        FT;
+        ν,
+        ν_ss_om,
+        ν_ss_quartz,
+        ν_ss_gravel,
+        hydrology_cm,
+        K_sat,
+        S_s,
+        θ_r,
+        PAR_albedo,
+        NIR_albedo,
+        emissivity,
+        z_0m,
+        z_0b,
     )
 end
 

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-NR1/US-NR1_parameters.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-NR1/US-NR1_parameters.jl
@@ -87,21 +87,21 @@ function soil_niwotridge(;
     NIR_albedo = FT(0.2),
 )
     hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
-    return EnergyHydrologyParameters{FT}(; # here, calls the src function, not the src struct    
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hydrology_cm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-        PAR_albedo = PAR_albedo,
-        NIR_albedo = NIR_albedo,
-        emissivity = emissivity,
-        z_0m = z_0m,
-        z_0b = z_0b,
-        earth_param_set = earth_param_set,
+    return EnergyHydrologyParameters(
+        FT;
+        ν,
+        ν_ss_om,
+        ν_ss_quartz,
+        ν_ss_gravel,
+        hydrology_cm,
+        K_sat,
+        S_s,
+        θ_r,
+        PAR_albedo,
+        NIR_albedo,
+        emissivity,
+        z_0m,
+        z_0b,
     )
 end
 

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Var/US-Var_parameters.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Var/US-Var_parameters.jl
@@ -87,21 +87,21 @@ function soil_vairaranch(;
     NIR_albedo = FT(0.2),
 )
     hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
-    return EnergyHydrologyParameters{FT}(; # here, calls the src function, not the src struct    
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hydrology_cm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-        PAR_albedo = PAR_albedo,
-        NIR_albedo = NIR_albedo,
-        emissivity = emissivity,
-        z_0m = z_0m,
-        z_0b = z_0b,
-        earth_param_set = earth_param_set,
+    return EnergyHydrologyParameters(
+        FT;
+        ν,
+        ν_ss_om,
+        ν_ss_quartz,
+        ν_ss_gravel,
+        hydrology_cm,
+        K_sat,
+        S_s,
+        θ_r,
+        PAR_albedo,
+        NIR_albedo,
+        emissivity,
+        z_0m,
+        z_0b,
     )
 end
 

--- a/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
@@ -21,7 +21,8 @@ function run_fluxnet(
     # Now we set up the model. For the soil model, we pick
     # a model type and model args:
     soil_domain = domain.land_domain
-    soil_ps = Soil.EnergyHydrologyParameters{FT}(;
+    soil_ps = Soil.EnergyHydrologyParameters(
+        FT;
         ν = params.soil.ν,
         ν_ss_om = params.soil.ν_ss_om,
         ν_ss_quartz = params.soil.ν_ss_quartz,
@@ -30,7 +31,6 @@ function run_fluxnet(
         K_sat = params.soil.K_sat,
         S_s = params.soil.S_s,
         θ_r = params.soil.θ_r,
-        earth_param_set = earth_param_set,
         z_0m = params.soil.z_0m,
         z_0b = params.soil.z_0b,
         emissivity = params.soil.emissivity,

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -18,22 +18,22 @@ for FT in (Float32, Float64)
         S_s = FT(1e-3) #inverse meters
         vg_n = FT(2.0)
         vg_α = FT(2.6) # inverse meters
-        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
+        hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0.1)
         ν_ss_om = FT(0.0)
         ν_ss_quartz = FT(1.0)
         ν_ss_gravel = FT(0.0)
 
-        soil_ps = Soil.EnergyHydrologyParameters{FT}(;
-            ν = ν,
-            ν_ss_om = ν_ss_om,
-            ν_ss_quartz = ν_ss_quartz,
-            ν_ss_gravel = ν_ss_gravel,
-            K_sat = K_sat,
-            hydrology_cm = hcm,
-            S_s = S_s,
-            θ_r = θ_r,
-            earth_param_set = earth_param_set,
+        soil_ps = Soil.EnergyHydrologyParameters(
+            FT;
+            ν,
+            ν_ss_om,
+            ν_ss_quartz,
+            ν_ss_gravel,
+            K_sat,
+            hydrology_cm,
+            S_s,
+            θ_r,
         )
         zmax = FT(0)
         zmin = FT(-1)

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -87,21 +87,21 @@ for FT in (Float32, Float64)
                 heat = zero_heat_flux,
             ),
         )
-        params = ClimaLand.Soil.EnergyHydrologyParameters{FT}(;
-            ν = ν,
-            ν_ss_om = ν_ss_om,
-            ν_ss_quartz = ν_ss_quartz,
-            ν_ss_gravel = ν_ss_gravel,
+        params = ClimaLand.Soil.EnergyHydrologyParameters(
+            FT;
+            ν,
+            ν_ss_om,
+            ν_ss_quartz,
+            ν_ss_gravel,
             hydrology_cm = hcm,
-            K_sat = K_sat,
-            S_s = S_s,
-            θ_r = θ_r,
-            PAR_albedo = PAR_albedo,
-            NIR_albedo = NIR_albedo,
-            emissivity = emissivity,
-            z_0m = z_0m,
-            z_0b = z_0b,
-            earth_param_set = earth_param_set,
+            K_sat,
+            S_s,
+            θ_r,
+            PAR_albedo,
+            NIR_albedo,
+            emissivity,
+            z_0m,
+            z_0b,
         )
 
         for domain in soil_domains

--- a/test/standalone/Soil/soil_bc.jl
+++ b/test/standalone/Soil/soil_bc.jl
@@ -6,6 +6,7 @@ using ClimaLand
 using ClimaLand.Soil
 using ClimaLand.Domains: HybridBox, SphericalShell, Column
 import ClimaLand.Parameters as LP
+import ClimaParams
 
 for FT in (Float32, Float64)
     @testset "WVector usage in gradient, FT = $FT" begin
@@ -136,21 +137,22 @@ for FT in (Float32, Float64)
         S_s = FT(1e-3) #inverse meters
         vg_n = FT(2.0)
         vg_α = FT(2.6) # inverse meters
-        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
+        hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0.1)
         ν_ss_om = FT(0.0)
         ν_ss_quartz = FT(1.0)
         ν_ss_gravel = FT(0.0)
-        parameters = Soil.EnergyHydrologyParameters{FT}(;
-            ν = ν,
-            ν_ss_om = ν_ss_om,
-            ν_ss_quartz = ν_ss_quartz,
-            ν_ss_gravel = ν_ss_gravel,
-            hydrology_cm = hcm,
-            K_sat = K_sat,
-            S_s = S_s,
-            θ_r = θ_r,
-            earth_param_set = earth_param_set,
+
+        parameters = Soil.EnergyHydrologyParameters(
+            FT;
+            ν,
+            ν_ss_om,
+            ν_ss_quartz,
+            ν_ss_gravel,
+            hydrology_cm,
+            K_sat,
+            S_s,
+            θ_r,
         )
 
         zmax = FT(0)
@@ -198,7 +200,7 @@ end
     S_s = FT(1e-3) #inverse meters
     vg_n = FT(2.0)
     vg_α = FT(2.6) # inverse meters
-    hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
+    hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
     θ_r = FT(0.1)
     ν_ss_om = FT(0.0)
     ν_ss_quartz = FT(1.0)
@@ -206,16 +208,16 @@ end
     κ_minerals = FT(2.5)
     ρp = FT(2.66 / 1e3 * 1e6)
     ρc_ds = @. FT(2e6 * (1.0 - ν))
-    parameters = Soil.EnergyHydrologyParameters{FT}(;
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hcm,
-        K_sat = K_sat,
-        S_s = S_s,
-        θ_r = θ_r,
-        earth_param_set = earth_param_set,
+    parameters = Soil.EnergyHydrologyParameters(
+        FT;
+        ν,
+        ν_ss_om,
+        ν_ss_quartz,
+        ν_ss_gravel,
+        hydrology_cm,
+        K_sat,
+        S_s,
+        θ_r,
     )
     zmax = FT(0)
     zmin = FT(-1)
@@ -236,16 +238,16 @@ end
         ),
     )
 
-    parameters = Soil.EnergyHydrologyParameters{FT}(;
-        ν = ν,
-        ν_ss_om = ν_ss_om,
-        ν_ss_quartz = ν_ss_quartz,
-        ν_ss_gravel = ν_ss_gravel,
-        hydrology_cm = hcm,
+    parameters = Soil.EnergyHydrologyParameters(
+        FT;
+        ν,
+        ν_ss_om,
+        ν_ss_quartz,
+        ν_ss_gravel,
+        hydrology_cm,
         K_sat = FT(0),
-        S_s = S_s,
-        θ_r = θ_r,
-        earth_param_set = earth_param_set,
+        S_s,
+        θ_r,
     )
     energy_hydrology = Soil.EnergyHydrology{FT}(;
         parameters = parameters,
@@ -300,7 +302,7 @@ end
 
     parameters = Soil.RichardsParameters(;
         ν = ν,
-        hydrology_cm = hcm,
+        hydrology_cm,
         K_sat = FT(0),
         S_s = S_s,
         θ_r = θ_r,

--- a/test/standalone/Soil/soil_parameterizations.jl
+++ b/test/standalone/Soil/soil_parameterizations.jl
@@ -52,16 +52,16 @@ for FT in (Float32, Float64)
         κ_ice = FT(2.21)
         κ_liq = FT(0.57)
 
-        parameters = EnergyHydrologyParameters{FT}(;
-            ν = ν,
-            ν_ss_om = ν_ss_om,
-            ν_ss_quartz = ν_ss_quartz,
-            ν_ss_gravel = ν_ss_gravel,
+        parameters = EnergyHydrologyParameters(
+            FT;
+            ν,
+            ν_ss_om,
+            ν_ss_quartz,
+            ν_ss_gravel,
             hydrology_cm = hcm,
-            K_sat = K_sat,
-            S_s = S_s,
-            θ_r = θ_r,
-            earth_param_set = param_set,
+            K_sat,
+            S_s,
+            θ_r,
         )
         # Test that the preset params are set properly
         (; α, β, Ω, hydrology_cm, γ, γT_ref) = parameters
@@ -308,16 +308,16 @@ for FT in (Float32, Float64)
         ν_ss_om = FT(0.1)
         ν_ss_gravel = FT(0.1)
         ν_ss_quartz = FT(0.1)
-        parameters = EnergyHydrologyParameters{FT}(;
-            ν = ν,
-            ν_ss_om = ν_ss_om,
-            ν_ss_quartz = ν_ss_quartz,
-            ν_ss_gravel = ν_ss_gravel,
+        parameters = EnergyHydrologyParameters(
+            FT;
+            ν,
+            ν_ss_om,
+            ν_ss_quartz,
+            ν_ss_gravel,
             hydrology_cm = hcm,
-            K_sat = K_sat,
-            S_s = S_s,
-            θ_r = θ_r,
-            earth_param_set = param_set,
+            K_sat,
+            S_s,
+            θ_r,
         )
 
         Δz = FT(1.0)

--- a/test/standalone/Soil/soil_test_3d.jl
+++ b/test/standalone/Soil/soil_test_3d.jl
@@ -239,21 +239,21 @@ for FT in (Float32, Float64)
         vg_n = FT(2.68)
         vg_α = FT(14.5) # inverse meters
         vg_m = 1 - 1 / vg_n
-        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
+        hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0.045)
         ν_ss_om = FT(0.0)
         ν_ss_quartz = FT(1.0)
         ν_ss_gravel = FT(0.0)
-        parameters = Soil.EnergyHydrologyParameters{FT}(
-            ν = ν,
-            ν_ss_om = ν_ss_om,
-            ν_ss_quartz = ν_ss_quartz,
-            ν_ss_gravel = ν_ss_gravel,
-            hydrology_cm = hcm,
-            K_sat = K_sat,
-            S_s = S_s,
-            θ_r = θ_r,
-            earth_param_set = earth_param_set,
+        parameters = Soil.EnergyHydrologyParameters(
+            FT;
+            ν,
+            ν_ss_om,
+            ν_ss_quartz,
+            ν_ss_gravel,
+            hydrology_cm,
+            K_sat,
+            S_s,
+            θ_r,
         )
         zmax = FT(0)
         zmin = FT(-1)

--- a/test/standalone/Soil/soiltest.jl
+++ b/test/standalone/Soil/soiltest.jl
@@ -91,7 +91,7 @@ for FT in (Float32, Float64)
         vg_n = FT(2.0)
         vg_α = FT(2.6) # inverse meters
         vg_m = FT(1) - FT(1) / vg_n
-        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
+        hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0.1)
         ν_ss_om = FT(0.0)
         ν_ss_quartz = FT(1.0)
@@ -120,16 +120,16 @@ for FT in (Float32, Float64)
 
 
         ###
-        hyd_off_en_on = Soil.EnergyHydrologyParameters{FT}(;
-            ν = ν,
-            ν_ss_om = ν_ss_om,
-            ν_ss_quartz = ν_ss_quartz,
-            ν_ss_gravel = ν_ss_gravel,
-            hydrology_cm = hcm,
+        hyd_off_en_on = Soil.EnergyHydrologyParameters(
+            FT;
+            ν,
+            ν_ss_om,
+            ν_ss_quartz,
+            ν_ss_gravel,
+            hydrology_cm,
             K_sat = FT(0),
-            S_s = S_s,
-            θ_r = θ_r,
-            earth_param_set = earth_param_set,
+            S_s,
+            θ_r,
         )
         soil_heat_on = Soil.EnergyHydrology{FT}(;
             parameters = hyd_off_en_on,
@@ -189,7 +189,7 @@ for FT in (Float32, Float64)
         hyd_on_en_off = Soil.EnergyHydrologyParameters{
             FT,
             FT,
-            typeof(hcm),
+            typeof(hydrology_cm),
             typeof(earth_param_set),
         }(
             FT(0), # κ_dry
@@ -202,17 +202,17 @@ for FT in (Float32, Float64)
             ν_ss_gravel,
             FT(0.24), #α
             FT(18.3), #β
-            hcm,
+            hydrology_cm,
             K_sat,
             S_s,
             θ_r,
-            FT(7),#Ω
-            FT(2.64e-2),#γ
-            FT(288),#γT_ref
-            FT(0.2),# NIR_albedo
-            FT(0.2), #PAR_albedo
-            FT(0.96),#ϵ
-            FT(0.001),# z_0m
+            FT(7), # Ω
+            FT(2.64e-2), # γ
+            FT(288), # γT_ref
+            FT(0.2), # NIR_albedo
+            FT(0.2), # PAR_albedo
+            FT(0.96), # ϵ
+            FT(0.001), # z_0m
             FT(0.01), # z_0b
             FT(0.015), #d_ds
             earth_param_set,
@@ -361,7 +361,7 @@ for FT in (Float32, Float64)
         hyd_off_en_off = Soil.EnergyHydrologyParameters{
             FT,
             FT,
-            typeof(hcm),
+            typeof(hydrology_cm),
             typeof(earth_param_set),
         }(
             FT(0), # κ_dry
@@ -374,7 +374,7 @@ for FT in (Float32, Float64)
             ν_ss_gravel,
             FT(0.24), #α
             FT(18.3), #β
-            hcm,
+            hydrology_cm,
             FT(0), # K_sat
             S_s,
             θ_r,
@@ -434,16 +434,16 @@ for FT in (Float32, Float64)
 
 
         ### Test with both energy and hydrology on
-        hyd_on_en_on = Soil.EnergyHydrologyParameters{FT}(;
-            ν = ν,
-            ν_ss_om = ν_ss_om,
-            ν_ss_quartz = ν_ss_quartz,
-            ν_ss_gravel = ν_ss_gravel,
-            hydrology_cm = hcm,
-            K_sat = K_sat,
-            S_s = S_s,
-            θ_r = θ_r,
-            earth_param_set = earth_param_set,
+        hyd_on_en_on = Soil.EnergyHydrologyParameters(
+            FT;
+            ν,
+            ν_ss_om,
+            ν_ss_quartz,
+            ν_ss_gravel,
+            hydrology_cm,
+            K_sat,
+            S_s,
+            θ_r,
         )
 
         soil_both_on = Soil.EnergyHydrology{FT}(;
@@ -553,7 +553,7 @@ for FT in (Float32, Float64)
         S_s = FT(1e-3) #inverse meters
         vg_n = FT(2.0)
         vg_α = FT(2.6) # inverse meters
-        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
+        hydrology_cm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
         θ_r = FT(0.1)
         ν_ss_om = FT(0.0)
         ν_ss_quartz = FT(1.0)
@@ -582,16 +582,16 @@ for FT in (Float32, Float64)
         sources = (PhaseChange{FT}(Δz),)
 
         ###
-        hyd_off_en_on = Soil.EnergyHydrologyParameters{FT}(;
-            ν = ν,
-            ν_ss_om = ν_ss_om,
-            ν_ss_quartz = ν_ss_quartz,
-            ν_ss_gravel = ν_ss_gravel,
-            hydrology_cm = hcm,
-            K_sat = K_sat,
-            S_s = S_s,
-            θ_r = θ_r,
-            earth_param_set = earth_param_set,
+        hyd_off_en_on = Soil.EnergyHydrologyParameters(
+            FT;
+            ν,
+            ν_ss_om,
+            ν_ss_quartz,
+            ν_ss_gravel,
+            hydrology_cm,
+            K_sat,
+            S_s,
+            θ_r,
         )
         soil_heat_on = Soil.EnergyHydrology{FT}(;
             parameters = hyd_off_en_on,


### PR DESCRIPTION
Same as #481 and #480, adds two new constructors for EnergyHydrologyParameters that use ClimaParams. One takes an FT, one takes a toml.
I also updated the experiment Manifest, for some reason Insolation was not updated.
```julia
  EnergyHydrologyParameters(
        ::Type{FT};
        ν,
        ν_ss_om,
        ν_ss_quartz,
        ν_ss_gravel,
        hydrology_cm,
        K_sat,
        S_s,
        θ_r,
        kwargs...,
)

    EnergyHydrologyParameters(
        toml_dict;
        ν,
        ν_ss_om,
        ν_ss_quartz,
        ν_ss_gravel,
        hydrology_cm,
        K_sat,
        S_s,
        θ_r,
        kwargs...,
)
```