### PR TITLE
Refactor Snow, Medlyn, TwoStream, BeerLambert parameter structs

### DIFF
--- a/docs/tutorials/integrated/soil_canopy_tutorial.jl
+++ b/docs/tutorials/integrated/soil_canopy_tutorial.jl
@@ -225,25 +225,18 @@ autotrophic_respiration_args =
     (; parameters = AutotrophicRespirationParameters(FT))
 
 radiative_transfer_args = (;
-    parameters = TwoStreamParameters{FT}(;
-        ld = FT(0.5),
-        α_PAR_leaf = FT(0.1),
-        α_NIR_leaf = FT(0.45),
-        τ_PAR_leaf = FT(0.05),
-        τ_NIR_leaf = FT(0.25),
-        Ω = FT(0.69),
-        λ_γ_PAR = FT(5e-7),
-        λ_γ_NIR = FT(1.65e-6),
+    parameters = TwoStreamParameters(
+        FT;
+        ld = 0.5,
+        α_PAR_leaf = 0.1,
+        α_NIR_leaf = 0.45,
+        τ_PAR_leaf = 0.05,
+        τ_NIR_leaf = 0.25,
+        Ω = 0.69,
     )
 )
 
-conductance_args = (;
-    parameters = MedlynConductanceParameters{FT}(;
-        g1 = FT(141),
-        Drel = FT(1.6),
-        g0 = FT(1e-4),
-    )
-)
+conductance_args = (; parameters = MedlynConductanceParameters(FT; g1 = 141))
 
 photosynthesis_args =
     (; parameters = FarquharParameters(FT, Canopy.C3(); Vcmax25 = FT(5e-5)));

--- a/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -169,8 +169,7 @@ rt_params = TwoStreamParameters(
 rt_model = TwoStreamModel{FT}(rt_params);
 
 # Arguments for conductance model:
-
-cond_params = MedlynConductanceParameters(FT; g1 = 141.0)
+cond_params = MedlynConductanceParameters(FT; g1 = FT(141.0))
 
 stomatal_model = MedlynConductanceModel{FT}(cond_params);
 

--- a/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -170,7 +170,7 @@ rt_model = TwoStreamModel{FT}(rt_params);
 
 # Arguments for conductance model:
 
-cond_params = MedlynConductanceParameters(FT; g1 = 141)
+cond_params = MedlynConductanceParameters(FT; g1 = 141.0)
 
 stomatal_model = MedlynConductanceModel{FT}(cond_params);
 

--- a/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -154,7 +154,8 @@ soil_driver = PrescribedSoil(
 # Now, setup the canopy model by component.
 # Provide arguments to each component, beginning with radiative transfer:
 
-rt_params = TwoStreamParameters{FT}(;
+rt_params = TwoStreamParameters(
+    FT;
     ld = FT(0.5),
     α_PAR_leaf = FT(0.1),
     α_NIR_leaf = FT(0.45),
@@ -169,11 +170,7 @@ rt_model = TwoStreamModel{FT}(rt_params);
 
 # Arguments for conductance model:
 
-cond_params = MedlynConductanceParameters{FT}(;
-    g1 = FT(141),
-    Drel = FT(1.6),
-    g0 = FT(1e-4),
-)
+cond_params = MedlynConductanceParameters(FT; g1 = 141)
 
 stomatal_model = MedlynConductanceModel{FT}(cond_params);
 

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -177,26 +177,18 @@ autotrophic_respiration_args =
     (; parameters = AutotrophicRespirationParameters(FT))
 # Set up radiative transfer
 radiative_transfer_args = (;
-    parameters = TwoStreamParameters{FT}(;
-        Ω = Ω,
-        ld = ld,
-        α_PAR_leaf = α_PAR_leaf,
-        λ_γ_PAR = λ_γ_PAR,
-        λ_γ_NIR = λ_γ_NIR,
-        τ_PAR_leaf = τ_PAR_leaf,
-        α_NIR_leaf = α_NIR_leaf,
-        τ_NIR_leaf = τ_NIR_leaf,
-        ϵ_canopy = ϵ_canopy,
+    parameters = TwoStreamParameters(
+        FT;
+        Ω,
+        ld,
+        α_PAR_leaf,
+        τ_PAR_leaf,
+        α_NIR_leaf,
+        τ_NIR_leaf,
     )
 )
 # Set up conductance
-conductance_args = (;
-    parameters = MedlynConductanceParameters{FT}(;
-        g1 = g1,
-        Drel = Drel,
-        g0 = g0,
-    )
-)
+conductance_args = (; parameters = MedlynConductanceParameters(FT; g1))
 # Set up photosynthesis
 # Set up photosynthesis
 photosynthesis_args =

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -137,26 +137,18 @@ autotrophic_respiration_args =
     (; parameters = AutotrophicRespirationParameters(FT))
 # Set up radiative transfer
 radiative_transfer_args = (;
-    parameters = TwoStreamParameters{FT}(;
-        Ω = Ω,
-        ld = ld,
-        α_PAR_leaf = α_PAR_leaf,
-        λ_γ_PAR = λ_γ_PAR,
-        λ_γ_NIR = λ_γ_NIR,
-        τ_PAR_leaf = τ_PAR_leaf,
-        α_NIR_leaf = α_NIR_leaf,
-        τ_NIR_leaf = τ_NIR_leaf,
-        ϵ_canopy = ϵ_canopy,
+    parameters = TwoStreamParameters(
+        FT;
+        Ω,
+        ld,
+        α_PAR_leaf,
+        τ_PAR_leaf,
+        α_NIR_leaf,
+        τ_NIR_leaf,
     )
 )
 # Set up conductance
-conductance_args = (;
-    parameters = MedlynConductanceParameters{FT}(;
-        g1 = g1,
-        Drel = Drel,
-        g0 = g0,
-    )
-)
+conductance_args = (; parameters = MedlynConductanceParameters(FT; g1))
 # Set up photosynthesis
 photosynthesis_args =
     (; parameters = FarquharParameters(FT, Canopy.C3(); Vcmax25 = Vcmax25))

--- a/experiments/integrated/ozark/conservation/ozark_conservation.jl
+++ b/experiments/integrated/ozark/conservation/ozark_conservation.jl
@@ -138,25 +138,18 @@ for float_type in (Float32, Float64)
         (; parameters = AutotrophicRespirationParameters(FT))
     # Set up radiative transfer
     radiative_transfer_args = (;
-        parameters = TwoStreamParameters{FT}(;
-            Ω = Ω,
-            ld = ld,
-            α_PAR_leaf = α_PAR_leaf,
-            λ_γ_PAR = λ_γ_PAR,
-            λ_γ_NIR = λ_γ_NIR,
-            τ_PAR_leaf = τ_PAR_leaf,
-            α_NIR_leaf = α_NIR_leaf,
-            τ_NIR_leaf = τ_NIR_leaf,
+        parameters = TwoStreamParameters(
+            FT;
+            Ω,
+            ld,
+            α_PAR_leaf,
+            τ_PAR_leaf,
+            α_NIR_leaf,
+            τ_NIR_leaf,
         )
     )
     # Set up conductance
-    conductance_args = (;
-        parameters = MedlynConductanceParameters{FT}(;
-            g1 = g1,
-            Drel = Drel,
-            g0 = g0,
-        )
-    )
+    conductance_args = (; parameters = MedlynConductanceParameters(FT; g1))
     # Set up photosynthesis
     photosynthesis_args =
         (; parameters = FarquharParameters(FT, Canopy.C3(); Vcmax25 = Vcmax25))

--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -656,7 +656,7 @@ function SnowParameters(toml_dict::CP.AbstractTOMLDict, Δt; kwargs...)
 
     parameters = CP.get_parameter_values(toml_dict, name_map, "Land")
     FT = CP.float_type(toml_dict)
-    earth_param_set = LandParameters(toml_dict)
+    earth_param_set = LP.LandParameters(toml_dict)
     PSE = typeof(earth_param_set)
     return SnowParameters{FT, PSE}(;
         Δt,

--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -15,6 +15,9 @@ import ClimaLand.Soil.EnergyHydrologyParameters
 import ClimaLand.Canopy.AutotrophicRespirationParameters
 import ClimaLand.Canopy.FarquharParameters
 import ClimaLand.Canopy.OptimalityFarquharParameters
+import ClimaLand.Canopy.BeerLambertParameters
+import ClimaLand.Canopy.TwoStreamParameters
+import ClimaLand.Snow.SnowParameters
 import ClimaLand.Bucket.BucketModelParameters
 import ClimaLand.Soil.Biogeochemistry.SoilCO2ModelParameters
 
@@ -489,6 +492,175 @@ function SoilCO2ModelParameters(toml_dict::CP.AbstractTOMLDict; kwargs...)
         earth_param_set,
         θ_a100,
         b,
+        parameters...,
+        kwargs...,
+    )
+end
+
+"""
+    function MedlynConductanceParameters(FT::AbstractFloat;
+        g1 = 790,
+        kwargs...
+    )
+    function MedlynConductanceParameters(toml_dict;
+        g1 = 790,
+        kwargs...
+    )
+
+Floating-point and toml dict based constructor supplying default values
+for the MedlynConductanceParameters struct.
+Additional parameter values can be directly set via kwargs.
+"""
+MedlynConductanceParameters(::Type{FT}; kwargs...) where {FT <: AbstractFloat} =
+    MedlynConductanceParameters(CP.create_toml_dict(FT); kwargs...)
+
+function MedlynConductanceParameters(
+    toml_dict::CP.AbstractTOMLDict;
+    g1 = 790,
+    kwargs...,
+)
+    name_map = (;
+        :relative_diffusivity_of_water_vapor => :Drel,
+        :min_stomatal_conductance => :g0,
+    )
+
+    parameters = CP.get_parameter_values(toml_dict, name_map, "Land")
+    FT = CP.float_type(toml_dict)
+    return MedlynConductanceParameters{FT}(; g1, parameters..., kwargs...)
+end
+
+"""
+    function TwoStreamParameters(FT::AbstractFloat;
+        ld = 0.5,
+        α_PAR_leaf = 0.3,
+        τ_PAR_leaf = 0.2,
+        α_NIR_leaf = 0.4,
+        τ_NIR_leaf = 0.25,
+        Ω = 1,
+        n_layers = UInt64(20),
+        kwargs...
+    )
+    function TwoStreamParameters(toml_dict;
+        ld = 0.5,
+        α_PAR_leaf = 0.3,
+        τ_PAR_leaf = 0.2,
+        α_NIR_leaf = 0.4,
+        τ_NIR_leaf = 0.25,
+        Ω = 1,
+        n_layers = UInt64(20),
+        kwargs...
+    )
+
+Floating-point and toml dict based constructor supplying default values
+for the TwoStreamParameters struct. Additional parameter values can be directly set via kwargs.
+"""
+TwoStreamParameters(::Type{FT}; kwargs...) where {FT <: AbstractFloat} =
+    TwoStreamParameters(CP.create_toml_dict(FT); kwargs...)
+
+function TwoStreamParameters(
+    toml_dict::CP.AbstractTOMLDict;
+    ld = 0.5,
+    α_PAR_leaf = 0.3,
+    τ_PAR_leaf = 0.2,
+    α_NIR_leaf = 0.4,
+    τ_NIR_leaf = 0.25,
+    Ω = 1,
+    n_layers = UInt64(20),
+    kwargs...,
+)
+    name_map = (;
+        :wavelength_per_PAR_photon => :λ_γ_PAR,
+        :wavelength_per_NIR_photon => :λ_γ_NIR,
+        :canopy_emissivity => :ϵ_canopy,
+    )
+
+    parameters = CP.get_parameter_values(toml_dict, name_map, "Land")
+    FT = CP.float_type(toml_dict)
+    return TwoStreamParameters{FT}(;
+        ld,
+        α_PAR_leaf,
+        τ_PAR_leaf,
+        α_NIR_leaf,
+        τ_NIR_leaf,
+        Ω,
+        n_layers,
+        parameters...,
+        kwargs...,
+    )
+end
+
+"""
+    function BeerLambertParameters(FT::AbstractFloat;
+        ld = 0.5,
+        α_PAR_leaf = 0.1,
+        α_NIR_leaf = 0.4,
+        Ω = 1,
+        kwargs...
+    )
+    function BeerLambertParameters(toml_dict;
+        ld = 0.5,
+        α_PAR_leaf = 0.1,
+        α_NIR_leaf = 0.4,
+        Ω = 1,
+        kwargs...
+    )
+
+Floating-point and toml dict based constructor supplying default values
+for the BeerLambertParameters struct. Additional parameter values can be directly set via kwargs.
+"""
+BeerLambertParameters(::Type{FT}; kwargs...) where {FT <: AbstractFloat} =
+    BeerLambertParameters(CP.create_toml_dict(FT); kwargs...)
+
+function BeerLambertParameters(
+    toml_dict::CP.AbstractTOMLDict;
+    ld = 0.5,
+    α_PAR_leaf = 0.1,
+    α_NIR_leaf = 0.4,
+    Ω = 1,
+    kwargs...,
+)
+    name_map = (;
+        :wavelength_per_PAR_photon => :λ_γ_PAR,
+        :wavelength_per_NIR_photon => :λ_γ_NIR,
+        :canopy_emissivity => :ϵ_canopy,
+    )
+
+    parameters = CP.get_parameter_values(toml_dict, name_map, "Land")
+    FT = CP.float_type(toml_dict)
+    return BeerLambertParameters{FT}(;
+        ld,
+        α_PAR_leaf,
+        α_NIR_leaf,
+        Ω,
+        parameters...,
+        kwargs...,
+    )
+end
+
+
+SnowParameters(::Type{FT}, Δt; kwargs...) where {FT <: AbstractFloat} =
+    SnowParameters(CP.create_toml_dict(FT), Δt; kwargs...)
+
+function SnowParameters(toml_dict::CP.AbstractTOMLDict, Δt; kwargs...)
+    name_map = (;
+        :snow_momentum_roughness_length => :z_0m,
+        :snow_scalar_roughness_length => :z_0b,
+        :thermal_conductivity_of_water_ice => :κ_ice,
+        :snow_density => :ρ_snow,
+        :snow_albedo => :α_snow,
+        :snow_emissivity => :ϵ_snow,
+        :holding_capacity_of_water_in_snow => :θ_r,
+        :wet_snow_hydraulic_conductivity => :Ksat,
+        :snow_cover_fraction_crit_threshold => :fS_c,
+    )
+
+    parameters = CP.get_parameter_values(toml_dict, name_map, "Land")
+    FT = CP.float_type(toml_dict)
+    earth_param_set = LandParameters(toml_dict)
+    PSE = typeof(earth_param_set)
+    return SnowParameters{FT, PSE}(;
+        Δt,
+        earth_param_set,
         parameters...,
         kwargs...,
     )

--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -15,6 +15,7 @@ import ClimaLand.Soil.EnergyHydrologyParameters
 import ClimaLand.Canopy.AutotrophicRespirationParameters
 import ClimaLand.Canopy.FarquharParameters
 import ClimaLand.Canopy.OptimalityFarquharParameters
+import ClimaLand.Canopy.MedlynConductanceParameters
 import ClimaLand.Canopy.BeerLambertParameters
 import ClimaLand.Canopy.TwoStreamParameters
 import ClimaLand.Snow.SnowParameters

--- a/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
@@ -111,7 +111,8 @@ function run_fluxnet(
     )
     # Set up radiative transfer
     radiative_transfer_args = (;
-        parameters = TwoStreamParameters{FT}(;
+        parameters = TwoStreamParameters(
+            FT;
             Ω = params.radiative_transfer.Ω,
             ld = params.radiative_transfer.ld,
             α_PAR_leaf = params.radiative_transfer.α_PAR_leaf,
@@ -126,7 +127,8 @@ function run_fluxnet(
     )
     # Set up conductance
     conductance_args = (;
-        parameters = MedlynConductanceParameters{FT}(;
+        parameters = MedlynConductanceParameters(
+            FT;
             g1 = params.conductance.g1,
             Drel = params.conductance.Drel,
             g0 = params.conductance.g0,

--- a/src/standalone/Snow/Snow.jl
+++ b/src/standalone/Snow/Snow.jl
@@ -9,7 +9,7 @@ export SnowParameters
 A struct for storing parameters of the `SnowModel`.
 $(DocStringExtensions.FIELDS)
 """
-struct SnowParameters{FT <: AbstractFloat, PSE}
+Base.@kwdef struct SnowParameters{FT <: AbstractFloat, PSE}
     "Density of snow (kg/m^3)"
     ρ_snow::FT
     "Roughness length over snow for momentum (m)"
@@ -33,51 +33,6 @@ struct SnowParameters{FT <: AbstractFloat, PSE}
     "Clima-wide parameters"
     earth_param_set::PSE
 end
-
-"""
-   SnowParameters{FT}(Δt;
-                      ρ_snow = FT(200),
-                      z_0m = FT(0.0024),
-                      z_0b = FT(0.00024),
-                      α_snow = FT(0.8),
-                      ϵ_snow = FT(0.99),
-                      θ_r = FT(0.08),
-                      Ksat = FT(1e-3),
-                      fS_c = FT(0.2),
-                      κ_ice = FT(2.21),
-                      earth_param_set::PSE) where {FT, PSE}
-
-An outer constructor for `SnowParameters` which supplies defaults for
-all arguments but `earth_param_set`.
-"""
-function SnowParameters{FT}(
-    Δt;
-    ρ_snow = FT(200),
-    z_0m = FT(0.0024),
-    z_0b = FT(0.00024),
-    α_snow = FT(0.8),
-    ϵ_snow = FT(0.99),
-    θ_r = FT(0.08),
-    Ksat = FT(1e-3),
-    fS_c = FT(0.2),
-    κ_ice = FT(2.21),
-    earth_param_set::PSE,
-) where {FT <: AbstractFloat, PSE}
-    return SnowParameters{FT, PSE}(
-        ρ_snow,
-        z_0m,
-        z_0b,
-        α_snow,
-        ϵ_snow,
-        θ_r,
-        Ksat,
-        fS_c,
-        κ_ice,
-        Δt,
-        earth_param_set,
-    )
-end
-
 
 include("./snow_parameterizations.jl")
 

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -14,7 +14,7 @@ abstract type AbstractRadiationModel{FT} <: AbstractCanopyComponent{FT} end
 The required parameters for the Beer-Lambert radiative transfer model.
 $(DocStringExtensions.FIELDS)
 """
-struct BeerLambertParameters{FT <: AbstractFloat}
+Base.@kwdef struct BeerLambertParameters{FT <: AbstractFloat}
     "Leaf angle distribution function (unitless)"
     ld::FT
     "PAR leaf reflectance (unitless)"
@@ -29,39 +29,6 @@ struct BeerLambertParameters{FT <: AbstractFloat}
     λ_γ_PAR::FT
     "Typical wavelength per NIR photon (m)"
     λ_γ_NIR::FT
-end
-
-"""
-    function BeerLambertParameters{FT}(;
-        ld = FT(0.5),
-        α_PAR_leaf = FT(0.1),
-        α_NIR_leaf = FT(0.4),
-        ϵ_canopy = FT(0.98),
-        Ω = FT(1),
-        λ_γ_PAR = FT(5e-7),
-        λ_γ_NIR = FT(1.65e-6),
-    ) where {FT}
-
-A constructor supplying default values for the BeerLambertParameters struct.
-        """
-function BeerLambertParameters{FT}(;
-    ld = FT(0.5),
-    α_PAR_leaf = FT(0.1),
-    α_NIR_leaf = FT(0.4),
-    ϵ_canopy = FT(0.98),
-    Ω = FT(1),
-    λ_γ_PAR = FT(5e-7),
-    λ_γ_NIR = FT(1.65e-6),
-) where {FT}
-    return BeerLambertParameters{FT}(
-        ld,
-        α_PAR_leaf,
-        α_NIR_leaf,
-        ϵ_canopy,
-        Ω,
-        λ_γ_PAR,
-        λ_γ_NIR,
-    )
 end
 
 Base.eltype(::BeerLambertParameters{FT}) where {FT} = FT
@@ -83,7 +50,7 @@ end
 The required parameters for the two-stream radiative transfer model.
 $(DocStringExtensions.FIELDS)
 """
-struct TwoStreamParameters{FT <: AbstractFloat}
+Base.@kwdef struct TwoStreamParameters{FT <: AbstractFloat}
     "Leaf angle distribution function (unitless)"
     ld::FT
     "PAR leaf reflectance (unitless)"
@@ -124,32 +91,7 @@ end
     ) where {FT}
 
 A constructor supplying default values for the TwoStreamParameters struct.
-    """
-function TwoStreamParameters{FT}(;
-    ld = FT(0.5),
-    α_PAR_leaf = FT(0.3),
-    τ_PAR_leaf = FT(0.2),
-    α_NIR_leaf = FT(0.4),
-    τ_NIR_leaf = FT(0.25),
-    ϵ_canopy = FT(0.98),
-    Ω = FT(1),
-    λ_γ_PAR = FT(5e-7),
-    λ_γ_NIR = FT(1.65e-6),
-    n_layers = UInt64(20),
-) where {FT}
-    return TwoStreamParameters{FT}(
-        ld,
-        α_PAR_leaf,
-        τ_PAR_leaf,
-        α_NIR_leaf,
-        τ_NIR_leaf,
-        ϵ_canopy,
-        Ω,
-        λ_γ_PAR,
-        λ_γ_NIR,
-        n_layers,
-    )
-end
+"""
 
 Base.eltype(::TwoStreamParameters{FT}) where {FT} = FT
 

--- a/src/standalone/Vegetation/stomatalconductance.jl
+++ b/src/standalone/Vegetation/stomatalconductance.jl
@@ -11,7 +11,6 @@ $(DocStringExtensions.FIELDS)
 """
 Base.@kwdef struct MedlynConductanceParameters{FT <: AbstractFloat}
     "Relative diffusivity of water vapor (unitless)"
-    # TODO: move to ClimaParams"
     Drel::FT
     "Minimum stomatal conductance mol/m^2/s"
     g0::FT

--- a/src/standalone/Vegetation/stomatalconductance.jl
+++ b/src/standalone/Vegetation/stomatalconductance.jl
@@ -9,7 +9,7 @@ abstract type AbstractStomatalConductanceModel{FT} <:
 The required parameters for the Medlyn stomatal conductance model.
 $(DocStringExtensions.FIELDS)
 """
-struct MedlynConductanceParameters{FT <: AbstractFloat}
+Base.@kwdef struct MedlynConductanceParameters{FT <: AbstractFloat}
     "Relative diffusivity of water vapor (unitless)"
     # TODO: move to ClimaParams"
     Drel::FT
@@ -17,23 +17,6 @@ struct MedlynConductanceParameters{FT <: AbstractFloat}
     g0::FT
     "Slope parameter, inversely proportional to the square root of marginal water use efficiency (Pa^{1/2})"
     g1::FT
-end
-
-"""
-    function MedlynConductanceParameters{FT}(;
-        Drel = FT(1.6), # unitless
-        g0 =  FT(1e-4), # mol/m^2/s 
-        g1 = FT(790) # converted from 5 √kPa to units of √Pa
-) where{FT}
-
-A constructor supplying default values for the MedlynConductanceParameters struct.
-"""
-function MedlynConductanceParameters{FT}(;
-    Drel = FT(1.6),
-    g0 = FT(1e-4),
-    g1 = FT(790),
-) where {FT}
-    return MedlynConductanceParameters{FT}(Drel, g0, g1)
 end
 
 Base.eltype(::MedlynConductanceParameters{FT}) where {FT} = FT

--- a/test/standalone/Snow/parameterizations.jl
+++ b/test/standalone/Snow/parameterizations.jl
@@ -25,14 +25,15 @@ for FT in (Float32, Float64)
 
         ρ_snow = FT(200)
         z_0m = FT(0.0024)
-        z_0b = FT(0.00024)
         α_snow = FT(0.8)
-        ϵ_snow = FT(0.99)
+        # These values should match ClimaParams
+        ϵ_snow = FT(0.97)
+        z_0b = FT(0.08)
         θ_r = FT(0.08)
         Ksat = FT(1e-3)
         κ_ice = FT(2.21)
         Δt = Float64(180.0)
-        parameters = SnowParameters{FT}(Δt; earth_param_set = param_set)
+        parameters = SnowParameters(FT, Δt)
         @test parameters.ρ_snow == ρ_snow
         @test typeof(parameters.ρ_snow) == FT
         @test parameters.z_0m == z_0m

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -14,15 +14,16 @@ import Insolation
 
 import ClimaLand
 import ClimaLand.Parameters as LP
+import ClimaParams
 
 for FT in (Float32, Float64)
     @testset "Canopy software pipes, FT = $FT" begin
         domain = Point(; z_sfc = FT(0.0))
 
         AR_params = AutotrophicRespirationParameters(FT)
-        RTparams = BeerLambertParameters{FT}()
+        RTparams = BeerLambertParameters(FT)
         photosynthesis_params = FarquharParameters(FT, C3())
-        stomatal_g_params = MedlynConductanceParameters{FT}()
+        stomatal_g_params = MedlynConductanceParameters(FT)
 
         AR_model = AutotrophicRespirationModel{FT}(AR_params)
         stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
@@ -481,9 +482,9 @@ for FT in (Float32, Float64)
     @testset "Canopy software pipes with energy model, FT = $FT" begin
         domain = Point(; z_sfc = FT(0.0))
 
-        RTparams = BeerLambertParameters{FT}()
+        RTparams = BeerLambertParameters(FT)
         photosynthesis_params = FarquharParameters(FT, C3())
-        stomatal_g_params = MedlynConductanceParameters{FT}()
+        stomatal_g_params = MedlynConductanceParameters(FT)
 
         stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
         photosynthesis_model = FarquharModel{FT}(photosynthesis_params)
@@ -658,7 +659,8 @@ for FT in (Float32, Float64)
             atmos = atmos,
             radiation = radiation,
         )
-        @test canopy.radiative_transfer.parameters.ϵ_canopy == FT(0.98)
+        # This test needs to match ClimaParams `canopy_emissivity`
+        @test canopy.radiative_transfer.parameters.ϵ_canopy == FT(0.97)
         @test canopy.energy.parameters.ac_canopy == FT(2.0e3)
         Y, p, coords = ClimaLand.initialize(canopy)
 

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -112,9 +112,9 @@ for FT in (Float32, Float64)
         ]
 
         AR_params = AutotrophicRespirationParameters(FT)
-        RTparams = BeerLambertParameters{FT}()
+        RTparams = BeerLambertParameters(FT)
         photosynthesis_params = FarquharParameters(FT, C3())
-        stomatal_g_params = MedlynConductanceParameters{FT}()
+        stomatal_g_params = MedlynConductanceParameters(FT)
 
         AR_model = AutotrophicRespirationModel{FT}(AR_params)
         stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
@@ -405,9 +405,9 @@ for FT in (Float32, Float64)
         domain = Point(; z_sfc = FT(0.0))
 
         AR_params = AutotrophicRespirationParameters(FT)
-        RTparams = BeerLambertParameters{FT}()
+        RTparams = BeerLambertParameters(FT)
         photosynthesis_params = FarquharParameters(FT, C3())
-        stomatal_g_params = MedlynConductanceParameters{FT}()
+        stomatal_g_params = MedlynConductanceParameters(FT)
 
         AR_model = AutotrophicRespirationModel{FT}(AR_params)
         stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)

--- a/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
+++ b/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
@@ -72,10 +72,10 @@ for FT in (Float32, Float64)
         earth_param_set = LP.LandParameters(FT)
         # Test with defaults
         ARparams = AutotrophicRespirationParameters(FT)
-        RTparams = BeerLambertParameters{FT}()
+        RTparams = BeerLambertParameters(FT)
         RT = BeerLambertModel{FT}(RTparams)
         photosynthesisparams = FarquharParameters(FT, C3())
-        stomatal_g_params = MedlynConductanceParameters{FT}()
+        stomatal_g_params = MedlynConductanceParameters(FT)
 
         LAI = FT(5.0) # m2 (leaf) m-2 (ground)
         RAI = FT(1.0)

--- a/test/standalone/Vegetation/test_two_stream.jl
+++ b/test/standalone/Vegetation/test_two_stream.jl
@@ -42,21 +42,16 @@ for FT in (Float32, Float64)
         py_FAPAR = FT.(test_set[2:end, column_names .== "FAPAR"])
 
         # Python code does not use clumping index, and λ_γ does not impact FAPAR
-        Ω = FT(1)
-        λ_γ_PAR = FT(5e-7)
-        λ_γ_NIR = FT(1.65e-6)
-
         # Test over all rows in the stored output from the Python module
         for i in 2:(size(test_set, 1) - 1)
 
             # Set the parameters based on the setup read from the file
-            RT_params = TwoStreamParameters{FT}(;
+            RT_params = TwoStreamParameters(
+                FT;
                 ld = ld[i],
                 α_PAR_leaf = α_PAR_leaf[i],
                 τ_PAR_leaf = τ[i],
-                Ω = Ω,
-                λ_γ_PAR = λ_γ_PAR,
-                λ_γ_NIR = λ_γ_NIR,
+                Ω = FT(1),
                 n_layers = n_layers[i],
             )
 


### PR DESCRIPTION
This PR adds constructors for the final parameter structs in `ext/CreateParametersExt.jl`. 

The constructors follow the same format as in previous PRs, taking either a float-type or a param dict and some kwargs:

```
    function MedlynConductanceParameters(FT::AbstractFloat;
        g1 = 790,
        kwargs...
    )
    function MedlynConductanceParameters(toml_dict;
        g1 = 790,
        kwargs...
    )
```
