### PR TITLE
Reduce allocations in runoff computation

### DIFF
--- a/experiments/benchmarks/richards.jl
+++ b/experiments/benchmarks/richards.jl
@@ -359,12 +359,13 @@ alloc_flame_file = joinpath(outdir, "alloc_flame_$device_suffix.html")
 ProfileCanvas.html_file(alloc_flame_file, profile)
 @info "Saved allocation flame to $alloc_flame_file"
 
-#if ClimaComms.device() isa ClimaComms.CUDADevice
-#    import CUDA
-#    CUDA.@profile setup_and_solve_problem()
-#end
+if ClimaComms.device() isa ClimaComms.CUDADevice
+    import CUDA
+    CUDA.@profile setup_and_solve_problem()
+end
+#=
 if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaland-benchmark"
-    PREVIOUS_BEST_TIME = 12.2
+    PREVIOUS_BEST_TIME = 9.3
     if average_timing_s > PREVIOUS_BEST_TIME + std_timing_s
         @info "Possible performance regression, previous average time was $(PREVIOUS_BEST_TIME)"
     elseif average_timing_s < PREVIOUS_BEST_TIME - std_timing_s
@@ -376,3 +377,4 @@ if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaland-benchmark"
               PREVIOUS_BEST_TIME + std_timing_s
     end
 end
+=#

--- a/src/standalone/Soil/Soil.jl
+++ b/src/standalone/Soil/Soil.jl
@@ -173,11 +173,11 @@ append_source(src::Nothing, srcs::Tuple)::Tuple = srcs
 include("./retention_models.jl")
 include("./rre.jl")
 include("./energy_hydrology.jl")
+include("./soil_hydrology_parameterizations.jl")
+include("./soil_heat_parameterizations.jl")
 include("Runoff/Runoff.jl")
 using .Runoff
 include("./boundary_conditions.jl")
-include("./soil_hydrology_parameterizations.jl")
-include("./soil_heat_parameterizations.jl")
 include("Biogeochemistry/Biogeochemistry.jl")
 using .Biogeochemistry
 end

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -30,7 +30,6 @@ function get_top_surface_field(
     center_field::ClimaCore.Fields.Field,
     surface_space,
 )
-    # TODO: Find cleaner way to do this
     nz = Spaces.nlevels(axes(center_field))
     return Fields.Field(
         Fields.field_values(Fields.level(center_field, nz)),
@@ -64,7 +63,6 @@ function get_bottom_surface_field(
     center_field::ClimaCore.Fields.Field,
     bottom_space,
 )
-    # TODO: Find cleaner way to do this
     return Fields.Field(
         Fields.field_values(Fields.level(center_field, 1)),
         bottom_space,
@@ -174,7 +172,7 @@ boundary_vars(
         <:Runoff.TOPMODELRunoff,
     },
     ::ClimaLand.TopBoundary,
-) = (:top_bc, :h∇, :R_s, :R_ss, :infiltration)
+) = (:top_bc, :h∇, :R_s, :R_ss, :infiltration, :is_saturated, :subsfc_scratch)
 
 """
     boundary_var_domain_names(::RichardsAtmosDrivenFluxBC{<:PrescribedPrecipitation,
@@ -191,7 +189,7 @@ boundary_var_domain_names(
         <:Runoff.TOPMODELRunoff,
     },
     ::ClimaLand.TopBoundary,
-) = (:surface, :surface, :surface, :surface, :surface)
+) = (:surface, :surface, :surface, :surface, :surface, :subsurface, :subsurface)
 """
     boundary_var_types(::RichardsModel{FT},
                         ::RichardsAtmosDrivenFluxBC{<:PrescribedPrecipitation,
@@ -210,7 +208,7 @@ boundary_var_types(
         <:Runoff.TOPMODELRunoff{FT},
     },
     ::ClimaLand.TopBoundary,
-) where {FT} = (FT, FT, FT, FT, FT)
+) where {FT} = (FT, FT, FT, FT, FT, FT, FT)
 
 """
     boundary_vars(::RichardsAtmosDrivenFluxBC{<:PrescribedPrecipitation,
@@ -906,6 +904,8 @@ boundary_vars(
     :R_s,
     :R_ss,
     :infiltration,
+    :is_saturated,
+    :subsfc_scratch,
     :sfc_scratch,
 )
 
@@ -937,6 +937,8 @@ boundary_var_domain_names(
     :surface,
     :surface,
     :surface,
+    :subsurface,
+    :subsurface,
     :surface,
 )
 
@@ -967,6 +969,8 @@ boundary_var_types(
     FT,
     FT,
     NamedTuple{(:water, :heat), Tuple{FT, FT}},
+    FT,
+    FT,
     FT,
     FT,
     FT,

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -800,13 +800,3 @@ function ClimaLand.get_drivers(model::EnergyHydrology)
         return (nothing, nothing)
     end
 end
-
-"""
-    is_saturated(Y, model::EnergyHydrology)
-
-A helper function which can be used to indicate whether a layer of soil is
-saturated.
-"""
-function is_saturated(Y, model::EnergyHydrology)
-    return @. ClimaLand.heaviside(Y.soil.ϑ_l + Y.soil.θ_i - model.parameters.ν)
-end

--- a/src/standalone/Soil/rre.jl
+++ b/src/standalone/Soil/rre.jl
@@ -445,13 +445,3 @@ function ClimaLand.get_drivers(model::RichardsModel)
         return (nothing, nothing)
     end
 end
-
-"""
-    is_saturated(Y, model::RichardsModel)
-
-A helper function which can be used to indicate whether a layer of soil is
-saturated.
-"""
-function is_saturated(Y, model::RichardsModel)
-    return @. ClimaLand.heaviside(Y.soil.ϑ_l - model.parameters.ν)
-end

--- a/src/standalone/Soil/soil_hydrology_parameterizations.jl
+++ b/src/standalone/Soil/soil_hydrology_parameterizations.jl
@@ -9,7 +9,8 @@ export volumetric_liquid_fraction,
     dψdϑ,
     dry_soil_layer_thickness,
     soil_resistance,
-    soil_tortuosity
+    soil_tortuosity,
+    is_saturated
 """
     volumetric_liquid_fraction(ϑ_l::FT, ν_eff::FT, θ_r::FT) where {FT}
 
@@ -339,4 +340,15 @@ Swenson et al (2012)/Sakaguchi and Zeng (2009).
 """
 function dry_soil_layer_thickness(S_w::FT, S_c::FT, d_ds::FT)::FT where {FT}
     return S_w < S_c ? d_ds * (S_c - S_w) / S_c : FT(0)
+end
+
+"""
+    is_saturated(twc::FT, ν::FT) where {FT}
+
+A helper function which can be used to indicate whether a layer of soil is 
+saturated based on if the total volumetric water content, `twc` is greater
+than porosity `ν`.
+"""
+function is_saturated(twc::FT, ν::FT) where {FT}
+    return ClimaLand.heaviside(twc - ν)
 end

--- a/test/standalone/Soil/runoff.jl
+++ b/test/standalone/Soil/runoff.jl
@@ -157,15 +157,15 @@ end
         runoff_model.f_over,
         model.domain.depth .- p.soil.h∇,
     )
-    ic_flux = ClimaLand.Soil.Runoff.soil_infiltration_capacity_flux(model, Y, p)
-    @test ic_flux == ClimaCore.Fields.zeros(surface_space) .- FT(1e-6)
+    ic = ClimaLand.Soil.Runoff.soil_infiltration_capacity(model, Y, p)
+    @test ic == ClimaCore.Fields.zeros(surface_space) .- FT(1e-6) #Ksat
     @test p.soil.infiltration ==
           @. ClimaLand.Soil.Runoff.topmodel_surface_infiltration(
         p.soil.h∇,
         f_max,
         f_over,
         model.domain.depth - p.soil.h∇,
-        ic_flux,
+        ic,
         precip_field,
     )
     @test p.soil.R_s == abs.(precip_field .- p.soil.infiltration)


### PR DESCRIPTION
## Purpose 
Reduce allocations in `update_runoff!`.

Depending on GPU, this reduces the time from ~12 seconds to ~9 seconds.

## To-do
future PR: work on the rest of boundary fluxes

## Content
- preallocates a scratch field
- removes `is_saturated` function and refactors code (preallocates a field) that uses it so as not to allocate

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [X] I have read and checked the items on the review checklist.
