### PR TITLE
initial cache method removal

### DIFF
--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -198,33 +198,6 @@ function make_update_boundary_fluxes(land::AbstractLandModel)
 end
 
 """
-    make_set_initial_cache(land::AbstractLandModel)
-
-Creates and returns the function which sets the initial cache
-with the correct values given the initial conditions Y0 and initial
-time t0. 
-
-Note that this will call update_drivers! multiple times, once
-per component model.
-"""
-function make_set_initial_cache(land::AbstractLandModel)
-    components = land_components(land)
-    # These functions also call update_aux
-    (atmos, radiation) = get_drivers(land)
-    update_drivers! = make_update_drivers(atmos, radiation)
-    set_initial_cache_function_list =
-        map(x -> make_set_initial_cache(getproperty(land, x)), components)
-
-    function set_initial_cache!(p, Y0, t0)
-        update_drivers!(p, t0)
-        for f! in set_initial_cache_function_list
-            f!(p, Y0, t0)
-        end
-    end
-    return set_initial_cache!
-end
-
-"""
     land_components(land::AbstractLandModel)
 
 Returns the component names of the `land` model, by calling

--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -45,7 +45,6 @@ import ClimaLand:
     initialize_vars,
     initialize,
     initialize_auxiliary,
-    make_set_initial_cache,
     surface_temperature,
     surface_air_density,
     surface_evaporative_scaling,
@@ -318,22 +317,6 @@ auxiliary_vars(::BucketModel) =
 auxiliary_domain_names(::BucketModel) =
     (:surface, :surface, :surface, :surface, :surface, :surface, :surface)
 
-"""
-    ClimaLand.make_set_initial_cache(model::BucketModel{FT}) where{FT}
-
-Returns the set_initial_cache! function, which updates the auxiliary
-state `p` in place with the initial values corresponding to Y(t=t0) = Y0.
-
-In this case, we also use this method to update the initial values for the
-spatially varying parameter fields, read in from data files.
-"""
-function ClimaLand.make_set_initial_cache(model::BucketModel)
-    update_cache! = make_update_cache(model)
-    function set_initial_cache!(p, Y0, t0)
-        update_cache!(p, Y0, t0)
-    end
-    return set_initial_cache!
-end
 
 """
     make_compute_exp_tendency(model::BucketModel{FT}) where {FT}

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -20,12 +20,10 @@ import ClimaLand:
     make_update_boundary_fluxes,
     make_update_aux,
     make_compute_exp_tendency,
-    make_set_initial_cache,
     get_drivers
 
 using ClimaLand.Domains: Point, Plane, SphericalSurface
-export SharedCanopyParameters,
-    CanopyModel, set_canopy_prescribed_field!, update_canopy_prescribed_field!
+export SharedCanopyParameters, CanopyModel, set_canopy_prescribed_field!
 include("./component_models.jl")
 include("./soil_drivers.jl")
 include("./PlantHydraulics.jl")
@@ -359,25 +357,6 @@ function initialize_auxiliary(model::CanopyModel{FT}, coords) where {FT}
 end
 
 """
-    ClimaLand.make_set_initial_cache(model::CanopyModel)
-
-Returns the set_initial_cache! function, which updates the auxiliary
-state `p` in place with the initial values corresponding to Y(t=t0) = Y0.
-
-In this case, we also use this method to update the initial values for the
-spatially and temporally varying canopy parameter fields,
-read in from data files or otherwise prescribed.
-"""
-function ClimaLand.make_set_initial_cache(model::CanopyModel)
-    update_cache! = make_update_cache(model)
-    function set_initial_cache!(p, Y0, t0)
-        set_canopy_prescribed_field!(model.hydraulics, p, t0)
-        update_cache!(p, Y0, t0)
-    end
-    return set_initial_cache!
-end
-
-"""
      ClimaLand.make_update_aux(canopy::CanopyModel{FT,
                                                   <:AutotrophicRespirationModel,
                                                   <:Union{BeerLambertModel, TwoStreamModel},
@@ -416,7 +395,7 @@ function ClimaLand.make_update_aux(
         # Update the prescribed fields to the current time `t`,
         # prior to updating the rest of the auxiliary state to
         # the current time, as they depend on prescribed fields.
-        update_canopy_prescribed_field!(canopy.hydraulics, p, t)
+        set_canopy_prescribed_field!(canopy.hydraulics, p, t)
 
         # Other auxiliary variables being updated:
         Ra = p.canopy.autotrophic_respiration.Ra

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -6,7 +6,6 @@ import ClimaUtilities.TimeVaryingInputs:
 import NCDatasets, ClimaCore, Interpolations # Needed to load TimeVaryingInputs
 using ..ClimaLand.Canopy:
     AbstractCanopyComponent,
-    update_canopy_prescribed_field!,
     set_canopy_prescribed_field!,
     AbstractSoilDriver,
     PrescribedSoil
@@ -309,42 +308,22 @@ ClimaLand.auxiliary_domain_names(::PlantHydraulicsModel) =
 """
     set_canopy_prescribed_field!(component::PlantHydraulics{FT},
                                  p,
-                                 t0,
+                                 t,
                                  ) where {FT}
 
 
 Sets the canopy prescribed fields pertaining to the PlantHydraulics
-component (the area indices) with their initial values at time t0.
+component (the area indices) with their values at time t.
 """
 function ClimaLand.Canopy.set_canopy_prescribed_field!(
     component::PlantHydraulicsModel{FT},
     p,
-    t0,
-) where {FT}
-    (; LAIfunction, SAI, RAI) = component.parameters.ai_parameterization
-    evaluate!(p.canopy.hydraulics.area_index.leaf, LAIfunction, t0)
-
-    @. p.canopy.hydraulics.area_index.stem = SAI
-    @. p.canopy.hydraulics.area_index.root = RAI
-end
-
-
-"""
-    update_canopy_prescribed_field!(component::PlantHydraulics{FT},
-                                    p,
-                                    t,
-                                    ) where {FT}
-
-Updates the canopy prescribed fields pertaining to the PlantHydraulics
-component (the LAI only in this case) with their values at time t.
-"""
-function ClimaLand.Canopy.update_canopy_prescribed_field!(
-    component::PlantHydraulicsModel{FT},
-    p,
     t,
 ) where {FT}
-    (; LAIfunction) = component.parameters.ai_parameterization
+    (; LAIfunction, SAI, RAI) = component.parameters.ai_parameterization
     evaluate!(p.canopy.hydraulics.area_index.leaf, LAIfunction, t)
+    @. p.canopy.hydraulics.area_index.stem = SAI
+    @. p.canopy.hydraulics.area_index.root = RAI
 end
 
 

--- a/src/standalone/Vegetation/component_models.jl
+++ b/src/standalone/Vegetation/component_models.jl
@@ -132,45 +132,15 @@ end
 """
      set_canopy_prescribed_field!(component::AbstractCanopyComponent,
                                   p,
-                                  t0,
+                                  t,
                                  ) end
 
-Sets the spatially and temporally varying prescribed fields of the `component`
-with their initial values.
-
-These fields are stored in the aux-state and *should not* depend on the prognostic
-state `Y` or other diagnostic variables stored in `p`; this allows them
-to be updated first, prior to updating the rest of the aux state and prognostic state.
-
-However, there is no
-guarantee on the order of operations in terms of when diagnostic auxiliary
-variables are updated vs. prescribed field auxiliary variables; any required
-order of operations must be enforced by the developer who writes the update_aux
-function.
-"""
-function set_canopy_prescribed_field!(component::AbstractCanopyComponent, p, t0) end
-
-"""
-     update_canopy_prescribed_field!(component::AbstractCanopyComponent,
-                                     p,
-                                     t,
-                                     ) end
- 
-Updates the spatially and temporally varying prescribed fields of the `component`
+Updates the spatio-temporally varying prescribed fields of the `component`
 with their values at time `t`.
 
-These fields are stored in the aux-state and *should not* depend on the prognostic
-state `Y` or other diagnostic variables stored in `p`; this allows them
-to be updated first, prior to updating the rest of the aux state and prognostic state.
-
-However, there is no
-guarantee on the order of operations in terms of when diagnostic auxiliary
-variables are updated vs. prescribed field auxiliary variables; any required
-order of operations must be enforced by the developer who writes the update_aux
+These fields are stored in the aux-state, and currently are updated at the
+beginning of the `update_aux!` function. Any required
+order of operations must be enforced by the developer who writes the `update_aux!`
 function.
 """
-function update_canopy_prescribed_field!(
-    component::AbstractCanopyComponent,
-    p,
-    t,
-) end
+function set_canopy_prescribed_field!(component::AbstractCanopyComponent, p, t) end

--- a/test/integrated/lsms.jl
+++ b/test/integrated/lsms.jl
@@ -140,6 +140,7 @@ for FT in (Float32, Float64)
         @test propertynames(p) == (:m1, :m2)
         function ClimaLand.make_update_aux(::DummyModel3{FT}) where {FT}
             function update_aux!(p, Y, t)
+                p.m1.a .= FT(2.0)
                 p.m1.b .= FT(10.0)
             end
             return update_aux!
@@ -153,20 +154,6 @@ for FT in (Float32, Float64)
             return update_aux!
         end
 
-        function ClimaLand.make_set_initial_cache(m::DummyModel3{FT}) where {FT}
-            update_cache! = ClimaLand.make_update_cache(m)
-            function set_initial_cache!(p, Y, t)
-                p.m1.a .= FT(2.0)
-                update_cache!(p, Y, t)
-            end
-            return set_initial_cache!
-        end
-
-        # The scenario here is that model 1 has a single prescribed but constant
-        # variable (a), with another that could get updated each step (b).
-        # DummyModel4 has only variables that get updated each step.
-        # Test that the land model function properly calls the individual
-        # model's functions
         set_initial_cache! = ClimaLand.make_set_initial_cache(m)
         set_initial_cache!(p, Y, FT(0.0))
         @test all(parent(p.m1.a) .== FT(2))

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -445,7 +445,7 @@ for FT in (Float32, Float64)
         )
 
         # Test that LAI is updated
-        update_canopy_prescribed_field!(plant_hydraulics, p, FT(200))
+        set_canopy_prescribed_field!(plant_hydraulics, p, FT(200))
         @test all(
             Array(parent(p.canopy.hydraulics.area_index.leaf)) .==
             FT(LAI * sin(200 * 2π / 365)),
@@ -453,7 +453,7 @@ for FT in (Float32, Float64)
 
         struct Default{FT} <: ClimaLand.Canopy.AbstractCanopyComponent{FT} end
         set_canopy_prescribed_field!(Default{FT}(), p, t0)
-        update_canopy_prescribed_field!(Default{FT}(), p, t0)
+        set_canopy_prescribed_field!(Default{FT}(), p, t0)
         # Test that they are unchanged
         @test all(
             parent(p.canopy.hydraulics.area_index.leaf) .==


### PR DESCRIPTION
## Purpose 
Removes special methods of `set_initial_cache`. All models can use the default


## To-do
review


## Content
- bucket model method was a duplicate of the default -> easy to remove
- canopy model was a default except for `set_prescribed_canopy_field` call. Now we call this in update_aux and can use the default initial cache setting method.
- LSM model should have been calling update drivers, then update aux for each model, and then update boundary fluxes for each model, since this is what we do each timestep. it was instead caling update drivers, and then set initial cache for each model. Now we use the default, which does what we want.


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [x] I have read and checked the items on the review checklist.
