### PR TITLE
Convert ld to Function type and Parameterize by Leaf Orientation Index

### DIFF
--- a/docs/tutorials/integrated/soil_canopy_tutorial.jl
+++ b/docs/tutorials/integrated/soil_canopy_tutorial.jl
@@ -227,7 +227,7 @@ autotrophic_respiration_args =
 radiative_transfer_args = (;
     parameters = TwoStreamParameters(
         FT;
-        ld = 0.5,
+        G_Function = ConstantGFunction(FT(0.5)),
         α_PAR_leaf = 0.1,
         α_NIR_leaf = 0.45,
         τ_PAR_leaf = 0.05,

--- a/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -156,7 +156,7 @@ soil_driver = PrescribedSoil(
 
 rt_params = TwoStreamParameters(
     FT;
-    ld = FT(0.5),
+    G_Function = ConstantGFunction(FT(0.5)),
     α_PAR_leaf = FT(0.1),
     α_NIR_leaf = FT(0.45),
     τ_PAR_leaf = FT(0.05),

--- a/experiments/integrated/fluxnet/US-Ha1/US-Ha1_parameters.jl
+++ b/experiments/integrated/fluxnet/US-Ha1/US-Ha1_parameters.jl
@@ -36,6 +36,7 @@ soil_α_NIR = FT(0.2)
 # TwoStreamModel parameters
 Ω = FT(0.69)
 ld = FT(0.5)
+G_Function = ConstantGFunction(ld)
 α_PAR_leaf = FT(0.1)
 λ_γ_PAR = FT(5e-7)
 λ_γ_NIR = FT(1.65e-6)

--- a/experiments/integrated/fluxnet/US-MOz/US-MOz_parameters.jl
+++ b/experiments/integrated/fluxnet/US-MOz/US-MOz_parameters.jl
@@ -34,7 +34,8 @@ soil_α_NIR = FT(0.2)
 
 # TwoStreamModel parameters
 Ω = FT(0.69)
-ld = FT(0.5)
+χl = FT(0.1)
+G_Function = CLMGFunction(χl)
 α_PAR_leaf = FT(0.1)
 λ_γ_PAR = FT(5e-7)
 λ_γ_NIR = FT(1.65e-6)

--- a/experiments/integrated/fluxnet/US-NR1/US-NR1_parameters.jl
+++ b/experiments/integrated/fluxnet/US-NR1/US-NR1_parameters.jl
@@ -39,6 +39,7 @@ soil_α_NIR = FT(0.2)
 # TwoStreamModel parameters
 Ω = FT(0.71)
 ld = FT(0.5)
+G_Function = ConstantGFunction(ld)
 α_PAR_leaf = FT(0.1)
 λ_γ_PAR = FT(5e-7)
 λ_γ_NIR = FT(1.65e-6)

--- a/experiments/integrated/fluxnet/US-Var/US-Var_parameters.jl
+++ b/experiments/integrated/fluxnet/US-Var/US-Var_parameters.jl
@@ -44,6 +44,7 @@ soil_α_NIR = FT(0.4)
 # TwoStreamModel parameters
 Ω = FT(1.0)
 ld = FT(0.5)
+G_Function = ConstantGFunction(ld)
 α_PAR_leaf = FT(0.11)
 λ_γ_PAR = FT(5e-7)
 λ_γ_NIR = FT(1.65e-6)

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -176,11 +176,12 @@ canopy_component_types = (;
 autotrophic_respiration_args =
     (; parameters = AutotrophicRespirationParameters(FT))
 # Set up radiative transfer
+G_Function = CLMGFunction(χl)
 radiative_transfer_args = (;
     parameters = TwoStreamParameters(
         FT;
         Ω,
-        ld,
+        G_Function,
         α_PAR_leaf,
         τ_PAR_leaf,
         α_NIR_leaf,

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -140,11 +140,11 @@ radiative_transfer_args = (;
     parameters = TwoStreamParameters(
         FT;
         Ω,
-        ld,
         α_PAR_leaf,
         τ_PAR_leaf,
         α_NIR_leaf,
         τ_NIR_leaf,
+        G_Function,
     )
 )
 # Set up conductance

--- a/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
+++ b/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
@@ -126,7 +126,7 @@ radiative_transfer_args = (;
     parameters = TwoStreamParameters(
         FT;
         Ω,
-        ld,
+        G_Function,
         α_PAR_leaf,
         τ_PAR_leaf,
         α_NIR_leaf,

--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -18,6 +18,7 @@ import ClimaLand.Canopy.OptimalityFarquharParameters
 import ClimaLand.Canopy.MedlynConductanceParameters
 import ClimaLand.Canopy.BeerLambertParameters
 import ClimaLand.Canopy.TwoStreamParameters
+import ClimaLand.Canopy.ConstantGFunction
 import ClimaLand.Snow.SnowParameters
 import ClimaLand.Bucket.BucketModelParameters
 import ClimaLand.Soil.Biogeochemistry.SoilCO2ModelParameters
@@ -532,7 +533,7 @@ end
 
 """
     function TwoStreamParameters(FT::AbstractFloat;
-        ld = 0.5,
+        ld = (_) -> 0.5,
         α_PAR_leaf = 0.3,
         τ_PAR_leaf = 0.2,
         α_NIR_leaf = 0.4,
@@ -542,7 +543,7 @@ end
         kwargs...
     )
     function TwoStreamParameters(toml_dict;
-        ld = 0.5,
+        ld = (_) -> 0.5,
         α_PAR_leaf = 0.3,
         τ_PAR_leaf = 0.2,
         α_NIR_leaf = 0.4,
@@ -560,7 +561,7 @@ TwoStreamParameters(::Type{FT}; kwargs...) where {FT <: AbstractFloat} =
 
 function TwoStreamParameters(
     toml_dict::CP.AbstractTOMLDict;
-    ld = 0.5,
+    G_Function = ConstantGFunction(CP.float_type(toml_dict)(0.5)),
     α_PAR_leaf = 0.3,
     τ_PAR_leaf = 0.2,
     α_NIR_leaf = 0.4,
@@ -577,8 +578,8 @@ function TwoStreamParameters(
 
     parameters = CP.get_parameter_values(toml_dict, name_map, "Land")
     FT = CP.float_type(toml_dict)
-    return TwoStreamParameters{FT}(;
-        ld,
+    return TwoStreamParameters{FT, typeof(G_Function)}(;
+        G_Function,
         α_PAR_leaf,
         τ_PAR_leaf,
         α_NIR_leaf,
@@ -592,14 +593,14 @@ end
 
 """
     function BeerLambertParameters(FT::AbstractFloat;
-        ld = 0.5,
+        ld = (_) -> 0.5,
         α_PAR_leaf = 0.1,
         α_NIR_leaf = 0.4,
         Ω = 1,
         kwargs...
     )
     function BeerLambertParameters(toml_dict;
-        ld = 0.5,
+        ld = (_) -> 0.5,
         α_PAR_leaf = 0.1,
         α_NIR_leaf = 0.4,
         Ω = 1,
@@ -614,7 +615,7 @@ BeerLambertParameters(::Type{FT}; kwargs...) where {FT <: AbstractFloat} =
 
 function BeerLambertParameters(
     toml_dict::CP.AbstractTOMLDict;
-    ld = 0.5,
+    G_Function = ConstantGFunction(CP.float_type(toml_dict)(0.5)),
     α_PAR_leaf = 0.1,
     α_NIR_leaf = 0.4,
     Ω = 1,
@@ -628,8 +629,8 @@ function BeerLambertParameters(
 
     parameters = CP.get_parameter_values(toml_dict, name_map, "Land")
     FT = CP.float_type(toml_dict)
-    return BeerLambertParameters{FT}(;
-        ld,
+    return BeerLambertParameters{FT, typeof(G_Function)}(;
+        G_Function,
         α_PAR_leaf,
         α_NIR_leaf,
         Ω,

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Ha1/US-Ha1_parameters.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Ha1/US-Ha1_parameters.jl
@@ -107,7 +107,7 @@ end
 
 function radiative_transfer_harvard(;
     Ω = FT(0.69),
-    ld = FT(0.5),
+    ld = ConstantGFunction(FT(0.5)),
     α_PAR_leaf = FT(0.1),
     λ_γ_PAR = FT(5e-7),
     λ_γ_NIR = FT(1.65e-6),
@@ -118,16 +118,16 @@ function radiative_transfer_harvard(;
     ϵ_canopy = FT(0.97),
 )
     return TwoStreamParameters(
-        ld,
-        α_PAR_leaf,
-        τ_PAR_leaf,
-        α_NIR_leaf,
-        τ_NIR_leaf,
-        ϵ_canopy,
-        Ω,
-        λ_γ_PAR,
-        λ_γ_NIR,
-        n_layers,
+        G_Function = ld,
+        α_PAR_leaf = α_PAR_leaf,
+        τ_PAR_leaf = τ_PAR_leaf,
+        α_NIR_leaf = α_NIR_leaf,
+        τ_NIR_leaf = τ_NIR_leaf,
+        ϵ_canopy = ϵ_canopy,
+        Ω = Ω,
+        λ_γ_PAR = λ_γ_PAR,
+        λ_γ_NIR = λ_γ_NIR,
+        n_layers = n_layers,
     )
 end
 

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-MOz/US-MOz_parameters.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-MOz/US-MOz_parameters.jl
@@ -107,7 +107,7 @@ end
 
 function radiative_transfer_ozark(;
     Ω = FT(0.69),
-    ld = FT(0.5),
+    ld = ConstantGFunction(FT(0.5)),
     α_PAR_leaf = FT(0.1),
     λ_γ_PAR = FT(5e-7),
     λ_γ_NIR = FT(1.65e-6),
@@ -118,16 +118,16 @@ function radiative_transfer_ozark(;
     ϵ_canopy = FT(0.97),
 )
     return TwoStreamParameters(
-        ld,
-        α_PAR_leaf,
-        τ_PAR_leaf,
-        α_NIR_leaf,
-        τ_NIR_leaf,
-        ϵ_canopy,
-        Ω,
-        λ_γ_PAR,
-        λ_γ_NIR,
-        n_layers,
+        G_Function = ld,
+        α_PAR_leaf = α_PAR_leaf,
+        τ_PAR_leaf = τ_PAR_leaf,
+        α_NIR_leaf = α_NIR_leaf,
+        τ_NIR_leaf = τ_NIR_leaf,
+        ϵ_canopy = ϵ_canopy,
+        Ω = Ω,
+        λ_γ_PAR = λ_γ_PAR,
+        λ_γ_NIR = λ_γ_NIR,
+        n_layers = n_layers,
     )
 end
 

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-NR1/US-NR1_parameters.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-NR1/US-NR1_parameters.jl
@@ -107,7 +107,7 @@ end
 
 function radiative_transfer_niwotridge(;
     Ω = FT(0.69),
-    ld = FT(0.5),
+    ld = ConstantGFunction(FT(0.5)),
     α_PAR_leaf = FT(0.1),
     λ_γ_PAR = FT(5e-7),
     λ_γ_NIR = FT(1.65e-6),
@@ -118,16 +118,16 @@ function radiative_transfer_niwotridge(;
     ϵ_canopy = FT(0.97),
 )
     return TwoStreamParameters(
-        ld,
-        α_PAR_leaf,
-        τ_PAR_leaf,
-        α_NIR_leaf,
-        τ_NIR_leaf,
-        ϵ_canopy,
-        Ω,
-        λ_γ_PAR,
-        λ_γ_NIR,
-        n_layers,
+        G_Function = ld,
+        α_PAR_leaf = α_PAR_leaf,
+        τ_PAR_leaf = τ_PAR_leaf,
+        α_NIR_leaf = α_NIR_leaf,
+        τ_NIR_leaf = τ_NIR_leaf,
+        ϵ_canopy = ϵ_canopy,
+        Ω = Ω,
+        λ_γ_PAR = λ_γ_PAR,
+        λ_γ_NIR = λ_γ_NIR,
+        n_layers = n_layers,
     )
 end
 

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Var/US-Var_parameters.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Var/US-Var_parameters.jl
@@ -107,7 +107,7 @@ end
 
 function radiative_transfer_vairaranch(;
     Ω = FT(0.69),
-    ld = FT(0.5),
+    ld = ConstantGFunction(FT(0.5)),
     α_PAR_leaf = FT(0.1),
     λ_γ_PAR = FT(5e-7),
     λ_γ_NIR = FT(1.65e-6),
@@ -118,16 +118,16 @@ function radiative_transfer_vairaranch(;
     ϵ_canopy = FT(0.97),
 )
     return TwoStreamParameters(
-        ld,
-        α_PAR_leaf,
-        τ_PAR_leaf,
-        α_NIR_leaf,
-        τ_NIR_leaf,
-        ϵ_canopy,
-        Ω,
-        λ_γ_PAR,
-        λ_γ_NIR,
-        n_layers,
+        G_Function = ld,
+        α_PAR_leaf = α_PAR_leaf,
+        τ_PAR_leaf = τ_PAR_leaf,
+        α_NIR_leaf = α_NIR_leaf,
+        τ_NIR_leaf = τ_NIR_leaf,
+        ϵ_canopy = ϵ_canopy,
+        Ω = Ω,
+        λ_γ_PAR = λ_γ_PAR,
+        λ_γ_NIR = λ_γ_NIR,
+        n_layers = n_layers,
     )
 end
 

--- a/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
@@ -114,7 +114,7 @@ function run_fluxnet(
         parameters = TwoStreamParameters(
             FT;
             Ω = params.radiative_transfer.Ω,
-            ld = params.radiative_transfer.ld,
+            G_Function = params.radiative_transfer.G_Function,
             α_PAR_leaf = params.radiative_transfer.α_PAR_leaf,
             λ_γ_PAR = params.radiative_transfer.λ_γ_PAR,
             λ_γ_NIR = params.radiative_transfer.λ_γ_NIR,

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -456,7 +456,8 @@ function ClimaLand.make_update_aux(
         ρ_l = FT(LP.ρ_cloud_liq(earth_param_set))
         R = FT(LP.gas_constant(earth_param_set))
         thermo_params = earth_param_set.thermo_params
-        (; ld, Ω, λ_γ_PAR, λ_γ_NIR) = canopy.radiative_transfer.parameters
+        (; G_Function, Ω, λ_γ_PAR, λ_γ_NIR) =
+            canopy.radiative_transfer.parameters
         energy_per_photon_PAR = planck_h * c / λ_γ_PAR
         energy_per_photon_NIR = planck_h * c / λ_γ_NIR
         (; g1, g0, Drel) = canopy.conductance.parameters
@@ -467,7 +468,7 @@ function ClimaLand.make_update_aux(
 
         # update radiative transfer
         RT = canopy.radiative_transfer
-        K = extinction_coeff.(ld, θs)
+        K = extinction_coeff.(G_Function, θs)
         PAR .= compute_PAR(RT, canopy.radiation, p, t)
         NIR .= compute_NIR(RT, canopy.radiation, p, t)
         e_sat =

--- a/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
+++ b/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
@@ -97,8 +97,7 @@ for FT in (Float32, Float64)
         θs = FT.(Array(0:0.1:(π / 2)))
         SW(θs) = cos.(θs) * FT.(500) # W/m^2
         PAR = SW(θs) ./ (energy_per_photon * N_a) # convert 500 W/m^2 to mol of photons per m^2/s
-        K_c = extinction_coeff.(RTparams.ld, θs)
-        @test all(K_c .≈ RTparams.ld ./ cos.(θs))
+        K_c = extinction_coeff.(RTparams.G_Function, θs)
         α_soil_PAR = FT(0.2)
         output =
             plant_absorbed_pfd.(

--- a/test/standalone/Vegetation/test_two_stream.jl
+++ b/test/standalone/Vegetation/test_two_stream.jl
@@ -31,7 +31,7 @@ for FT in (Float32, Float64)
         column_names = test_set[1, :]
         θs = acos.(FT.(test_set[2:end, column_names .== "mu"]))
         LAI = FT.(test_set[2:end, column_names .== "LAI"])
-        ld = FT.(test_set[2:end, column_names .== "ld"])
+        lds = FT.(test_set[2:end, column_names .== "ld"])
         α_PAR_leaf = FT.(test_set[2:end, column_names .== "rho"])
         τ = FT.(test_set[2:end, column_names .== "tau"])
         a_soil = FT.(test_set[2:end, column_names .== "a_soil"])
@@ -48,7 +48,7 @@ for FT in (Float32, Float64)
             # Set the parameters based on the setup read from the file
             RT_params = TwoStreamParameters(
                 FT;
-                ld = ld[i],
+                G_Function = ConstantGFunction(FT(lds[i])),
                 α_PAR_leaf = α_PAR_leaf[i],
                 τ_PAR_leaf = τ[i],
                 Ω = FT(1),
@@ -59,7 +59,7 @@ for FT in (Float32, Float64)
             RT = TwoStreamModel(RT_params)
 
             # Compute the predicted FAPAR using the ClimaLand TwoStream implementation
-            K = extinction_coeff(ld[i], θs[i])
+            K = extinction_coeff(RT_params.G_Function, θs[i])
             output = plant_absorbed_pfd(
                 RT,
                 FT(1),


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Converts `ld` in the TwoStreamModel from a floating point number to a Function pointer, and adds a method for getting `ld` in terms of `χl` as is done in CLM. See [here](https://www2.cesm.ucar.edu/models/cesm2/land/CLM50_Tech_Note.pdf)


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- [x] Change `ld` in `BeerLambert` model to function for compatibility
- [x] Fix all tests, experiments, and tutorials for use with functional `ld`


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
 - Changes `ld` to a submodel `AbstractGFunction`
 - Creates 2 types of G Functions, for each the CLM method and the constant G function we used before
 - Propagates changes throughout tests, tutorials, and experiments
 - Adds methods dispatching off the type of GFunction model used to compute the current value of the G function for the current time step based on the solar zenith angle


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
