### PR TITLE
Refactor boundary condition types

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,6 +19,7 @@ tutorials = [
             "standalone/Bucket/coupled_bucket.jl",
         ],
         "Soil modeling" => [
+            "Boundary conditions" => "standalone/Soil/boundary_conditions.jl",
             "Richards Equation" => "standalone/Soil/richards_equation.jl",
             "Energy and Hydrology" => "standalone/Soil/soil_energy_hydrology.jl",
             "Phase Changes" => "standalone/Soil/freezing_front.jl",

--- a/docs/src/APIs/Soil.md
+++ b/docs/src/APIs/Soil.md
@@ -72,16 +72,15 @@ ClimaLand.Soil.soil_surface_infiltration
 ## Soil BC Methods and Types
 
 ```@docs
-ClimaLand.Soil.AbstractSoilBC
 ClimaLand.Soil.MoistureStateBC
-ClimaLand.Soil.FluxBC
+ClimaLand.Soil.HeatFluxBC
+ClimaLand.Soil.WaterFluxBC
 ClimaLand.Soil.TemperatureStateBC
 ClimaLand.Soil.FreeDrainage
 ClimaLand.Soil.RichardsAtmosDrivenFluxBC
 ClimaLand.Soil.AtmosDrivenFluxBC
-ClimaLand.Soil.boundary_vars
-ClimaLand.Soil.boundary_var_domain_names
-ClimaLand.Soil.boundary_var_types
+ClimaLand.Soil.WaterHeatBC
+ClimaLand.Soil.soil_boundary_fluxes!
 ```
 
 ## Soil Source Types

--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -54,6 +54,9 @@ ClimaLand.BottomBoundary
 ClimaLand.boundary_flux
 ClimaLand.diffusive_flux
 ClimaLand.get_Δz
+ClimaLand.boundary_vars
+ClimaLand.boundary_var_domain_names
+ClimaLand.boundary_var_types
 ClimaLand.make_tendency_jacobian
 ClimaLand.make_update_jacobian
 ClimaLand.∂tendencyBC∂Y

--- a/docs/tutorials/integrated/soil_canopy_tutorial.jl
+++ b/docs/tutorials/integrated/soil_canopy_tutorial.jl
@@ -209,8 +209,7 @@ soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
 soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> 0.0);
 soilco2_sources = (MicrobeProduction{FT}(),);
 
-soilco2_boundary_conditions =
-    (; top = (CO2 = soilco2_top_bc,), bottom = (CO2 = soilco2_bot_bc,));
+soilco2_boundary_conditions = (; top = soilco2_top_bc, bottom = soilco2_bot_bc);
 
 soilco2_drivers = Soil.Biogeochemistry.SoilDrivers(
     Soil.Biogeochemistry.PrognosticMet{FT}(),

--- a/docs/tutorials/standalone/Soil/boundary_conditions.jl
+++ b/docs/tutorials/standalone/Soil/boundary_conditions.jl
@@ -1,0 +1,31 @@
+# # Boundary conditions for the soil model
+
+# In general, you must supply two boundary conditions for each PDE being
+# solved. These are passed to the model as a NamedTuple
+# of the form `(; top = top_bc, bottom = bottom_bc)`, where both `top_bc`
+# and `bottom_bc` are of type `ClimaLand.AbstractBC`.
+
+# Flux boundary conditions are always passed as the (scalar)
+# z-component of the flux `f`, i.e. F⃗ = f ẑ.
+
+# # Boundary conditions for Richards equation
+# 1. `FreeDrainage <: AbstractWaterBC`: this only can be used at the bottom of the domain.
+
+# 2. `WaterFluxBC <: AbstractWaterBC`: this accepts a prescribed analytic function of the cache `p` and simulation time `t` which returns the flux value. e.g: `WaterFluxBC((p,t) -> 0.0)`.
+
+# 3. `MoistureStateBC <: AbstractWaterBC`: this accepts a prescribed analytic function of the cache `p` and simulation time `t` which returns the value of `ϑ_l` at the boundary . e.g: `MoistureStateBC((p,t) -> 0.2)`.
+
+# 4. `RichardsAtmosDrivenFluxBC <: AbstractWaterBC`: this requires a single argument of abstract type `AbstractTimeVaryingInput`. Under the hood, this specifies the precipitation as a function of space and time (using data read in from a file, or an analytic function) and applies this a flux BC, optionally accounting for surface/subsurface runoff.
+
+# # Boundary conditions for the soil heat equation
+
+# 1. `HeatFluxBC <: AbstractHeatBC`: this accepts a prescribed analytic function of the cache `p` and simulation time `t` which returns the flux value. e.g: `HeatFluxBC((p,t) -> 0.0)`.
+
+# 2. `TemperatureStateBC <: AbstractHeatBC`: this accepts a prescribed analytic function of the cache `p` and simulation time `t` which returns the value of `T` at the boundary . e.g: `TemperatureStateBC((p,t) -> 273.15)`.
+
+# # Boundary conditions for the soil heat + water equations (EnergyHydrology model)
+# The full soil model requires boundary conditions for both Richards equation and the soil heat equation.
+
+# 1. `WaterHeatBC <: AbstractEnergyHydrologyBC`: In many cases, the two boundary conditions can be treated independently. The `WaterHeatBC` requires a boundary condition of abstract type `AbstractWaterBC` and one of type `AbstractHeatBC`, for example, `top = WaterHeatBC(; water = MoistureBC(ϑ_l(p,t)), heat = TemperatureBC(T(p,t)))`.
+
+# 2. `AtmosDrivenFluxBC <: AbstractEnergyHydrologyBC`: This is an example of a set of boundary conditions for the full soil model which cannot be decomposed into two independent boundary conditions for water and heat. In this case, we compute the turbulent surface fluxes with the atmosphere, obtaining a sensible heat, latent heat, and water vapor flux. We also take into account the net radiation at the surface and any precipitation or runoff. This is the BC type used in most land simulations.

--- a/docs/tutorials/standalone/Soil/freezing_front.jl
+++ b/docs/tutorials/standalone/Soil/freezing_front.jl
@@ -128,7 +128,7 @@ nelems = 20
 soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems);
 
 # Set the boundary conditions:
-zero_flux_bc = FluxBC((p, t) -> 0.0)
+zero_water_flux_bc = WaterFluxBC((p, t) -> 0.0)
 function top_heat_flux(p, t)
     FT = eltype(p.soil.T)
     p_len = ClimaCore.Spaces.nlevels(axes(p.soil.T))
@@ -140,11 +140,14 @@ function bottom_heat_flux(p, t)
     T_c = ClimaCore.Fields.level(p.soil.T, 1)
     return @. FT(-3 * (T_c - 279.85))
 end
-top_heat_flux_bc = FluxBC(top_heat_flux)
-bottom_heat_flux_bc = FluxBC(bottom_heat_flux)
+top_heat_flux_bc = HeatFluxBC(top_heat_flux)
+bottom_heat_flux_bc = HeatFluxBC(bottom_heat_flux)
 boundary_fluxes = (;
-    top = (water = zero_flux_bc, heat = top_heat_flux_bc),
-    bottom = (water = zero_flux_bc, heat = bottom_heat_flux_bc),
+    top = WaterHeatBC(; water = zero_water_flux_bc, heat = top_heat_flux_bc),
+    bottom = WaterHeatBC(;
+        water = zero_water_flux_bc,
+        heat = bottom_heat_flux_bc,
+    ),
 );
 
 # Create the source term instance. Our phase change model requires

--- a/docs/tutorials/standalone/Soil/layered_soil.jl
+++ b/docs/tutorials/standalone/Soil/layered_soil.jl
@@ -93,9 +93,9 @@ params = ClimaLand.Soil.RichardsParameters(;
 function top_flux_function(p, t)
     return -0.0001033
 end
-top_bc = ClimaLand.Soil.FluxBC(top_flux_function)
+top_bc = ClimaLand.Soil.WaterFluxBC(top_flux_function)
 bottom_bc = ClimaLand.Soil.FreeDrainage()
-boundary_fluxes = (; top = (water = top_bc,), bottom = (water = bottom_bc,))
+boundary_fluxes = (; top = top_bc, bottom = bottom_bc)
 soil = Soil.RichardsModel{FT}(;
     parameters = params,
     domain = soil_domain,

--- a/docs/tutorials/standalone/Soil/richards_equation.jl
+++ b/docs/tutorials/standalone/Soil/richards_equation.jl
@@ -106,16 +106,21 @@ zmin = FT(-5)
 nelems = 10
 soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems);
 
-# We also need to specify the boundary conditions. The user can specify two conditions,
-# either at the top or at the bottom, and they can either be either
-# on the state `ϑ_l` or on the flux  `-K∇h`. Flux boundary conditions
+# We also need to specify the boundary conditions. The user must
+# specify two conditions,  at the top and at the bottom of the domain.
+# We currently support two broad types of boundary conditions: boundary
+# conditions on the state ϑ_l = ϑ_l_BC (`MoistureStateBC`) or on the
+# flux (`WaterFluxBC`, `FreeDrainag`e, or `RichardsAtmosDrivenFluxBC`).
+# Flux boundary conditions
 # are passed as the (scalar) z-component of the flux `f`, i.e. F⃗ = f ẑ.
-# In either case, the user must pass a function of the auxiliary variables `p` and time `t`:
-
-surface_flux = Soil.FluxBC((p, t) -> 0.0)
-bottom_flux = Soil.FluxBC((p, t) -> 0.0)
-boundary_conditions =
-    (; top = (water = surface_flux,), bottom = (water = bottom_flux,));
+# The flux BC `RichardsAtmosDrivenFluxBC` is for driving Richards
+# equation with a spatially and temporally varying map of precipitation.
+# `FreeDrainage` is an option only at the bottom of the domain.
+# Here, we set zero flux boundary conditons.
+# WaterFluxBCs require a function of the cache `p` and the simulation time `t`:
+surface_flux = Soil.WaterFluxBC((p, t) -> 0.0)
+bottom_flux = Soil.WaterFluxBC((p, t) -> 0.0)
+boundary_conditions = (; top = surface_flux, bottom = bottom_flux);
 
 # Lastly, in this case we don't have any sources, so we pass an empty tuple:
 sources = ();

--- a/docs/tutorials/standalone/Soil/soil_energy_hydrology.jl
+++ b/docs/tutorials/standalone/Soil/soil_energy_hydrology.jl
@@ -139,24 +139,27 @@ soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems);
 
 # The boundary value problem in this case
 # requires a boundary condition at the top and the bottom of the domain
-# for each equation being solved. These conditions can be on the state (`ϑ_l`
+# for each equation being solved. We support conditions on the state (`ϑ_l`
 # or `T`), or on the fluxes (`-K∇h` or `-κ∇T`). In the case of fluxes,
 # we return the magnitude of the flux, assumed to point along `ẑ`. And, in each case,
 # the boundary conditions are supplied in the form of a function of auxiliary variables
 # `p` and time `t`.
+#  Here we choose flux boundary conditions. The flux boundary condition
+# requires a function of the cache and simulation time which returns
+# the boundary flux.
 
 # Water boundary conditions:
-surface_water_flux = FluxBC((p, t) -> 0.0)
-bottom_water_flux = FluxBC((p, t) -> 0.0);
+surface_water_flux = WaterFluxBC((p, t) -> 0.0)
+bottom_water_flux = WaterFluxBC((p, t) -> 0.0);
 
 # The boundary conditions for the heat equation:
-surface_heat_flux = FluxBC((p, t) -> 0.0)
-bottom_heat_flux = FluxBC((p, t) -> 0.0);
+surface_heat_flux = HeatFluxBC((p, t) -> 0.0)
+bottom_heat_flux = HeatFluxBC((p, t) -> 0.0);
 
-# We wrap up all of those in a NamedTuple:
+# We wrap up all of those in a WaterHeatBC struct:
 boundary_fluxes = (;
-    top = (water = surface_water_flux, heat = surface_heat_flux),
-    bottom = (water = bottom_water_flux, heat = bottom_water_flux),
+    top = WaterHeatBC(; water = surface_water_flux, heat = surface_heat_flux),
+    bottom = WaterHeatBC(; water = bottom_water_flux, heat = bottom_heat_flux),
 );
 
 

--- a/docs/tutorials/standalone/Usage/LSM_single_column_tutorial.jl
+++ b/docs/tutorials/standalone/Usage/LSM_single_column_tutorial.jl
@@ -92,11 +92,10 @@ nelems = 20;
 soil_domain = Column(; zlim = (zmin, zmax), nelements = nelems);
 
 # And boundary conditions and source terms (none currently):
-top_flux_bc = FluxBC((p, t) -> 0.0);
-bot_flux_bc = FluxBC((p, t) -> 0.0);
+top_flux_bc = WaterFluxBC((p, t) -> 0.0);
+bot_flux_bc = WaterFluxBC((p, t) -> 0.0);
 sources = ()
-boundary_fluxes =
-    (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
+boundary_fluxes = (; top = top_flux_bc, bottom = bot_flux_bc)
 
 # With this information, we can make our model:
 soil = Soil.RichardsModel{FT}(;

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -117,8 +117,7 @@ soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
 soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2FluxBC((p, t) -> 0.0) # no flux
 soilco2_sources = (MicrobeProduction{FT}(),)
 
-soilco2_boundary_conditions =
-    (; top = (CO2 = soilco2_top_bc,), bottom = (CO2 = soilco2_bot_bc,))
+soilco2_boundary_conditions = (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
 
 soilco2_drivers = Soil.Biogeochemistry.SoilDrivers(
     Soil.Biogeochemistry.PrognosticMet{FT}(),

--- a/experiments/integrated/ozark/conservation/ozark_conservation.jl
+++ b/experiments/integrated/ozark/conservation/ozark_conservation.jl
@@ -119,7 +119,7 @@ for float_type in (Float32, Float64)
     soilco2_sources = (MicrobeProduction{FT}(),)
 
     soilco2_boundary_conditions =
-        (; top = (CO2 = soilco2_top_bc,), bottom = (CO2 = soilco2_bot_bc,))
+        (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
 
     soilco2_drivers = Soil.Biogeochemistry.SoilDrivers(
         Soil.Biogeochemistry.PrognosticMet{FT}(),

--- a/experiments/standalone/Biogeochemistry/experiment.jl
+++ b/experiments/standalone/Biogeochemistry/experiment.jl
@@ -49,17 +49,17 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
 
     lsm_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
 
-    top_flux_bc_w = Soil.FluxBC((p, t) -> -0.00001)
+    top_flux_bc_w = Soil.WaterFluxBC((p, t) -> -0.00001)
     bot_flux_bc_w = Soil.FreeDrainage()
 
-    top_flux_bc_h = Soil.FluxBC((p, t) -> 0.0)
-    bot_flux_bc_h = Soil.FluxBC((p, t) -> 0.0)
+    top_flux_bc_h = Soil.HeatFluxBC((p, t) -> 0.0)
+    bot_flux_bc_h = Soil.HeatFluxBC((p, t) -> 0.0)
 
 
     sources = (PhaseChange{FT}(Δz),)
     boundary_fluxes = (;
-        top = (water = top_flux_bc_w, heat = bot_flux_bc_h),
-        bottom = (water = bot_flux_bc_w, heat = bot_flux_bc_h),
+        top = WaterHeatBC(; water = top_flux_bc_w, heat = bot_flux_bc_h),
+        bottom = WaterHeatBC(; water = bot_flux_bc_w, heat = bot_flux_bc_h),
     )
     soil_args = (;
         boundary_conditions = boundary_fluxes,
@@ -79,8 +79,7 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
     co2_top_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> 0.0)
     co2_bot_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> 0.0)
     co2_sources = (MicrobeProduction{FT}(),)
-    co2_boundary_conditions =
-        (; top = (CO2 = co2_top_bc,), bottom = (CO2 = co2_bot_bc,))
+    co2_boundary_conditions = (; top = co2_top_bc, bottom = co2_bot_bc)
 
     # Make a PrescribedAtmosphere - we only care about atmos_p though
     precipitation_function = (t) -> 1.0

--- a/experiments/standalone/Soil/evaporation.jl
+++ b/experiments/standalone/Soil/evaporation.jl
@@ -89,9 +89,12 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
         gustiness = gustiness,
     )
     top_bc = ClimaLand.Soil.AtmosDrivenFluxBC(atmos, radiation)
-    zero_flux = FluxBC((p, t) -> 0)
-    boundary_fluxes =
-        (; top = top_bc, bottom = (water = zero_flux, heat = zero_flux))
+    zero_water_flux = WaterFluxBC((p, t) -> 0)
+    zero_heat_flux = HeatFluxBC((p, t) -> 0)
+    boundary_fluxes = (;
+        top = top_bc,
+        bottom = WaterHeatBC(; water = zero_water_flux, heat = zero_heat_flux),
+    )
     params = ClimaLand.Soil.EnergyHydrologyParameters{FT}(;
         ν = ν,
         ν_ss_om = ν_ss_om,

--- a/experiments/standalone/Soil/richards_comparison.jl
+++ b/experiments/standalone/Soil/richards_comparison.jl
@@ -56,8 +56,7 @@ bonan_sand_dataset = ArtifactWrapper(
         top_state_bc = MoistureStateBC((p, t) -> ν - 1e-3)
         bot_flux_bc = FreeDrainage()
         sources = ()
-        boundary_states =
-            (; top = (water = top_state_bc,), bottom = (water = bot_flux_bc,))
+        boundary_states = (; top = top_state_bc, bottom = bot_flux_bc)
         params = Soil.RichardsParameters(;
             ν = ν,
             hydrology_cm = hcm,
@@ -161,8 +160,7 @@ end
         top_state_bc = MoistureStateBC((p, t) -> 0.267)
         bot_flux_bc = FreeDrainage()
         sources = ()
-        boundary_states =
-            (; top = (water = top_state_bc,), bottom = (water = bot_flux_bc,))
+        boundary_states = (; top = top_state_bc, bottom = bot_flux_bc)
 
         params =
             Soil.RichardsParameters{FT, typeof(hcm)}(ν, hcm, K_sat, S_s, θ_r)

--- a/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
@@ -69,7 +69,7 @@ function run_fluxnet(
     soilco2_sources = (MicrobeProduction{FT}(),)
 
     soilco2_boundary_conditions =
-        (; top = (CO2 = soilco2_top_bc,), bottom = (CO2 = soilco2_bot_bc,))
+        (; top = soilco2_top_bc, bottom = CO2 = soilco2_bot_bc)
 
     soilco2_drivers = Soil.Biogeochemistry.SoilDrivers(
         Soil.Biogeochemistry.PrognosticMet{FT}(),

--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -324,7 +324,7 @@ using .Pond
 import .Pond: surface_runoff
 include("standalone/Soil/Soil.jl")
 using .Soil
-import .Soil: soil_boundary_fluxes
+import .Soil: soil_boundary_fluxes!
 import .Soil.Biogeochemistry: soil_temperature, soil_moisture
 include("standalone/Snow/Snow.jl")
 using .Snow

--- a/src/integrated/pond_soil_model.jl
+++ b/src/integrated/pond_soil_model.jl
@@ -60,8 +60,7 @@ function LandHydrology{FT}(;
 
     sources = ()
     surface_runoff = PrognosticRunoff{FT}(precip)
-    boundary_conditions =
-        (; top = (water = RunoffBC(),), bottom = (water = Soil.FreeDrainage(),))
+    boundary_conditions = (; top = RunoffBC(), bottom = Soil.FreeDrainage())
 
     soil = soil_model_type(;
         boundary_conditions = boundary_conditions,
@@ -243,7 +242,7 @@ time,
 ensuring that the infiltration used for the boundary condition of soil
 is also used to compute the runoff for the surface water.
 """
-struct RunoffBC <: Soil.AbstractSoilBC end
+struct RunoffBC <: Soil.AbstractWaterBC end
 
 """
     function ClimaLand.boundary_flux(

--- a/src/shared_utilities/boundary_conditions.jl
+++ b/src/shared_utilities/boundary_conditions.jl
@@ -4,8 +4,16 @@ export boundary_flux,
     TopBoundary,
     BottomBoundary,
     diffusive_flux,
-    get_Δz
+    get_Δz,
+    boundary_var_domain_names,
+    boundary_var_types,
+    boundary_vars
 
+
+### These methods and types are not required for all models. They
+### are only useful for models using ClimaCore's differential operators
+### for solving PDEs. Your model may not need them.
+## Currently, only the soil and soil CO2 models use these.
 """
     AbstractBC
 
@@ -13,6 +21,7 @@ An abstract type for types of boundary conditions, which will include
 prescribed functions of space and time as Dirichlet conditions or
 Neumann conditions, in addition to other 
 convenient conditions.
+
 """
 abstract type AbstractBC end
 
@@ -30,7 +39,7 @@ abstract type AbstractBoundary end
     TopBoundary{} <: AbstractBoundary{}
 
 A simple object which should be passed into a function to
-indicate that we are considering the top boundary of the soil.
+indicate that we are considering the top boundary.
 """
 struct TopBoundary <: AbstractBoundary end
 
@@ -38,9 +47,13 @@ struct TopBoundary <: AbstractBoundary end
     BottomBoundary{} <: AbstractBoundary{}
 
 A simple object which should be passed into a function to
-indicate that we are considering the bottom boundary of the soil.
+indicate that we are considering the bottom boundary.
 """
 struct BottomBoundary <: AbstractBoundary end
+
+
+bc_name(::BottomBoundary) = :bottom_bc
+bc_name(::TopBoundary) = :top_bc
 
 """
     get_Δz(z::ClimaCore.Fields.Field)
@@ -84,3 +97,83 @@ function boundary_flux(
     Δz,
     _...,
 )::ClimaCore.Fields.Field end
+
+
+"""
+    boundary_vars(::AbstractBC , ::ClimaLand.TopBoundary)
+
+The list of symbols for additional variables to add to the
+model auxiliary state, for models solving PDEs, which defaults 
+to adding storage for the top boundary flux fields,
+but which can be extended depending on the type of 
+boundary condition used.
+
+For the Soil and SoilCO2 models - which solve PDEs - the 
+tendency functions and 
+update_boundary_fluxes functions are coded to access the field 
+`:top_bc`  to be present in the model cache, which is why 
+this is the default.  If this is not your (PDE) model's 
+desired behavior, you can extend this function with a new method.
+
+Use this function in the exact same way you would use `auxiliary_vars`.
+"""
+boundary_vars(::AbstractBC, ::ClimaLand.TopBoundary) = (:top_bc,)
+
+"""
+    boundary_vars(::AbstractBC, ::ClimaLand.BottomBoundary)
+
+The list of symbols for additional variables to add to the
+model auxiliary state, for models solving PDEs, which defaults 
+to adding storage for the bottom boundary flux fields,
+but which can be extended depending on the type of 
+boundary condition used.
+
+For the Soil and SoilCO2 models - which solve PDEs - the 
+tendency functions and 
+update_boundary_fluxes functions are coded to access the field 
+`:bottom_bc`  to be present in the model cache, which is why 
+this is the default.  If this is not your (PDE) model's 
+desired behavior, you can extend this function with a new method.
+
+Use this function in the exact same way you would use `auxiliary_vars`.
+"""
+boundary_vars(::AbstractBC, ::ClimaLand.BottomBoundary) = (:bottom_bc,)
+
+"""
+    boundary_var_domain_names(::AbstractBC, ::ClimaLand.AbstractBoundary)
+
+The list of domain names for additional variables to add to the
+model auxiliary state, for models solving PDEs, which defaults 
+to adding storage on the surface domain 
+for the top or bottom boundary flux fields,
+but which can be extended depending on the type of 
+boundary condition used.
+
+Use in conjunction with `boundary_vars`, in the same way you would use
+`auxiliary_var_domain_names`. 
+"""
+boundary_var_domain_names(::AbstractBC, ::ClimaLand.AbstractBoundary) =
+    (:surface,)
+
+"""
+    boundary_var_types(model::AbstractModel{FT}, ::AbstractBC, ::ClimaLand.AbstractBoundary) where {FT}
+
+The list of types for additional variables to add to the
+model auxiliary state, for models solving PDEs, which defaults 
+to adding a scalar variable on the surface domain 
+for the top or bottom boundary flux fields,
+but which can be extended depending on the type of 
+boundary condition used.
+
+Use in conjunction with `boundary_vars`, in the same way you would use
+`auxiliary_var_types`. The use of a scalar is appropriate for
+models with a single PDE; models with multiple PDEs will need to supply
+multiple scalar fields.
+"""
+function boundary_var_types(
+    model::AbstractModel{FT},
+    ::AbstractBC,
+    ::ClimaLand.AbstractBoundary,
+) where {FT}
+    (FT,)
+end

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -236,7 +236,7 @@ function make_update_boundary_fluxes(model::EnergyHydrology)
     function update_boundary_fluxes!(p, Y, t)
         z = ClimaCore.Fields.coordinate_field(model.domain.space.subsurface).z
         Δz_top, Δz_bottom = get_Δz(z)
-        p.soil.top_bc .= soil_boundary_fluxes(
+        soil_boundary_fluxes!(
             model.boundary_conditions.top,
             ClimaLand.TopBoundary(),
             model,
@@ -246,7 +246,7 @@ function make_update_boundary_fluxes(model::EnergyHydrology)
             t,
         )
 
-        p.soil.bottom_bc .= soil_boundary_fluxes(
+        soil_boundary_fluxes!(
             model.boundary_conditions.bottom,
             ClimaLand.BottomBoundary(),
             model,

--- a/test/integrated/pond_soil_lsm.jl
+++ b/test/integrated/pond_soil_lsm.jl
@@ -76,7 +76,7 @@ for FT in (Float32, Float64)
             # set cache values to those corresponding with Y(t=0)
             set_initial_cache! = make_set_initial_cache(land)
             set_initial_cache!(p, Y, t)
-            @test p.soil.top_bc.water == p.soil_infiltration
+            @test p.soil.top_bc == p.soil_infiltration
 
             if typeof(lsm_domain) <: ClimaLand.HybridBox
                 # test that the dss buffers are correctly added

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -1,5 +1,6 @@
 using Test
 using ClimaCore
+import ClimaParams
 using ClimaLand
 using ClimaLand.Domains: Column
 using ClimaLand.Soil
@@ -38,11 +39,18 @@ for FT in (Float32, Float64)
         zmin = FT(-1)
         nelems = 20
         lsm_domain = Column(; zlim = (zmin, zmax), nelements = nelems)
-        zero_flux_bc = Soil.FluxBC((p, t) -> 0.0)
-        sources = () # PhaseChange
+        zero_water_flux_bc = Soil.WaterFluxBC((p, t) -> 0.0)
+        zero_heat_flux_bc = Soil.HeatFluxBC((p, t) -> 0.0)
+        sources = ()
         boundary_fluxes = (;
-            top = (water = zero_flux_bc, heat = zero_flux_bc),
-            bottom = (water = zero_flux_bc, heat = zero_flux_bc),
+            top = WaterHeatBC(;
+                water = zero_water_flux_bc,
+                heat = zero_heat_flux_bc,
+            ),
+            bottom = WaterHeatBC(;
+                water = zero_water_flux_bc,
+                heat = zero_heat_flux_bc,
+            ),
         )
         soil_args = (;
             boundary_conditions = boundary_fluxes,
@@ -61,8 +69,7 @@ for FT in (Float32, Float64)
         co2_top_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> C)
         co2_bot_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> C)
         co2_sources = ()
-        co2_boundary_conditions =
-            (; (top = (; CO2 = co2_top_bc)), (bottom = (; CO2 = co2_bot_bc)))
+        co2_boundary_conditions = (; top = co2_top_bc, bottom = co2_bot_bc)
 
         # Make a PrescribedAtmosphere - we only care about atmos_p though
         precipitation_function = (t) -> 1.0

--- a/test/shared_utilities/implicit_timestepping/richards_model.jl
+++ b/test/shared_utilities/implicit_timestepping/richards_model.jl
@@ -35,8 +35,7 @@ for FT in (Float32, Float64)
         top_state_bc = MoistureStateBC((p, t) -> ν - 1e-3)
         bot_flux_bc = FreeDrainage()
         sources = ()
-        boundary_states =
-            (; top = (water = top_state_bc,), bottom = (water = bot_flux_bc,))
+        boundary_states = (; top = top_state_bc, bottom = bot_flux_bc)
         params = Soil.RichardsParameters(ν, hcm, K_sat, S_s, θ_r)
 
         for domain in soil_domains
@@ -143,11 +142,10 @@ for FT in (Float32, Float64)
                 npolynomial = 3,
             ),
         ]
-        top_flux_bc = FluxBC((p, t) -> -K_sat)
+        top_flux_bc = WaterFluxBC((p, t) -> -K_sat)
         bot_flux_bc = FreeDrainage()
         sources = ()
-        boundary_states =
-            (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
+        boundary_states = (; top = top_flux_bc, bottom = bot_flux_bc)
         params = Soil.RichardsParameters(ν, hcm, K_sat, S_s, θ_r)
         for domain in soil_domains
             soil = Soil.RichardsModel{FT}(;

--- a/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
+++ b/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
@@ -30,8 +30,7 @@ for FT in (Float32, Float64)
         top_bc = SoilCO2StateBC((p, t) -> 3000.0)
         bot_bc = SoilCO2StateBC((p, t) -> 100.0)
         sources = (MicrobeProduction{FT}(),)
-        boundary_conditions =
-            (; top = (CO2 = top_bc,), bottom = (CO2 = bot_bc,))
+        boundary_conditions = (; top = top_bc, bottom = bot_bc)
 
         # Make a PrescribedAtmosphere - we only care about atmos_p though
         precipitation_function = (t) -> 1.0
@@ -101,8 +100,7 @@ for FT in (Float32, Float64)
         top_bc = SoilCO2StateBC((p, t) -> C)
         bot_bc = SoilCO2StateBC((p, t) -> C)
         sources = ()
-        boundary_conditions =
-            (; top = (CO2 = top_bc,), bottom = (CO2 = bot_bc,))
+        boundary_conditions = (; top = top_bc, bottom = bot_bc)
 
         # Make a PrescribedAtmosphere - we only care about atmos_p though
         precipitation_function = (t) -> 1.0

--- a/test/standalone/Soil/soil_test_3d.jl
+++ b/test/standalone/Soil/soil_test_3d.jl
@@ -28,11 +28,10 @@ for FT in (Float32, Float64)
             nelements = (100, 2, 100),
             npolynomial = 3,
         )
-        top_flux_bc = FluxBC((p, t) -> 0.0)
-        bot_flux_bc = FluxBC((p, t) -> 0.0)
+        top_flux_bc = WaterFluxBC((p, t) -> 0.0)
+        bot_flux_bc = WaterFluxBC((p, t) -> 0.0)
         sources = ()
-        boundary_fluxes =
-            (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
+        boundary_fluxes = (; top = top_flux_bc, bottom = bot_flux_bc)
         params = Soil.RichardsParameters(;
             ν = ν,
             hydrology_cm = hcm,
@@ -267,11 +266,17 @@ for FT in (Float32, Float64)
             npolynomial = 3,
         )
 
-        top_flux_bc = FluxBC((p, t) -> 0.0)
-        bot_flux_bc = FluxBC((p, t) -> 0.0)
+        zero_water_flux_bc = WaterFluxBC((p, t) -> 0.0)
+        zero_heat_flux_bc = HeatFluxBC((p, t) -> 0.0)
         boundary_fluxes = (;
-            top = (water = top_flux_bc, heat = top_flux_bc),
-            bottom = (water = bot_flux_bc, heat = bot_flux_bc),
+            top = WaterHeatBC(;
+                water = zero_water_flux_bc,
+                heat = zero_heat_flux_bc,
+            ),
+            bottom = WaterHeatBC(;
+                water = zero_water_flux_bc,
+                heat = zero_heat_flux_bc,
+            ),
         )
         sources = ()
 
@@ -360,11 +365,10 @@ for FT in (Float32, Float64)
             nelements = (1, 30),
             npolynomial = 3,
         )
-        top_flux_bc = FluxBC((p, t) -> K_sat)
-        bot_flux_bc = FluxBC((p, t) -> K_sat)
+        top_flux_bc = WaterFluxBC((p, t) -> K_sat)
+        bot_flux_bc = WaterFluxBC((p, t) -> K_sat)
         sources = ()
-        boundary_fluxes =
-            (; top = (water = top_flux_bc,), bottom = (water = bot_flux_bc,))
+        boundary_fluxes = (; top = top_flux_bc, bottom = bot_flux_bc)
 
         soil = Soil.RichardsModel{FT}(;
             parameters = parameters,


### PR DESCRIPTION
## Purpose 
Refactor boundary condition types.

What we had in place was a little confusing (you could either pass a NamedTuple with values of type "AbstractSoilBC" or something of type "AbstractSoilBC" as your boundary condition), had very little unification between how we handled BC between soil +soil co2, and had nested named tuples for models with only a single boundary condition needed.

I was also finding it very hard to use the RichardsAtmosDrivenBC in PR #511 due to the design.




After this PR, we would have:
Instead of:
```
boundary_fluxes = (top = RichardsAtmosDrivenFluxBC(), bottom = (water = WaterFluxBC(),))
```
you now have 
```
boundary_fluxes = (top = RichardsAtmosDrivenFluxBC(), bottom = WaterFluxBC()).
```
instead of
```
boundary_fluxes = (top = (water = MoistureBC(), bottom = (water = WaterFluxBC(),))
```
you now have
```
boundary_fluxes = (top = MoistureBC(), bottom = WaterFluxBC())
```
instead of :
```
boundary_fluxes = (top = (water = MoistureBC(), heat = TemperatureBC()), bottom = (water = WaterFluxBC(), heat = HeatFluxBC(),))
```
you now have:
```
boundary_fluxes = (top = WaterHeatBC(; water = MoistureBC(), heat = TemperatureBC()),
                   bottom = WaterHeatBC(; water = WaterFluxBC(), heat = HeatFluxBC()))
```
instead of
```
boundary_fluxes = (top = AtmosDrivenFluxBC(), bottom = (water = WaterFluxBC(), heat = HeatFluxBC(),)) 
```

now, we would have
```
boundary_fluxes = (top = AtmosDrivenFluxBC(), bottom = WaterHeatBC(; water = WaterFluxBC(), heat = HeatFluxBC())) 
```
## To-do
review

## Content
This PR refactors the code so that 
1. You can make types of `AbstractWaterBC` which can be used for RichardsModel or for the water equation in the EnergyHydrologyModel. All of our old BC types are now subtyped from this.
2. You can also define types of `AbstractHeatBC` for the soil heat equation. All of our old BC types are now subtyped from this.
3. To create BC for the EnergyHydrologyModel, you can combined an AbstractHeat and AbstractWater BC if these are treated independently, or use a BC that indicates that the water and heat BC are set in way that depend on each other. The former is a `WaterHeatBC <: AbstractEnergyHydrologyBC`, the second has one example currently: `AtmosDrivenFluxBC <: AbstractEnergyHydrologyBC`. (change: introduce WaterHeatBC struct instead of using a NamedTuple, introduce abstract type)
4. The SoilCO2 model follows the same conventions as RichardsModel (single equation, single BC).
5. Since boundary condition types may require additional variables, all PDE models now use and extend the `boundary_var` methods instead of this being done haphazardly/only for soil.
6. I removed the nested named tuples with redundant information for soil co2 and richards equation. This means we specify BC like `top = WaterFluxBC()` and not `top = (;water = WaterFluxBC()))`
7. `soil_boundary_fluxes` now updates in place (easy change to make but not directly related to this PR)


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [x] I have read and checked the items on the review checklist.
