### PR TITLE
Global run of complex land model with ERA5 forcing

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -109,6 +109,12 @@ steps:
         agents:
           slurm_mem: 16G
 
+      - label: "Global Run CPU"
+        command: "julia --color=yes --project=.buildkite experiments/integrated/global/global_soil_canopy.jl"
+        artifact_paths: "experiments/integrated/global/plots/*png"
+        agents:
+          slurm_mem: 16G
+
   - group: "Experiments on GPU"
     steps:
       - label: "Richards Runoff GPU"

--- a/.buildkite/target/pipeline.yml
+++ b/.buildkite/target/pipeline.yml
@@ -45,3 +45,13 @@ steps:
         agents:
           slurm_mem: 8GB
           slurm_gpus: 1
+
+      - label: "Soil/Canopy"
+        command: "julia --color=yes --project=.buildkite experiments/benchmarks/land.jl"
+        artifact_paths:
+          - "land_benchmark_gpu/*html"
+        env:
+          CLIMACOMMS_DEVICE: CUDA
+        agents:
+          slurm_mem: 8GB
+          slurm_gpus: 1

--- a/docs/tutorials/integrated/soil_canopy_tutorial.jl
+++ b/docs/tutorials/integrated/soil_canopy_tutorial.jl
@@ -339,14 +339,14 @@ Y.soil.ϑ_l = FT(0.4)
 Y.soil.θ_i = FT(0.0)
 T_0 = FT(288.7)
 ρc_s =
-    volumetric_heat_capacity.(Y.soil.ϑ_l, Y.soil.θ_i, Ref(land.soil.parameters))
-Y.soil.ρe_int =
-    volumetric_internal_energy.(
+    volumetric_heat_capacity.(
+        Y.soil.ϑ_l,
         Y.soil.θ_i,
-        ρc_s,
-        T_0,
-        Ref(land.soil.parameters),
+        land.soil.parameters.ρc_ds,
+        earth_param_set,
     )
+Y.soil.ρe_int =
+    volumetric_internal_energy.(Y.soil.θ_i, ρc_s, T_0, earth_param_set)
 
 Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
 

--- a/docs/tutorials/standalone/Soil/evaporation.jl
+++ b/docs/tutorials/standalone/Soil/evaporation.jl
@@ -158,9 +158,14 @@ function init_soil!(Y, z, params)
     Y.soil.ϑ_l .= hydrostatic_equilibrium.(z, FT(-0.001), params)
     Y.soil.θ_i .= 0
     T = FT(296.15)
-    ρc_s = @. Soil.volumetric_heat_capacity(Y.soil.ϑ_l, FT(0), params)
+    ρc_s = @. Soil.volumetric_heat_capacity(
+        Y.soil.ϑ_l,
+        FT(0),
+        params.ρc_ds,
+        params.earth_param_set,
+    )
     Y.soil.ρe_int =
-        Soil.volumetric_internal_energy.(FT(0), ρc_s, T, Ref(params))
+        Soil.volumetric_internal_energy.(FT(0), ρc_s, T, params.earth_param_set)
 end
 init_soil!(Y, z, soil.parameters);
 

--- a/docs/tutorials/standalone/Soil/evaporation_gilat_loess.jl
+++ b/docs/tutorials/standalone/Soil/evaporation_gilat_loess.jl
@@ -146,9 +146,19 @@ function init_soil!(Y, z, params)
     Y.soil.ϑ_l .= estimated_ic.(z)
     Y.soil.θ_i .= 0
     T = FT(294.15)
-    ρc_s = @. Soil.volumetric_heat_capacity(Y.soil.ϑ_l, Y.soil.θ_i, params)
+    ρc_s = @. Soil.volumetric_heat_capacity(
+        Y.soil.ϑ_l,
+        Y.soil.θ_i,
+        params.ρc_ds,
+        params.earth_param_set,
+    )
     Y.soil.ρe_int =
-        Soil.volumetric_internal_energy.(Y.soil.θ_i, ρc_s, T, Ref(params))
+        Soil.volumetric_internal_energy.(
+            Y.soil.θ_i,
+            ρc_s,
+            T,
+            params.earth_param_set,
+        )
 end
 
 init_soil!(Y, z, soil.parameters)

--- a/docs/tutorials/standalone/Soil/freezing_front.jl
+++ b/docs/tutorials/standalone/Soil/freezing_front.jl
@@ -183,9 +183,19 @@ function init_soil!(Ysoil, z, params)
     Ysoil.soil.ϑ_l .= FT(0.33)
     Ysoil.soil.θ_i .= FT(0.0)
     T = FT(279.85)
-    ρc_s = Soil.volumetric_heat_capacity(FT(0.33), FT(0.0), params)
+    ρc_s = Soil.volumetric_heat_capacity(
+        FT(0.33),
+        FT(0.0),
+        params.ρc_ds,
+        params.earth_param_set,
+    )
     Ysoil.soil.ρe_int .=
-        Soil.volumetric_internal_energy.(FT(0.0), ρc_s, T, Ref(params))
+        Soil.volumetric_internal_energy.(
+            FT(0.0),
+            ρc_s,
+            T,
+            params.earth_param_set,
+        )
 end
 
 init_soil!(Y, coords.subsurface.z, soil.parameters);

--- a/docs/tutorials/standalone/Soil/soil_energy_hydrology.jl
+++ b/docs/tutorials/standalone/Soil/soil_energy_hydrology.jl
@@ -221,9 +221,20 @@ function init_soil!(Y, z, params)
     T = @.(T_min + (T_max - T_min) * exp(-(z - zmax) / (zmin - zmax) * c))
 
     θ_l = Soil.volumetric_liquid_fraction.(Y.soil.ϑ_l, ν, θ_r)
-    ρc_s = Soil.volumetric_heat_capacity.(θ_l, Y.soil.θ_i, Ref(params))
+    ρc_s =
+        Soil.volumetric_heat_capacity.(
+            θ_l,
+            Y.soil.θ_i,
+            params.ρc_ds,
+            params.earth_param_set,
+        )
     Y.soil.ρe_int .=
-        Soil.volumetric_internal_energy.(Y.soil.θ_i, ρc_s, T, Ref(params))
+        Soil.volumetric_internal_energy.(
+            Y.soil.θ_i,
+            ρc_s,
+            T,
+            params.earth_param_set,
+        )
 end
 
 init_soil!(Y, coords.subsurface.z, soil.parameters);

--- a/docs/tutorials/standalone/Soil/sublimation.jl
+++ b/docs/tutorials/standalone/Soil/sublimation.jl
@@ -144,9 +144,14 @@ function init_soil!(Y, z, params)
     Y.soil.ϑ_l .= hydrostatic_equilibrium.(z, FT(-0.1), params)
     Y.soil.θ_i .= 0
     T = FT(275.0)
-    ρc_s = @. Soil.volumetric_heat_capacity(Y.soil.ϑ_l, FT(0), params)
+    ρc_s = @. Soil.volumetric_heat_capacity(
+        Y.soil.ϑ_l,
+        FT(0),
+        params.ρc_ds,
+        params.earth_param_set,
+    )
     Y.soil.ρe_int =
-        Soil.volumetric_internal_energy.(FT(0), ρc_s, T, Ref(params))
+        Soil.volumetric_internal_energy.(FT(0), ρc_s, T, params.earth_param_set)
 end
 init_soil!(Y, z, soil.parameters);
 

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -1,0 +1,676 @@
+# # Global run of land model
+
+# The code sets up and runs the soil/canopy model for 6 hours on a spherical domain,
+# using ERA5 data. In this simulation, we have
+# turned lateral flow off because horizontal boundary conditions and the
+# land/sea mask are not yet supported by ClimaCore.
+
+# This code runs the model multiple times and collects statistics for execution time and
+# allocations
+#
+# When run with buildkite on clima, this code also compares with the previous best time
+# saved at the bottom of this file
+
+# Simulation Setup
+# Number of spatial elements: 101 in horizontal, 15 in vertical
+# Soil depth: 50 m
+# Simulation duration: 6 hours
+# Timestep: 180 s
+# Timestepper: ARS343
+# Maximum iterations: 1
+# Convergence criterion: 1e-8
+# Jacobian update: Every Newton iteration
+# Precipitation data update: every timestep
+import SciMLBase
+import ClimaComms
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
+import ClimaTimeSteppers as CTS
+using ClimaCore
+using ClimaUtilities.ClimaArtifacts
+import Interpolations
+using Insolation
+
+import ClimaUtilities.TimeVaryingInputs: TimeVaryingInput
+import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
+import ClimaUtilities.Regridders: InterpolationsRegridder
+import ClimaUtilities.ClimaArtifacts: @clima_artifact
+import ClimaParams as CP
+
+using ClimaLand
+using ClimaLand.Soil
+using ClimaLand.Canopy
+import ClimaLand
+import ClimaLand.Parameters as LP
+
+using Statistics
+using Dates
+import NCDatasets
+import Profile, ProfileCanvas
+
+const FT = Float64;
+
+regridder_type = :InterpolationsRegridder
+context = ClimaComms.context()
+device = ClimaComms.device()
+device_suffix = device isa ClimaComms.CPUSingleThreaded ? "cpu" : "gpu"
+
+outdir = "land_benchmark_$(device_suffix)"
+!ispath(outdir) && mkpath(outdir)
+
+function setup_prob(t0, tf, Δt; nelements = (101, 15))
+
+    earth_param_set = LP.LandParameters(FT)
+    radius = FT(6378.1e3)
+    depth = FT(50)
+    domain = ClimaLand.Domains.SphericalShell(;
+        radius = radius,
+        depth = depth,
+        nelements = nelements,
+        npolynomial = 1,
+        dz_tuple = FT.((10.0, 0.1)),
+    )
+    surface_space = domain.space.surface
+    subsurface_space = domain.space.subsurface
+
+    ref_time = DateTime(2021)
+    t_start = 0.0
+
+    # Forcing data
+    era5_artifact_path =
+        ClimaLand.Artifacts.era5_land_forcing_data2021_folder_path(; context)    # Precipitation:
+    precip = TimeVaryingInput(
+        joinpath(era5_artifact_path, "era5_2021_0.9x1.25_clima.nc"),
+        "rf",
+        surface_space;
+        reference_date = ref_time,
+        t_start,
+        regridder_type,
+        file_reader_kwargs = (; preprocess_func = (data) -> -data / 3600,),
+    )
+
+    snow_precip = TimeVaryingInput(
+        joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc"),
+        "sf",
+        surface_space;
+        reference_date = ref_time,
+        t_start,
+        regridder_type,
+        file_reader_kwargs = (; preprocess_func = (data) -> -data / 3600,),
+    )
+
+    u_atmos = TimeVaryingInput(
+        joinpath(era5_artifact_path, "era5_2021_0.9x1.25_clima.nc"),
+        "ws",
+        surface_space;
+        reference_date = ref_time,
+        t_start,
+        regridder_type,
+    )
+    q_atmos = TimeVaryingInput(
+        joinpath(era5_artifact_path, "era5_2021_0.9x1.25_clima.nc"),
+        "q",
+        surface_space;
+        reference_date = ref_time,
+        t_start,
+        regridder_type,
+    )
+    P_atmos = TimeVaryingInput(
+        joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc"),
+        "sp",
+        surface_space;
+        reference_date = ref_time,
+        t_start,
+        regridder_type,
+    )
+
+    T_atmos = TimeVaryingInput(
+        joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc"),
+        "t2m",
+        surface_space;
+        reference_date = ref_time,
+        t_start,
+        regridder_type,
+    )
+    h_atmos = FT(10)
+
+    atmos = PrescribedAtmosphere(
+        precip,
+        snow_precip,
+        T_atmos,
+        u_atmos,
+        q_atmos,
+        P_atmos,
+        ref_time,
+        h_atmos,
+        earth_param_set,
+    )
+
+    # Prescribed radiation
+    SW_d = TimeVaryingInput(
+        joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc"),
+        "ssrd",
+        surface_space;
+        reference_date = ref_time,
+        t_start,
+        regridder_type,
+        file_reader_kwargs = (; preprocess_func = (data) -> data / 3600,),
+    )
+    LW_d = TimeVaryingInput(
+        joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc"),
+        "strd",
+        surface_space;
+        reference_date = ref_time,
+        t_start,
+        regridder_type,
+        file_reader_kwargs = (; preprocess_func = (data) -> data / 3600,),
+    )
+
+    function zenith_angle(
+        t,
+        ref_time;
+        latitude = ClimaCore.Fields.coordinate_field(surface_space).lat,
+        longitude = ClimaCore.Fields.coordinate_field(surface_space).long,
+        insol_params::Insolation.Parameters.InsolationParameters{FT} = earth_param_set.insol_params,
+    ) where {FT}
+        # This should be time in UTC
+        current_datetime = ref_time + Dates.Second(round(t))
+
+        # Orbital Data uses Float64, so we need to convert to our sim FT
+        d, δ, η_UTC =
+            FT.(
+                Insolation.helper_instantaneous_zenith_angle(
+                    current_datetime,
+                    ref_time,
+                    insol_params,
+                )
+            )
+
+        Insolation.instantaneous_zenith_angle.(
+            d,
+            δ,
+            η_UTC,
+            longitude,
+            latitude,
+        ).:1
+    end
+    radiation =
+        PrescribedRadiativeFluxes(FT, SW_d, LW_d, ref_time; θs = zenith_angle)
+
+    soil_params_artifact_path =
+        ClimaLand.Artifacts.soil_params_artifact_folder_path(; context)
+    extrapolation_bc = (
+        Interpolations.Periodic(),
+        Interpolations.Flat(),
+        Interpolations.Flat(),
+    )
+    soil_params_mask = SpaceVaryingInput(
+        joinpath(
+            soil_params_artifact_path,
+            "vGalpha_map_gupta_etal2020_2.5x2.5x4.nc",
+        ),
+        "α",
+        subsurface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+        file_reader_kwargs = (; preprocess_func = (data) -> data > 0,),
+    )
+    oceans_to_value(field, mask, value) =
+        mask == 1.0 ? field : eltype(field)(value)
+
+    vg_α = SpaceVaryingInput(
+        joinpath(
+            soil_params_artifact_path,
+            "vGalpha_map_gupta_etal2020_2.5x2.5x4.nc",
+        ),
+        "α",
+        subsurface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    vg_n = SpaceVaryingInput(
+        joinpath(
+            soil_params_artifact_path,
+            "vGn_map_gupta_etal2020_2.5x2.5x4.nc",
+        ),
+        "n",
+        subsurface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    x = parent(vg_α)
+    μ = mean(log10.(x[x .> 0]))
+    vg_α .= oceans_to_value.(vg_α, soil_params_mask, 10.0^μ)
+
+    x = parent(vg_n)
+    μ = mean(x[x .> 0])
+    vg_n .= oceans_to_value.(vg_n, soil_params_mask, μ)
+
+    vg_fields_to_hcm_field(α::FT, n::FT) where {FT} =
+        ClimaLand.Soil.vanGenuchten{FT}(; @NamedTuple{α::FT, n::FT}((α, n))...)
+    hydrology_cm = vg_fields_to_hcm_field.(vg_α, vg_n)
+
+    θ_r = SpaceVaryingInput(
+        joinpath(
+            soil_params_artifact_path,
+            "residual_map_gupta_etal2020_2.5x2.5x4.nc",
+        ),
+        "θ_r",
+        subsurface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+
+    ν = SpaceVaryingInput(
+        joinpath(
+            soil_params_artifact_path,
+            "porosity_map_gupta_etal2020_2.5x2.5x4.nc",
+        ),
+        "ν",
+        subsurface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    K_sat = SpaceVaryingInput(
+        joinpath(
+            soil_params_artifact_path,
+            "ksat_map_gupta_etal2020_2.5x2.5x4.nc",
+        ),
+        "Ksat",
+        subsurface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+
+    x = parent(K_sat)
+    μ = mean(log10.(x[x .> 0]))
+    K_sat .= oceans_to_value.(K_sat, soil_params_mask, 10.0^μ)
+
+    ν .= oceans_to_value.(ν, soil_params_mask, 1)
+
+    θ_r .= oceans_to_value.(θ_r, soil_params_mask, 0)
+
+
+    S_s =
+        oceans_to_value.(
+            ClimaCore.Fields.zeros(subsurface_space) .+ FT(1e-3),
+            soil_params_mask,
+            1,
+        )
+    ν_ss_om =
+        oceans_to_value.(
+            ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+            soil_params_mask,
+            0,
+        )
+    ν_ss_quartz =
+        oceans_to_value.(
+            ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+            soil_params_mask,
+            0,
+        )
+    ν_ss_gravel =
+        oceans_to_value.(
+            ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+            soil_params_mask,
+            0,
+        )
+    PAR_albedo = ClimaCore.Fields.zeros(surface_space) .+ FT(0.2)
+    NIR_albedo = ClimaCore.Fields.zeros(surface_space) .+ FT(0.2)
+    soil_params = Soil.EnergyHydrologyParameters(
+        FT;
+        ν,
+        ν_ss_om,
+        ν_ss_quartz,
+        ν_ss_gravel,
+        hydrology_cm,
+        K_sat,
+        S_s,
+        θ_r,
+        PAR_albedo = PAR_albedo,
+        NIR_albedo = NIR_albedo,
+    )
+
+
+    # TwoStreamModel parameters
+    Ω = FT(0.69)
+    ld = FT(0.5)
+    α_PAR_leaf = FT(0.1)
+    τ_PAR_leaf = FT(0.05)
+    α_NIR_leaf = FT(0.45)
+    τ_NIR_leaf = FT(0.25)
+
+    # Energy Balance model
+    ac_canopy = FT(2.5e5)
+
+    # Conductance Model
+    g1 = FT(141) # Wang et al: 141 sqrt(Pa) for Medlyn model; Natan used 300.
+
+    #Photosynthesis model
+    Vcmax25 = FT(9e-5) # from Yujie's paper 4.5e-5 , Natan used 9e-5
+
+    # Plant Hydraulics and general plant parameters
+    SAI = FT(0.0) # m2/m2
+    f_root_to_shoot = FT(3.5)
+    RAI = FT(1.0)
+    K_sat_plant = 5e-9 # m/s # seems much too small?
+    ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value is -4 MPa
+    Weibull_param = FT(4) # unitless, Holtzman's original c param value
+    a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
+    conductivity_model =
+        Canopy.PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+    retention_model = Canopy.PlantHydraulics.LinearRetentionCurve{FT}(a)
+    plant_ν = FT(1.44e-4)
+    plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
+    rooting_depth = FT(0.5) # from Natan
+    n_stem = 0
+    n_leaf = 1
+    h_stem = 0.0
+    h_leaf = 1.0
+    zmax = 0.0
+    h_canopy = h_stem + h_leaf
+    compartment_midpoints =
+        n_stem > 0 ? [h_stem / 2, h_stem + h_leaf / 2] : [h_leaf / 2]
+    compartment_surfaces =
+        n_stem > 0 ? [zmax, h_stem, h_canopy] : [zmax, h_leaf]
+
+    z0_m = FT(0.13) * h_canopy
+    z0_b = FT(0.1) * z0_m
+
+
+    soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(
+        FT;
+        ν = 1.0,# INCORRECT!
+    )
+
+    soil_args = (domain = domain, parameters = soil_params)
+    soil_model_type = Soil.EnergyHydrology{FT}
+
+    # Soil microbes model
+    soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
+
+    # soil microbes args
+    Csom = (z, t) -> eltype(z)(5.0)
+
+    # Set the soil CO2 BC to being atmospheric CO2
+    soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
+    soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2FluxBC((p, t) -> 0.0) # no flux
+    soilco2_sources = (Soil.Biogeochemistry.MicrobeProduction{FT}(),)
+
+    soilco2_boundary_conditions =
+        (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
+
+    soilco2_drivers = Soil.Biogeochemistry.SoilDrivers(
+        Soil.Biogeochemistry.PrognosticMet{FT}(),
+        Soil.Biogeochemistry.PrescribedSOC{FT}(Csom),
+        atmos,
+    )
+
+    soilco2_args = (;
+        boundary_conditions = soilco2_boundary_conditions,
+        sources = soilco2_sources,
+        domain = domain,
+        parameters = soilco2_ps,
+        drivers = soilco2_drivers,
+    )
+
+    # Now we set up the canopy model, which we set up by component:
+    # Component Types
+    canopy_component_types = (;
+        autotrophic_respiration = Canopy.AutotrophicRespirationModel{FT},
+        radiative_transfer = Canopy.TwoStreamModel{FT},
+        photosynthesis = Canopy.FarquharModel{FT},
+        conductance = Canopy.MedlynConductanceModel{FT},
+        hydraulics = Canopy.PlantHydraulicsModel{FT},
+        energy = Canopy.BigLeafEnergyModel{FT},
+    )
+    # Individual Component arguments
+    # Set up autotrophic respiration
+    autotrophic_respiration_args =
+        (; parameters = Canopy.AutotrophicRespirationParameters(FT))
+    # Set up radiative transfer
+    radiative_transfer_args = (;
+        parameters = Canopy.TwoStreamParameters(
+            FT;
+            Ω,
+            α_PAR_leaf,
+            τ_PAR_leaf,
+            α_NIR_leaf,
+            τ_NIR_leaf,
+        )
+    )
+    # Set up conductance
+    conductance_args =
+        (; parameters = Canopy.MedlynConductanceParameters(FT; g1))
+    # Set up photosynthesis
+    photosynthesis_args = (;
+        parameters = Canopy.FarquharParameters(
+            FT,
+            Canopy.C3();
+            Vcmax25 = Vcmax25,
+        )
+    )
+    # Set up plant hydraulics
+    # Note that we clip all values of LAI below 0.05 to zero.
+    # This is because we currently run into issues when LAI is
+    # of order eps(FT) in the SW radiation code.
+    # Please see Issue #644
+    # or PR #645 for details.
+    # For now, this clipping is similar to what CLM does.
+    LAIfunction = TimeVaryingInput(
+        joinpath(era5_artifact_path, "era5_2021_0.9x1.25_clima.nc"),
+        "lai",
+        surface_space;
+        reference_date = ref_time,
+        t_start,
+        regridder_type,
+        file_reader_kwargs = (;
+            preprocess_func = (data) -> data > 0.05 ? data : 0.0,
+        ),
+    )
+    ai_parameterization =
+        Canopy.PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
+
+    function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
+        return T(1.0 / rooting_depth) * exp(z / T(rooting_depth)) # 1/m
+    end
+
+    plant_hydraulics_ps = Canopy.PlantHydraulics.PlantHydraulicsParameters(;
+        ai_parameterization = ai_parameterization,
+        ν = plant_ν,
+        S_s = plant_S_s,
+        root_distribution = root_distribution,
+        conductivity_model = conductivity_model,
+        retention_model = retention_model,
+    )
+    plant_hydraulics_args = (
+        parameters = plant_hydraulics_ps,
+        n_stem = n_stem,
+        n_leaf = n_leaf,
+        compartment_midpoints = compartment_midpoints,
+        compartment_surfaces = compartment_surfaces,
+    )
+
+    energy_args = (parameters = Canopy.BigLeafEnergyParameters{FT}(ac_canopy),)
+
+    # Canopy component args
+    canopy_component_args = (;
+        autotrophic_respiration = autotrophic_respiration_args,
+        radiative_transfer = radiative_transfer_args,
+        photosynthesis = photosynthesis_args,
+        conductance = conductance_args,
+        hydraulics = plant_hydraulics_args,
+        energy = energy_args,
+    )
+
+    # Other info needed
+    shared_params = Canopy.SharedCanopyParameters{FT, typeof(earth_param_set)}(
+        z0_m,
+        z0_b,
+        earth_param_set,
+    )
+
+    canopy_model_args = (;
+        parameters = shared_params,
+        domain = ClimaLand.obtain_surface_domain(domain),
+    )
+
+    # Integrated plant hydraulics and soil model
+    land_input = (atmos = atmos, radiation = radiation)
+    land = SoilCanopyModel{FT}(;
+        soilco2_type = soilco2_type,
+        soilco2_args = soilco2_args,
+        land_args = land_input,
+        soil_model_type = soil_model_type,
+        soil_args = soil_args,
+        canopy_component_types = canopy_component_types,
+        canopy_component_args = canopy_component_args,
+        canopy_model_args = canopy_model_args,
+    )
+
+    Y, p, cds = initialize(land)
+
+    init_soil(ν, θ_r) = θ_r + (ν - θ_r) / 2
+    Y.soil.ϑ_l .= init_soil.(ν, θ_r)
+    Y.soil.θ_i .= FT(0.0)
+    T = FT(276.85)
+    ρc_s =
+        Soil.volumetric_heat_capacity.(
+            Y.soil.ϑ_l,
+            Y.soil.θ_i,
+            soil_params.ρc_ds,
+            soil_params.earth_param_set,
+        )
+    Y.soil.ρe_int .=
+        Soil.volumetric_internal_energy.(
+            Y.soil.θ_i,
+            ρc_s,
+            T,
+            soil_params.earth_param_set,
+        )
+    Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
+    Y.canopy.hydraulics.ϑ_l.:1 .= plant_ν
+    evaluate!(Y.canopy.energy.T, atmos.T, t0)
+
+    set_initial_cache! = make_set_initial_cache(land)
+    exp_tendency! = make_exp_tendency(land)
+    imp_tendency! = ClimaLand.make_imp_tendency(land)
+    tendency_jacobian! = ClimaLand.make_tendency_jacobian(land)
+    set_initial_cache!(p, Y, t0)
+
+    # set up jacobian info
+    jac_kwargs = (;
+        jac_prototype = ImplicitEquationJacobian(Y),
+        Wfact = tendency_jacobian!,
+    )
+
+    prob = SciMLBase.ODEProblem(
+        CTS.ClimaODEFunction(
+            T_exp! = exp_tendency!,
+            T_imp! = SciMLBase.ODEFunction(imp_tendency!; jac_kwargs...),
+            dss! = ClimaLand.dss!,
+        ),
+        Y,
+        (t0, tf),
+        p,
+    )
+
+    updateat = Array(t0:(3600 * 3):tf)
+    updatefunc = ClimaLand.make_update_drivers(atmos, radiation)
+    cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
+    return prob, cb
+end
+
+function setup_and_solve_problem(; greet = false)
+    # We profile the setup phase as well here. This is not intended, but it is the easiest
+    # to set up for both CPU/GPU at the same time
+    t0 = 0.0
+    tf = 60 * 60.0 * 6
+    Δt = 180.0
+    nelements = (101, 15)
+    if greet
+        @info "Run: Global RichardsModel"
+        @info "Resolution: $nelements"
+        @info "Timestep: $Δt s"
+        @info "Duration: $(tf - t0) s"
+    end
+
+    prob, cb = setup_prob(t0, tf, Δt; nelements)
+
+    # Define timestepper and ODE algorithm
+    stepper = CTS.ARS343()
+    norm_condition = CTS.MaximumError(FT(1e-8))
+    conv_checker = CTS.ConvergenceChecker(; norm_condition = norm_condition)
+    ode_algo = CTS.IMEXAlgorithm(
+        stepper,
+        CTS.NewtonsMethod(
+            max_iters = 1,
+            update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
+            convergence_checker = conv_checker,
+        ),
+    )
+
+    SciMLBase.solve(prob, ode_algo; dt = Δt, callback = cb)
+    return nothing
+end
+
+# Warm up and greet
+setup_and_solve_problem(; greet = true)
+
+@info "Starting profiling"
+# Stop when we profile for MAX_PROFILING_TIME_SECONDS or MAX_PROFILING_SAMPLES
+MAX_PROFILING_TIME_SECONDS = 1000
+MAX_PROFILING_SAMPLES = 100
+time_now = time()
+timings_s = Float64[]
+while (time() - time_now) < MAX_PROFILING_TIME_SECONDS &&
+    length(timings_s) < MAX_PROFILING_SAMPLES
+    push!(timings_s, ClimaComms.@elapsed device setup_and_solve_problem())
+end
+num_samples = length(timings_s)
+average_timing_s = round(sum(timings_s) / num_samples, sigdigits = 3)
+max_timing_s = round(maximum(timings_s), sigdigits = 3)
+min_timing_s = round(minimum(timings_s), sigdigits = 3)
+std_timing_s = round(
+    sum(((timings_s .- average_timing_s) .^ 2) / num_samples),
+    sigdigits = 3,
+)
+@info "Num samples: $num_samples"
+@info "Average time: $(average_timing_s) s"
+@info "Max time: $(max_timing_s) s"
+@info "Min time: $(min_timing_s) s"
+@info "Standard deviation time: $(std_timing_s) s"
+@info "Done profiling"
+
+Profile.@profile setup_and_solve_problem()
+results = Profile.fetch()
+flame_file = joinpath(outdir, "flame_$device_suffix.html")
+ProfileCanvas.html_file(flame_file, results)
+@info "Saved compute flame to $flame_file"
+
+Profile.Allocs.@profile sample_rate = 0.01 setup_and_solve_problem()
+results = Profile.Allocs.fetch()
+profile = ProfileCanvas.view_allocs(results)
+alloc_flame_file = joinpath(outdir, "alloc_flame_$device_suffix.html")
+ProfileCanvas.html_file(alloc_flame_file, profile)
+@info "Saved allocation flame to $alloc_flame_file"
+
+#=
+if ClimaComms.device() isa ClimaComms.CUDADevice
+    import CUDA
+    CUDA.@profile setup_and_solve_problem()
+end
+
+if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaland-benchmark"
+    PREVIOUS_BEST_TIME = 9.3
+    if average_timing_s > PREVIOUS_BEST_TIME + std_timing_s
+        @info "Possible performance regression, previous average time was $(PREVIOUS_BEST_TIME)"
+    elseif average_timing_s < PREVIOUS_BEST_TIME - std_timing_s
+        @info "Possible significant performance improvement, please update PREVIOUS_BEST_TIME in $(@__DIR__)"
+    end
+    @testset "Performance" begin
+        @test PREVIOUS_BEST_TIME - std_timing_s <=
+              average_timing_s ≤
+              PREVIOUS_BEST_TIME + std_timing_s
+    end
+end
+=#

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -271,14 +271,15 @@ T_0 =
     drivers.TS.values[1 + Int(round(t0 / DATA_DT))] :
     drivers.TA.values[1 + Int(round(t0 / DATA_DT))] + 40# Get soil temperature at t0
 ρc_s =
-    volumetric_heat_capacity.(Y.soil.ϑ_l, Y.soil.θ_i, Ref(land.soil.parameters))
-Y.soil.ρe_int =
-    volumetric_internal_energy.(
+    volumetric_heat_capacity.(
+        Y.soil.ϑ_l,
         Y.soil.θ_i,
-        ρc_s,
-        T_0,
-        Ref(land.soil.parameters),
+        land.soil.parameters.ρc_ds,
+        earth_param_set,
     )
+Y.soil.ρe_int =
+    volumetric_internal_energy.(Y.soil.θ_i, ρc_s, T_0, earth_param_set)
+
 Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
 ψ_stem_0 = FT(-1e5 / 9800) # pressure in the leaf divided by rho_liquid*gravitational acceleration [m]
 ψ_leaf_0 = FT(-2e5 / 9800)

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -231,14 +231,14 @@ T_0 =
     drivers.TS.values[1 + Int(round(t0 / DATA_DT))] :
     drivers.TA.values[1 + Int(round(t0 / DATA_DT))] + 40# Get soil temperature at t0
 ρc_s =
-    volumetric_heat_capacity.(Y.soil.ϑ_l, Y.soil.θ_i, Ref(land.soil.parameters))
-Y.soil.ρe_int =
-    volumetric_internal_energy.(
+    volumetric_heat_capacity.(
+        Y.soil.ϑ_l,
         Y.soil.θ_i,
-        ρc_s,
-        T_0,
-        Ref(land.soil.parameters),
+        land.soil.parameters.ρc_ds,
+        earth_param_set,
     )
+Y.soil.ρe_int =
+    volumetric_internal_energy.(Y.soil.θ_i, ρc_s, T_0, earth_param_set)
 Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
 ψ_stem_0 = FT(-1e5 / 9800) # pressure in the leaf divided by rho_liquid*gravitational acceleration [m]
 ψ_leaf_0 = FT(-2e5 / 9800)

--- a/experiments/integrated/global/global_parameters.jl
+++ b/experiments/integrated/global/global_parameters.jl
@@ -1,0 +1,211 @@
+using ArtifactWrappers
+#currently not being used
+#=
+# Read in f_max data and land sea mask
+topmodel_dataset = ArtifactWrapper(
+    @__DIR__,
+    "processed_topographic_index 2.5 deg",
+    ArtifactFile[ArtifactFile(
+        url = "https://caltech.box.com/shared/static/dwa7g0uzhxd50a2z3thbx3a12n0r887s.nc",
+        filename = "means_2.5_new.nc",
+    ),],
+)
+infile_path = joinpath(get_data_folder(topmodel_dataset), "means_2.5_new.nc")
+
+f_max = SpaceVaryingInput(
+    infile_path,
+    "fmax",
+    surface_space;
+    regridder_type
+)
+mask = SpaceVaryingInput(
+    infile_path,
+    "landsea_mask",
+    surface_space;
+    regridder_type
+)
+
+oceans_to_zero(field, mask) = mask > 0.5 ? field : eltype(field)(0)
+f_over = FT(3.28) # 1/m
+R_sb = FT(1.484e-4 / 1000) # m/s
+runoff_model = ClimaLand.Soil.Runoff.TOPMODELRunoff{FT}(;
+    f_over = f_over,
+    f_max = f_max,
+    R_sb = R_sb,
+)
+=#
+soil_params_artifact_path =
+    ClimaLand.Artifacts.soil_params_artifact_folder_path(; context)
+extrapolation_bc =
+    (Interpolations.Periodic(), Interpolations.Flat(), Interpolations.Flat())
+soil_params_mask = SpaceVaryingInput(
+    joinpath(
+        soil_params_artifact_path,
+        "vGalpha_map_gupta_etal2020_2.5x2.5x4.nc",
+    ),
+    "α",
+    subsurface_space;
+    regridder_type,
+    regridder_kwargs = (; extrapolation_bc,),
+    file_reader_kwargs = (; preprocess_func = (data) -> data > 0,),
+)
+oceans_to_value(field, mask, value) = mask == 1.0 ? field : eltype(field)(value)
+
+vg_α = SpaceVaryingInput(
+    joinpath(
+        soil_params_artifact_path,
+        "vGalpha_map_gupta_etal2020_2.5x2.5x4.nc",
+    ),
+    "α",
+    subsurface_space;
+    regridder_type,
+    regridder_kwargs = (; extrapolation_bc,),
+)
+vg_n = SpaceVaryingInput(
+    joinpath(soil_params_artifact_path, "vGn_map_gupta_etal2020_2.5x2.5x4.nc"),
+    "n",
+    subsurface_space;
+    regridder_type,
+    regridder_kwargs = (; extrapolation_bc,),
+)
+x = parent(vg_α)
+μ = mean(log10.(x[x .> 0]))
+vg_α .= oceans_to_value.(vg_α, soil_params_mask, 10.0^μ)
+
+x = parent(vg_n)
+μ = mean(x[x .> 0])
+vg_n .= oceans_to_value.(vg_n, soil_params_mask, μ)
+
+vg_fields_to_hcm_field(α::FT, n::FT) where {FT} =
+    ClimaLand.Soil.vanGenuchten{FT}(; @NamedTuple{α::FT, n::FT}((α, n))...)
+hydrology_cm = vg_fields_to_hcm_field.(vg_α, vg_n)
+
+θ_r = SpaceVaryingInput(
+    joinpath(
+        soil_params_artifact_path,
+        "residual_map_gupta_etal2020_2.5x2.5x4.nc",
+    ),
+    "θ_r",
+    subsurface_space;
+    regridder_type,
+    regridder_kwargs = (; extrapolation_bc,),
+)
+
+ν = SpaceVaryingInput(
+    joinpath(
+        soil_params_artifact_path,
+        "porosity_map_gupta_etal2020_2.5x2.5x4.nc",
+    ),
+    "ν",
+    subsurface_space;
+    regridder_type,
+    regridder_kwargs = (; extrapolation_bc,),
+)
+K_sat = SpaceVaryingInput(
+    joinpath(soil_params_artifact_path, "ksat_map_gupta_etal2020_2.5x2.5x4.nc"),
+    "Ksat",
+    subsurface_space;
+    regridder_type,
+    regridder_kwargs = (; extrapolation_bc,),
+)
+
+x = parent(K_sat)
+μ = mean(log10.(x[x .> 0]))
+K_sat .= oceans_to_value.(K_sat, soil_params_mask, 10.0^μ)
+
+ν .= oceans_to_value.(ν, soil_params_mask, 1)
+
+θ_r .= oceans_to_value.(θ_r, soil_params_mask, 0)
+
+
+S_s =
+    oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(1e-3),
+        soil_params_mask,
+        1,
+    )
+ν_ss_om =
+    oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+        soil_params_mask,
+        0,
+    )
+ν_ss_quartz =
+    oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+        soil_params_mask,
+        0,
+    )
+ν_ss_gravel =
+    oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+        soil_params_mask,
+        0,
+    )
+PAR_albedo = ClimaCore.Fields.zeros(surface_space) .+ FT(0.2)
+NIR_albedo = ClimaCore.Fields.zeros(surface_space) .+ FT(0.2)
+soil_params = Soil.EnergyHydrologyParameters(
+    FT;
+    ν,
+    ν_ss_om,
+    ν_ss_quartz,
+    ν_ss_gravel,
+    hydrology_cm,
+    K_sat,
+    S_s,
+    θ_r,
+    PAR_albedo = PAR_albedo,
+    NIR_albedo = NIR_albedo,
+);
+
+
+# TwoStreamModel parameters
+Ω = FT(0.69)
+ld = FT(0.5)
+α_PAR_leaf = FT(0.1)
+τ_PAR_leaf = FT(0.05)
+α_NIR_leaf = FT(0.45)
+τ_NIR_leaf = FT(0.25)
+
+# Energy Balance model
+ac_canopy = FT(2.5e4)
+
+# Conductance Model
+g1 = FT(141) # Wang et al: 141 sqrt(Pa) for Medlyn model; Natan used 300.
+
+#Photosynthesis model
+Vcmax25 = FT(9e-5) # from Yujie's paper 4.5e-5 , Natan used 9e-5
+
+# Plant Hydraulics and general plant parameters
+SAI = FT(0.0) # m2/m2
+f_root_to_shoot = FT(3.5)
+RAI = FT(1.0)
+K_sat_plant = 5e-9 # m/s # seems much too small?
+ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value is -4 MPa
+Weibull_param = FT(4) # unitless, Holtzman's original c param value
+a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
+conductivity_model =
+    Canopy.PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+retention_model = Canopy.PlantHydraulics.LinearRetentionCurve{FT}(a)
+plant_ν = FT(1.44e-4)
+plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
+rooting_depth = FT(0.5) # from Natan
+n_stem = 0
+n_leaf = 1
+h_stem = 0.0
+h_leaf = 1.0
+zmax = 0.0
+h_canopy = h_stem + h_leaf
+compartment_midpoints =
+    n_stem > 0 ? [h_stem / 2, h_stem + h_leaf / 2] : [h_leaf / 2]
+compartment_surfaces = n_stem > 0 ? [zmax, h_stem, h_canopy] : [zmax, h_leaf]
+
+z0_m = FT(0.13) * h_canopy
+z0_b = FT(0.1) * z0_m
+
+
+soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(
+    FT;
+    ν = 1.0,# INCORRECT! This should be the same as the soil porosity, but
+    # currently, SoilCO2 does not support spatially varying parameters
+)

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -1,0 +1,444 @@
+import SciMLBase
+import ClimaComms
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
+import ClimaTimeSteppers as CTS
+using ClimaCore
+using ClimaUtilities.ClimaArtifacts
+import Interpolations
+using Insolation
+
+import ClimaUtilities.TimeVaryingInputs: TimeVaryingInput
+import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
+import ClimaUtilities.Regridders: InterpolationsRegridder
+import ClimaUtilities.ClimaArtifacts: @clima_artifact
+import ClimaParams as CP
+
+using ClimaLand
+using ClimaLand.Soil
+using ClimaLand.Canopy
+import ClimaLand
+import ClimaLand.Parameters as LP
+
+using CairoMakie
+using Statistics
+using Dates
+import NCDatasets
+
+regridder_type = :InterpolationsRegridder
+extrapolation_bc =
+    (Interpolations.Periodic(), Interpolations.Flat(), Interpolations.Flat())
+context = ClimaComms.context()
+outdir = joinpath(pkgdir(ClimaLand), "experiments/integrated/global/plots")
+!ispath(outdir) && mkpath(outdir)
+
+device_suffix =
+    typeof(ClimaComms.context().device) <: ClimaComms.CPUSingleThreaded ?
+    "cpu" : "gpu"
+
+FT = Float64
+earth_param_set = LP.LandParameters(FT)
+radius = FT(6378.1e3);
+depth = FT(50)
+nelements = (50, 10)
+domain = ClimaLand.Domains.SphericalShell(;
+    radius = radius,
+    depth = depth,
+    nelements = nelements,
+    npolynomial = 1,
+    dz_tuple = FT.((10.0, 0.1)),
+);
+surface_space = domain.space.surface
+subsurface_space = domain.space.subsurface
+
+ref_time = DateTime(2021);
+t_start = 0.0
+
+# Forcing data
+era5_artifact_path =
+    ClimaLand.Artifacts.era5_land_forcing_data2021_folder_path(; context)
+precip = TimeVaryingInput(
+    joinpath(era5_artifact_path, "era5_2021_0.9x1.25_clima.nc"),
+    "rf",
+    surface_space;
+    reference_date = ref_time,
+    t_start,
+    regridder_type,
+    file_reader_kwargs = (; preprocess_func = (data) -> -data / 3600,),
+)
+
+snow_precip = TimeVaryingInput(
+    joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc"),
+    "sf",
+    surface_space;
+    reference_date = ref_time,
+    t_start,
+    regridder_type,
+    file_reader_kwargs = (; preprocess_func = (data) -> -data / 3600,),
+)
+
+u_atmos = TimeVaryingInput(
+    joinpath(era5_artifact_path, "era5_2021_0.9x1.25_clima.nc"),
+    "ws",
+    surface_space;
+    reference_date = ref_time,
+    t_start,
+    regridder_type,
+)
+q_atmos = TimeVaryingInput(
+    joinpath(era5_artifact_path, "era5_2021_0.9x1.25_clima.nc"),
+    "q",
+    surface_space;
+    reference_date = ref_time,
+    t_start,
+    regridder_type,
+)
+P_atmos = TimeVaryingInput(
+    joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc"),
+    "sp",
+    surface_space;
+    reference_date = ref_time,
+    t_start,
+    regridder_type,
+)
+
+T_atmos = TimeVaryingInput(
+    joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc"),
+    "t2m",
+    surface_space;
+    reference_date = ref_time,
+    t_start,
+    regridder_type,
+)
+h_atmos = FT(10);
+
+atmos = PrescribedAtmosphere(
+    precip,
+    snow_precip,
+    T_atmos,
+    u_atmos,
+    q_atmos,
+    P_atmos,
+    ref_time,
+    h_atmos,
+    earth_param_set,
+);
+
+# Prescribed radiation
+SW_d = TimeVaryingInput(
+    joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc"),
+    "ssrd",
+    surface_space;
+    reference_date = ref_time,
+    t_start,
+    regridder_type,
+    file_reader_kwargs = (; preprocess_func = (data) -> data / 3600,),
+)
+LW_d = TimeVaryingInput(
+    joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc"),
+    "strd",
+    surface_space;
+    reference_date = ref_time,
+    t_start,
+    regridder_type,
+    file_reader_kwargs = (; preprocess_func = (data) -> data / 3600,),
+)
+
+function zenith_angle(
+    t,
+    ref_time;
+    latitude = ClimaCore.Fields.coordinate_field(surface_space).lat,
+    longitude = ClimaCore.Fields.coordinate_field(surface_space).long,
+    insol_params::Insolation.Parameters.InsolationParameters{FT} = earth_param_set.insol_params,
+) where {FT}
+    # This should be time in UTC
+    current_datetime = ref_time + Dates.Second(round(t))
+
+    # Orbital Data uses Float64, so we need to convert to our sim FT
+    d, δ, η_UTC =
+        FT.(
+            Insolation.helper_instantaneous_zenith_angle(
+                current_datetime,
+                ref_time,
+                insol_params,
+            )
+        )
+
+    Insolation.instantaneous_zenith_angle.(d, δ, η_UTC, longitude, latitude).:1
+end
+radiation =
+    PrescribedRadiativeFluxes(FT, SW_d, LW_d, ref_time; θs = zenith_angle);
+
+include(
+    joinpath(
+        pkgdir(ClimaLand),
+        "experiments/integrated/global/global_parameters.jl",
+    ),
+)
+soil_args = (domain = domain, parameters = soil_params)
+soil_model_type = Soil.EnergyHydrology{FT}
+
+# Soil microbes model
+soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
+
+# soil microbes args
+Csom = (z, t) -> eltype(z)(5.0)
+
+# Set the soil CO2 BC to being atmospheric CO2
+soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
+soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2FluxBC((p, t) -> 0.0) # no flux
+soilco2_sources = (Soil.Biogeochemistry.MicrobeProduction{FT}(),)
+
+soilco2_boundary_conditions = (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
+
+soilco2_drivers = Soil.Biogeochemistry.SoilDrivers(
+    Soil.Biogeochemistry.PrognosticMet{FT}(),
+    Soil.Biogeochemistry.PrescribedSOC{FT}(Csom),
+    atmos,
+)
+
+soilco2_args = (;
+    boundary_conditions = soilco2_boundary_conditions,
+    sources = soilco2_sources,
+    domain = domain,
+    parameters = soilco2_ps,
+    drivers = soilco2_drivers,
+)
+
+# Now we set up the canopy model, which we set up by component:
+# Component Types
+canopy_component_types = (;
+    autotrophic_respiration = Canopy.AutotrophicRespirationModel{FT},
+    radiative_transfer = Canopy.TwoStreamModel{FT},
+    photosynthesis = Canopy.FarquharModel{FT},
+    conductance = Canopy.MedlynConductanceModel{FT},
+    hydraulics = Canopy.PlantHydraulicsModel{FT},
+    energy = Canopy.BigLeafEnergyModel{FT},
+)
+# Individual Component arguments
+# Set up autotrophic respiration
+autotrophic_respiration_args =
+    (; parameters = Canopy.AutotrophicRespirationParameters(FT))
+# Set up radiative transfer
+radiative_transfer_args = (;
+    parameters = Canopy.TwoStreamParameters(
+        FT;
+        Ω,
+        α_PAR_leaf,
+        τ_PAR_leaf,
+        α_NIR_leaf,
+        τ_NIR_leaf,
+    )
+)
+# Set up conductance
+conductance_args = (; parameters = Canopy.MedlynConductanceParameters(FT; g1))
+# Set up photosynthesis
+photosynthesis_args = (;
+    parameters = Canopy.FarquharParameters(FT, Canopy.C3(); Vcmax25 = Vcmax25)
+)
+# Set up plant hydraulics
+# Not ideal
+LAIfunction = TimeVaryingInput(
+    joinpath(era5_artifact_path, "era5_2021_0.9x1.25_clima.nc"),
+    "lai",
+    surface_space;
+    reference_date = ref_time,
+    t_start,
+    regridder_type,
+    file_reader_kwargs = (;
+        preprocess_func = (data) -> data > 0.05 ? data : 0.0,
+    ),
+)
+ai_parameterization = Canopy.PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
+
+function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
+    return T(1.0 / rooting_depth) * exp(z / T(rooting_depth)) # 1/m
+end
+
+plant_hydraulics_ps = Canopy.PlantHydraulics.PlantHydraulicsParameters(;
+    ai_parameterization = ai_parameterization,
+    ν = plant_ν,
+    S_s = plant_S_s,
+    root_distribution = root_distribution,
+    conductivity_model = conductivity_model,
+    retention_model = retention_model,
+)
+plant_hydraulics_args = (
+    parameters = plant_hydraulics_ps,
+    n_stem = n_stem,
+    n_leaf = n_leaf,
+    compartment_midpoints = compartment_midpoints,
+    compartment_surfaces = compartment_surfaces,
+)
+
+energy_args = (parameters = Canopy.BigLeafEnergyParameters{FT}(ac_canopy),)
+
+# Canopy component args
+canopy_component_args = (;
+    autotrophic_respiration = autotrophic_respiration_args,
+    radiative_transfer = radiative_transfer_args,
+    photosynthesis = photosynthesis_args,
+    conductance = conductance_args,
+    hydraulics = plant_hydraulics_args,
+    energy = energy_args,
+)
+
+# Other info needed
+shared_params = Canopy.SharedCanopyParameters{FT, typeof(earth_param_set)}(
+    z0_m,
+    z0_b,
+    earth_param_set,
+)
+
+canopy_model_args = (;
+    parameters = shared_params,
+    domain = ClimaLand.obtain_surface_domain(domain),
+)
+
+# Integrated plant hydraulics and soil model
+land_input = (atmos = atmos, radiation = radiation)
+land = SoilCanopyModel{FT}(;
+    soilco2_type = soilco2_type,
+    soilco2_args = soilco2_args,
+    land_args = land_input,
+    soil_model_type = soil_model_type,
+    soil_args = soil_args,
+    canopy_component_types = canopy_component_types,
+    canopy_component_args = canopy_component_args,
+    canopy_model_args = canopy_model_args,
+)
+
+Y, p, cds = initialize(land)
+
+t0 = 0.0
+dt = 180.0
+tf = 3600
+
+init_soil(ν, θ_r) = θ_r + (ν - θ_r) / 2
+Y.soil.ϑ_l .= init_soil.(ν, θ_r)
+Y.soil.θ_i .= FT(0.0)
+T = FT(276.85)
+ρc_s =
+    Soil.volumetric_heat_capacity.(
+        Y.soil.ϑ_l,
+        Y.soil.θ_i,
+        soil_params.ρc_ds,
+        soil_params.earth_param_set,
+    )
+Y.soil.ρe_int .=
+    Soil.volumetric_internal_energy.(
+        Y.soil.θ_i,
+        ρc_s,
+        T,
+        soil_params.earth_param_set,
+    )
+Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
+# On the Caltech cluster, this is not permitted, so we allowscalar.
+# This operation is fine on clima cluster
+Y.canopy.hydraulics.ϑ_l.:1 .= plant_ν
+evaluate!(Y.canopy.energy.T, atmos.T, t0)
+
+set_initial_cache! = make_set_initial_cache(land)
+exp_tendency! = make_exp_tendency(land);
+imp_tendency! = ClimaLand.make_imp_tendency(land);
+tendency_jacobian! = ClimaLand.make_tendency_jacobian(land);
+set_initial_cache!(p, Y, t0)
+stepper = CTS.ARS343()
+norm_condition = CTS.MaximumError(FT(1e-8))
+conv_checker = CTS.ConvergenceChecker(; norm_condition = norm_condition)
+ode_algo = CTS.IMEXAlgorithm(
+    stepper,
+    CTS.NewtonsMethod(
+        max_iters = 1,
+        update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
+        convergence_checker = conv_checker,
+    ),
+)
+
+# set up jacobian info
+jac_kwargs =
+    (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = tendency_jacobian!)
+
+prob = SciMLBase.ODEProblem(
+    CTS.ClimaODEFunction(
+        T_exp! = exp_tendency!,
+        T_imp! = SciMLBase.ODEFunction(imp_tendency!; jac_kwargs...),
+        dss! = ClimaLand.dss!,
+    ),
+    Y,
+    (t0, tf),
+    p,
+)
+
+saveat = [t0, tf]
+sv = (;
+    t = Array{Float64}(undef, length(saveat)),
+    saveval = Array{NamedTuple}(undef, length(saveat)),
+)
+saving_cb = ClimaLand.NonInterpSavingCallback(sv, saveat)
+updateat = Array(t0:(3600 * 3):tf)
+updatefunc = ClimaLand.make_update_drivers(atmos, radiation)
+driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
+cb = SciMLBase.CallbackSet(driver_cb, saving_cb)
+@time sol = SciMLBase.solve(
+    prob,
+    ode_algo;
+    dt = dt,
+    callback = cb,
+    adaptive = false,
+    saveat = saveat,
+)
+
+if device_suffix == "cpu"
+    longpts = range(-180.0, 180.0, 101)
+    latpts = range(-90.0, 90.0, 101)
+    hcoords = [
+        ClimaCore.Geometry.LatLongPoint(lat, long) for long in longpts,
+        lat in reverse(latpts)
+    ]
+    remapper = ClimaCore.Remapping.Remapper(surface_space, hcoords)
+    S = ClimaLand.Domains.top_center_to_surface(
+        (sol.u[end].soil.ϑ_l .- θ_r) ./ (ν .- θ_r),
+    )
+    S_ice = ClimaLand.Domains.top_center_to_surface(sol.u[end].soil.θ_i ./ ν)
+    T_soil = ClimaLand.Domains.top_center_to_surface(sv.saveval[end].soil.T)
+    SW = sv.saveval[end].drivers.SW_d
+
+    GPP = sv.saveval[end].canopy.photosynthesis.GPP .* 1e6
+    T_canopy = sol.u[end].canopy.energy.T
+    fields = [S, S_ice, T_soil, GPP, T_canopy, SW]
+    titles = [
+        "Effective saturation",
+        "Effective ice saturation",
+        "Temperature (K) - Soil",
+        "GPP",
+        "Temperature (K) - Canopy",
+        "Incident SW",
+    ]
+    plotnames = ["S", "Sice", "temp", "gpp", "temp_canopy", "sw"]
+    mask_top = ClimaLand.Domains.top_center_to_surface(soil_params_mask)
+    mask_remap = ClimaCore.Remapping.interpolate(remapper, mask_top)
+    for (id, x) in enumerate(fields)
+        title = titles[id]
+        plotname = plotnames[id]
+        x_remap = ClimaCore.Remapping.interpolate(remapper, x)
+
+        fig = Figure(size = (600, 400))
+        ax = Axis(
+            fig[1, 1],
+            xlabel = "Longitude",
+            ylabel = "Latitude",
+            title = title,
+        )
+        clims = extrema(x_remap)
+        CairoMakie.heatmap!(
+            ax,
+            longpts,
+            latpts,
+            oceans_to_value.(x_remap, mask_remap, 0.0),
+            colorrange = clims,
+        )
+        Colorbar(fig[:, end + 1], colorrange = clims)
+        outfile = joinpath(outdir, "$plotname.png")
+        CairoMakie.save(outfile, fig)
+    end
+end

--- a/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
+++ b/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
@@ -209,14 +209,14 @@ Y.soil.ϑ_l = drivers.SWC.values[1 + Int(round(t0 / 1800))] # Get soil water con
 Y.soil.θ_i = FT(0.0)
 T_0 = FT(drivers.TS.values[1 + Int(round(t0 / 1800))]) # Get soil temperature at t0
 ρc_s =
-    volumetric_heat_capacity.(Y.soil.ϑ_l, Y.soil.θ_i, Ref(land.soil.parameters))
-Y.soil.ρe_int =
-    volumetric_internal_energy.(
+    volumetric_heat_capacity.(
+        Y.soil.ϑ_l,
         Y.soil.θ_i,
-        ρc_s,
-        T_0,
-        Ref(land.soil.parameters),
+        land.soil.parameters.ρc_ds,
+        earth_param_set,
     )
+Y.soil.ρe_int =
+    volumetric_internal_energy.(Y.soil.θ_i, ρc_s, T_0, earth_param_set)
 
 Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
 

--- a/experiments/integrated/performance/profile_allocations.jl
+++ b/experiments/integrated/performance/profile_allocations.jl
@@ -37,14 +37,15 @@ function set_initial_conditions(land, t0)
         volumetric_heat_capacity.(
             Y.soil.ϑ_l,
             Y.soil.θ_i,
-            Ref(land.soil.parameters),
+            land.soil.parameters.ρc_ds,
+            land.soil.parameters.earth_param_set,
         )
     Y.soil.ρe_int =
         volumetric_internal_energy.(
             Y.soil.θ_i,
             ρc_s,
             T_0,
-            Ref(land.soil.parameters),
+            land.soil.parameters.earth_param_set,
         )
 
     Y.soilco2.C = FT(0.000412) # set to atmospheric co2, mol co2 per mol air

--- a/experiments/standalone/Biogeochemistry/experiment.jl
+++ b/experiments/standalone/Biogeochemistry/experiment.jl
@@ -132,9 +132,19 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
         Y.soil.ϑ_l .= FT(0.33)
         Y.soil.θ_i .= FT(0.1)
         T = FT(279.85)
-        ρc_s = Soil.volumetric_heat_capacity(FT(0.33), FT(0.1), params)
+        ρc_s = Soil.volumetric_heat_capacity(
+            FT(0.33),
+            FT(0.1),
+            params.ρc_ds,
+            params.earth_param_set,
+        )
         Y.soil.ρe_int .=
-            Soil.volumetric_internal_energy.(FT(0.0), ρc_s, T, Ref(params))
+            Soil.volumetric_internal_energy.(
+                FT(0.0),
+                ρc_s,
+                T,
+                params.earth_param_set,
+            )
     end
 
     function init_co2!(Y, z)

--- a/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
@@ -249,14 +249,15 @@ function run_fluxnet(
         volumetric_heat_capacity.(
             Y.soil.ϑ_l,
             Y.soil.θ_i,
-            Ref(land.soil.parameters),
+            land.soil.parameters.ρc_ds,
+            land.soil.parameters.earth_param_set,
         )
     Y.soil.ρe_int =
         volumetric_internal_energy.(
             Y.soil.θ_i,
             ρc_s,
             T_0,
-            Ref(land.soil.parameters),
+            land.soil.parameters.earth_param_set,
         )
     Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
     ψ_stem_0 = FT(-1e5 / 9800) # pressure in the leaf divided by rho_liquid*gravitational acceleration [m] 

--- a/src/standalone/Soil/soil_heat_parameterizations.jl
+++ b/src/standalone/Soil/soil_heat_parameterizations.jl
@@ -29,9 +29,11 @@ end
         θ_i::FT,
         T::FT,
         τ::FT,
-        params::EnergyHydrologyParameters{FT},
-    ) where {FT}
-
+        ν::FT,
+        θ_r::FT,
+        hydrology_cm::C,
+        earth_param_set::EP,
+    ) where {FT, EP, C}
 Returns the source term (1/s) used for converting liquid water
 and ice into each other during phase changes. Note that
 there are unitless prefactors multiplying this term in the 
@@ -46,9 +48,11 @@ function phase_change_source(
     θ_i::FT,
     T::FT,
     τ::FT,
-    params::EnergyHydrologyParameters{FT},
-) where {FT}
-    (; ν, θ_r, hydrology_cm, earth_param_set) = params
+    ν::FT,
+    θ_r::FT,
+    hydrology_cm::C,
+    earth_param_set::EP,
+) where {FT, EP, C}
     _ρ_i = FT(LP.ρ_cloud_ice(earth_param_set))
     _ρ_l = FT(LP.ρ_cloud_liq(earth_param_set))
     _LH_f0 = FT(LP.LH_f0(earth_param_set))
@@ -72,28 +76,30 @@ end
     volumetric_heat_capacity(
         θ_l::FT,
         θ_i::FT,
-        parameters::EnergyHydrologyParameters{FT},
-    ) where {FT}
+        ρc_ds::FT,
+        earth_param_set::EP,
+    ) where {FT,EP}
 
 Compute the expression for volumetric heat capacity.
 """
 function volumetric_heat_capacity(
     θ_l::FT,
     θ_i::FT,
-    parameters::EnergyHydrologyParameters{FT},
-) where {FT}
-    _ρ_i = FT(LP.ρ_cloud_ice(parameters.earth_param_set))
-    ρcp_i = FT(LP.cp_i(parameters.earth_param_set) * _ρ_i)
+    ρc_ds::FT,
+    earth_param_set::EP,
+) where {FT, EP}
+    _ρ_i = FT(LP.ρ_cloud_ice(earth_param_set))
+    ρcp_i = FT(LP.cp_i(earth_param_set) * _ρ_i)
 
-    _ρ_l = FT(LP.ρ_cloud_liq(parameters.earth_param_set))
-    ρcp_l = FT(LP.cp_l(parameters.earth_param_set) * _ρ_l)
+    _ρ_l = FT(LP.ρ_cloud_liq(earth_param_set))
+    ρcp_l = FT(LP.cp_l(earth_param_set) * _ρ_l)
 
-    ρc_s = parameters.ρc_ds + θ_l * ρcp_l + θ_i * ρcp_i
+    ρc_s = ρc_ds + θ_l * ρcp_l + θ_i * ρcp_i
     return ρc_s
 end
 """
     temperature_from_ρe_int(ρe_int::FT, θ_i::FT, ρc_s::FT
-                            parameters::EnergyHydrologyParameters{FT}) where {FT}
+                            earth_param_set::EP) where {FT, EP}
 
 A pointwise function for computing the temperature from the volumetric
 internal energy, volumetric ice content, and volumetric heat capacity of
@@ -103,19 +109,19 @@ function temperature_from_ρe_int(
     ρe_int::FT,
     θ_i::FT,
     ρc_s::FT,
-    parameters::EnergyHydrologyParameters{FT},
-) where {FT}
+    earth_param_set::EP,
+) where {FT, EP}
 
-    _ρ_i = FT(LP.ρ_cloud_ice(parameters.earth_param_set))
-    _T_ref = FT(LP.T_0(parameters.earth_param_set))
-    _LH_f0 = FT(LP.LH_f0(parameters.earth_param_set))
+    _ρ_i = FT(LP.ρ_cloud_ice(earth_param_set))
+    _T_ref = FT(LP.T_0(earth_param_set))
+    _LH_f0 = FT(LP.LH_f0(earth_param_set))
     T = _T_ref + (ρe_int + θ_i * _ρ_i * _LH_f0) / ρc_s
     return T
 end
 
 """
     volumetric_internal_energy(θ_i::FT, ρc_s::FT, T::FT,
-                                 parameters::EnergyHydrologyParameters{FT}) where {FT}
+                                 earth_param_set::EP) where {FT, EP}
 
 A pointwise function for computing the volumetric internal energy of the soil,
 given the volumetric ice content, volumetric heat capacity, and temperature.
@@ -124,17 +130,17 @@ function volumetric_internal_energy(
     θ_i::FT,
     ρc_s::FT,
     T::FT,
-    parameters::EnergyHydrologyParameters{FT},
-) where {FT}
-    _ρ_i = FT(LP.ρ_cloud_ice(parameters.earth_param_set))
-    _LH_f0 = FT(LP.LH_f0(parameters.earth_param_set))
-    _T_ref = FT(LP.T_0(parameters.earth_param_set))
+    earth_param_set::EP,
+) where {FT, EP}
+    _ρ_i = FT(LP.ρ_cloud_ice(earth_param_set))
+    _LH_f0 = FT(LP.LH_f0(earth_param_set))
+    _T_ref = FT(LP.T_0(earth_param_set))
     ρe_int = ρc_s * (T - _T_ref) - θ_i * _ρ_i * _LH_f0
     return ρe_int
 end
 
 """
-    volumetric_internal_energy_liq(T::FT, parameters::EnergyHydrologyParameters{FT}) where {FT}
+    volumetric_internal_energy_liq(T::FT, earth_param_set::EP) where {FT, EP}
 
 
 A pointwise function for computing the volumetric internal energy
@@ -142,12 +148,12 @@ of the liquid water in the soil, given the temperature T.
 """
 function volumetric_internal_energy_liq(
     T::FT,
-    parameters::EnergyHydrologyParameters{FT},
-) where {FT}
+    earth_param_set::EP,
+) where {FT, EP}
 
-    _T_ref = FT(LP.T_0(parameters.earth_param_set))
-    _ρ_l = FT(LP.ρ_cloud_liq(parameters.earth_param_set))
-    ρcp_l = FT(LP.cp_l(parameters.earth_param_set) * _ρ_l)
+    _T_ref = FT(LP.T_0(earth_param_set))
+    _ρ_l = FT(LP.ρ_cloud_liq(earth_param_set))
+    ρcp_l = FT(LP.cp_l(earth_param_set) * _ρ_l)
     ρe_int_l = ρcp_l * (T - _T_ref)
     return ρe_int_l
 end
@@ -210,8 +216,12 @@ end
     kersten_number(
         θ_i::FT,
         S_r::FT,
-        parameters::EnergyHydrologyParameters{FT},
-    ) where {FT}
+        α::FT,
+        β::FT,
+        ν_ss_om::FT,
+        ν_ss_quartz::FT,
+        ν_ss_gravel::FT,
+        ) where {FT}
 
 Compute the expression for the Kersten number, using the Balland
 and Arp model.
@@ -219,14 +229,12 @@ and Arp model.
 function kersten_number(
     θ_i::FT,
     S_r::FT,
-    parameters::EnergyHydrologyParameters{FT},
+    α::FT,
+    β::FT,
+    ν_ss_om::FT,
+    ν_ss_quartz::FT,
+    ν_ss_gravel::FT,
 ) where {FT}
-    α = parameters.α
-    β = parameters.β
-    ν_ss_om = parameters.ν_ss_om
-    ν_ss_quartz = parameters.ν_ss_quartz
-    ν_ss_gravel = parameters.ν_ss_gravel
-
     if θ_i < eps(FT)
         K_e =
             S_r^((FT(1) + ν_ss_om - α * ν_ss_quartz - ν_ss_gravel) / FT(2)) *

--- a/src/standalone/Soil/soil_hydrology_parameterizations.jl
+++ b/src/standalone/Soil/soil_hydrology_parameterizations.jl
@@ -89,7 +89,8 @@ function pressure_head(
     ν_eff::FT,
     S_s::FT,
 ) where {FT}
-    S_l_eff = effective_saturation(ν_eff, ϑ_l, θ_r)
+    ϑ_l_safe = max(ϑ_l, θ_r + eps(FT))
+    S_l_eff = effective_saturation(ν_eff, ϑ_l_safe, θ_r)
     if S_l_eff <= FT(1.0)
         ψ = matric_potential(cm, S_l_eff)
     else
@@ -308,7 +309,14 @@ function soil_tortuosity(θ_l::FT, θ_i::FT, ν::FT) where {FT}
 end
 
 """
-    soil_resistance(θ_l, θ_i, parameters::EnergyHydrologyParameters::FT)
+    soil_resistance(θ_l::FT,
+                    θ_i::FT,
+                    hydrology_cm::C,
+                    ν::FT,
+                    θ_r::FT,
+                    d_ds::FT,
+                    earth_param_set::EP,
+                   ) where {FT, EP, C}
 
 Computes the resistance of the top of the soil column to
 water vapor diffusion, as a function of the surface 
@@ -319,9 +327,12 @@ fraction `θ_i`, and other soil parameters.
 function soil_resistance(
     θ_l::FT,
     θ_i::FT,
-    parameters::EnergyHydrologyParameters{FT},
-) where {FT}
-    (; ν, hydrology_cm, θ_r, d_ds, earth_param_set) = parameters
+    hydrology_cm::C,
+    ν::FT,
+    θ_r::FT,
+    d_ds::FT,
+    earth_param_set::EP,
+) where {FT, EP, C}
     (; S_c) = hydrology_cm
     _D_vapor = FT(LP.D_vapor(earth_param_set))
     S_w = effective_saturation(ν, θ_l + θ_i, θ_r)

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -321,7 +321,7 @@ function ClimaLand.Canopy.set_canopy_prescribed_field!(
     t,
 ) where {FT}
     (; LAIfunction, SAI, RAI) = component.parameters.ai_parameterization
-    evaluate!(p.canopy.hydraulics.area_index.leaf, LAIfunction, t)
+    evaluate!(p.canopy.hydraulics.area_index.leaf, LAIfunction, floor(t))
     @. p.canopy.hydraulics.area_index.stem = SAI
     @. p.canopy.hydraulics.area_index.root = RAI
 end

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -236,8 +236,6 @@ function canopy_radiant_energy_fluxes!(
     @. p.canopy.radiative_transfer.SW_n =
         (energy_per_photon_PAR * N_a * APAR) +
         (energy_per_photon_NIR * N_a * ANIR)
-    LAI = p.canopy.hydraulics.area_index.leaf
-    SAI = p.canopy.hydraulics.area_index.stem
     ϵ_canopy = p.canopy.radiative_transfer.ϵ # this takes into account LAI/SAI
     # Long wave: use soil conditions from the PrescribedSoil driver
     T_soil::FT = s.T(t)

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -124,9 +124,22 @@ for FT in (Float32, Float64)
             Y.soil.ϑ_l .= FT(0.33)
             Y.soil.θ_i .= FT(0.0)
             T = FT(279.85)
-            ρc_s = FT.(Soil.volumetric_heat_capacity(FT(0.33), FT(0.0), params))
+            ρc_s =
+                FT.(
+                    Soil.volumetric_heat_capacity(
+                        FT(0.33),
+                        FT(0.0),
+                        params.ρc_ds,
+                        params.earth_param_set,
+                    )
+                )
             Y.soil.ρe_int .=
-                Soil.volumetric_internal_energy.(FT(0.0), ρc_s, T, Ref(params))
+                Soil.volumetric_internal_energy.(
+                    FT(0.0),
+                    ρc_s,
+                    T,
+                    params.earth_param_set,
+                )
         end
 
         function init_co2!(Y, C_0)
@@ -195,13 +208,18 @@ for FT in (Float32, Float64)
                 Y.soil.ϑ_l .= FT(0.33)
                 Y.soil.θ_i .= FT(0.0)
                 T = FT(279.85)
-                ρc_s = Soil.volumetric_heat_capacity(FT(0.33), FT(0.0), params)
+                ρc_s = Soil.volumetric_heat_capacity(
+                    FT(0.33),
+                    FT(0.0),
+                    params.ρc_ds,
+                    params.earth_params_set,
+                )
                 Y.soil.ρe_int .=
                     Soil.volumetric_internal_energy.(
                         FT(0.0),
                         ρc_s,
                         T,
-                        Ref(params),
+                        params.earth_param_set,
                     )
             end
 

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -151,13 +151,18 @@ for FT in (Float32, Float64)
                 Y.soil.ϑ_l .= ν / 2
                 Y.soil.θ_i .= 0
                 T = FT(280)
-                ρc_s = Soil.volumetric_heat_capacity(ν / 2, FT(0), params)
+                ρc_s = Soil.volumetric_heat_capacity(
+                    ν / 2,
+                    FT(0),
+                    params.ρc_ds,
+                    params.earth_param_set,
+                )
                 Y.soil.ρe_int =
                     Soil.volumetric_internal_energy.(
                         FT(0),
                         ρc_s,
                         T,
-                        Ref(params),
+                        params.earth_param_set,
                     )
             end
 

--- a/test/standalone/Soil/soil_bc.jl
+++ b/test/standalone/Soil/soil_bc.jl
@@ -174,7 +174,11 @@ for FT in (Float32, Float64)
                 kersten_number.(
                     θ_i,
                     relative_saturation.(ϑ_c, θ_i, ν),
-                    Ref(parameters),
+                    parameters.α,
+                    parameters.β,
+                    ν_ss_om,
+                    ν_ss_quartz,
+                    ν_ss_gravel,
                 ),
                 κ_sat.(
                     ϑ_c,

--- a/test/standalone/Soil/soil_test_3d.jl
+++ b/test/standalone/Soil/soil_test_3d.jl
@@ -316,14 +316,19 @@ for FT in (Float32, Float64)
 
         θ_l = Soil.volumetric_liquid_fraction.(Y.soil.ϑ_l, ν, θ_r)
         volumetric_heat_capacity =
-            Soil.volumetric_heat_capacity.(θ_l, Y.soil.θ_i, Ref(parameters))
+            Soil.volumetric_heat_capacity.(
+                θ_l,
+                Y.soil.θ_i,
+                parameters.ρc_ds,
+                parameters.earth_param_set,
+            )
         Y.soil.ρe_int .=
             ClimaCore.Fields.zeros(FT, axes(Y.soil.ρe_int)) .+
             volumetric_internal_energy.(
                 FT(0),
                 volumetric_heat_capacity,
                 FT(280),
-                Ref(parameters),
+                parameters.earth_param_set,
             )
 
 

--- a/test/standalone/Soil/soiltest.jl
+++ b/test/standalone/Soil/soiltest.jl
@@ -122,6 +122,7 @@ for FT in (Float32, Float64)
 
 
         ###
+        K_sat = FT(0)
         hyd_off_en_on = Soil.EnergyHydrologyParameters(
             FT;
             ν,
@@ -129,7 +130,7 @@ for FT in (Float32, Float64)
             ν_ss_quartz,
             ν_ss_gravel,
             hydrology_cm,
-            K_sat = FT(0),
+            K_sat,
             S_s,
             θ_r,
         )
@@ -152,13 +153,14 @@ for FT in (Float32, Float64)
             ρc_s = @. Soil.volumetric_heat_capacity(
                 Ysoil.soil.ϑ_l,
                 Ysoil.soil.θ_i,
-                params,
+                params.ρc_ds,
+                params.earth_param_set,
             )
             Ysoil.soil.ρe_int = @. Soil.volumetric_internal_energy.(
                 Ysoil.soil.θ_i,
                 ρc_s,
                 T,
-                params,
+                params.earth_param_set,
             )
         end
 
@@ -198,6 +200,7 @@ for FT in (Float32, Float64)
         ### the thermal conductivities to zero, but at the expense of being unreadable.
         ### Because this is only for a test, we tolerate it :)
         hyd_on_en_off = Soil.EnergyHydrologyParameters{
+            FT,
             FT,
             FT,
             typeof(hydrology_cm),
@@ -246,13 +249,14 @@ for FT in (Float32, Float64)
             ρc_s = @. Soil.volumetric_heat_capacity.(
                 Y.soil.ϑ_l,
                 Ysoil.soil.θ_i,
-                params,
+                params.ρc_ds,
+                params.earth_param_set,
             )
             Ysoil.soil.ρe_int = @. volumetric_internal_energy.(
                 Ysoil.soil.θ_i,
                 ρc_s,
                 FT(288),
-                params,
+                params.earth_param_set,
             )
         end
 
@@ -351,7 +355,7 @@ for FT in (Float32, Float64)
             parent(
                 Soil.volumetric_internal_energy_liq.(
                     p.soil.T,
-                    Ref(soil_water_on.parameters),
+                    Ref(soil_water_on.parameters.earth_param_set),
                 ),
             ),
         )
@@ -393,6 +397,7 @@ for FT in (Float32, Float64)
         ### the thermal conductivities to zero, but at the expense of being unreadable.
         ### Because this is only for a test, we tolerate it :)
         hyd_off_en_off = Soil.EnergyHydrologyParameters{
+            FT,
             FT,
             FT,
             typeof(hydrology_cm),
@@ -443,13 +448,14 @@ for FT in (Float32, Float64)
             ρc_s = @. Soil.volumetric_heat_capacity(
                 Ysoil.soil.ϑ_l,
                 Ysoil.soil.θ_i,
-                params,
+                params.ρc_ds,
+                params.earth_param_set,
             )
             Ysoil.soil.ρe_int = @. Soil.volumetric_internal_energy.(
                 Ysoil.soil.θ_i,
                 ρc_s,
                 T,
-                params,
+                params.earth_param_set,
             )
         end
 
@@ -508,10 +514,15 @@ for FT in (Float32, Float64)
             ρc_s = @. Soil.volumetric_heat_capacity.(
                 Y.soil.ϑ_l,
                 Ysoil.soil.θ_i,
-                params,
+                params.ρc_ds,
+                params.earth_param_set,
             )
-            Ysoil.soil.ρe_int =
-                @. volumetric_internal_energy.(Ysoil.soil.θ_i, ρc_s, T, params)
+            Ysoil.soil.ρe_int = @. volumetric_internal_energy.(
+                Ysoil.soil.θ_i,
+                ρc_s,
+                T,
+                params.earth_param_set,
+            )
         end
 
         t0 = FT(0)
@@ -533,7 +544,7 @@ for FT in (Float32, Float64)
             parent(
                 Soil.volumetric_internal_energy_liq.(
                     p.soil.T,
-                    Ref(soil_both_on.parameters),
+                    Ref(soil_both_on.parameters.earth_param_set),
                 ),
             ),
         )
@@ -681,13 +692,14 @@ for FT in (Float32, Float64)
             ρc_s = @. Soil.volumetric_heat_capacity(
                 Ysoil.soil.ϑ_l,
                 Ysoil.soil.θ_i,
-                params,
+                params.ρc_ds,
+                params.earth_param_set,
             )
             Ysoil.soil.ρe_int = @. Soil.volumetric_internal_energy.(
                 Ysoil.soil.θ_i,
                 ρc_s,
                 T,
-                params,
+                params.earth_param_set,
             )
         end
 


### PR DESCRIPTION
## Purpose 
Carry out global run of soil+canopy model on GPU and CPU
## To-do
- Future PR: add in runoff. [This requires altering our land model constructor, which will then involve changing a number of files more (to supply runoff instead of using the default). I will follow up this PR with a quick one adding that.](https://github.com/CliMA/ClimaLand.jl/pull/669)

## Content
1. Previously, we had only ever simulated Richards model globally. Because the soil properties vary spatially, certain functions that are only used by EnergyHydrology needed to be updated to be broadcastable. The primary change is because the parameter struct contains fields, but is not a field of a parameter structs. this means that functions that we broadcasted over a Ref of the parameter struct before now must be supplied each parameter field as an argument. This led to a LOT of changes (volumetric_heat_capacity, volumetric_internal_energy, volumetric_internal_energy_liq, phase_change_source, soil_resistance)
2. Parameters that were marked as FT in the EnergyHydrologyParameter struct now are a unionof FT and Field. Some parameters are only defined on the surface, rather than throughout the soil, so they need a different parametric type
3. added benchmark - on GPU
4. added experiment - GPU/CPU


Note: For the benchmark -  currently about 1/4 of the time is in setup rather than solve, so maybe we need to change the setup of the simulation. however, making it longer leads to failures, so Im not sure yet.

Note: The experiment does not run on GPU in CI - on caltech - , but it does on GPU on clima (benchmark). For now I removed the run on caltech
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
