### PR TITLE
Cleanup richards equation BC specification

### DIFF
--- a/docs/tutorials/standalone/Soil/layered_soil.jl
+++ b/docs/tutorials/standalone/Soil/layered_soil.jl
@@ -95,7 +95,7 @@ function top_flux_function(p, t)
 end
 top_bc = ClimaLand.Soil.FluxBC(top_flux_function)
 bottom_bc = ClimaLand.Soil.FreeDrainage()
-boundary_fluxes = (; top = (water = top_bc,), bottom = (water = bottom_bc,))
+boundary_fluxes = (; top = top_bc, bottom = bottom_bc)
 soil = Soil.RichardsModel{FT}(;
     parameters = params,
     domain = soil_domain,

--- a/docs/tutorials/standalone/Soil/richards_equation.jl
+++ b/docs/tutorials/standalone/Soil/richards_equation.jl
@@ -114,8 +114,7 @@ soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems);
 
 surface_flux = Soil.FluxBC((p, t) -> 0.0)
 bottom_flux = Soil.FluxBC((p, t) -> 0.0)
-boundary_conditions =
-    (; top = (water = surface_flux,), bottom = (water = bottom_flux,));
+boundary_conditions = (; top = surface_flux, bottom = bottom_flux);
 
 # Lastly, in this case we don't have any sources, so we pass an empty tuple:
 sources = ();

--- a/docs/tutorials/standalone/Usage/LSM_single_column_tutorial.jl
+++ b/docs/tutorials/standalone/Usage/LSM_single_column_tutorial.jl
@@ -95,8 +95,7 @@ soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems);
 top_flux_bc = FluxBC((p, t) -> 0.0);
 bot_flux_bc = FluxBC((p, t) -> 0.0);
 sources = ()
-boundary_fluxes =
-    (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
+boundary_fluxes = (; top = top_flux_bc, bottom = bot_flux_bc)
 
 # With this information, we can make our model:
 soil = Soil.RichardsModel{FT}(;

--- a/experiments/standalone/Soil/richards_comparison.jl
+++ b/experiments/standalone/Soil/richards_comparison.jl
@@ -56,8 +56,7 @@ bonan_sand_dataset = ArtifactWrapper(
         top_state_bc = MoistureStateBC((p, t) -> ν - 1e-3)
         bot_flux_bc = FreeDrainage()
         sources = ()
-        boundary_states =
-            (; top = (water = top_state_bc,), bottom = (water = bot_flux_bc,))
+        boundary_states = (; top = top_state_bc, bottom = bot_flux_bc)
         params = Soil.RichardsParameters(;
             ν = ν,
             hydrology_cm = hcm,
@@ -161,8 +160,7 @@ end
         top_state_bc = MoistureStateBC((p, t) -> 0.267)
         bot_flux_bc = FreeDrainage()
         sources = ()
-        boundary_states =
-            (; top = (water = top_state_bc,), bottom = (water = bot_flux_bc,))
+        boundary_states = (; top = top_state_bc, bottom = bot_flux_bc)
 
         params =
             Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)

--- a/src/integrated/pond_soil_model.jl
+++ b/src/integrated/pond_soil_model.jl
@@ -60,8 +60,7 @@ function LandHydrology{FT}(;
 
     sources = ()
     surface_runoff = PrognosticRunoff{FT}(precip)
-    boundary_conditions =
-        (; top = (water = RunoffBC(),), bottom = (water = Soil.FreeDrainage(),))
+    boundary_conditions = (; top = RunoffBC(), bottom = Soil.FreeDrainage())
 
     soil = soil_model_type(;
         boundary_conditions = boundary_conditions,

--- a/src/standalone/Soil/rre.jl
+++ b/src/standalone/Soil/rre.jl
@@ -464,7 +464,7 @@ function ClimaLand.make_update_jacobian(model::RichardsModel{FT}) where {FT}
         Δz_top, Δz_bottom = get_Δz(z)
         ∂T_bc∂YN = ClimaLand.∂tendencyBC∂Y(
             model,
-            model.boundary_conditions.top.water,
+            model.boundary_conditions.top,
             ClimaLand.TopBoundary(),
             Δz_top,
             Y,

--- a/src/standalone/Soil/rre.jl
+++ b/src/standalone/Soil/rre.jl
@@ -85,7 +85,7 @@ function RichardsModel{FT}(;
     sources::Tuple,
     lateral_flow::Bool = true,
 ) where {FT, D}
-    top_bc = boundary_conditions.top.water
+    top_bc = boundary_conditions.top
     if typeof(top_bc) <: RichardsAtmosDrivenFluxBC
         # If the top BC indicates precipitation is driving the model,
         # add baseflow as a sink/source term
@@ -100,8 +100,8 @@ function make_update_boundary_fluxes(model::RichardsModel)
     function update_boundary_fluxes!(p, Y, t)
         z = ClimaCore.Fields.coordinate_field(model.domain.space.subsurface).z
         Δz_top, Δz_bottom = get_Δz(z)
-        p.soil.top_bc.water .= boundary_flux(
-            model.boundary_conditions.top.water,
+        p.soil.top_bc .= boundary_flux(
+            model.boundary_conditions.top,
             TopBoundary(),
             model,
             Δz_top,
@@ -109,8 +109,8 @@ function make_update_boundary_fluxes(model::RichardsModel)
             p,
             t,
         )
-        p.soil.bottom_bc.water .= boundary_flux(
-            model.boundary_conditions.bottom.water,
+        p.soil.bottom_bc .= boundary_flux(
+            model.boundary_conditions.bottom,
             BottomBoundary(),
             model,
             Δz_bottom,
@@ -135,8 +135,8 @@ with that value.
 function ClimaLand.make_compute_imp_tendency(model::RichardsModel)
     function compute_imp_tendency!(dY, Y, p, t)
         z = ClimaCore.Fields.coordinate_field(model.domain.space.subsurface).z
-        top_flux_bc = p.soil.top_bc.water
-        bottom_flux_bc = p.soil.bottom_bc.water
+        top_flux_bc = p.soil.top_bc
+        bottom_flux_bc = p.soil.bottom_bc
 
         interpc2f = Operators.InterpolateC2F()
         gradc2f_water = Operators.GradientC2F()
@@ -479,4 +479,24 @@ function ClimaLand.make_update_jacobian(model::RichardsModel{FT}) where {FT}
 
     end
     return update_jacobian!
+end
+
+"""
+    ClimaLand.get_drivers(model::RichardsModel)
+
+Returns the driver variable symbols for the RichardsModel; these
+depend on the boundary condition type and currently only are required
+for the RichardsAtmosDrivenFluxBC, which is driven by
+a prescribed time and space varying precipitation.
+"""
+function ClimaLand.get_drivers(model::RichardsModel)
+    bc = model.boundary_conditions.top
+    if typeof(bc) <: RichardsAtmosDrivenFluxBC{
+        <:PrescribedPrecipitation,
+        <:AbstractRunoffModel,
+    }
+        return (bc.precip, nothing)
+    else
+        return (nothing, nothing)
+    end
 end

--- a/test/integrated/pond_soil_lsm.jl
+++ b/test/integrated/pond_soil_lsm.jl
@@ -76,7 +76,7 @@ for FT in (Float32, Float64)
             # set cache values to those corresponding with Y(t=0)
             set_initial_cache! = make_set_initial_cache(land)
             set_initial_cache!(p, Y, t)
-            @test p.soil.top_bc.water == p.soil_infiltration
+            @test p.soil.top_bc == p.soil_infiltration
 
             if typeof(lsm_domain) <: ClimaLand.HybridBox
                 # test that the dss buffers are correctly added

--- a/test/shared_utilities/implicit_timestepping/richards_model.jl
+++ b/test/shared_utilities/implicit_timestepping/richards_model.jl
@@ -35,8 +35,7 @@ for FT in (Float32, Float64)
         top_state_bc = MoistureStateBC((p, t) -> ν - 1e-3)
         bot_flux_bc = FreeDrainage()
         sources = ()
-        boundary_states =
-            (; top = (water = top_state_bc,), bottom = (water = bot_flux_bc,))
+        boundary_states = (; top = top_state_bc, bottom = bot_flux_bc)
         params = Soil.RichardsParameters(ν, hcm, K_sat, S_s, θ_r)
 
         for domain in soil_domains
@@ -146,8 +145,7 @@ for FT in (Float32, Float64)
         top_flux_bc = FluxBC((p, t) -> -K_sat)
         bot_flux_bc = FreeDrainage()
         sources = ()
-        boundary_states =
-            (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
+        boundary_states = (; top = top_flux_bc, bottom = bot_flux_bc)
         params = Soil.RichardsParameters(ν, hcm, K_sat, S_s, θ_r)
         for domain in soil_domains
             soil = Soil.RichardsModel{FT}(;

--- a/test/standalone/Soil/soil_test_3d.jl
+++ b/test/standalone/Soil/soil_test_3d.jl
@@ -31,8 +31,7 @@ for FT in (Float32, Float64)
         top_flux_bc = FluxBC((p, t) -> 0.0)
         bot_flux_bc = FluxBC((p, t) -> 0.0)
         sources = ()
-        boundary_fluxes =
-            (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
+        boundary_fluxes = (; top = top_flux_bc, bottom = bot_flux_bc)
         params = Soil.RichardsParameters(;
             ν = ν,
             hydrology_cm = hcm,
@@ -363,8 +362,7 @@ for FT in (Float32, Float64)
         top_flux_bc = FluxBC((p, t) -> K_sat)
         bot_flux_bc = FluxBC((p, t) -> K_sat)
         sources = ()
-        boundary_fluxes =
-            (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
+        boundary_fluxes = (; top = top_flux_bc, bottom = bot_flux_bc)
 
         soil = Soil.RichardsModel{FT}(;
             parameters = parameters,

--- a/test/standalone/Soil/soiltest.jl
+++ b/test/standalone/Soil/soiltest.jl
@@ -26,8 +26,7 @@ for FT in (Float32, Float64)
         top_flux_bc = FluxBC((p, t) -> 0.0)
         bot_flux_bc = FluxBC((p, t) -> 0.0)
         sources = ()
-        boundary_fluxes =
-            (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
+        boundary_fluxes = (; top = top_flux_bc, bottom = bot_flux_bc)
         params = Soil.RichardsParameters(;
             ν = ν,
             hydrology_cm = hcm,


### PR DESCRIPTION
## Purpose 
Simplifies RichardsModel BC specification from a nested named tuple `(top = (;water = BC,), bottom = (;water = BC,))` to a simpler named tuple `(top = = BC, bottom = BC,)`, where `typeof(BC) <: AbstractSoilBC`.

This is cleaner IMO and it proved useful when working with the `RichardsAtmosDrivenFluxBC` (reduced the number of methods I needed to define)


## To-do


## Content
- Change type of `p.soil.top_bc` and `p.soil.bottom_bc` from a NamedTuple to a scalar
- propagate
- I also made a small change to `RichardsAtmosFluxBC` to have it take the new PrescribedPrecipitation type instead of a function (uses the TimeVaryingInput infrastructure, updates via callbacks like all of our drivers).


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [X] I have read and checked the items on the review checklist.
