### PR TITLE
Bucket albedo parameterization cleanup

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -32,9 +32,9 @@ weakdeps = ["ChainRulesCore", "Test"]
     AbstractFFTsTestExt = "Test"
 
 [[deps.AbstractTrees]]
-git-tree-sha1 = "faa260e4cb5aba097a73fab382dd4b5819d8ec8c"
+git-tree-sha1 = "2d9c9a55f9c93e8887ad391fbae72f8ef55e1177"
 uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
-version = "0.4.4"
+version = "0.4.5"
 
 [[deps.Adapt]]
 deps = ["LinearAlgebra", "Requires"]
@@ -194,9 +194,9 @@ version = "0.1.2"
 
 [[deps.CLIMAParameters]]
 deps = ["DocStringExtensions", "TOML", "Test"]
-git-tree-sha1 = "10473c458cd10f3808a438492447ca10d4dde7d0"
+git-tree-sha1 = "9fcb37be791b4762943cbbf15ccf35c99d91460c"
 uuid = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
-version = "0.9.0"
+version = "0.9.1"
 
 [[deps.CPUSummary]]
 deps = ["CpuId", "IfElse", "PrecompileTools", "Static"]
@@ -259,9 +259,9 @@ version = "1.63.0"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra"]
-git-tree-sha1 = "ad25e7d21ce10e01de973cdc68ad0f850a953c52"
+git-tree-sha1 = "aef70bb349b20aa81a82a19704c3ef339d4ee494"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.21.1"
+version = "1.22.1"
 weakdeps = ["SparseArrays"]
 
     [deps.ChainRulesCore.extensions]
@@ -269,15 +269,15 @@ weakdeps = ["SparseArrays"]
 
 [[deps.ClimaComms]]
 deps = ["CUDA", "MPI"]
-git-tree-sha1 = "57c054ddd4280ca8e2b5915ef1cf1395c4edbc78"
+git-tree-sha1 = "f0350e34c91c8f3b5a11b5e39990439303d727b1"
 uuid = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
-version = "0.5.6"
+version = "0.5.7"
 
 [[deps.ClimaCore]]
 deps = ["Adapt", "BandedMatrices", "BlockArrays", "CUDA", "ClimaComms", "CubedSphere", "DataStructures", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "KrylovKit", "LinearAlgebra", "PkgVersion", "RecursiveArrayTools", "RootSolvers", "SparseArrays", "Static", "StaticArrays", "Statistics", "Unrolled"]
-git-tree-sha1 = "c9f8744c0ca7fd0f3f1833625ab4aa8edba28149"
+git-tree-sha1 = "fd3bb1f7655ebcc8c8a652a8cc6c4f7f2620ae72"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.12.0"
+version = "0.12.1"
 weakdeps = ["Krylov"]
 
     [deps.ClimaCore.extensions]
@@ -347,9 +347,9 @@ version = "0.12.10"
 
 [[deps.CommonDataModel]]
 deps = ["CFTime", "DataStructures", "Dates", "Preferences", "Printf", "Statistics"]
-git-tree-sha1 = "a132d267a055e8173a4a8e83d0d4ddcaeae70f91"
+git-tree-sha1 = "d7d7b58e149f19c322840a50d1bc20e8c23addb4"
 uuid = "1fbeeb36-5f17-413c-809b-666fb144f157"
-version = "0.3.4"
+version = "0.3.5"
 
 [[deps.CommonSolve]]
 git-tree-sha1 = "0eee5eb66b1cf62cd6ad1b460238e60e4b09400c"
@@ -364,9 +364,9 @@ version = "0.3.0"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
-git-tree-sha1 = "75bd5b6fc5089df449b5d35fa501c846c9b6549b"
+git-tree-sha1 = "d2c021fbdde94f6cdaa799639adfeeaa17fd67f5"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.12.0"
+version = "4.13.0"
 weakdeps = ["Dates", "LinearAlgebra"]
 
     [deps.Compat.extensions]
@@ -446,9 +446,9 @@ version = "1.6.1"
 
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "ac67408d9ddf207de5cfa9a97e114352430f01ed"
+git-tree-sha1 = "1fb174f0d48fe7d142e1109a10636bc1d14f5ac2"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.16"
+version = "0.18.17"
 
 [[deps.DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -698,9 +698,9 @@ version = "0.8.4"
 
 [[deps.Flux]]
 deps = ["Adapt", "ChainRulesCore", "Compat", "Functors", "LinearAlgebra", "MLUtils", "MacroTools", "NNlib", "OneHotArrays", "Optimisers", "Preferences", "ProgressLogging", "Random", "Reexport", "SparseArrays", "SpecialFunctions", "Statistics", "Zygote"]
-git-tree-sha1 = "39a9e46b4e92d5b56c0712adeb507555a2327240"
+git-tree-sha1 = "fd7b23aa8013a7528563d429f6eaf406f60364ed"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.14.11"
+version = "0.14.12"
 
     [deps.Flux.extensions]
     FluxAMDGPUExt = "AMDGPU"
@@ -880,9 +880,9 @@ version = "1.14.3+1"
 
 [[deps.HTTP]]
 deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
-git-tree-sha1 = "abbbb9ec3afd783a7cbd82ef01dcd088ea051398"
+git-tree-sha1 = "ac7b73d562b8f4287c3b67b4c66a5395a19c1ae8"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "1.10.1"
+version = "1.10.2"
 
 [[deps.HarfBuzz_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg"]
@@ -1000,9 +1000,9 @@ version = "0.21.4"
 
 [[deps.JpegTurbo_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "60b1194df0a3298f460063de985eae7b01bc011a"
+git-tree-sha1 = "3336abae9a713d2210bb57ab484b1e065edd7d23"
 uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
-version = "3.0.1+0"
+version = "3.0.2+0"
 
 [[deps.JuliaNVTXCallbacks_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -1058,9 +1058,9 @@ version = "3.0.0+1"
 
 [[deps.LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Preferences", "Printf", "Requires", "Unicode"]
-git-tree-sha1 = "9e70165cca7459d25406367f0c55e517a9a7bfe7"
+git-tree-sha1 = "ddab4d40513bce53c8e3157825e245224f74fae7"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "6.5.0"
+version = "6.6.0"
 weakdeps = ["BFloat16s"]
 
     [deps.LLVM.extensions]
@@ -1068,9 +1068,9 @@ weakdeps = ["BFloat16s"]
 
 [[deps.LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
-git-tree-sha1 = "114e3a48f13d4c18ddd7fd6a00107b4b96f60f9c"
+git-tree-sha1 = "88b916503aac4fb7f701bb625cd84ca5dd1677bc"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.28+0"
+version = "0.0.29+0"
 
 [[deps.LLVMLoopInfo]]
 git-tree-sha1 = "2e5c102cfc41f48ae4740c7eca7743cc7e7b75ea"
@@ -1241,9 +1241,9 @@ version = "2.16.1"
 
 [[deps.LogExpFunctions]]
 deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "7d6dd4e9212aebaeed356de34ccf262a3cd415aa"
+git-tree-sha1 = "18144f3e9cbe9b15b070288eef858f71b291ce37"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.26"
+version = "0.3.27"
 
     [deps.LogExpFunctions.extensions]
     LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
@@ -1702,9 +1702,9 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[deps.Random123]]
 deps = ["Random", "RandomNumbers"]
-git-tree-sha1 = "c860e84651f58ce240dd79e5d9e055d55234c35a"
+git-tree-sha1 = "4743b43e5a9c4a2ede372de7061eed81795b12e7"
 uuid = "74087812-796a-5b5d-8853-05524746bad3"
-version = "1.6.2"
+version = "1.7.0"
 
 [[deps.RandomNumbers]]
 deps = ["Random", "Requires"]
@@ -1742,9 +1742,9 @@ version = "0.6.12"
 
 [[deps.RecursiveArrayTools]]
 deps = ["Adapt", "ArrayInterface", "DocStringExtensions", "GPUArraysCore", "IteratorInterfaceExtensions", "LinearAlgebra", "RecipesBase", "SparseArrays", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface", "Tables"]
-git-tree-sha1 = "09c906ce9fa905d40e0706cdb62422422091c22f"
+git-tree-sha1 = "1bbc4bb050165cc57ca2876cd53cc23395948650"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
-version = "3.8.1"
+version = "3.10.0"
 
     [deps.RecursiveArrayTools.extensions]
     RecursiveArrayToolsFastBroadcastExt = "FastBroadcast"
@@ -1810,9 +1810,9 @@ version = "0.1.0"
 
 [[deps.SciMLBase]]
 deps = ["ADTypes", "ArrayInterface", "CommonSolve", "ConstructionBase", "Distributed", "DocStringExtensions", "EnumX", "FillArrays", "FunctionWrappersWrappers", "IteratorInterfaceExtensions", "LinearAlgebra", "Logging", "Markdown", "PrecompileTools", "Preferences", "Printf", "RecipesBase", "RecursiveArrayTools", "Reexport", "RuntimeGeneratedFunctions", "SciMLOperators", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface", "Tables", "TruncatedStacktraces"]
-git-tree-sha1 = "a123011b1711f3449bc4e5d66746be5725af92fd"
+git-tree-sha1 = "16dd1ea058e1c080d7f1ba47a9094f87a1c50e4c"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "2.26.0"
+version = "2.26.2"
 
     [deps.SciMLBase.extensions]
     SciMLBaseChainRulesCoreExt = "ChainRulesCore"
@@ -1941,9 +1941,9 @@ weakdeps = ["OffsetArrays", "StaticArrays"]
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
-git-tree-sha1 = "7b0e9c14c624e435076d19aea1e5cbdec2b9ca37"
+git-tree-sha1 = "bf074c045d3d5ffd956fa0a461da38a44685d6b2"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.2"
+version = "1.9.3"
 weakdeps = ["ChainRulesCore", "Statistics"]
 
     [deps.StaticArrays.extensions]
@@ -1985,10 +1985,17 @@ uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
 version = "0.3.4"
 
 [[deps.StructArrays]]
-deps = ["Adapt", "ConstructionBase", "DataAPI", "GPUArraysCore", "StaticArraysCore", "Tables"]
-git-tree-sha1 = "1b0b1205a56dc288b71b1961d48e351520702e24"
+deps = ["ConstructionBase", "DataAPI", "Tables"]
+git-tree-sha1 = "f4dc295e983502292c4c3f951dbb4e985e35b3be"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.17"
+version = "0.6.18"
+weakdeps = ["Adapt", "GPUArraysCore", "SparseArrays", "StaticArrays"]
+
+    [deps.StructArrays.extensions]
+    StructArraysAdaptExt = "Adapt"
+    StructArraysGPUArraysCoreExt = "GPUArraysCore"
+    StructArraysSparseArraysExt = "SparseArrays"
+    StructArraysStaticArraysExt = "StaticArrays"
 
 [[deps.SuiteSparse]]
 deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
@@ -2001,18 +2008,18 @@ version = "7.2.1+1"
 
 [[deps.SurfaceFluxes]]
 deps = ["DocStringExtensions", "RootSolvers", "Thermodynamics"]
-git-tree-sha1 = "3ded2d347cab67d1727b4d25bb5c99fb4982a868"
+git-tree-sha1 = "58b50249d670491d0907a03f6700278a61cb8a8d"
 uuid = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
-version = "0.9.2"
+version = "0.9.3"
 weakdeps = ["CLIMAParameters"]
 
     [deps.SurfaceFluxes.extensions]
     CreateParametersExt = "CLIMAParameters"
 
 [[deps.SymbolicIndexingInterface]]
-git-tree-sha1 = "dc7186d456f9ff2bef0cb754a59758920f0b2382"
+git-tree-sha1 = "b74cb9508b6c0aa91d729dcbc7e35faf8998c549"
 uuid = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
-version = "0.3.6"
+version = "0.3.7"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -2066,9 +2073,9 @@ uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[deps.Thermodynamics]]
 deps = ["DocStringExtensions", "KernelAbstractions", "Random", "RootSolvers"]
-git-tree-sha1 = "798aaff125b5c58ae17be1cae73d94c07abe7546"
+git-tree-sha1 = "ea5dc9b8b01932616bcd9f9fae6eea07bb29cf8e"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
-version = "0.12.0"
+version = "0.12.2"
 weakdeps = ["CLIMAParameters"]
 
     [deps.Thermodynamics.extensions]
@@ -2240,9 +2247,9 @@ version = "1.1.34+0"
 
 [[deps.XZ_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "522b8414d40c4cbbab8dee346ac3a09f9768f25d"
+git-tree-sha1 = "ac88fb95ae6447c8dda6a5503f3bafd496ae8632"
 uuid = "ffd25f8a-64ca-5728-b0f7-c24cf3aae800"
-version = "5.4.5+0"
+version = "5.4.6+0"
 
 [[deps.Xorg_libICE_jll]]
 deps = ["Libdl", "Pkg"]

--- a/docs/src/APIs/Bucket.md
+++ b/docs/src/APIs/Bucket.md
@@ -7,9 +7,8 @@ CurrentModule = ClimaLand.Bucket
 
 ```@docs
 ClimaLand.Bucket.BucketModelParameters
-ClimaLand.Bucket.BulkAlbedoStatic
-ClimaLand.Bucket.BulkAlbedoTemporal
-ClimaLand.Bucket.BulkAlbedoFunction
+ClimaLand.Bucket.PrescribedBaregroundAlbedo
+ClimaLand.Bucket.PrescribedSurfaceAlbedo
 ClimaLand.Bucket.BucketModel
 ```
 

--- a/docs/tutorials/standalone/Bucket/bucket_tutorial.jl
+++ b/docs/tutorials/standalone/Bucket/bucket_tutorial.jl
@@ -141,7 +141,8 @@ import CLIMAParameters as CP
 # Lastly, let's bring in the bucket model types (from ClimaLand) that we
 # will need access to.
 
-using ClimaLand.Bucket: BucketModel, BucketModelParameters, BulkAlbedoFunction
+using ClimaLand.Bucket:
+    BucketModel, BucketModelParameters, PrescribedBaregroundAlbedo
 using ClimaLand.Domains: coordinates, Column
 using ClimaLand:
     initialize,
@@ -179,16 +180,15 @@ soil_depth = FT(3.5);
 bucket_domain = Column(; zlim = (-soil_depth, FT(0.0)), nelements = 10);
 surface_space = bucket_domain.space.surface
 
-# Define our `BulkAlbedoFunction` model using a constant bareground surface and
+# Define our `PrescribedBaregroundAlbedo` model using a constant bareground surface and
 # snow albedo:
 # The bareground albedo is a function of coordinates, which would be
-# (x,y) on a plane, and (lat,lon) on a sphere. Another albedo
-# option is to specify a `BulkAlbedoStatic` or `BulkAlbedoFunction`,
-# which uses a NetCDF file to read in bareground albedo.
-# These options only applies when coordinates are (lat,lon).
+# (x,y) on a plane, and (lat,lon) on a sphere. It is also an option to supply
+# a netcdf file with the bareground albedo.
 α_bareground_func = (coordinate_point) -> 0.2;
 α_snow = FT(0.8);
-albedo = BulkAlbedoFunction{FT}(α_snow, α_bareground_func, surface_space);
+albedo =
+    PrescribedBaregroundAlbedo{FT}(α_snow, α_bareground_func, surface_space);
 # The critical snow level setting the scale for when we interpolate between
 # snow and surface albedo
 σS_c = FT(0.2);

--- a/experiments/standalone/Bucket/global_bucket_function.jl
+++ b/experiments/standalone/Bucket/global_bucket_function.jl
@@ -25,7 +25,8 @@ import ClimaComms
 import ClimaLand
 import ClimaLand.Parameters as LP
 import CLIMAParameters
-using ClimaLand.Bucket: BucketModel, BucketModelParameters, BulkAlbedoFunction
+using ClimaLand.Bucket:
+    BucketModel, BucketModelParameters, PrescribedBaregroundAlbedo
 using ClimaLand.Domains: coordinates, Column
 using ClimaLand:
     initialize,
@@ -70,7 +71,8 @@ surface_space = bucket_domain.space.surface
 # Set up parameters
 α_bareground_func = (coordinate_point) -> 0.2;
 α_snow = FT(0.8);
-albedo = BulkAlbedoFunction{FT}(α_snow, α_bareground_func, surface_space);
+albedo =
+    PrescribedBaregroundAlbedo{FT}(α_snow, α_bareground_func, surface_space);
 σS_c = FT(0.2);
 W_f = FT(0.15);
 z_0m = FT(1e-2);

--- a/experiments/standalone/Bucket/global_bucket_staticmap.jl
+++ b/experiments/standalone/Bucket/global_bucket_staticmap.jl
@@ -29,7 +29,8 @@ import ClimaComms
 import ClimaLand
 import ClimaLand.Parameters as LP
 import CLIMAParameters
-using ClimaLand.Bucket: BucketModel, BucketModelParameters, BulkAlbedoStatic
+using ClimaLand.Bucket:
+    BucketModel, BucketModelParameters, PrescribedBaregroundAlbedo
 using ClimaLand.Domains: coordinates, Column
 using ClimaLand:
     initialize,
@@ -97,7 +98,8 @@ regrid_dir = joinpath(
 )
 !ispath(regrid_dir) && mkpath(regrid_dir)
 surface_space = bucket_domain.space.surface
-albedo = BulkAlbedoStatic{FT}(regrid_dir, surface_space);
+α_snow = FT(0.8)
+albedo = PrescribedBaregroundAlbedo{FT}(α_snow, regrid_dir, surface_space);
 
 bucket_parameters = BucketModelParameters(
     κ_soil,

--- a/experiments/standalone/Bucket/global_bucket_temporalmap.jl
+++ b/experiments/standalone/Bucket/global_bucket_temporalmap.jl
@@ -27,7 +27,8 @@ import ClimaComms
 import ClimaLand
 import ClimaLand.Parameters as LP
 import CLIMAParameters
-using ClimaLand.Bucket: BucketModel, BucketModelParameters, BulkAlbedoTemporal
+using ClimaLand.Bucket:
+    BucketModel, BucketModelParameters, PrescribedSurfaceAlbedo
 using ClimaLand.Domains: coordinates, Column
 using ClimaLand:
     initialize,
@@ -96,7 +97,7 @@ regrid_dir = joinpath(
 )
 !ispath(regrid_dir) && mkpath(regrid_dir)
 surface_space = bucket_domain.space.surface
-albedo = BulkAlbedoTemporal{FT}(regrid_dir, ref_time, t0, surface_space);
+albedo = PrescribedSurfaceAlbedo{FT}(regrid_dir, ref_time, t0, surface_space);
 
 bucket_parameters = BucketModelParameters(
     κ_soil,

--- a/test/standalone/Bucket/snow_bucket_tests.jl
+++ b/test/standalone/Bucket/snow_bucket_tests.jl
@@ -8,7 +8,7 @@ using ClimaCore
 using ClimaLand.Bucket:
     BucketModel,
     BucketModelParameters,
-    BulkAlbedoFunction,
+    PrescribedBaregroundAlbedo,
     partition_snow_surface_fluxes
 using ClimaLand.Domains: coordinates, Column, HybridBox, SphericalShell
 using ClimaLand:
@@ -88,8 +88,11 @@ for FT in (Float32, Float64)
 
         τc = FT(10.0)
         surface_space = d.space.surface
-        albedo =
-            BulkAlbedoFunction{FT}(α_snow, α_bareground_func, surface_space)
+        albedo = PrescribedBaregroundAlbedo{FT}(
+            α_snow,
+            α_bareground_func,
+            surface_space,
+        )
         bucket_parameters = BucketModelParameters(
             κ_soil,
             ρc_soil,
@@ -211,8 +214,11 @@ for FT in (Float32, Float64)
 
             τc = FT(10.0)
             surface_space = bucket_domains[i].space.surface
-            albedo =
-                BulkAlbedoFunction{FT}(α_snow, α_bareground_func, surface_space)
+            albedo = PrescribedBaregroundAlbedo{FT}(
+                α_snow,
+                α_bareground_func,
+                surface_space,
+            )
             bucket_parameters = BucketModelParameters(
                 κ_soil,
                 ρc_soil,
@@ -330,8 +336,11 @@ for FT in (Float32, Float64)
 
             τc = FT(10.0)
             surface_space = bucket_domains[i].space.surface
-            albedo =
-                BulkAlbedoFunction{FT}(α_snow, α_bareground_func, surface_space)
+            albedo = PrescribedBaregroundAlbedo{FT}(
+                α_snow,
+                α_bareground_func,
+                surface_space,
+            )
             bucket_parameters = BucketModelParameters(
                 κ_soil,
                 ρc_soil,
@@ -449,8 +458,11 @@ for FT in (Float32, Float64)
 
         τc = FT(10.0)
         surface_space = bucket_domains[i].space.surface
-        albedo =
-            BulkAlbedoFunction{FT}(α_snow, α_bareground_func, surface_space)
+        albedo = PrescribedBaregroundAlbedo{FT}(
+            α_snow,
+            α_bareground_func,
+            surface_space,
+        )
         bucket_parameters = BucketModelParameters(
             κ_soil,
             ρc_soil,

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -5,7 +5,8 @@ using Statistics
 
 using ClimaCore
 import CLIMAParameters as CP
-using ClimaLand.Bucket: BucketModel, BucketModelParameters, BulkAlbedoFunction
+using ClimaLand.Bucket:
+    BucketModel, BucketModelParameters, PrescribedBaregroundAlbedo
 using ClimaLand.Domains: coordinates, Column, HybridBox, SphericalShell
 using ClimaLand:
     initialize,
@@ -51,8 +52,11 @@ for FT in (Float32, Float64)
     init_temp(z::FT, value::FT) where {FT} = FT(value)
     for bucket_domain in bucket_domains
         surface_space = bucket_domain.space.surface
-        albedo =
-            BulkAlbedoFunction{FT}(α_snow, α_bareground_func, surface_space)
+        albedo = PrescribedBaregroundAlbedo{FT}(
+            α_snow,
+            α_bareground_func,
+            surface_space,
+        )
 
         @testset "Zero flux tendency, FT = $FT" begin
             # Radiation


### PR DESCRIPTION
## Purpose 
Previously we had three albedo model types (BulkAlbedoFunction, Static, Temporal), but two of them were conceptually the same model (specifying bareground albedo, using a linear combination of snow and bareground albedo as the surface albedo). The bareground albedo was treated as constant in time. The Temporal option specified the entire surface albedo as a function of time.

This PR refactors our interface so that we have two albedo models, `PrescribedBaregroundAlbedo` and `PrescribedSurfaceAlbedo`, and with the former you can either use a function or a static map.


## To-do
review


## Content
-Creates two new albedo model types
-Removes 3 previous albedo model types
-unifies the BulkFunction and BulkStatic into a single model type which stores the bareground albedo field, and does the `map` vs `function` route for creating that based on two different methods & multiple dispatch.
-updates tests, docs, experiments.


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [x] I have read and checked the items on the review checklist.
