### PR TITLE
Bug fix for atmos type

### DIFF
--- a/src/shared_utilities/models.jl
+++ b/src/shared_utilities/models.jl
@@ -388,7 +388,7 @@ function add_drivers_to_cache(p::NamedTuple, model::AbstractModel, coords)
     (atmos, radiation) = get_drivers(model)
     if hasproperty(model, :parameters) &&
        hasproperty(model.parameters, :earth_param_set) &&
-       !isnothing(atmos)
+       atmos isa ClimaLand.PrescribedAtmosphere
         if LP.thermodynamic_parameters(model.parameters.earth_param_set) !=
            atmos.thermo_params
             error(


### PR DESCRIPTION
## Purpose 
if the land model has an atmosphere driver, we check if the params stored in the atmos type agree with the params of the land model itself. The coupled atmos driver does not have these params, so coupled runs break. this updates the check to only be carried out in the prescribed atmos case.


## To-do



## Content



