### PR TITLE
precribed precip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.txt
 *#
 *~
+*.nc
 *.png
 *.mp4
 *.pdf

--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -64,6 +64,7 @@ ClimaLand.get_drivers
 ## Drivers
 ```@docs
 ClimaLand.PrescribedAtmosphere
+ClimaLand.PrescribedPrecipitation
 ClimaLand.PrescribedRadiativeFluxes
 ClimaLand.CoupledAtmosphere
 ClimaLand.CoupledRadiativeFluxes

--- a/test/shared_utilities/drivers.jl
+++ b/test/shared_utilities/drivers.jl
@@ -16,7 +16,12 @@ FT = Float32
         FT(1);
     )
     pr = ClimaLand.PrescribedRadiativeFluxes(FT, nothing, nothing, nothing)
+    liquid_precip =
+        ClimaLand.TimeVaryingInputs.AnalyticTimeVaryingInput((t) -> -1.0)
+    pp = ClimaLand.PrescribedPrecipitation{FT}(liquid_precip)
     coords = (; surface = [1, 2, 3])
+    @test ClimaLand.initialize_drivers(pp, nothing, coords) ==
+          NamedTuple{(:P_liq,)}((zeros(FT, 3),))
     @test ClimaLand.initialize_drivers(nothing, nothing, coords) == (;)
     pa_keys = (:P_liq, :P_snow, :T, :P, :u, :q, :c_co2)
     pa_vals = ([zeros(FT, 3) for k in pa_keys]...,)
@@ -116,4 +121,12 @@ end
     @test p.drivers.SW_d == [FT(10)]
     @test p.drivers.LW_d == [FT(10)]
     @test p.drivers.θs == [FT(0)]
+
+    liquid_precip =
+        ClimaLand.TimeVaryingInputs.AnalyticTimeVaryingInput((t) -> -1.0)
+    pp = ClimaLand.PrescribedPrecipitation{FT}(liquid_precip)
+    precip_update! = ClimaLand.make_update_drivers(pp, nothing)
+    p = (; drivers = ClimaLand.initialize_drivers(pp, nothing, coords))
+    precip_update!(p, 0.0)
+    @test p.drivers.P_liq == [FT(-1.0)]
 end


### PR DESCRIPTION
## Purpose 
Adds in the PrescribedPrecipitation "driver". This will be necessary for testing global simulations with Richards model + runoff, spatially varying soil properties, etc. prior to testing the full soil+bigleaf model globally.


## To-do

## Content
- Adds new PrescribedPrecipitation type
- Adds unit tests


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [X] I have read and checked the items on the review checklist.
