### PR TITLE
Add runoff to soil canopy model

### DIFF
--- a/.buildkite/target/pipeline.yml
+++ b/.buildkite/target/pipeline.yml
@@ -46,7 +46,7 @@ steps:
           slurm_mem: 8GB
           slurm_gpus: 1
 
-      - label: "Soil/Canopy"
+      - label: ":seedling: Soil/Canopy"
         command: "julia --color=yes --project=.buildkite experiments/benchmarks/land.jl"
         artifact_paths:
           - "land_benchmark_gpu/*html"

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,8 @@ main
 Improve Performance of soil canopy model
 - PR [#666]
 Add base global soil canopy run to benchmark and experiments
-- PR [#591]
+- PR [#591] adds benchmark run
+- PR [#669] adds topmodel runoff
 
 v0.12.4
 --------

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -88,13 +88,19 @@ function SoilCanopyModel{FT}(;
     MM <: Soil.Biogeochemistry.SoilCO2Model{FT},
 }
 
-    # These may be passed in, or set, depending on use scenario.
     (; atmos, radiation) = land_args
     # These should always be set by the constructor.
     sources = (RootExtraction{FT}(), Soil.PhaseChange{FT}())
-    # How to add TOPMODEL??
-    top_bc =
-        ClimaLand.Soil.AtmosDrivenFluxBC(atmos, CanopyRadiativeFluxes{FT}())
+    if :runoff ∈ propertynames(land_args)
+        top_bc = ClimaLand.Soil.AtmosDrivenFluxBC(
+            atmos,
+            CanopyRadiativeFluxes{FT}(),
+            land_args.runoff,
+        )
+    else #no runoff model
+        top_bc =
+            ClimaLand.Soil.AtmosDrivenFluxBC(atmos, CanopyRadiativeFluxes{FT}())
+    end
     zero_flux = Soil.HeatFluxBC((p, t) -> 0.0)
     boundary_conditions = (;
         top = top_bc,

--- a/src/standalone/Soil/Runoff/Runoff.jl
+++ b/src/standalone/Soil/Runoff/Runoff.jl
@@ -253,8 +253,11 @@ function soil_infiltration_capacity(model::EnergyHydrology, Y, p)
     surface_space = model.domain.space.surface
     @. p.soil.subsfc_scratch =
         -K_sat *
-        impedance_factor(Y.soil.θ_i / (p.soil.θ_l + Y.soil.θ_i - θ_r), Ω) *
-        viscosity_factor(p.soil.T, γ, γT_ref)
+        ClimaLand.Soil.impedance_factor(
+            Y.soil.θ_i / (p.soil.θ_l + Y.soil.θ_i - θ_r),
+            Ω,
+        ) *
+        ClimaLand.Soil.viscosity_factor(p.soil.T, γ, γT_ref)
     return ClimaLand.Soil.get_top_surface_field(
         p.soil.subsfc_scratch,
         surface_space,

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -711,6 +711,9 @@ end
 
 
 function AtmosDrivenFluxBC(atmos, radiation; runoff = NoRunoff())
+    if typeof(runoff) <: NoRunoff
+        @info("Warning: No runoff model was provided; zero runoff generated.")
+    end
     args = (atmos, radiation, runoff)
     return AtmosDrivenFluxBC{typeof.(args)...}(args...)
 end


### PR DESCRIPTION
## Purpose 
Adds runoff option to soil canopy model constructor; use the TOPMODEL runoff model in the global benchmark/experiment.


## To-do

## Content