### PR TITLE
Remove compat_depot, add concurrency group

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -171,7 +171,3 @@ steps:
         depends_on:
           - "global_bucket_temporalmap_cpu"
           - "global_bucket_temporalmap_gpu"
-
-  - wait
-
-  - command: "compact_depot"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,6 +13,8 @@ env:
 steps:
   - label: "init environment :computer:"
     key: "init_cpu_env"
+    concurrency: 1
+    concurrency_group: 'depot/climaland-ci'
     command:
       - "echo $$JULIA_DEPOT_PATH"
 


### PR DESCRIPTION
Lately, we've often seen issues with the shared depot. This PR disables it. This comes at no cost to us or any other package since this shared depot is only used by ClimaLand at the moment.

This PR also adds a concurrency group to reduce conflicts between different init jobs.
