### PR TITLE
absorbed radiation is not zero if LAI is zero

### DIFF
--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -539,6 +539,7 @@ end
         α_NIR_leaf = 0.4,
         τ_NIR_leaf = 0.25,
         Ω = 1,
+        LS_c = 0.05,
         n_layers = UInt64(20),
         kwargs...
     )
@@ -549,6 +550,7 @@ end
         α_NIR_leaf = 0.4,
         τ_NIR_leaf = 0.25,
         Ω = 1,
+        LS_c = 0.05,
         n_layers = UInt64(20),
         kwargs...
     )
@@ -556,7 +558,11 @@ end
 Floating-point and toml dict based constructor supplying default values
 for the TwoStreamParameters struct. Additional parameter values can be directly set via kwargs.
 """
-TwoStreamParameters(::Type{FT}; kwargs...) where {FT <: AbstractFloat} =
+TwoStreamParameters(
+    ::Type{FT};
+    LS_c = FT(0.05),
+    kwargs...,
+) where {FT <: AbstractFloat} =
     TwoStreamParameters(CP.create_toml_dict(FT); kwargs...)
 
 function TwoStreamParameters(
@@ -567,6 +573,7 @@ function TwoStreamParameters(
     α_NIR_leaf = 0.4,
     τ_NIR_leaf = 0.25,
     Ω = 1,
+    LS_c = 0.05,
     n_layers = UInt64(20),
     kwargs...,
 )
@@ -585,6 +592,7 @@ function TwoStreamParameters(
         α_NIR_leaf,
         τ_NIR_leaf,
         Ω,
+        LS_c,
         n_layers,
         parameters...,
         kwargs...,
@@ -597,6 +605,7 @@ end
         α_PAR_leaf = 0.1,
         α_NIR_leaf = 0.4,
         Ω = 1,
+        LS_c = 0.05,
         kwargs...
     )
     function BeerLambertParameters(toml_dict;
@@ -604,13 +613,18 @@ end
         α_PAR_leaf = 0.1,
         α_NIR_leaf = 0.4,
         Ω = 1,
+        LS_c = 0.05,
         kwargs...
     )
 
 Floating-point and toml dict based constructor supplying default values
 for the BeerLambertParameters struct. Additional parameter values can be directly set via kwargs.
 """
-BeerLambertParameters(::Type{FT}; kwargs...) where {FT <: AbstractFloat} =
+BeerLambertParameters(
+    ::Type{FT};
+    LS_c = FT(0.05),
+    kwargs...,
+) where {FT <: AbstractFloat} =
     BeerLambertParameters(CP.create_toml_dict(FT); kwargs...)
 
 function BeerLambertParameters(
@@ -619,6 +633,7 @@ function BeerLambertParameters(
     α_PAR_leaf = 0.1,
     α_NIR_leaf = 0.4,
     Ω = 1,
+    LS_c = 0.05,
     kwargs...,
 )
     name_map = (;
@@ -634,6 +649,7 @@ function BeerLambertParameters(
         α_PAR_leaf,
         α_NIR_leaf,
         Ω,
+        LS_c,
         parameters...,
         kwargs...,
     )

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -435,7 +435,7 @@ function ClimaLand.make_update_aux(
         ρ_l = FT(LP.ρ_cloud_liq(earth_param_set))
         R = FT(LP.gas_constant(earth_param_set))
         thermo_params = earth_param_set.thermo_params
-        (; G_Function, Ω, λ_γ_PAR, λ_γ_NIR) =
+        (; G_Function, Ω, λ_γ_PAR, λ_γ_NIR, LS_c) =
             canopy.radiative_transfer.parameters
         energy_per_photon_PAR = planck_h * c / λ_γ_PAR
         energy_per_photon_NIR = planck_h * c / λ_γ_NIR
@@ -563,7 +563,7 @@ function ClimaLand.make_update_aux(
             c_co2_air,
             R,
         )
-        @. GPP = compute_GPP(An, K, LAI, Ω)
+        @. GPP = compute_GPP(An, K, LAI, Ω, LS_c)
         @. gs = medlyn_conductance(g0, Drel, medlyn_factor, An, c_co2_air)
         # update autotrophic respiration
         h_canopy = hydraulics.compartment_surfaces[end]

--- a/src/standalone/Vegetation/canopy_parameterizations.jl
+++ b/src/standalone/Vegetation/canopy_parameterizations.jl
@@ -188,8 +188,15 @@ function plant_absorbed_pfd(
     α_soil::FT,
 ) where {FT}
     RTP = RT.parameters
-    AR = SW_IN * (1 - α_leaf) * (1 - exp(-K * LAI * RTP.Ω)) * (1 - α_soil)
-    TR = SW_IN * exp(-K * LAI * RTP.Ω)
+
+    if LAI < FT(0.05)
+        exp_factor = FT(1)
+    else
+        exp_factor = exp(-K * LAI * RTP.Ω)
+    end
+
+    AR = SW_IN * (1 - α_leaf) * (1 - exp_factor) * (1 - α_soil)
+    TR = SW_IN * exp_factor
     RR = SW_IN - AR - TR * (1 - α_soil)
     return (; abs = AR, refl = RR, trans = TR)
 end
@@ -229,156 +236,164 @@ function plant_absorbed_pfd(
     α_soil::FT,
     frac_diff::FT,
 ) where {FT}
-
-    (; G_Function, Ω, n_layers) = RT.parameters
-
-    # Get the current leaf angular distribution value based on the solar zenith angle
-    G = compute_G(G_Function, θs)
-
-    # Compute μ̄, the average inverse diffuse optical length per LAI
-    μ̄ = 1 / (2G)
-
-    ω = α_leaf + τ_leaf
-
-    # Compute aₛ, the single scattering albedo
-    aₛ = 0.5 * ω * (1 - cos(θs) * log((abs(cos(θs)) + 1) / abs(cos(θs))))
-
-    # Compute β₀, the direct upscattering parameter
-    β₀ = (1 / ω) * aₛ * (1 + μ̄ * K) / (μ̄ * K)
-
-    # Compute β, the diffuse upscattering parameter
-    diff = α_leaf - τ_leaf
-    # With uniform distribution, Dickinson integral becomes following:
-    c²θ̄ = pi * G / 4
-    β = 0.5 * (ω + diff * c²θ̄) / ω
-
-    # Compute coefficients for two-stream solution 
-    b = 1 - ω + ω * β
-    c = ω * β
-    d = ω * β₀ * μ̄ * K
-    f = ω * μ̄ * K * (1 - β₀)
-    h = √(b^2 - c^2) / μ̄
-    σ = (μ̄ * K)^2 + c^2 - b^2
-
-    u₁ = b - c / α_soil
-    u₂ = b - c * α_soil
-    u₃ = f + c * α_soil
-
-    s₁ = exp(-h * LAI * Ω)
-    s₂ = exp(-K * LAI * Ω)
-
-    p₁ = b + μ̄ * h
-    p₂ = b - μ̄ * h
-    p₃ = b + μ̄ * K
-    p₄ = b - μ̄ * K
-
-    d₁ = p₁ * (u₁ - μ̄ * h) / s₁ - p₂ * (u₁ + μ̄ * h) * s₁
-    d₂ = (u₂ + μ̄ * h) / s₁ - (u₂ - μ̄ * h) * s₁
-
-    # h coefficients for direct upward flux
-    h₁ = -d * p₄ - c * f
-    h₂ =
-        1 / d₁ * (
-            (d - h₁ / σ * p₃) * (u₁ - μ̄ * h) / s₁ -
-            p₂ * s₂ * (d - c - h₁ / σ * (u₁ + μ̄ * K))
+    if LAI < 0.05
+        F_abs = FT(0)
+        F_refl = α_soil
+        F_trans = (1 - F_abs - F_refl) / (1 - α_soil)
+        return (;
+            abs = FT(SW_IN * F_abs),
+            refl = FT(SW_IN * F_refl),
+            trans = FT(SW_IN * F_trans),
         )
-    h₃ =
-        -1 / d₁ * (
-            (d - h₁ / σ * p₃) * (u₁ + μ̄ * h) * s₁ -
-            p₁ * s₂ * (d - c - h₁ / σ * (u₁ + μ̄ * K))
+    else
+
+        (; G_Function, Ω, n_layers) = RT.parameters
+
+        # Get the current leaf angular distribution value based on the solar zenith angle
+        G = compute_G(G_Function, θs)
+
+        # Compute μ̄, the average inverse diffuse optical length per LAI
+        μ̄ = 1 / (2G)
+
+        ω = α_leaf + τ_leaf
+
+        # Compute aₛ, the single scattering albedo
+        # if θs = π/2 this seems OK
+        aₛ = 0.5 * ω * (1 - cos(θs) * log((abs(cos(θs)) + 1) / abs(cos(θs))))
+
+        # Compute β₀, the direct upscattering parameter
+        β₀ = (1 / ω) * aₛ * (1 + μ̄ * K) / (μ̄ * K)
+
+        # Compute β, the diffuse upscattering parameter
+        diff = α_leaf - τ_leaf
+        # With uniform distribution, Dickinson integral becomes following:
+        c²θ̄ = pi * G / 4
+        β = 0.5 * (ω + diff * c²θ̄) / ω
+
+        # Compute coefficients for two-stream solution 
+        b = 1 - ω + ω * β
+        c = ω * β
+        d = ω * β₀ * μ̄ * K
+        f = ω * μ̄ * K * (1 - β₀)
+        h = √(b^2 - c^2) / μ̄
+        σ = (μ̄ * K)^2 + c^2 - b^2
+
+        u₁ = b - c / α_soil
+        u₂ = b - c * α_soil
+        u₃ = f + c * α_soil
+
+        s₁ = exp(-h * LAI * Ω)
+        s₂ = LAI > 0.05 ? exp(-K * LAI * Ω) : FT(1)
+
+        p₁ = b + μ̄ * h
+        p₂ = b - μ̄ * h
+        p₃ = b + μ̄ * K
+        p₄ = b - μ̄ * K
+
+        d₁ = p₁ * (u₁ - μ̄ * h) / s₁ - p₂ * (u₁ + μ̄ * h) * s₁
+        d₂ = (u₂ + μ̄ * h) / s₁ - (u₂ - μ̄ * h) * s₁
+
+        # h coefficients for direct upward flux
+        h₁ = -d * p₄ - c * f
+        h₂ =
+            1 / d₁ * (
+                (d - h₁ / σ * p₃) * (u₁ - μ̄ * h) / s₁ -
+                p₂ * s₂ * (d - c - h₁ / σ * (u₁ + μ̄ * K))
+            )
+        h₃ =
+            -1 / d₁ * (
+                (d - h₁ / σ * p₃) * (u₁ + μ̄ * h) * s₁ -
+                p₁ * s₂ * (d - c - h₁ / σ * (u₁ + μ̄ * K))
+            )
+
+        # h coefficients for direct downward flux 
+        h₄ = -f * p₃ - c * d
+        h₅ =
+            -1 / d₂ *
+            (h₄ * (u₂ + μ̄ * h) / (σ * s₁) + (u₃ - h₄ / σ * (u₂ - μ̄ * K)) * s₂)
+        h₆ =
+            1 / d₂ *
+            (h₄ / σ * (u₂ - μ̄ * h) * s₁ + (u₃ - h₄ / σ * (u₂ - μ̄ * K)) * s₂)
+
+        # h coefficients for diffuse upward flux
+        h₇ = c * (u₁ - μ̄ * h) / (d₁ * s₁)
+        h₈ = -c * s₁ * (u₁ + μ̄ * h) / d₁
+
+        # h coefficients for diffuse downward flux
+        h₉ = (u₂ + μ̄ * h) / (d₂ * s₁)
+        h₁₀ = -s₁ * (u₂ - μ̄ * h) / d₂
+
+        # Compute the LAI per layer for this canopy
+        Lₗ = LAI / n_layers
+
+        # Initialize the fraction absorbed value and layer counter
+        F_abs = 0
+        i = 0
+
+        # Total light reflected form top of canopy
+        F_refl = 0
+
+        # Intialize vars to save computed fluxes from each layer for the next layer
+        I_dir_up_prev = 0
+        I_dir_dn_prev = 0
+        I_dif_up_prev = 0
+        I_dif_dn_prev = 0
+
+
+        # Compute F_abs in each canopy layer
+        while i <= n_layers
+
+            # Compute cumulative LAI at this layer
+            L = i * Lₗ
+            exp_factor = LAI > 0.05 ? exp(-K * L * Ω) : FT(1)
+            # Compute the direct fluxes into/out of the layer 
+            I_dir_up =
+                h₁ * exp_factor / σ + h₂ * exp(-h * L * Ω) + h₃ * exp(h * L * Ω)
+            I_dir_dn =
+                h₄ * exp_factor / σ + h₅ * exp(-h * L * Ω) + h₆ * exp(h * L * Ω)
+
+            # Add collimated radiation to downard flux
+            I_dir_dn += exp_factor
+
+            # Compute the diffuse fluxes into/out of the layer
+            I_dif_up = h₇ * exp(-h * L * Ω) + h₈ * exp(h * L * Ω)
+            I_dif_dn = h₉ * exp(-h * L * Ω) + h₁₀ * exp(h * L * Ω)
+
+            # Energy balance giving radiation absorbed in the layer 
+            if i == 0
+                I_dir_abs = 0
+                I_dif_abs = 0
+            else
+                I_dir_abs = I_dir_up - I_dir_up_prev - I_dir_dn + I_dir_dn_prev
+                I_dif_abs = I_dif_up - I_dif_up_prev - I_dif_dn + I_dif_dn_prev
+            end
+
+            if i == 1
+                F_refl = (1 - frac_diff) * I_dir_up + (frac_diff) * I_dif_up
+            end
+
+
+            # Add radiation absorbed in the layer to total absorbed radiation
+            F_abs += (1 - frac_diff) * I_dir_abs + (frac_diff) * I_dif_abs
+
+            # Save input/output values to compute energy balance of next layer 
+            I_dir_up_prev = I_dir_up
+            I_dir_dn_prev = I_dir_dn
+            I_dif_up_prev = I_dif_up
+            I_dif_dn_prev = I_dif_dn
+
+            # Move on to the next layer
+            i += 1
+        end
+        # Convert fractional absorption into absorption and return
+        # Ensure floating point precision is correct (it may be different for PAR)
+        F_trans = (1 - F_abs - F_refl) / (1 - α_soil)
+        return (;
+            abs = FT(SW_IN * F_abs),
+            refl = FT(SW_IN * F_refl),
+            trans = FT(SW_IN * F_trans),
         )
-
-    # h coefficients for direct downward flux 
-    h₄ = -f * p₃ - c * d
-    h₅ =
-        -1 / d₂ *
-        (h₄ * (u₂ + μ̄ * h) / (σ * s₁) + (u₃ - h₄ / σ * (u₂ - μ̄ * K)) * s₂)
-    h₆ =
-        1 / d₂ *
-        (h₄ / σ * (u₂ - μ̄ * h) * s₁ + (u₃ - h₄ / σ * (u₂ - μ̄ * K)) * s₂)
-
-    # h coefficients for diffuse upward flux
-    h₇ = c * (u₁ - μ̄ * h) / (d₁ * s₁)
-    h₈ = -c * s₁ * (u₁ + μ̄ * h) / d₁
-
-    # h coefficients for diffuse downward flux
-    h₉ = (u₂ + μ̄ * h) / (d₂ * s₁)
-    h₁₀ = -s₁ * (u₂ - μ̄ * h) / d₂
-
-    # Compute the LAI per layer for this canopy
-    Lₗ = LAI / n_layers
-
-    # Initialize the fraction absorbed value and layer counter
-    F_abs = 0
-    i = 0
-
-    # Total light reflected form top of canopy
-    F_refl = 0
-
-    # Intialize vars to save computed fluxes from each layer for the next layer
-    I_dir_up_prev = 0
-    I_dir_dn_prev = 0
-    I_dif_up_prev = 0
-    I_dif_dn_prev = 0
-
-    # Compute F_abs in each canopy layer
-    while i <= n_layers
-
-        # Compute cumulative LAI at this layer
-        L = i * Lₗ
-
-        # Compute the direct fluxes into/out of the layer 
-        I_dir_up =
-            h₁ * exp(-K * L * Ω) / σ +
-            h₂ * exp(-h * L * Ω) +
-            h₃ * exp(h * L * Ω)
-        I_dir_dn =
-            h₄ * exp(-K * L * Ω) / σ +
-            h₅ * exp(-h * L * Ω) +
-            h₆ * exp(h * L * Ω)
-
-        # Add collimated radiation to downard flux
-        I_dir_dn += exp(-K * L * Ω)
-
-        # Compute the diffuse fluxes into/out of the layer
-        I_dif_up = h₇ * exp(-h * L * Ω) + h₈ * exp(h * L * Ω)
-        I_dif_dn = h₉ * exp(-h * L * Ω) + h₁₀ * exp(h * L * Ω)
-
-        # Energy balance giving radiation absorbed in the layer 
-        if i == 0
-            I_dir_abs = 0
-            I_dif_abs = 0
-        else
-            I_dir_abs = I_dir_up - I_dir_up_prev - I_dir_dn + I_dir_dn_prev
-            I_dif_abs = I_dif_up - I_dif_up_prev - I_dif_dn + I_dif_dn_prev
-        end
-
-        if i == 1
-            F_refl = (1 - frac_diff) * I_dir_up + (frac_diff) * I_dif_up
-        end
-
-
-        # Add radiation absorbed in the layer to total absorbed radiation
-        F_abs += (1 - frac_diff) * I_dir_abs + (frac_diff) * I_dif_abs
-
-        # Save input/output values to compute energy balance of next layer 
-        I_dir_up_prev = I_dir_up
-        I_dir_dn_prev = I_dir_dn
-        I_dif_up_prev = I_dif_up
-        I_dif_dn_prev = I_dif_dn
-
-        # Move on to the next layer
-        i += 1
     end
-
-    # Convert fractional absorption into absorption and return
-    # Ensure floating point precision is correct (it may be different for PAR)
-    F_trans = (1 - F_abs - F_refl) / (1 - α_soil)
-    return (;
-        abs = FT(SW_IN * F_abs),
-        refl = FT(SW_IN * F_refl),
-        trans = FT(SW_IN * F_trans),
-    )
 end
 
 """

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -64,6 +64,8 @@ Base.@kwdef struct BeerLambertParameters{
     λ_γ_NIR::FT
     "Leaf angle distribution function"
     G_Function::G
+    "Critical value of LAI+SAI below which land is treated as unvegetated"
+    LS_c::FT
 end
 
 Base.eltype(::BeerLambertParameters{FT}) where {FT} = FT
@@ -112,23 +114,9 @@ Base.@kwdef struct TwoStreamParameters{
     n_layers::UInt64
     "Leaf angle distribution function"
     G_Function::G
+    "Critical value of LAI+SAI below which land is treated as unvegetated"
+    LS_c::FT
 end
-"""
-    function TwoStreamParameters{FT, G}(;
-        ld = ConstantGFunction(FT(0.5)),
-        α_PAR_leaf = FT(0.3),
-        τ_PAR_leaf = FT(0.2),
-        α_NIR_leaf = FT(0.4),
-        τ_NIR_leaf = FT(0.25),
-        ϵ_canopy = FT(0.98),
-        Ω = FT(1),
-        λ_γ_PAR = FT(5e-7),
-        λ_γ_NIR = FT(1.65e-6),
-        n_layers = UInt64(20),
-    ) where {FT}
-
-A constructor supplying default values for the TwoStreamParameters struct.
-"""
 
 Base.eltype(::TwoStreamParameters{FT}) where {FT} = FT
 

--- a/test/standalone/Vegetation/radiation_roundoff.jl
+++ b/test/standalone/Vegetation/radiation_roundoff.jl
@@ -1,0 +1,87 @@
+using Test
+using ClimaLand
+
+
+for FT in (Float32, Float64)
+    @testset "Roundoff bug, FT = $FT" begin
+        Ω = FT(0.69)
+        χl = FT(0.1)
+        G_Function = ClimaLand.Canopy.CLMGFunction(χl)
+        α_PAR_leaf = FT(0.1)
+        λ_γ_PAR = FT(5e-7)
+        λ_γ_NIR = FT(1.65e-6)
+        τ_PAR_leaf = FT(0.05)
+        α_NIR_leaf = FT(0.45)
+        τ_NIR_leaf = FT(0.25)
+        ϵ_canopy = FT(0.97)
+        ts_params = ClimaLand.Canopy.TwoStreamParameters(
+            α_PAR_leaf,
+            τ_PAR_leaf,
+            α_NIR_leaf,
+            τ_NIR_leaf,
+            ϵ_canopy,
+            Ω,
+            λ_γ_PAR,
+            λ_γ_NIR,
+            UInt64(20),
+            G_Function,
+        )
+
+        BL_params = ClimaLand.Canopy.BeerLambertParameters(
+            α_PAR_leaf,
+            α_NIR_leaf,
+            ϵ_canopy,
+            Ω,
+            λ_γ_PAR,
+            λ_γ_NIR,
+            G_Function,
+        )
+
+        RTmodels = [
+            ClimaLand.Canopy.TwoStreamModel{FT, typeof(ts_params)}(ts_params),
+            ClimaLand.Canopy.BeerLambertModel{FT, typeof(BL_params)}(BL_params),
+        ]
+
+        PAR = FT(1.0)
+
+        LAI = eps(FT)
+        θs = FT(π / 2)
+        K = ClimaLand.Canopy.extinction_coeff(G_Function, θs)
+        α_soil_PAR = FT(0.2)
+        frac_diff = FT(0.0)
+
+        RT = RTmodels[1]
+        canopy_par_ts = @. ClimaLand.Canopy.plant_absorbed_pfd(
+            RT,
+            PAR,
+            RT.parameters.α_PAR_leaf,
+            RT.parameters.τ_PAR_leaf,
+            LAI,
+            K,
+            θs,
+            α_soil_PAR,
+            frac_diff,
+        )[1]
+        # INC - OUT = CANOPY_ABS + (1-α_soil)*CANOPY_TRANS
+        # OUT = REFL
+        @test canopy_par_ts.abs ≈ FT(0)
+        @test canopy_par_ts.refl ≈ FT(α_soil_PAR)
+        @test canopy_par_ts.trans ≈ FT(1)
+
+        RT = RTmodels[2]
+        canopy_par_bl = @. ClimaLand.Canopy.plant_absorbed_pfd(
+            RT,
+            PAR,
+            RT.parameters.α_PAR_leaf,
+            LAI,
+            K,
+            α_soil_PAR,
+        )[1]
+        # INC - OUT = CANOPY_ABS + (1-α_soil)*CANOPY_TRANS
+        # OUT = REFL
+        @test canopy_par_bl.abs ≈ FT(0)
+        @test canopy_par_bl.refl ≈ FT(α_soil_PAR)
+        @test canopy_par_bl.trans ≈ FT(1)
+
+    end
+end

--- a/test/standalone/Vegetation/radiation_roundoff.jl
+++ b/test/standalone/Vegetation/radiation_roundoff.jl
@@ -25,6 +25,7 @@ for FT in (Float32, Float64)
             λ_γ_NIR,
             UInt64(20),
             G_Function,
+            FT(0.05),
         )
 
         BL_params = ClimaLand.Canopy.BeerLambertParameters(
@@ -35,6 +36,7 @@ for FT in (Float32, Float64)
             λ_γ_PAR,
             λ_γ_NIR,
             G_Function,
+            FT(0.05),
         )
 
         RTmodels = [
@@ -64,7 +66,7 @@ for FT in (Float32, Float64)
         )[1]
         # INC - OUT = CANOPY_ABS + (1-α_soil)*CANOPY_TRANS
         # OUT = REFL
-        @test canopy_par_ts.abs ≈ FT(0)
+        @test canopy_par_ts.abs < eps(FT)
         @test canopy_par_ts.refl ≈ FT(α_soil_PAR)
         @test canopy_par_ts.trans ≈ FT(1)
 
@@ -79,7 +81,7 @@ for FT in (Float32, Float64)
         )[1]
         # INC - OUT = CANOPY_ABS + (1-α_soil)*CANOPY_TRANS
         # OUT = REFL
-        @test canopy_par_bl.abs ≈ FT(0)
+        @test canopy_par_bl.abs < eps(FT)
         @test canopy_par_bl.refl ≈ FT(α_soil_PAR)
         @test canopy_par_bl.trans ≈ FT(1)
 


### PR DESCRIPTION
## Purpose 
Fixes #645 
We compute transmitted radiation as proportional to exp(-K*LAI*Omega), where Omega is O(1). The absorbed radiation is proportional to (1- exp(-K*LAI*Omega)). 

When the sun is at the horizon, K ~ 1/eps(FT), and no radiation is transmitted (the extinction coefficient K -> infinity).

However, when LAI -> 0, we need to have exp(-K*LAI*Omega) -> 1, so absorbed radiation -> 0. The issue is that if LAI is O(eps(FT)), K*LAI ~O(1), and absorbed radiative fraction is O(1/e).

Solution: 
Im not sure. I dont understand the behavior of K with zenith angle


## To-do
deal with 1/cos(theta) when theta = pi/2
deal with exp(-K*LAI) when K ~ 1/eps(FT) (from 1/cos(theta)) and LAI ~ eps(FT)


## Content
added failing test


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [X] I have read and checked the items on the review checklist.
