### PR TITLE
zero flux if zero lai

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,6 +43,18 @@ steps:
         command: "julia --color=yes --project=.buildkite experiments/standalone/Snow/snow_cdp.jl"
         artifact_paths: "experiments/standalone/Snow/*png"
 
+      - label: "Varying LAI, no stem compartment"
+        command: "julia --color=yes --project=.buildkite experiments/standalone/Vegetation/varying_lai.jl"
+        artifact_paths: "experiments/standalone/Vegetation/varying_lai_no_stem*png"
+
+      - label: "Varying LAI, with stem compartment"
+        command: "julia --color=yes --project=.buildkite experiments/standalone/Vegetation/varying_lai_with_stem.jl"
+        artifact_paths: "experiments/standalone/Vegetation/varying_lai_with_stem*png"
+
+      - label: "zero LAI, zero SAI"
+        command: "julia --color=yes --project=.buildkite experiments/standalone/Vegetation/no_vegetation.jl"
+        artifact_paths: "experiments/standalone/Vegetation/no_veg*png"
+
       - label: "Richards comparison to Bonan"
         command: "julia --color=yes --project=.buildkite experiments/standalone/Soil/richards_comparison.jl"
         artifact_paths: "experiments/standalone/Soil/cpu/comparison*png"

--- a/experiments/Manifest.toml
+++ b/experiments/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.3"
+julia_version = "1.10.4"
 manifest_format = "2.0"
 project_hash = "973443a0a609649a9289253b6f5bc3de181d9006"
 

--- a/experiments/standalone/Vegetation/no_vegetation.jl
+++ b/experiments/standalone/Vegetation/no_vegetation.jl
@@ -1,0 +1,270 @@
+import SciMLBase
+using CairoMakie
+using Statistics
+using Dates
+using Insolation
+
+# Load CliMA Packages and ClimaLand Modules:
+
+using ClimaCore
+import ClimaParams as CP
+import ClimaTimeSteppers as CTS
+using StaticArrays
+using ClimaLand
+using ClimaLand.Domains: Point
+using ClimaLand.Canopy
+using ClimaLand.Canopy.PlantHydraulics
+import ClimaLand
+import ClimaLand.Parameters as LP
+const FT = Float32;
+earth_param_set = LP.LandParameters(FT);
+f_root_to_shoot = FT(3.5)
+SAI = FT(0.0)
+plant_ν = FT(2.46e-4) # kg/m^2
+n_stem = Int64(0)
+n_leaf = Int64(1)
+h_leaf = FT(9.5)
+compartment_midpoints = [h_leaf / 2]
+compartment_surfaces = [FT(0), h_leaf]
+land_domain = Point(; z_sfc = FT(0.0))
+include(
+    joinpath(pkgdir(ClimaLand), "experiments/integrated/fluxnet/data_tools.jl"),
+);
+time_offset = 7
+lat = FT(38.7441) # degree
+long = FT(-92.2000) # degree
+atmos_h = FT(32)
+site_ID = "US-MOz"
+data_link = "https://caltech.box.com/shared/static/7r0ci9pacsnwyo0o9c25mhhcjhsu6d72.csv"
+
+include(
+    joinpath(
+        pkgdir(ClimaLand),
+        "experiments/integrated/fluxnet/met_drivers_FLUXNET.jl",
+    ),
+);
+
+z0_m = FT(2)
+z0_b = FT(0.2)
+
+shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
+    z0_m,
+    z0_b,
+    earth_param_set,
+);
+ψ_soil0 = FT(0.0)
+
+soil_driver = PrescribedSoil(
+    FT;
+    root_depths = SVector{10, FT}(-(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0),
+    ψ = t -> ψ_soil0,
+    α_PAR = FT(0.2),
+    α_NIR = FT(0.4),
+    T = t -> 298.0,
+    ϵ = FT(0.99),
+);
+
+rt_params = TwoStreamParameters(
+    FT;
+    G_Function = ConstantGFunction(FT(0.5)),
+    α_PAR_leaf = FT(0.1),
+    α_NIR_leaf = FT(0.45),
+    τ_PAR_leaf = FT(0.05),
+    τ_NIR_leaf = FT(0.25),
+    Ω = FT(0.69),
+    λ_γ_PAR = FT(5e-7),
+    λ_γ_NIR = FT(1.65e-6),
+)
+
+rt_model = TwoStreamModel{FT}(rt_params);
+
+cond_params = MedlynConductanceParameters(FT; g1 = FT(141.0))
+
+stomatal_model = MedlynConductanceModel{FT}(cond_params);
+
+
+photo_params = FarquharParameters(FT, Canopy.C3(); Vcmax25 = FT(5e-5))
+
+photosynthesis_model = FarquharModel{FT}(photo_params);
+
+AR_params = AutotrophicRespirationParameters(FT)
+AR_model = AutotrophicRespirationModel{FT}(AR_params);
+
+function fakeLAIfunction(t)
+    if t < 30 * 24 * 3600
+        0.0
+    elseif t < (364 - 30) * 24 * 3600.0
+        max(2.0 * sin(2 * π / (730 * 24 * 3600) * (t - 30 * 24 * 3600)), 0)
+    else
+        0.0
+    end
+end
+
+
+f_root_to_shoot = FT(3.5)
+SAI = FT(0)
+RAI = FT(2 * f_root_to_shoot)
+ai_parameterization =
+    PrescribedSiteAreaIndex{FT}(TimeVaryingInput(fakeLAIfunction), SAI, RAI)
+rooting_depth = FT(1.0);
+
+function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
+    return T(1.0 / rooting_depth) * exp(z / T(rooting_depth))
+end;
+
+K_sat_plant = FT(1.8e-8)
+ψ63 = FT(-4 / 0.0098)
+Weibull_param = FT(4)
+a = FT(0.05 * 0.0098)
+
+conductivity_model =
+    PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+
+retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a);
+
+ν = FT(0.7)
+S_s = FT(1e-2 * 0.0098)
+
+plant_hydraulics_ps = PlantHydraulics.PlantHydraulicsParameters(;
+    ai_parameterization = ai_parameterization,
+    ν = ν,
+    S_s = S_s,
+    root_distribution = root_distribution,
+    conductivity_model = conductivity_model,
+    retention_model = retention_model,
+);
+
+
+plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
+    parameters = plant_hydraulics_ps,
+    n_stem = n_stem,
+    n_leaf = n_leaf,
+    compartment_surfaces = compartment_surfaces,
+    compartment_midpoints = compartment_midpoints,
+);
+
+energy_model = ClimaLand.Canopy.BigLeafEnergyModel{FT}(
+    BigLeafEnergyParameters{FT}(FT(1e3)),
+)
+
+canopy = ClimaLand.Canopy.CanopyModel{FT}(;
+    parameters = shared_params,
+    domain = land_domain,
+    autotrophic_respiration = AR_model,
+    radiative_transfer = rt_model,
+    photosynthesis = photosynthesis_model,
+    conductance = stomatal_model,
+    energy = energy_model,
+    hydraulics = plant_hydraulics,
+    soil_driver = soil_driver,
+    atmos = atmos,
+    radiation = radiation,
+);
+
+
+Y, p, coords = ClimaLand.initialize(canopy)
+exp_tendency! = make_exp_tendency(canopy);
+
+
+ψ_leaf_0 = FT(-2e5 / 9800)
+
+S_l_ini = inverse_water_retention_curve(retention_model, ψ_leaf_0, ν, S_s)
+
+Y.canopy.hydraulics.ϑ_l.:1 .= augmented_liquid_fraction.(ν, S_l_ini)
+
+
+
+t0 = 0.0
+N_days = 10
+tf = t0 + 3600 * 24 * N_days
+dt = 225.0;
+evaluate!(Y.canopy.energy.T, atmos.T, t0)
+set_initial_cache! = make_set_initial_cache(canopy)
+set_initial_cache!(p, Y, t0);
+
+
+n = 16
+saveat = Array(t0:(n * dt):tf)
+sv = (;
+    t = Array{Float64}(undef, length(saveat)),
+    saveval = Array{NamedTuple}(undef, length(saveat)),
+)
+saving_cb = ClimaLand.NonInterpSavingCallback(sv, saveat);
+
+updateat = Array(t0:1800:tf)
+updatefunc = ClimaLand.make_update_drivers(atmos, radiation)
+driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
+cb = SciMLBase.CallbackSet(driver_cb, saving_cb);
+
+timestepper = CTS.RK4();
+ode_algo = CTS.ExplicitAlgorithm(timestepper)
+
+prob = SciMLBase.ODEProblem(
+    CTS.ClimaODEFunction(T_exp! = exp_tendency!, dss! = ClimaLand.dss!),
+    Y,
+    (t0, tf),
+    p,
+);
+
+sol = SciMLBase.solve(prob, ode_algo; dt = dt, callback = cb, saveat = saveat);
+
+savedir = joinpath(pkgdir(ClimaLand), "experiments/standalone/Vegetation");
+T = [parent(sol.u[k].canopy.energy.T)[1] for k in 1:length(sol.t)]
+T_atmos = [parent(sv.saveval[k].drivers.T)[1] for k in 1:length(sol.t)]
+ϑ = [parent(sol.u[k].canopy.hydraulics.ϑ_l.:1)[1] for k in 1:length(sol.t)]
+GPP = [
+    parent(sv.saveval[k].canopy.photosynthesis.GPP)[1] * 1e6 for
+    k in 1:length(sol.t)
+]
+resp = [
+    parent(sv.saveval[k].canopy.autotrophic_respiration.Ra)[1] * 1e6 for
+    k in 1:length(sol.t)
+]
+SW_abs = [
+    parent(sv.saveval[k].canopy.radiative_transfer.SW_n)[1] for
+    k in 1:length(sol.t)
+]
+LW_abs = [
+    parent(sv.saveval[k].canopy.radiative_transfer.LW_n)[1] for
+    k in 1:length(sol.t)
+]
+SHF = [parent(sv.saveval[k].canopy.energy.shf)[1] for k in 1:length(sol.t)]
+LHF = [parent(sv.saveval[k].canopy.energy.lhf)[1] for k in 1:length(sol.t)]
+RE = [
+    parent(sv.saveval[k].canopy.energy.fa_energy_roots)[1] for
+    k in 1:length(sol.t)
+]
+R = [
+    parent(sv.saveval[k].canopy.hydraulics.fa_roots)[1] for k in 1:length(sol.t)
+]
+Tr = [parent(sv.saveval[k].canopy.hydraulics.fa.:1)[1] for k in 1:length(sol.t)]
+fig = Figure()
+ax = Axis(fig[1, 1], xlabel = "Time (days)", ylabel = "Temperature (K)")
+lines!(ax, sol.t ./ 24 ./ 3600, T, label = "Canopy")
+lines!(ax, sol.t ./ 24 ./ 3600, T_atmos, label = "Atmos")
+axislegend(ax)
+ax = Axis(fig[2, 1], xlabel = "Time (days)", ylabel = "Volumetric Water")
+lines!(ax, sol.t ./ 24 ./ 3600, ϑ, label = "Canopy")
+axislegend(ax)
+ax = Axis(fig[3, 1], xlabel = "Time (days)", ylabel = "LAI")
+lines!(ax, sol.t ./ 24 ./ 3600, fakeLAIfunction.(sol.t), label = "Canopy")
+axislegend(ax)
+save(joinpath(savedir, "no_veg_state.png"), fig)
+fig2 = Figure()
+ax = Axis(fig2[1, 1], xlabel = "Time (days)", ylabel = "Energy Fluxes")
+lines!(ax, sol.t ./ 24 ./ 3600, SW_abs, label = "SW")
+lines!(ax, sol.t ./ 24 ./ 3600, LW_abs, label = "LW")
+lines!(ax, sol.t ./ 24 ./ 3600, SHF, label = "SHF")
+lines!(ax, sol.t ./ 24 ./ 3600, LHF, label = "LHF")
+lines!(ax, sol.t ./ 24 ./ 3600, RE, label = "RE")
+axislegend(ax)
+ax = Axis(fig2[2, 1], xlabel = "Time (days)", ylabel = "Water Fluxes")
+lines!(ax, sol.t ./ 24 ./ 3600, Tr, label = "Transpiration")
+lines!(ax, sol.t ./ 24 ./ 3600, R, label = "R")
+
+axislegend(ax)
+ax = Axis(fig2[3, 1], xlabel = "Time (days)", ylabel = "Carbon Fluxes")
+lines!(ax, sol.t ./ 24 ./ 3600, GPP, label = "GPP")
+lines!(ax, sol.t ./ 24 ./ 3600, resp, label = "Respiration")
+axislegend(ax)
+save(joinpath(savedir, "no_veg_fluxes.png"), fig2)

--- a/experiments/standalone/Vegetation/varying_lai.jl
+++ b/experiments/standalone/Vegetation/varying_lai.jl
@@ -1,0 +1,270 @@
+import SciMLBase
+using CairoMakie
+using Statistics
+using Dates
+using Insolation
+
+# Load CliMA Packages and ClimaLand Modules:
+
+using ClimaCore
+import ClimaParams as CP
+import ClimaTimeSteppers as CTS
+using StaticArrays
+using ClimaLand
+using ClimaLand.Domains: Point
+using ClimaLand.Canopy
+using ClimaLand.Canopy.PlantHydraulics
+import ClimaLand
+import ClimaLand.Parameters as LP
+const FT = Float32;
+earth_param_set = LP.LandParameters(FT);
+f_root_to_shoot = FT(3.5)
+SAI = FT(0.0)
+plant_ν = FT(2.46e-4) # kg/m^2
+n_stem = Int64(0)
+n_leaf = Int64(1)
+h_leaf = FT(9.5)
+compartment_midpoints = [h_leaf / 2]
+compartment_surfaces = [FT(0), h_leaf]
+land_domain = Point(; z_sfc = FT(0.0))
+include(
+    joinpath(pkgdir(ClimaLand), "experiments/integrated/fluxnet/data_tools.jl"),
+);
+time_offset = 7
+lat = FT(38.7441) # degree
+long = FT(-92.2000) # degree
+atmos_h = FT(32)
+site_ID = "US-MOz"
+data_link = "https://caltech.box.com/shared/static/7r0ci9pacsnwyo0o9c25mhhcjhsu6d72.csv"
+
+include(
+    joinpath(
+        pkgdir(ClimaLand),
+        "experiments/integrated/fluxnet/met_drivers_FLUXNET.jl",
+    ),
+);
+
+z0_m = FT(2)
+z0_b = FT(0.2)
+
+shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
+    z0_m,
+    z0_b,
+    earth_param_set,
+);
+ψ_soil0 = FT(0.0)
+
+soil_driver = PrescribedSoil(
+    FT;
+    root_depths = SVector{10, FT}(-(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0),
+    ψ = t -> ψ_soil0,
+    α_PAR = FT(0.2),
+    α_NIR = FT(0.4),
+    T = t -> 298.0,
+    ϵ = FT(0.99),
+);
+
+rt_params = TwoStreamParameters(
+    FT;
+    G_Function = ConstantGFunction(FT(0.5)),
+    α_PAR_leaf = FT(0.1),
+    α_NIR_leaf = FT(0.45),
+    τ_PAR_leaf = FT(0.05),
+    τ_NIR_leaf = FT(0.25),
+    Ω = FT(0.69),
+    λ_γ_PAR = FT(5e-7),
+    λ_γ_NIR = FT(1.65e-6),
+)
+
+rt_model = TwoStreamModel{FT}(rt_params);
+
+cond_params = MedlynConductanceParameters(FT; g1 = FT(141.0))
+
+stomatal_model = MedlynConductanceModel{FT}(cond_params);
+
+
+photo_params = FarquharParameters(FT, Canopy.C3(); Vcmax25 = FT(5e-5))
+
+photosynthesis_model = FarquharModel{FT}(photo_params);
+
+AR_params = AutotrophicRespirationParameters(FT)
+AR_model = AutotrophicRespirationModel{FT}(AR_params);
+
+function fakeLAIfunction(t)
+    if t < 30 * 24 * 3600
+        0.0
+    elseif t < (364 - 30) * 24 * 3600.0
+        max(2.0 * sin(2 * π / (730 * 24 * 3600) * (t - 30 * 24 * 3600)), 0)
+    else
+        0.0
+    end
+end
+
+
+f_root_to_shoot = FT(3.5)
+SAI = FT(0)
+RAI = FT(2 * f_root_to_shoot)
+ai_parameterization =
+    PrescribedSiteAreaIndex{FT}(TimeVaryingInput(fakeLAIfunction), SAI, RAI)
+rooting_depth = FT(1.0);
+
+function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
+    return T(1.0 / rooting_depth) * exp(z / T(rooting_depth))
+end;
+
+K_sat_plant = FT(1.8e-8)
+ψ63 = FT(-4 / 0.0098)
+Weibull_param = FT(4)
+a = FT(0.05 * 0.0098)
+
+conductivity_model =
+    PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+
+retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a);
+
+ν = FT(0.7)
+S_s = FT(1e-2 * 0.0098)
+
+plant_hydraulics_ps = PlantHydraulics.PlantHydraulicsParameters(;
+    ai_parameterization = ai_parameterization,
+    ν = ν,
+    S_s = S_s,
+    root_distribution = root_distribution,
+    conductivity_model = conductivity_model,
+    retention_model = retention_model,
+);
+
+
+plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
+    parameters = plant_hydraulics_ps,
+    n_stem = n_stem,
+    n_leaf = n_leaf,
+    compartment_surfaces = compartment_surfaces,
+    compartment_midpoints = compartment_midpoints,
+);
+
+energy_model = ClimaLand.Canopy.BigLeafEnergyModel{FT}(
+    BigLeafEnergyParameters{FT}(FT(1e4)),
+)
+
+canopy = ClimaLand.Canopy.CanopyModel{FT}(;
+    parameters = shared_params,
+    domain = land_domain,
+    autotrophic_respiration = AR_model,
+    radiative_transfer = rt_model,
+    photosynthesis = photosynthesis_model,
+    conductance = stomatal_model,
+    energy = energy_model,
+    hydraulics = plant_hydraulics,
+    soil_driver = soil_driver,
+    atmos = atmos,
+    radiation = radiation,
+);
+
+
+Y, p, coords = ClimaLand.initialize(canopy)
+exp_tendency! = make_exp_tendency(canopy);
+
+
+ψ_leaf_0 = FT(-2e5 / 9800)
+
+S_l_ini = inverse_water_retention_curve(retention_model, ψ_leaf_0, ν, S_s)
+
+Y.canopy.hydraulics.ϑ_l.:1 .= augmented_liquid_fraction.(ν, S_l_ini)
+
+
+
+t0 = 0.0
+N_days = 364
+tf = t0 + 3600 * 24 * N_days
+dt = 225.0;
+evaluate!(Y.canopy.energy.T, atmos.T, t0)
+set_initial_cache! = make_set_initial_cache(canopy)
+set_initial_cache!(p, Y, t0);
+
+
+n = 16
+saveat = Array(t0:(n * dt):tf)
+sv = (;
+    t = Array{Float64}(undef, length(saveat)),
+    saveval = Array{NamedTuple}(undef, length(saveat)),
+)
+saving_cb = ClimaLand.NonInterpSavingCallback(sv, saveat);
+
+updateat = Array(t0:1800:tf)
+updatefunc = ClimaLand.make_update_drivers(atmos, radiation)
+driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
+cb = SciMLBase.CallbackSet(driver_cb, saving_cb);
+
+timestepper = CTS.RK4();
+ode_algo = CTS.ExplicitAlgorithm(timestepper)
+
+prob = SciMLBase.ODEProblem(
+    CTS.ClimaODEFunction(T_exp! = exp_tendency!, dss! = ClimaLand.dss!),
+    Y,
+    (t0, tf),
+    p,
+);
+
+sol = SciMLBase.solve(prob, ode_algo; dt = dt, callback = cb, saveat = saveat);
+
+savedir = joinpath(pkgdir(ClimaLand), "experiments/standalone/Vegetation");
+T = [parent(sol.u[k].canopy.energy.T)[1] for k in 1:length(sol.t)]
+T_atmos = [parent(sv.saveval[k].drivers.T)[1] for k in 1:length(sol.t)]
+ϑ = [parent(sol.u[k].canopy.hydraulics.ϑ_l.:1)[1] for k in 1:length(sol.t)]
+GPP = [
+    parent(sv.saveval[k].canopy.photosynthesis.GPP)[1] * 1e6 for
+    k in 1:length(sol.t)
+]
+resp = [
+    parent(sv.saveval[k].canopy.autotrophic_respiration.Ra)[1] * 1e6 for
+    k in 1:length(sol.t)
+]
+SW_abs = [
+    parent(sv.saveval[k].canopy.radiative_transfer.SW_n)[1] for
+    k in 1:length(sol.t)
+]
+LW_abs = [
+    parent(sv.saveval[k].canopy.radiative_transfer.LW_n)[1] for
+    k in 1:length(sol.t)
+]
+SHF = [parent(sv.saveval[k].canopy.energy.shf)[1] for k in 1:length(sol.t)]
+LHF = [parent(sv.saveval[k].canopy.energy.lhf)[1] for k in 1:length(sol.t)]
+RE = [
+    parent(sv.saveval[k].canopy.energy.fa_energy_roots)[1] for
+    k in 1:length(sol.t)
+]
+R = [
+    parent(sv.saveval[k].canopy.hydraulics.fa_roots)[1] for k in 1:length(sol.t)
+]
+Tr = [parent(sv.saveval[k].canopy.hydraulics.fa.:1)[1] for k in 1:length(sol.t)]
+fig = Figure()
+ax = Axis(fig[1, 1], xlabel = "Time (days)", ylabel = "Temperature (K)")
+lines!(ax, sol.t ./ 24 ./ 3600, T, label = "Canopy")
+lines!(ax, sol.t ./ 24 ./ 3600, T_atmos, label = "Atmos")
+axislegend(ax)
+ax = Axis(fig[2, 1], xlabel = "Time (days)", ylabel = "Volumetric Water")
+lines!(ax, sol.t ./ 24 ./ 3600, ϑ, label = "Canopy")
+axislegend(ax)
+ax = Axis(fig[3, 1], xlabel = "Time (days)", ylabel = "LAI")
+lines!(ax, sol.t ./ 24 ./ 3600, fakeLAIfunction.(sol.t), label = "Canopy")
+axislegend(ax)
+save(joinpath(savedir, "varying_lai_state.png"), fig)
+fig2 = Figure()
+ax = Axis(fig2[1, 1], xlabel = "Time (days)", ylabel = "Energy Fluxes")
+lines!(ax, sol.t ./ 24 ./ 3600, SW_abs, label = "SW")
+lines!(ax, sol.t ./ 24 ./ 3600, LW_abs, label = "LW")
+lines!(ax, sol.t ./ 24 ./ 3600, SHF, label = "SHF")
+lines!(ax, sol.t ./ 24 ./ 3600, LHF, label = "LHF")
+lines!(ax, sol.t ./ 24 ./ 3600, RE, label = "RE")
+axislegend(ax)
+ax = Axis(fig2[2, 1], xlabel = "Time (days)", ylabel = "Water Fluxes")
+lines!(ax, sol.t ./ 24 ./ 3600, Tr, label = "Transpiration")
+lines!(ax, sol.t ./ 24 ./ 3600, R, label = "R")
+
+axislegend(ax)
+ax = Axis(fig2[3, 1], xlabel = "Time (days)", ylabel = "Carbon Fluxes")
+lines!(ax, sol.t ./ 24 ./ 3600, GPP, label = "GPP")
+lines!(ax, sol.t ./ 24 ./ 3600, resp, label = "Respiration")
+axislegend(ax)
+save(joinpath(savedir, "varying_lai_fluxes.png"), fig2)

--- a/experiments/standalone/Vegetation/varying_lai_with_stem.jl
+++ b/experiments/standalone/Vegetation/varying_lai_with_stem.jl
@@ -1,0 +1,283 @@
+import SciMLBase
+using CairoMakie
+using Statistics
+using Dates
+using Insolation
+
+# Load CliMA Packages and ClimaLand Modules:
+
+using ClimaCore
+import ClimaParams as CP
+import ClimaTimeSteppers as CTS
+using StaticArrays
+using ClimaLand
+using ClimaLand.Domains: Point
+using ClimaLand.Canopy
+using ClimaLand.Canopy.PlantHydraulics
+import ClimaLand
+import ClimaLand.Parameters as LP
+const FT = Float32;
+earth_param_set = LP.LandParameters(FT);
+f_root_to_shoot = FT(3.5)
+plant_ν = FT(2.46e-4) # kg/m^2
+n_stem = Int64(1)
+n_leaf = Int64(1)
+h_leaf = FT(9.5)
+h_stem = FT(9)
+compartment_midpoints = [h_stem / 2, h_stem + h_leaf / 2]
+compartment_surfaces = [FT(0), h_stem, h_stem + h_leaf]
+land_domain = Point(; z_sfc = FT(0.0))
+include(
+    joinpath(pkgdir(ClimaLand), "experiments/integrated/fluxnet/data_tools.jl"),
+);
+time_offset = 7
+lat = FT(38.7441) # degree
+long = FT(-92.2000) # degree
+atmos_h = FT(32)
+site_ID = "US-MOz"
+data_link = "https://caltech.box.com/shared/static/7r0ci9pacsnwyo0o9c25mhhcjhsu6d72.csv"
+
+include(
+    joinpath(
+        pkgdir(ClimaLand),
+        "experiments/integrated/fluxnet/met_drivers_FLUXNET.jl",
+    ),
+);
+
+z0_m = FT(2)
+z0_b = FT(0.2)
+
+shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
+    z0_m,
+    z0_b,
+    earth_param_set,
+);
+ψ_soil0 = FT(0.0)
+
+soil_driver = PrescribedSoil(
+    FT;
+    root_depths = SVector{10, FT}(-(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0),
+    ψ = t -> ψ_soil0,
+    α_PAR = FT(0.2),
+    α_NIR = FT(0.4),
+    T = t -> 298.0,
+    ϵ = FT(0.99),
+);
+
+rt_params = TwoStreamParameters(
+    FT;
+    G_Function = ConstantGFunction(FT(0.5)),
+    α_PAR_leaf = FT(0.1),
+    α_NIR_leaf = FT(0.45),
+    τ_PAR_leaf = FT(0.05),
+    τ_NIR_leaf = FT(0.25),
+    Ω = FT(0.69),
+    λ_γ_PAR = FT(5e-7),
+    λ_γ_NIR = FT(1.65e-6),
+)
+
+rt_model = TwoStreamModel{FT}(rt_params);
+
+cond_params = MedlynConductanceParameters(FT; g1 = FT(141.0))
+
+stomatal_model = MedlynConductanceModel{FT}(cond_params);
+
+
+photo_params = FarquharParameters(FT, Canopy.C3(); Vcmax25 = FT(5e-5))
+
+photosynthesis_model = FarquharModel{FT}(photo_params);
+
+AR_params = AutotrophicRespirationParameters(FT)
+AR_model = AutotrophicRespirationModel{FT}(AR_params);
+
+function fakeLAIfunction2(t)
+    if t < 10 * 24 * 3600
+        0.0
+    elseif t < (60 - 10) * 24 * 3600.0
+        max(2.0 * sin(2 * π / (730 * 24 * 3600) * (t - 10 * 24 * 3600)), 0)
+    else
+        0.0
+    end
+end
+
+f_root_to_shoot = FT(3.5)
+SAI = FT(1.0)
+RAI = FT(3 * f_root_to_shoot)
+ai_parameterization =
+    PrescribedSiteAreaIndex{FT}(TimeVaryingInput(fakeLAIfunction2), SAI, RAI)
+rooting_depth = FT(1.0);
+
+function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
+    return T(1.0 / rooting_depth) * exp(z / T(rooting_depth))
+end;
+
+K_sat_plant = FT(1.8e-6)
+ψ63 = FT(-4 / 0.0098)
+Weibull_param = FT(4)
+a = FT(0.05 * 0.0098)
+
+conductivity_model =
+    PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+
+retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a);
+
+ν = FT(0.7)
+S_s = FT(1e-2 * 0.0098)
+
+plant_hydraulics_ps = PlantHydraulics.PlantHydraulicsParameters(;
+    ai_parameterization = ai_parameterization,
+    ν = ν,
+    S_s = S_s,
+    root_distribution = root_distribution,
+    conductivity_model = conductivity_model,
+    retention_model = retention_model,
+);
+
+
+plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
+    parameters = plant_hydraulics_ps,
+    n_stem = n_stem,
+    n_leaf = n_leaf,
+    compartment_surfaces = compartment_surfaces,
+    compartment_midpoints = compartment_midpoints,
+);
+
+energy_model = ClimaLand.Canopy.BigLeafEnergyModel{FT}(
+    BigLeafEnergyParameters{FT}(FT(1e4)),
+)
+
+canopy = ClimaLand.Canopy.CanopyModel{FT}(;
+    parameters = shared_params,
+    domain = land_domain,
+    autotrophic_respiration = AR_model,
+    radiative_transfer = rt_model,
+    photosynthesis = photosynthesis_model,
+    conductance = stomatal_model,
+    energy = energy_model,
+    hydraulics = plant_hydraulics,
+    soil_driver = soil_driver,
+    atmos = atmos,
+    radiation = radiation,
+);
+
+
+Y, p, coords = ClimaLand.initialize(canopy)
+exp_tendency! = make_exp_tendency(canopy);
+
+
+ψ_leaf_0 = FT(-2e5 / 9800)
+ψ_stem_0 = FT(-1e5 / 9800)
+
+S_l_ini =
+    inverse_water_retention_curve.(
+        retention_model,
+        [ψ_stem_0, ψ_leaf_0],
+        ν,
+        S_s,
+    )
+
+Y.canopy.hydraulics.ϑ_l.:1 .= augmented_liquid_fraction.(ν, S_l_ini[1])
+Y.canopy.hydraulics.ϑ_l.:2 .= augmented_liquid_fraction.(ν, S_l_ini[2])
+
+
+
+t0 = 0.0
+N_days = 60
+tf = t0 + 3600 * 24 * N_days
+dt = 225.0;
+evaluate!(Y.canopy.energy.T, atmos.T, t0)
+set_initial_cache! = make_set_initial_cache(canopy)
+set_initial_cache!(p, Y, t0);
+
+
+n = 16
+saveat = Array(t0:(n * dt):tf)
+sv = (;
+    t = Array{Float64}(undef, length(saveat)),
+    saveval = Array{NamedTuple}(undef, length(saveat)),
+)
+saving_cb = ClimaLand.NonInterpSavingCallback(sv, saveat);
+
+updateat = Array(t0:1800:tf)
+updatefunc = ClimaLand.make_update_drivers(atmos, radiation)
+driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
+cb = SciMLBase.CallbackSet(driver_cb, saving_cb);
+
+timestepper = CTS.RK4();
+ode_algo = CTS.ExplicitAlgorithm(timestepper)
+
+prob = SciMLBase.ODEProblem(
+    CTS.ClimaODEFunction(T_exp! = exp_tendency!, dss! = ClimaLand.dss!),
+    Y,
+    (t0, tf),
+    p,
+);
+
+sol = SciMLBase.solve(prob, ode_algo; dt = dt, callback = cb, saveat = saveat);
+
+savedir = joinpath(pkgdir(ClimaLand), "experiments/standalone/Vegetation");
+T = [parent(sol.u[k].canopy.energy.T)[1] for k in 1:length(sol.t)]
+T_atmos = [parent(sv.saveval[k].drivers.T)[1] for k in 1:length(sol.t)]
+ϑ_l = [parent(sol.u[k].canopy.hydraulics.ϑ_l.:2)[1] for k in 1:length(sol.t)]
+ϑ_s = [parent(sol.u[k].canopy.hydraulics.ϑ_l.:1)[1] for k in 1:length(sol.t)]
+GPP = [
+    parent(sv.saveval[k].canopy.photosynthesis.GPP)[1] * 1e6 for
+    k in 1:length(sol.t)
+]
+resp = [
+    parent(sv.saveval[k].canopy.autotrophic_respiration.Ra)[1] * 1e6 for
+    k in 1:length(sol.t)
+]
+SW_abs = [
+    parent(sv.saveval[k].canopy.radiative_transfer.SW_n)[1] for
+    k in 1:length(sol.t)
+]
+LW_abs = [
+    parent(sv.saveval[k].canopy.radiative_transfer.LW_n)[1] for
+    k in 1:length(sol.t)
+]
+SHF = [parent(sv.saveval[k].canopy.energy.shf)[1] for k in 1:length(sol.t)]
+LHF = [parent(sv.saveval[k].canopy.energy.lhf)[1] for k in 1:length(sol.t)]
+RE = [
+    parent(sv.saveval[k].canopy.energy.fa_energy_roots)[1] for
+    k in 1:length(sol.t)
+]
+R = [
+    parent(sv.saveval[k].canopy.hydraulics.fa_roots)[1] for k in 1:length(sol.t)
+]
+R_stem_leaf =
+    [parent(sv.saveval[k].canopy.hydraulics.fa.:1)[1] for k in 1:length(sol.t)]
+Tr = [parent(sv.saveval[k].canopy.hydraulics.fa.:2)[1] for k in 1:length(sol.t)]
+fig = Figure()
+ax = Axis(fig[1, 1], xlabel = "Time (days)", ylabel = "Temperature (K)")
+lines!(ax, sol.t ./ 24 ./ 3600, T, label = "Canopy")
+lines!(ax, sol.t ./ 24 ./ 3600, T_atmos, label = "Atmos")
+axislegend(ax)
+ax = Axis(fig[2, 1], xlabel = "Time (days)", ylabel = "Volumetric Water")
+lines!(ax, sol.t ./ 24 ./ 3600, ϑ_l, label = "Leaf")
+lines!(ax, sol.t ./ 24 ./ 3600, ϑ_s, label = "Stem")
+axislegend(ax)
+ax = Axis(fig[3, 1], xlabel = "Time (days)", ylabel = "LAI")
+lines!(ax, sol.t ./ 24 ./ 3600, fakeLAIfunction2.(sol.t), label = "Canopy")
+axislegend(ax)
+save(joinpath(savedir, "varying_lai_with_stem_state.png"), fig)
+fig2 = Figure()
+ax = Axis(fig2[1, 1], xlabel = "Time (days)", ylabel = "Energy Fluxes")
+lines!(ax, sol.t ./ 24 ./ 3600, SW_abs, label = "SW")
+lines!(ax, sol.t ./ 24 ./ 3600, LW_abs, label = "LW")
+lines!(ax, sol.t ./ 24 ./ 3600, SHF, label = "SHF")
+lines!(ax, sol.t ./ 24 ./ 3600, LHF, label = "LHF")
+lines!(ax, sol.t ./ 24 ./ 3600, RE, label = "RE")
+axislegend(ax)
+ax = Axis(fig2[2, 1], xlabel = "Time (days)", ylabel = "Water Fluxes")
+ylims!(ax, (0, 1e-7))
+lines!(ax, sol.t ./ 24 ./ 3600, Tr, label = "Transpiration")
+lines!(ax, sol.t ./ 24 ./ 3600, R, label = "R")
+lines!(ax, sol.t ./ 24 ./ 3600, R_stem_leaf, label = "R_stem_leaf")
+
+axislegend(ax)
+ax = Axis(fig2[3, 1], xlabel = "Time (days)", ylabel = "Carbon Fluxes")
+lines!(ax, sol.t ./ 24 ./ 3600, GPP, label = "GPP")
+lines!(ax, sol.t ./ 24 ./ 3600, resp, label = "Respiration")
+axislegend(ax)
+save(joinpath(savedir, "varying_lai_with_stem_fluxes.png"), fig2)

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -262,7 +262,7 @@ function make_update_boundary_fluxes(
         )
 
         @. p.root_extraction =
-            (area_index.root + above_ground_area_index) / 2 *
+            above_ground_area_index *
             PlantHydraulics.flux(
                 z,
                 land.canopy.hydraulics.compartment_midpoints[1],
@@ -335,7 +335,7 @@ function lsm_radiant_energy_fluxes!(
     c = LP.light_speed(earth_param_set)
     h = LP.planck_constant(earth_param_set)
     N_a = LP.avogadro_constant(earth_param_set)
-    (; λ_γ_PAR, λ_γ_NIR, ϵ_canopy) = canopy_radiation.parameters
+    (; λ_γ_PAR, λ_γ_NIR) = canopy_radiation.parameters
     energy_per_photon_PAR = h * c / λ_γ_PAR
     energy_per_photon_NIR = h * c / λ_γ_NIR
     T_canopy =
@@ -380,8 +380,8 @@ function lsm_radiant_energy_fluxes!(
         N_a *
         p.canopy.radiative_transfer.tpar *
         (1 - α_soil_PAR)
-
-    @. LW_d_canopy = (1 - ϵ_canopy) * LW_d + ϵ_canopy * _σ * T_canopy^4 # double checked
+    ϵ_canopy = p.canopy.radiative_transfer.ϵ # this takes into account LAI/SAI
+    @. LW_d_canopy = ((1 - ϵ_canopy) * LW_d + ϵ_canopy * _σ * T_canopy^4) # double checked
     @. LW_u_soil = ϵ_soil * _σ * p.T_ground^4 + (1 - ϵ_soil) * LW_d_canopy # double checked
     @. R_net_soil += ϵ_soil * LW_d_canopy - ϵ_soil * _σ * p.T_ground^4 # double checked
     @. LW_net_canopy =

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -620,7 +620,7 @@ function root_water_flux_per_ground_area!(
                 ) *
                 root_distribution(root_depths[i]) *
                 (root_depths[i + 1] - root_depths[i]) *
-                (area_index.root + above_ground_area_index) / 2
+                above_ground_area_index
         else
             @. fa +=
                 flux(
@@ -633,7 +633,7 @@ function root_water_flux_per_ground_area!(
                 ) *
                 root_distribution(root_depths[i]) *
                 (model.compartment_surfaces[1] - root_depths[n_root_layers]) *
-                (area_index.root + above_ground_area_index) / 2
+                above_ground_area_index
         end
     end
 end

--- a/src/standalone/Vegetation/canopy_parameterizations.jl
+++ b/src/standalone/Vegetation/canopy_parameterizations.jl
@@ -935,6 +935,7 @@ end
                      ne::FT, # Mean leaf nitrogen concentration (kg N (kg C)-1)
                      Vcmax25::FT, #
                      LAI::FT, # Leaf area index
+                     SAI::FT,
                      RAI::FT,
                      ηsl::FT, # live stem  wood coefficient (kg C m-3) 
                      h::FT, # canopy height (m)
@@ -943,15 +944,13 @@ end
                      μs::FT, # Ratio stem nitrogen to top leaf nitrogen (-), typical value 0.1 
                     ) where {FT}
 
-Computes the nitrogen content of leafs (Nl), roots (Nr) and stems (Ns)
-as a function of leaf area index (LAI), specific leaf density (σl),
-the carbon content of roots (Rc), the carbon content of stems (Rs), 
-and mean leaf nitrogen concentration (nm).
+Computes the nitrogen content of leafs (Nl), roots (Nr) and stems (Ns).
 """
 function nitrogen_content(
     ne::FT, # Mean leaf nitrogen concentration (kg N (kg C)-1)
     Vcmax25::FT, #
     LAI::FT, # Leaf area index
+    SAI::FT,
     RAI::FT,
     ηsl::FT, # live stem  wood coefficient (kg C m-3) 
     h::FT, # canopy height (m)
@@ -959,7 +958,7 @@ function nitrogen_content(
     μr::FT, # Ratio root nitrogen to top leaf nitrogen (-), typical value 1.0
     μs::FT, # Ratio stem nitrogen to top leaf nitrogen (-), typical value 0.1 
 ) where {FT}
-    Sc = ηsl * h * LAI
+    Sc = ηsl * h * LAI * ClimaLand.heaviside(SAI)
     Rc = σl * RAI
     nm = Vcmax25 / ne
     Nl = nm * σl * LAI
@@ -998,18 +997,14 @@ end
 """
     plant_respiration_growth(
         f::FT, # Factor of relative contribution
-        GPP::FT, # Gross primary productivity
+        An::FT, # Net photosynthesis
         Rpm::FT # Plant maintenance respiration
         ) where {FT}
 
-Computes plant growth respiration as a function of gross primary productivity (GPP),
+Computes plant growth respiration as a function of net photosynthesis (An),
 plant maintenance respiration (Rpm), and a relative contribution factor, f.
 """
-function plant_respiration_growth(
-    f2::FT, # Factor of relative contribution, usually 0.25
-    GPP::FT, # Gross primary productivity
-    Rpm::FT, # Plant maintenance respiration
-) where {FT}
-    Rg = f2 * (GPP - Rpm)
+function plant_respiration_growth(f2::FT, An::FT, Rpm::FT) where {FT}
+    Rg = f2 * (An - Rpm)
     return Rg
 end

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -232,7 +232,13 @@ for FT in (Float32, Float64)
         # check that this is updated correctly:
         # @test p.canopy.autotrophic_respiration.Ra ==
         exp_tendency!(dY, Y, p, t0)
-        turb_fluxes = ClimaLand.turbulent_fluxes(canopy.atmos, canopy, Y, p, t0)
+        turb_fluxes = ClimaLand.Canopy.canopy_turbulent_fluxes(
+            canopy.atmos,
+            canopy,
+            Y,
+            p,
+            t0,
+        )
 
         @test p.canopy.hydraulics.fa.:1 == turb_fluxes.vapor_flux
         @test p.canopy.energy.shf == turb_fluxes.shf
@@ -242,8 +248,7 @@ for FT in (Float32, Float64)
         h = FT(LP.planck_constant(earth_param_set))
         N_a = FT(LP.avogadro_constant(earth_param_set))
         _σ = FT(LP.Stefan(earth_param_set))
-        (; α_PAR_leaf, λ_γ_PAR, λ_γ_NIR, ϵ_canopy) =
-            canopy.radiative_transfer.parameters
+        (; α_PAR_leaf, λ_γ_PAR, λ_γ_NIR) = canopy.radiative_transfer.parameters
         APAR = p.canopy.radiative_transfer.apar
         ANIR = p.canopy.radiative_transfer.anir
         energy_per_photon_PAR = h * c / λ_γ_PAR
@@ -252,16 +257,17 @@ for FT in (Float32, Float64)
         @test p.canopy.radiative_transfer.SW_n ==
               @. (energy_per_photon_PAR * N_a * APAR) +
                  (energy_per_photon_NIR * N_a * ANIR)
-
+        ϵ_canopy = p.canopy.radiative_transfer.ϵ
         T_canopy = FT.(T_atmos(t0))
         T_soil = FT.(soil_driver.T(t0))
         ϵ_soil = FT.(soil_driver.ϵ)
         LW_d = FT.(longwave_radiation(t0))
-        LW_d_canopy = (1 - ϵ_canopy) * LW_d + ϵ_canopy * _σ * T_canopy^4
-        LW_u_soil = ϵ_soil * _σ * T_soil^4 + (1 - ϵ_soil) * LW_d_canopy
-        @test Array(parent(p.canopy.radiative_transfer.LW_n))[1] ≈
-              ϵ_canopy * LW_d - 2 * ϵ_canopy * _σ * T_canopy^4 +
-              ϵ_canopy * LW_u_soil
+        LW_d_canopy = @. (1 - ϵ_canopy) * LW_d + ϵ_canopy * _σ * T_canopy^4
+        LW_u_soil = @. ϵ_soil * _σ * T_soil^4 + (1 - ϵ_soil) * LW_d_canopy
+        @test p.canopy.radiative_transfer.LW_n == @. (
+            ϵ_canopy * LW_d - 2 * ϵ_canopy * _σ * T_canopy^4 +
+            ϵ_canopy * LW_u_soil
+        )
 
 
         # Penman-monteith
@@ -715,7 +721,13 @@ for FT in (Float32, Float64)
         exp_tendency! = make_exp_tendency(canopy)
         dY = similar(Y)
         exp_tendency!(dY, Y, p, t0)
-        turb_fluxes = turbulent_fluxes(canopy.atmos, canopy, Y, p, t0)
+        turb_fluxes = ClimaLand.Canopy.canopy_turbulent_fluxes(
+            canopy.atmos,
+            canopy,
+            Y,
+            p,
+            t0,
+        )
         @test p.canopy.hydraulics.fa.:1 == turb_fluxes.vapor_flux
         @test p.canopy.energy.lhf == turb_fluxes.lhf
         @test p.canopy.energy.shf == turb_fluxes.shf
@@ -738,5 +750,234 @@ for FT in (Float32, Float64)
                 ),
             ) .== FT(289),
         )
+    end
+
+
+    @testset "Zero LAI; FT = $FT" begin
+        domain = Point(; z_sfc = FT(0.0))
+
+        BeerLambertparams = BeerLambertParameters(FT)
+        # TwoStreamModel parameters
+        Ω = FT(0.69)
+        χl = FT(0.1)
+        G_Function = CLMGFunction(χl)
+        α_PAR_leaf = FT(0.1)
+        λ_γ_PAR = FT(5e-7)
+        λ_γ_NIR = FT(1.65e-6)
+        τ_PAR_leaf = FT(0.05)
+        α_NIR_leaf = FT(0.45)
+        τ_NIR_leaf = FT(0.25)
+        ϵ_canopy = FT(0.97)
+        TwoStreamparams = TwoStreamParameters(
+            FT;
+            Ω,
+            α_PAR_leaf,
+            τ_PAR_leaf,
+            α_NIR_leaf,
+            τ_NIR_leaf,
+            G_Function,
+        )
+        photosynthesis_params = FarquharParameters(FT, C3())
+        stomatal_g_params = MedlynConductanceParameters(FT)
+
+        stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
+        photosynthesis_model = FarquharModel{FT}(photosynthesis_params)
+        rt_models = (
+            BeerLambertModel{FT}(BeerLambertparams),
+            TwoStreamModel{FT}(TwoStreamparams),
+        )
+        energy_model = BigLeafEnergyModel{FT}(BigLeafEnergyParameters{FT}())
+        earth_param_set = LP.LandParameters(FT)
+        LAI = FT(0.0) # m2 [leaf] m-2 [ground]
+        z_0m = FT(2.0) # m, Roughness length for momentum - value from tall forest ChatGPT
+        z_0b = FT(0.1) # m, Roughness length for scalars - value from tall forest ChatGPT
+        h_int = FT(30.0) # m, "where measurements would be taken at a typical flux tower of a 20m canopy"
+        shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
+            z_0m,
+            z_0b,
+            earth_param_set,
+        )
+        lat = FT(0.0) # degree
+        long = FT(-180) # degree
+
+        function zenith_angle(
+            t,
+            ref_time;
+            latitude = lat,
+            longitude = long,
+            insol_params = earth_param_set.insol_params,
+        )
+            current_datetime = ref_time + Dates.Second(round(t))
+            d, δ, η_UTC =
+                FT.(
+                    Insolation.helper_instantaneous_zenith_angle(
+                        current_datetime,
+                        ref_time,
+                        insol_params,
+                    )
+                )
+            return Insolation.instantaneous_zenith_angle(
+                d,
+                δ,
+                η_UTC,
+                longitude,
+                latitude,
+            )[1]
+        end
+
+        function shortwave_radiation(
+            t;
+            latitude = lat,
+            longitude = long,
+            insol_params = earth_param_set.insol_params,
+        )
+            return 1000 # W/m^2
+        end
+
+        function longwave_radiation(t)
+            return 200 # W/m^2
+        end
+
+        u_atmos = t -> 10 #m.s-1
+
+        liquid_precip = (t) -> 0 # m
+        snow_precip = (t) -> 0 # m
+        T_atmos = t -> 290 # Kelvin
+        q_atmos = t -> 0.001 # kg/kg
+        P_atmos = t -> 1e5 # Pa
+        h_atmos = h_int # m
+        c_atmos = (t) -> 4.11e-4 # mol/mol
+        ref_time = DateTime(2005)
+        atmos = PrescribedAtmosphere(
+            TimeVaryingInput(liquid_precip),
+            TimeVaryingInput(snow_precip),
+            TimeVaryingInput(T_atmos),
+            TimeVaryingInput(u_atmos),
+            TimeVaryingInput(q_atmos),
+            TimeVaryingInput(P_atmos),
+            ref_time,
+            h_atmos,
+            earth_param_set;
+            c_co2 = TimeVaryingInput(c_atmos),
+        )
+        radiation = PrescribedRadiativeFluxes(
+            FT,
+            TimeVaryingInput(shortwave_radiation),
+            TimeVaryingInput(longwave_radiation),
+            ref_time;
+            θs = zenith_angle,
+        )
+
+        # Plant Hydraulics
+        RAI = FT(0)
+        SAI = FT(0)
+        lai_fun = t -> LAI
+        ai_parameterization = PlantHydraulics.PrescribedSiteAreaIndex{FT}(
+            TimeVaryingInput(lai_fun),
+            SAI,
+            RAI,
+        )
+        K_sat_plant = FT(1.8e-8) # m/s
+        ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value
+        Weibull_param = FT(4) # unitless, Holtzman's original c param value
+        a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
+        plant_ν = FT(0.7) # m3/m3
+        plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
+        conductivity_model =
+            PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+        retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
+        root_depths = SVector{10, FT}(-(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0) # 1st element is the deepest root depth
+        function root_distribution(z::T) where {T}
+            return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
+        end
+        param_set = PlantHydraulics.PlantHydraulicsParameters(;
+            ai_parameterization = ai_parameterization,
+            ν = plant_ν,
+            S_s = plant_S_s,
+            root_distribution = root_distribution,
+            conductivity_model = conductivity_model,
+            retention_model = retention_model,
+        )
+        Δz = FT(1.0) # height of compartments
+        n_stem = Int64(0) # number of stem elements
+        n_leaf = Int64(1) # number of leaf elements
+        compartment_centers =
+            FT.(
+                Vector(
+                    range(
+                        start = Δz / 2,
+                        step = Δz,
+                        stop = Δz * (n_stem + n_leaf) - (Δz / 2),
+                    ),
+                ),
+            )
+        compartment_faces =
+            FT.(
+                Vector(
+                    range(
+                        start = 0.0,
+                        step = Δz,
+                        stop = Δz * (n_stem + n_leaf),
+                    ),
+                )
+            )
+
+        ψ_soil0 = FT(0.0)
+        T_soil0 = FT(290)
+        soil_driver = PrescribedSoil(
+            root_depths,
+            (t) -> ψ_soil0,
+            (t) -> T_soil0,
+            FT(0.2),
+            FT(0.4),
+            FT(0.98),
+        )
+
+        plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
+            parameters = param_set,
+            n_stem = n_stem,
+            n_leaf = n_leaf,
+            compartment_surfaces = compartment_faces,
+            compartment_midpoints = compartment_centers,
+        )
+        autotrophic_parameters = AutotrophicRespirationParameters(FT)
+        autotrophic_respiration_model =
+            AutotrophicRespirationModel{FT}(autotrophic_parameters)
+        for rt_model in rt_models
+            canopy = ClimaLand.Canopy.CanopyModel{FT}(;
+                parameters = shared_params,
+                domain = domain,
+                radiative_transfer = rt_model,
+                photosynthesis = photosynthesis_model,
+                conductance = stomatal_model,
+                autotrophic_respiration = autotrophic_respiration_model,
+                energy = energy_model,
+                hydraulics = plant_hydraulics,
+                soil_driver = soil_driver,
+                atmos = atmos,
+                radiation = radiation,
+            )
+
+            Y, p, coords = ClimaLand.initialize(canopy)
+            Y.canopy.hydraulics .= plant_ν
+            Y.canopy.energy.T = FT(289)
+            set_initial_cache! = make_set_initial_cache(canopy)
+            t0 = FT(0.0)
+            set_initial_cache!(p, Y, t0)
+
+            @test all(parent(p.canopy.hydraulics.fa.:1) .== FT(0))
+            @test all(parent(p.canopy.energy.lhf) .== FT(0))
+            @test all(parent(p.canopy.energy.shf) .== FT(0))
+            @test all(parent(p.canopy.energy.fa_energy_roots) .== FT(0))
+            @test all(parent(p.canopy.hydraulics.fa_roots) .== FT(0))
+            @test all(parent(p.canopy.conductance.transpiration) .== FT(0))
+            @test all(parent(p.canopy.radiative_transfer.LW_n) .== FT(0))
+            @test all(parent(p.canopy.radiative_transfer.SW_n) .== FT(0))
+            @test all(parent(p.canopy.radiative_transfer.apar) .== FT(0))
+            @test all(parent(p.canopy.radiative_transfer.anir) .== FT(0))
+            @test all(parent(p.canopy.autotrophic_respiration.Ra) .== FT(0))
+        end
+
+
     end
 end

--- a/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
+++ b/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
@@ -81,6 +81,7 @@ for FT in (Float32, Float64)
 
         LAI = FT(5.0) # m2 (leaf) m-2 (ground)
         RAI = FT(1.0)
+        SAI = FT(1.0)
         thermo_params = LP.thermodynamic_parameters(earth_param_set)
         c = FT(LP.light_speed(earth_param_set))
         h = FT(LP.planck_constant(earth_param_set))
@@ -282,6 +283,7 @@ for FT in (Float32, Float64)
             ARparams.ne,
             photosynthesisparams.Vcmax25,
             LAI,
+            SAI,
             RAI,
             ARparams.ηsl,
             h_canopy,
@@ -290,7 +292,7 @@ for FT in (Float32, Float64)
             ARparams.μs,
         )
         Rpm = plant_respiration_maintenance(Rd, β, Nl, Nr, Ns, ARparams.f1)
-        Rg = plant_respiration_growth.(ARparams.f2, GPP, Rpm)
+        Rg = plant_respiration_growth.(ARparams.f2, An, Rpm)
 
         @test Nl ==
               photosynthesisparams.Vcmax25 / ARparams.ne * ARparams.σl * LAI
@@ -302,9 +304,10 @@ for FT in (Float32, Float64)
               ARparams.μs * photosynthesisparams.Vcmax25 / ARparams.ne *
               ARparams.ηsl *
               h_canopy *
-              LAI # == gives a very small error
+              LAI *
+              ClimaLand.heaviside(SAI)# == gives a very small error
         @test Rpm == ARparams.f1 * Rd * (β + (Nr + Ns) / Nl)
-        @test all(@.(Rg ≈ ARparams.f2 * (GPP - Rpm)))
+        @test all(@.(Rg ≈ ARparams.f2 * (An - Rpm)))
 
     end
 end


### PR DESCRIPTION
## Purpose 
When LAI = SAI = RAI is zero, we still have a nonzero net LW radiation for the canopy, a SHF for the canopy, and nonzero autotrophic respiration.

## To-do
[X] Go over with Alexis and Renato
[X] Update tests


## Content
1. In the canopy parameters, we define canopy emissivity. We now scale that by a factor following CLM as emissiv = emissiv_0*(1-exp(-(LAI+SAI)). This behaves correctly: as LAI+SAI -> 0, emissivity -> 0 and LW absorbed by the canopy -> 0. @braghiere 
2. Autotrophic respiration now uses the stem area index to compute Ns, which is zero if SAI is zero (check with @AlexisRenchon)
3. Autotrophic respiration was before combining GPP with Rd. But, GPP is computed as An scaled by LAI, while Rd is at level of An. I am guessing GPP is canopy level, while An/Rd are leaf level. A possible fix (implemented) is to use An in computing the respiration instead of GPP, and then scaled to canopy at the end. Then we would satisfy that respiration is zero as LAI -> 0. Im not sure if this should be LAI+SAI, though. @AlexisRenchon 
4. SHF change would would be easier to discuss in person @braghiere 
5. we no longer use root area index, also easier to discuss in person @braghiere. 

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [X] I have read and checked the items on the review checklist.
