### PR TITLE
Add implicit tendency for canopy temperature

### DIFF
--- a/.buildkite/Manifest.toml
+++ b/.buildkite/Manifest.toml
@@ -371,9 +371,9 @@ weakdeps = ["CUDA", "MPI"]
 
 [[deps.ClimaCore]]
 deps = ["Adapt", "BandedMatrices", "BlockArrays", "ClimaComms", "CubedSphere", "DataStructures", "DocStringExtensions", "ForwardDiff", "GaussQuadrature", "GilbertCurves", "HDF5", "InteractiveUtils", "IntervalSets", "KrylovKit", "LinearAlgebra", "MultiBroadcastFusion", "NVTX", "PkgVersion", "RecursiveArrayTools", "RootSolvers", "SparseArrays", "StaticArrays", "Statistics", "Unrolled"]
-git-tree-sha1 = "13c2f4e58c78fa54a22705d15e039c99462112ed"
+git-tree-sha1 = "6db06e8234dc67c021d636936803300ea710e0c6"
 uuid = "d414da3d-4745-48bb-8d80-42e94e092884"
-version = "0.14.17"
+version = "0.14.18"
 weakdeps = ["CUDA", "Krylov"]
 
     [deps.ClimaCore.extensions]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,6 +127,14 @@ steps:
         agents:
           slurm_mem: 16G
 
+      - label: "Canopy Implicit Stepping CPU"
+        command: "julia --color=yes --project=.buildkite experiments/standalone/Vegetation/timestep_test.jl"
+        artifact_paths: "experiments/standalone/Vegetation/timestep_test/*"
+
+      - label: "SoilCanopy Implicit Stepping CPU"
+        command: "julia --color=yes --project=.buildkite experiments/integrated/performance/integrated_timestep_test.jl"
+        artifact_paths: "experiments/integrated/performance/integrated_timestep_test/*"
+
   - group: "Experiments on GPU"
     steps:
       - label: "Richards Runoff GPU"

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ main
 - Add a longrun simulation for the bucket PR[#807](https://github.com/CliMA/ClimaLand.jl/pull/807)
 - Add ground heat flux to snow-soil model PR[#796](https://github.com/CliMA/ClimaLand.jl/pull/796)
 - Add snow-soil model PR [#779](https://github.com/CliMA/ClimaLand.jl/pull/779)
+- Step canopy temperature implicitly. PR [#675](https://github.com/CliMA/ClimaLand.jl/pull/675)
 
 v0.15.0
 --------

--- a/docs/src/APIs/canopy/Photosynthesis.md
+++ b/docs/src/APIs/canopy/Photosynthesis.md
@@ -20,8 +20,6 @@ ClimaLand.Canopy.intercellular_co2
 ClimaLand.Canopy.co2_compensation
 ClimaLand.Canopy.rubisco_assimilation
 ClimaLand.Canopy.light_assimilation
-ClimaLand.Canopy.C3
-ClimaLand.Canopy.C4
 ClimaLand.Canopy.max_electron_transport
 ClimaLand.Canopy.electron_transport
 ClimaLand.Canopy.net_photosynthesis

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -608,7 +608,7 @@ function setup_simulation(; greet = false)
     Δt = 900.0
     nelements = (101, 15)
     if greet
-        @info "Run: Global RichardsModel"
+        @info "Run: Global Land Model"
         @info "Resolution: $nelements"
         @info "Timestep: $Δt s"
         @info "Duration: $(tf - t0) s"
@@ -617,12 +617,12 @@ function setup_simulation(; greet = false)
     prob, cb = setup_prob(t0, tf, Δt; nelements)
 
     # Define timestepper and ODE algorithm
-    stepper = CTS.ARS343()
+    stepper = CTS.ARS111()
     ode_algo = CTS.IMEXAlgorithm(
         stepper,
         CTS.NewtonsMethod(
-            max_iters = 1,
-            update_j = CTS.UpdateEvery(CTS.NewTimeStep),
+            max_iters = 6,
+            update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
         ),
     )
     return prob, ode_algo, Δt, cb
@@ -634,7 +634,7 @@ SciMLBase.solve(prob, ode_algo; dt = Δt, callback = cb)
 
 @info "Starting profiling"
 # Stop when we profile for MAX_PROFILING_TIME_SECONDS or MAX_PROFILING_SAMPLES
-MAX_PROFILING_TIME_SECONDS = 1000
+MAX_PROFILING_TIME_SECONDS = 500
 MAX_PROFILING_SAMPLES = 100
 time_now = time()
 timings_s = Float64[]

--- a/experiments/integrated/fluxnet/US-Ha1/US-Ha1_simulation.jl
+++ b/experiments/integrated/fluxnet/US-Ha1/US-Ha1_simulation.jl
@@ -20,7 +20,4 @@ h_stem = FT(14) # m
 t0 = Float64(120 * 3600 * 24)# start mid year to avoid snow
 
 # Time step size:
-dt = Float64(40)
-
-# Number of timesteps between saving output:
-n = 45
+dt = Float64(450)

--- a/experiments/integrated/fluxnet/US-MOz/US-MOz_simulation.jl
+++ b/experiments/integrated/fluxnet/US-MOz/US-MOz_simulation.jl
@@ -20,7 +20,4 @@ h_leaf = FT(9.5) # m
 t0 = Float64(120 * 3600 * 24)# start mid year to avoid snow
 
 # Time step size:
-dt = Float64(450)
-
-# Number of timesteps between saving output:
-n = 4
+dt = Float64(900)

--- a/experiments/integrated/fluxnet/US-NR1/US-NR1_simulation.jl
+++ b/experiments/integrated/fluxnet/US-NR1/US-NR1_simulation.jl
@@ -20,7 +20,4 @@ h_stem = FT(7.5) # m
 t0 = Float64(120 * 3600 * 24)# start mid year to avoid snow
 
 # Time step size:
-dt = Float64(40)
-
-# Number of timesteps between saving output:
-n = 45
+dt = Float64(450)

--- a/experiments/integrated/fluxnet/US-Var/US-Var_simulation.jl
+++ b/experiments/integrated/fluxnet/US-Var/US-Var_simulation.jl
@@ -20,7 +20,4 @@ h_stem = FT(0) # m
 t0 = Float64(21 * 3600 * 24)# start day 21 of the year
 
 # Time step size:
-dt = Float64(20)
-
-# Number of timesteps between saving output:
-n = 45
+dt = Float64(900)

--- a/experiments/integrated/fluxnet/fluxnet_simulation.jl
+++ b/experiments/integrated/fluxnet/fluxnet_simulation.jl
@@ -6,14 +6,15 @@ N_spinup_days = 30
 N_days = N_spinup_days + 30
 tf = Float64(t0 + 3600 * 24 * N_days)
 t_spinup = Float64(t0 + N_spinup_days * 3600 * 24)
-saveat = Array(t_spinup:(n * dt):tf)
+dt_save = 3600.0
+saveat = Array(t_spinup:dt_save:tf)
 
 # Set up timestepper
-timestepper = CTS.ARS343();
+timestepper = CTS.ARS111();
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
     CTS.NewtonsMethod(
-        max_iters = 1,
+        max_iters = 6,
         update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
     ),
 );

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -344,7 +344,7 @@ num_days = N_days - N_spinup_days
 
 # Time series of model and data outputs
 data_times = [0:DATA_DT:(num_days * S_PER_DAY);]
-model_times = [0:(n * dt):(num_days * S_PER_DAY);]
+model_times = [0:dt_save:(num_days * S_PER_DAY);]
 
 # Plot model diurnal cycles without data comparisons
 # Autotrophic Respiration
@@ -353,7 +353,15 @@ AR =
         parent(sv.saveval[k].canopy.autotrophic_respiration.Ra)[1] for
         k in 1:length(sv.saveval)
     ] .* 1e6
-plot_daily_avg("AutoResp", AR, dt * n, num_days, "μmol/m^2/s", savedir, "Model")
+plot_daily_avg(
+    "AutoResp",
+    AR,
+    dt_save,
+    num_days,
+    "μmol/m^2/s",
+    savedir,
+    "Model",
+)
 
 # Plot all comparisons of model diurnal cycles to data diurnal cycles
 # GPP
@@ -367,7 +375,7 @@ if drivers.GPP.status == absent
     plot_daily_avg(
         "GPP",
         model_GPP,
-        dt * n,
+        dt_save,
         num_days,
         "μmol/m^2/s",
         savedir,
@@ -379,7 +387,7 @@ else
     plot_avg_comp(
         "GPP",
         model_GPP,
-        dt * n,
+        dt_save,
         GPP_data,
         FT(DATA_DT),
         num_days,
@@ -394,7 +402,7 @@ if drivers.SW_OUT.status == absent
     plot_daily_avg(
         "SW OUT",
         SW_out_model,
-        dt * n,
+        dt_save,
         num_days,
         "w/m^2",
         savedir,
@@ -407,7 +415,7 @@ else
     plot_avg_comp(
         "SW OUT",
         SW_out_model,
-        dt * n,
+        dt_save,
         SW_out_data,
         FT(DATA_DT),
         num_days,
@@ -422,7 +430,7 @@ if drivers.LW_OUT.status == absent
     plot_daily_avg(
         "LW OUT",
         LW_out_model,
-        dt * n,
+        dt_save,
         num_days,
         "w/m^2",
         savedir,
@@ -435,7 +443,7 @@ else
     plot_avg_comp(
         "LW OUT",
         LW_out_model,
-        dt * n,
+        dt_save,
         LW_out_data,
         FT(DATA_DT),
         num_days,
@@ -459,7 +467,15 @@ E =
     ] .* (1e3 * 24 * 3600)
 ET_model = T .+ E
 if drivers.LE.status == absent
-    plot_daily_avg("ET", ET_model, dt * n, num_days, "mm/day", savedir, "Model")
+    plot_daily_avg(
+        "ET",
+        ET_model,
+        dt_save,
+        num_days,
+        "mm/day",
+        savedir,
+        "Model",
+    )
 else
     measured_T =
         drivers.LE.values ./ (LP.LH_v0(earth_param_set) * 1000) .*
@@ -468,7 +484,7 @@ else
     plot_avg_comp(
         "ET",
         ET_model,
-        dt * n,
+        dt_save,
         ET_data,
         FT(DATA_DT),
         num_days,
@@ -488,7 +504,7 @@ if drivers.H.status == absent
     plot_daily_avg(
         "SHF",
         SHF_model,
-        dt * n,
+        dt_save,
         num_days,
         "w/m^2",
         savedir,
@@ -499,7 +515,7 @@ else
     plot_avg_comp(
         "SHF",
         SHF_model,
-        dt * n,
+        dt_save,
         SHF_data,
         FT(DATA_DT),
         N_days - N_spinup_days,
@@ -516,13 +532,13 @@ LHF_canopy =
     [parent(sv.saveval[k].canopy.energy.lhf)[1] for k in 1:length(sol.t)]
 LHF_model = LHF_soil + LHF_canopy
 if drivers.LE.status == absent
-    plot_daily_avg("LHF", LHF_model, dt * n, num_days, "w/m^2", savedir)
+    plot_daily_avg("LHF", LHF_model, dt_save, num_days, "w/m^2", savedir)
 else
     LHF_data = drivers.LE.values[Int64(t_spinup ÷ DATA_DT):Int64(tf ÷ DATA_DT)]
     plot_avg_comp(
         "LHF",
         LHF_model,
-        dt * n,
+        dt_save,
         LHF_data,
         FT(DATA_DT),
         N_days - N_spinup_days,

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -288,7 +288,7 @@ num_days = N_days - N_spinup_days
 
 # Time series of model and data outputs
 data_times = [0:DATA_DT:(num_days * S_PER_DAY);]
-model_times = [0:(n * dt):(num_days * S_PER_DAY);]
+model_times = [0:dt_save:(num_days * S_PER_DAY);]
 
 # Plot model diurnal cycles without data comparisons
 # Autotrophic Respiration
@@ -297,7 +297,15 @@ AR =
         parent(sv.saveval[k].canopy.autotrophic_respiration.Ra)[1] for
         k in 1:length(sv.saveval)
     ] .* 1e6
-plot_daily_avg("AutoResp", AR, dt * n, num_days, "μmol/m^2/s", savedir, "Model")
+plot_daily_avg(
+    "AutoResp",
+    AR,
+    dt_save,
+    num_days,
+    "μmol/m^2/s",
+    savedir,
+    "Model",
+)
 
 # Plot all comparisons of model diurnal cycles to data diurnal cycles
 # GPP
@@ -311,7 +319,7 @@ if drivers.GPP.status == absent
     plot_daily_avg(
         "GPP",
         model_GPP,
-        dt * n,
+        dt_save,
         num_days,
         "μmol/m^2/s",
         savedir,
@@ -323,7 +331,7 @@ else
     plot_avg_comp(
         "GPP",
         model_GPP,
-        dt * n,
+        dt_save,
         GPP_data,
         FT(DATA_DT),
         num_days,
@@ -338,7 +346,7 @@ if drivers.SW_OUT.status == absent
     plot_daily_avg(
         "SW OUT",
         SW_out_model,
-        dt * n,
+        dt_save,
         num_days,
         "w/m^2",
         savedir,
@@ -351,7 +359,7 @@ else
     plot_avg_comp(
         "SW OUT",
         SW_out_model,
-        dt * n,
+        dt_save,
         SW_out_data,
         FT(DATA_DT),
         num_days,
@@ -366,7 +374,7 @@ if drivers.LW_OUT.status == absent
     plot_daily_avg(
         "LW OUT",
         LW_out_model,
-        dt * n,
+        dt_save,
         num_days,
         "w/m^2",
         savedir,
@@ -379,7 +387,7 @@ else
     plot_avg_comp(
         "LW OUT",
         LW_out_model,
-        dt * n,
+        dt_save,
         LW_out_data,
         FT(DATA_DT),
         num_days,
@@ -403,7 +411,15 @@ E =
     ] .* (1e3 * 24 * 3600)
 ET_model = T .+ E
 if drivers.LE.status == absent
-    plot_daily_avg("ET", ET_model, dt * n, num_days, "mm/day", savedir, "Model")
+    plot_daily_avg(
+        "ET",
+        ET_model,
+        dt_save,
+        num_days,
+        "mm/day",
+        savedir,
+        "Model",
+    )
 else
     measured_T =
         drivers.LE.values ./ (LP.LH_v0(earth_param_set) * 1000) .*
@@ -412,7 +428,7 @@ else
     plot_avg_comp(
         "ET",
         ET_model,
-        dt * n,
+        dt_save,
         ET_data,
         FT(DATA_DT),
         num_days,
@@ -432,7 +448,7 @@ if drivers.H.status == absent
     plot_daily_avg(
         "SHF",
         SHF_model,
-        dt * n,
+        dt_save,
         num_days,
         "w/m^2",
         savedir,
@@ -443,7 +459,7 @@ else
     plot_avg_comp(
         "SHF",
         SHF_model,
-        dt * n,
+        dt_save,
         SHF_data,
         FT(DATA_DT),
         N_days - N_spinup_days,
@@ -460,13 +476,13 @@ LHF_canopy =
     [parent(sv.saveval[k].canopy.energy.lhf)[1] for k in 1:length(sol.t)]
 LHF_model = LHF_soil + LHF_canopy
 if drivers.LE.status == absent
-    plot_daily_avg("LHF", LHF_model, dt * n, num_days, "w/m^2", savedir)
+    plot_daily_avg("LHF", LHF_model, dt_save, num_days, "w/m^2", savedir)
 else
     LHF_data = drivers.LE.values[Int64(t_spinup ÷ DATA_DT):Int64(tf ÷ DATA_DT)]
     plot_avg_comp(
         "LHF",
         LHF_model,
-        dt * n,
+        dt_save,
         LHF_data,
         FT(DATA_DT),
         N_days - N_spinup_days,

--- a/experiments/integrated/performance/integrated_timestep_test.jl
+++ b/experiments/integrated/performance/integrated_timestep_test.jl
@@ -1,9 +1,50 @@
+# # Timestep test for integrated SoilCanopyModel
+
+# This experiment runs the standalone canopy model for 12.5 hours on a spherical domain
+# and outputs useful plots related to the timestepping and stability of
+# the simulation using different timesteps. This information can be used to
+# determine the optimal timestep for a this simulation setup.
+
+# The simulation is run multiple times: first, with a small reference timestep,
+# then with increasing timestep sizes. The goal here is to see which timesteps
+# are small enough to produce a stable simulation, and which timesteps are too
+# large to produce accurate results.
+
+# The runs with larger timesteps are compared with the reference timestep run
+# using multiple metrics, including:
+# - mean, 99%th, and 95th% error over the course of the simulation
+# - T at the end of the simulation (used to test convergence with each dt)
+# - T throughout the entire simulation
+
+# Note that the simulation is run for 12.5 hours to allow us to test the
+# convergence behavior of the solver.
+# Convergence behavior must be assessed when T is actively changing, rather
+# than when it is in equilibrium. T changes in the time period after a driver
+# update, which occurs every 3 hours (so exactly at 12 hours). Running for
+# just longer than 12 hours allows us to observe convergence behavior at a time
+# when T is actively changing. See the discussion in
+# https://github.com/CliMA/ClimaLand.jl/pull/675 for more information.
+
+# Simulation Setup
+# Number of spatial elements: 10 in horizontal, 5 in vertical
+# Soil depth: 5 m
+# Simulation duration: 12.5 hours
+# Timestep: variable, ranging from 0.6s to 3600s
+# Timestepper: ARS111
+# Fixed number of iterations: 6
+# Jacobian update: Every Newton iteration
+# Atmospheric and radiation driver updates: Every 3 hours
+
 import SciMLBase
 import ClimaTimeSteppers as CTS
 using ClimaCore
 using Dates
 using Insolation
+using Statistics
+import StatsBase: percentile
+using CairoMakie
 import ClimaComms
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
 import ClimaUtilities.TimeVaryingInputs: TimeVaryingInput
 
 using ClimaLand
@@ -71,15 +112,11 @@ function set_initial_conditions(land, t0)
     return Y, p
 end
 
-
-
 context = ClimaComms.context()
 device_suffix =
     typeof(ClimaComms.context().device) <: ClimaComms.CPUSingleThreaded ?
     "cpu" : "gpu"
 const FT = Float64
-climaland_dir = pkgdir(ClimaLand)
-savedir = joinpath(climaland_dir, "experiments/integrated/performance")
 earth_param_set = LP.LandParameters(FT)
 
 # Set the model domain
@@ -105,6 +142,7 @@ land_domain = ClimaLand.Domains.SphericalShell(;
 );
 canopy_domain = ClimaLand.Domains.obtain_surface_domain(land_domain)
 sfc_cds = ClimaCore.Fields.coordinate_field(land_domain.space.surface)
+
 # First pick the start date and time of the simulation, since time varying input depends on that
 t0 = Float64(0) # start at start date
 start_date = DateTime("202001010000", "yyyymmddHHMM")
@@ -328,11 +366,11 @@ exp_tendency! = make_exp_tendency(land)
 imp_tendency! = make_imp_tendency(land);
 jacobian! = make_jacobian(land);
 
-# Set up timestepping and simulation callbacks
-dt = Float64(900)
-tf = Float64(t0 + 100dt)
-saveat = Array(t0:dt:tf)
-updateat = Array(t0:dt:tf)
+# Timestepping information
+N_hours = 12.5
+tf = Float64(t0 + N_hours * 3600.0)
+sim_time = round((tf - t0) / 3600, digits = 2) # simulation length in hours
+
 timestepper = CTS.ARS111()
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
@@ -342,85 +380,124 @@ ode_algo = CTS.IMEXAlgorithm(
     ),
 );
 
+# Set up simulation callbacks
 drivers = ClimaLand.get_drivers(land)
 updatefunc = ClimaLand.make_update_drivers(drivers)
-driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
-# Set initial conditions
-Y, p = set_initial_conditions(land, t0)
 
-# Set up jacobian info
-jac_kwargs =
-    (; jac_prototype = ClimaLand.ImplicitEquationJacobian(Y), Wfact = jacobian!);
+# Choose timesteps and set up arrays to store information
+ref_dt = 50.0
+dts = [ref_dt, 100.0, 200.0, 450.0, 900.0, 1800.0, 3600.0]
 
-# Solve simulation
-prob = SciMLBase.ODEProblem(
-    CTS.ClimaODEFunction(
-        T_exp! = exp_tendency!,
-        T_imp! = SciMLBase.ODEFunction(imp_tendency!; jac_kwargs...),
-        dss! = ClimaLand.dss!,
-    ),
-    Y,
-    (t0, tf),
-    p,
-)
-sol = SciMLBase.solve(
-    prob,
-    ode_algo;
-    dt = dt,
-    callback = driver_cb,
-    adaptive = false,
-)
-if PROFILING
-    # Now that we compiled, solve again but collect profiling information
+ref_T = []
+mean_err = []
+p95_err = []
+p99_err = []
+sol_err = []
+T_states = []
+times = []
+ΔT = FT(0)
+for dt in dts
+    @info dt
+    # Initialize model and set initial conditions before each simulation
     Y, p = set_initial_conditions(land, t0)
-    updateat = Array(t0:dt:tf)
-    drivers = ClimaLand.get_drivers(land)
-    updatefunc = ClimaLand.make_update_drivers(drivers)
+    jac_kwargs = (;
+        jac_prototype = ClimaLand.ImplicitEquationJacobian(Y),
+        Wfact = jacobian!,
+    )
+
+    # Create callback for driver updates
+    saveat = vcat(Array(t0:(3 * 3600):tf), tf)
+    updateat = vcat(Array(t0:(3 * 3600):tf), tf)
     driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
+
+    # Solve simulation
     prob = SciMLBase.ODEProblem(
         CTS.ClimaODEFunction(
             T_exp! = exp_tendency!,
+            T_imp! = SciMLBase.ODEFunction(imp_tendency!; jac_kwargs...),
             dss! = ClimaLand.dss!,
-            T_imp! = nothing,
         ),
         Y,
         (t0, tf),
         p,
     )
-    Profile.@profile SciMLBase.solve(
+    @time sol = SciMLBase.solve(
         prob,
         ode_algo;
         dt = dt,
         callback = driver_cb,
+        saveat = saveat,
     )
-    results = Profile.fetch()
-    flame_file = joinpath(savedir, "flame_$(device_suffix).html")
-    ProfileCanvas.html_file(flame_file, results)
-    @info "Save compute flame to $(flame_file)"
-    Y, p = set_initial_conditions(land, t0)
-    updateat = Array(t0:dt:tf)
-    drivers = ClimaLand.get_drivers(land)
-    updatefunc = ClimaLand.make_update_drivers(drivers)
-    driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
-    prob = SciMLBase.ODEProblem(
-        CTS.ClimaODEFunction(
-            T_exp! = exp_tendency!,
-            dss! = ClimaLand.dss!,
-            T_imp! = nothing,
-        ),
-        Y,
-        (t0, tf),
-        p,
-    )
-    Profile.Allocs.@profile sample_rate = 0.01 SciMLBase.solve(
-        prob,
-        ode_algo;
-        dt = dt,
-        callback = driver_cb,
-    )
-    results = Profile.Allocs.fetch()
-    profile = ProfileCanvas.view_allocs(results)
-    alloc_flame_file = joinpath(savedir, "alloc_flame_$(device_suffix).html")
-    ProfileCanvas.html_file(alloc_flame_file, profile)
-    @info "Save allocation flame to $(alloc_flame_file)"
+
+    # Save results for comparison
+    if dt == ref_dt
+        global ref_T =
+            [parent(sol.u[k].canopy.energy.T)[1] for k in 1:length(sol.t)]
+    else
+        T = [parent(sol.u[k].canopy.energy.T)[1] for k in 1:length(sol.t)]
+
+        ΔT = abs.(T .- ref_T)
+        push!(mean_err, FT(mean(ΔT)))
+        push!(p95_err, FT(percentile(ΔT, 95)))
+        push!(p99_err, FT(percentile(ΔT, 99)))
+        push!(sol_err, ΔT[end])
+        push!(T_states, T)
+        push!(times, sol.t)
+    end
 end
+
+savedir = joinpath(
+    pkgdir(ClimaLand),
+    "experiments",
+    "integrated",
+    "performance",
+    "integrated_timestep_test",
+);
+!ispath(savedir) && mkpath(savedir)
+
+# Create plot with statistics
+# Compare T state computed with small vs large dt
+fig = Figure()
+ax = Axis(
+    fig[1, 1],
+    xlabel = "Timestep (sec)",
+    ylabel = "Temperature (K)",
+    xscale = log10,
+    yscale = log10,
+    title = "Error in T over $(sim_time) hour sim, dts in [$(dts[1]), $(dts[end])]",
+)
+dts = dts[2:end]
+lines!(ax, dts, FT.(mean_err), label = "Mean Error")
+lines!(ax, dts, FT.(p95_err), label = "95th% Error")
+lines!(ax, dts, FT.(p99_err), label = "99th% Error")
+axislegend(ax)
+save(joinpath(savedir, "errors.png"), fig)
+
+# Create convergence plot
+fig2 = Figure()
+ax2 = Axis(
+    fig2[1, 1],
+    xlabel = "log(dt)",
+    ylabel = "log(|T[end] - T_ref[end]|)",
+    xscale = log10,
+    yscale = log10,
+    title = "Convergence of T; sim time = $(sim_time) hours, dts in [$(dts[1]), $(dts[end])]",
+)
+scatter!(ax2, dts, FT.(sol_err))
+lines!(ax2, dts, dts / 1e3)
+save(joinpath(savedir, "convergence.png"), fig2)
+
+# Plot T throughout full simulation for each run
+fig3 = Figure()
+ax3 = Axis(
+    fig3[1, 1],
+    xlabel = "time (hr)",
+    ylabel = "T (K)",
+    title = "T throughout simulation; length = $(sim_time) hours, dts in [$(dts[1]), $(dts[end])]",
+)
+times = times ./ 3600.0 # hours
+for i in 1:length(times)
+    lines!(ax3, times[i], T_states[i], label = "dt $(dts[i]) s")
+end
+axislegend(ax3, position = :rt)
+save(joinpath(savedir, "states.png"), fig3)

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -662,7 +662,7 @@ setup_and_solve_problem(; greet = true);
 # read in diagnostics and make some plots!
 #### ClimaAnalysis ####
 simdir = ClimaAnalysis.SimDir(outdir)
-short_names = ["gpp", "ct", "lai", "swc", "si"]
+short_names = ["gpp", "ct", "lai", "swc", "si", "swo", "lwo", "et", "er", "sr"]
 for short_name in short_names
     var = get(simdir; short_name)
     times = ClimaAnalysis.times(var)

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -9,10 +9,10 @@
 # Number of spatial elements: 101 in horizontal, 15 in vertical
 # Soil depth: 50 m
 # Simulation duration: 365 d
-# Timestep: 900 s
-# Timestepper: ARS343
-# Fixed number of iterations: 1
-# Jacobian update: every new timestep
+# Timestep: 450 s
+# Timestepper: ARS111
+# Fixed number of iterations: 3
+# Jacobian update: every new Newton iteration
 # Atmos forcing update: every 3 hours
 import SciMLBase
 import ClimaComms
@@ -363,7 +363,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     τ_NIR_leaf = FT(0.25)
 
     # Energy Balance model
-    ac_canopy = FT(2.5e4) # this will likely be 10x smaller!
+    ac_canopy = FT(2.5e3)
 
     #clm_data is used for g1 and vcmax maps
     clm_artifact_path = ClimaLand.Artifacts.clm_data_folder_path(; context)
@@ -634,7 +634,7 @@ function setup_and_solve_problem(; greet = false)
 
     t0 = 0.0
     tf = 60 * 60.0 * 24 * 365
-    Δt = 900.0
+    Δt = 450.0
     nelements = (101, 15)
     if greet
         @info "Run: Global Soil-Canopy Model"

--- a/experiments/standalone/Vegetation/timestep_test.jl
+++ b/experiments/standalone/Vegetation/timestep_test.jl
@@ -1,0 +1,332 @@
+# # Timestep test for standalone CanopyModel
+
+# This experiment runs the standalone canopy model for 20 days at a single point
+# and outputs useful plots related to the timestepping and stability of
+# the simulation using different timesteps. This was initially implemented to
+# test the behavior of stepping canopy temperature (T) implicitly.
+
+# The simulation is run multiple times: first, with a small reference timestep,
+# then with increasing timestep sizes. The goal here is to see which timesteps
+# are small enough to produce a stable simulation, and which timesteps are too
+# large to produce accurate results.
+
+# The runs with larger timesteps are compared with the reference timestep run
+# using multiple metrics, including:
+# - mean, 99%th, and 95th% error over the course of the simulation
+# - T at the end of the simulation (used to test convergence with each dt)
+# - T throughout the entire simulation
+
+# Note that the simulation is run for 20 days + 80 seconds. This somewhat
+# unusual length is necessary to test the convergence behavior of the solver.
+# Convergence behavior must be assessed when T is actively changing, rather
+# than when it is in equilibrium. T changes in the time period after a driver
+# update, which occurs every 3 hours (so exactly at 20 days). Running for
+# 20 days + 80 seconds allows us to look at results over a longer simulation,
+# as well as convergence behavior. See the discussion in
+# https://github.com/CliMA/ClimaLand.jl/pull/675 for more information.
+
+# Simulation Setup
+# Space: single point
+# Simulation duration: 20 days + 80 seconds (= 480.02 hours)
+# Timestep: variable, ranging from 0.6s to 3600s
+# Timestepper: ARS111
+# Fixed number of iterations: 6
+# Jacobian update: Every Newton iteration
+# Atmospheric and radiation driver updates: Every 3 hours
+
+import SciMLBase
+import ClimaComms
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
+using CairoMakie
+using Statistics
+import StatsBase: percentile
+using Dates
+using Insolation
+using StaticArrays
+
+# Load CliMA Packages and ClimaLand Modules:
+
+using ClimaCore
+import ClimaParams as CP
+import ClimaTimeSteppers as CTS
+using ClimaLand
+using ClimaLand.Domains: Point
+using ClimaLand.Canopy
+using ClimaLand.Canopy.PlantHydraulics
+import ClimaLand
+import ClimaLand.Parameters as LP
+const FT = Float64;
+earth_param_set = LP.LandParameters(FT);
+f_root_to_shoot = FT(3.5)
+plant_ν = FT(2.46e-4) # kg/m^2
+n_stem = Int64(1)
+n_leaf = Int64(1)
+h_leaf = FT(9.5)
+h_stem = FT(9)
+compartment_midpoints = [h_stem / 2, h_stem + h_leaf / 2]
+compartment_surfaces = [FT(0), h_stem, h_stem + h_leaf]
+land_domain = Point(; z_sfc = FT(0.0))
+include(
+    joinpath(pkgdir(ClimaLand), "experiments/integrated/fluxnet/data_tools.jl"),
+);
+time_offset = 7
+lat = FT(38.7441) # degree
+long = FT(-92.2000) # degree
+atmos_h = FT(32)
+site_ID = "US-MOz"
+data_link = "https://caltech.box.com/shared/static/7r0ci9pacsnwyo0o9c25mhhcjhsu6d72.csv"
+
+include(
+    joinpath(
+        pkgdir(ClimaLand),
+        "experiments/integrated/fluxnet/met_drivers_FLUXNET.jl",
+    ),
+);
+
+z0_m = FT(2)
+z0_b = FT(0.2)
+
+shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
+    z0_m,
+    z0_b,
+    earth_param_set,
+);
+ψ_soil0 = FT(0.0)
+
+soil_driver = PrescribedSoil(
+    FT;
+    root_depths = SVector{10, FT}(-(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0),
+    ψ = t -> ψ_soil0,
+    α_PAR = FT(0.2),
+    α_NIR = FT(0.4),
+    T = t -> 298.0,
+    ϵ = FT(0.99),
+);
+
+rt_params = TwoStreamParameters(
+    FT;
+    G_Function = ConstantGFunction(FT(0.5)),
+    α_PAR_leaf = FT(0.1),
+    α_NIR_leaf = FT(0.45),
+    τ_PAR_leaf = FT(0.05),
+    τ_NIR_leaf = FT(0.25),
+    Ω = FT(0.69),
+    λ_γ_PAR = FT(5e-7),
+    λ_γ_NIR = FT(1.65e-6),
+)
+rt_model = TwoStreamModel{FT}(rt_params);
+
+cond_params = MedlynConductanceParameters(FT; g1 = FT(141.0))
+stomatal_model = MedlynConductanceModel{FT}(cond_params);
+
+is_c3 = FT(1)
+photo_params = FarquharParameters(FT, is_c3; Vcmax25 = FT(5e-5))
+photosynthesis_model = FarquharModel{FT}(photo_params);
+
+AR_params = AutotrophicRespirationParameters(FT)
+AR_model = AutotrophicRespirationModel{FT}(AR_params);
+
+f_root_to_shoot = FT(3.5)
+SAI = FT(1.0)
+RAI = FT(3f_root_to_shoot)
+ai_parameterization = PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
+
+K_sat_plant = FT(1.8e-6)
+ψ63 = FT(-4 / 0.0098)
+Weibull_param = FT(4)
+a = FT(0.05 * 0.0098)
+
+conductivity_model =
+    PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+
+retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a);
+
+ν = FT(0.7)
+S_s = FT(1e-2 * 0.0098)
+
+plant_hydraulics_ps = PlantHydraulics.PlantHydraulicsParameters(;
+    ai_parameterization = ai_parameterization,
+    ν = ν,
+    S_s = S_s,
+    rooting_depth = FT(0.5),
+    conductivity_model = conductivity_model,
+    retention_model = retention_model,
+);
+
+
+plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
+    parameters = plant_hydraulics_ps,
+    n_stem = n_stem,
+    n_leaf = n_leaf,
+    compartment_surfaces = compartment_surfaces,
+    compartment_midpoints = compartment_midpoints,
+);
+ac_canopy = FT(1e3)
+energy_model = ClimaLand.Canopy.BigLeafEnergyModel{FT}(
+    BigLeafEnergyParameters{FT}(ac_canopy),
+)
+
+canopy = ClimaLand.Canopy.CanopyModel{FT}(;
+    parameters = shared_params,
+    domain = land_domain,
+    autotrophic_respiration = AR_model,
+    radiative_transfer = rt_model,
+    photosynthesis = photosynthesis_model,
+    conductance = stomatal_model,
+    energy = energy_model,
+    hydraulics = plant_hydraulics,
+    soil_driver = soil_driver,
+    atmos = atmos,
+    radiation = radiation,
+);
+
+exp_tendency! = make_exp_tendency(canopy)
+imp_tendency! = make_imp_tendency(canopy)
+jacobian! = make_jacobian(canopy)
+drivers = ClimaLand.get_drivers(canopy)
+updatefunc = ClimaLand.make_update_drivers(drivers)
+
+ψ_leaf_0 = FT(-2e5 / 9800)
+ψ_stem_0 = FT(-1e5 / 9800)
+S_l_ini =
+    inverse_water_retention_curve.(
+        retention_model,
+        [ψ_stem_0, ψ_leaf_0],
+        ν,
+        S_s,
+    )
+
+seconds_per_day = 3600 * 24.0
+t0 = 150seconds_per_day
+N_days = 20.0
+tf = t0 + N_days * seconds_per_day + 80
+sim_time = round((tf - t0) / 3600, digits = 2) # simulation length in hours
+set_initial_cache! = make_set_initial_cache(canopy)
+
+timestepper = CTS.ARS111();
+ode_algo = CTS.IMEXAlgorithm(
+    timestepper,
+    CTS.NewtonsMethod(
+        max_iters = 6,
+        update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
+    ),
+);
+
+ref_dt = 6.0
+dts = [ref_dt, 12.0, 48.0, 225.0, 450.0, 900.0, 1800.0, 3600.0]
+
+ref_T = []
+mean_err = []
+p95_err = []
+p99_err = []
+sol_err = []
+T_states = []
+times = []
+ΔT = FT(0)
+for dt in dts
+    @info dt
+
+    # Initialize model before each simulation
+    Y, p, coords = ClimaLand.initialize(canopy)
+    jac_kwargs = (;
+        jac_prototype = ClimaLand.ImplicitEquationJacobian(Y),
+        Wfact = jacobian!,
+    )
+
+    # Set initial conditions
+    Y.canopy.hydraulics.ϑ_l.:1 .= augmented_liquid_fraction.(ν, S_l_ini[1])
+    Y.canopy.hydraulics.ϑ_l.:2 .= augmented_liquid_fraction.(ν, S_l_ini[2])
+    evaluate!(Y.canopy.energy.T, atmos.T, t0)
+    set_initial_cache!(p, Y, t0)
+
+    # Create callback for driver updates
+    saveat = vcat(Array(t0:(3 * 3600):tf), tf)
+    updateat = vcat(Array(t0:(3 * 3600):tf), tf)
+    cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
+
+    # Solve simulation
+    prob = SciMLBase.ODEProblem(
+        CTS.ClimaODEFunction(
+            T_exp! = exp_tendency!,
+            T_imp! = SciMLBase.ODEFunction(imp_tendency!; jac_kwargs...),
+            dss! = ClimaLand.dss!,
+        ),
+        Y,
+        (t0, tf),
+        p,
+    )
+    @time sol =
+        SciMLBase.solve(prob, ode_algo; dt = dt, callback = cb, saveat = saveat)
+
+    # Save results for comparison
+    if dt == ref_dt
+        global ref_T =
+            [parent(sol.u[k].canopy.energy.T)[1] for k in 1:length(sol.t)]
+    else
+        T = [parent(sol.u[k].canopy.energy.T)[1] for k in 1:length(sol.t)]
+
+        global ΔT = abs.(T .- ref_T)
+        push!(mean_err, FT(mean(ΔT)))
+        push!(p95_err, FT(percentile(ΔT, 95)))
+        push!(p99_err, FT(percentile(ΔT, 99)))
+        push!(sol_err, ΔT[end])
+        push!(T_states, T)
+        push!(times, sol.t)
+    end
+end
+
+savedir = joinpath(
+    pkgdir(ClimaLand),
+    "experiments",
+    "standalone",
+    "Vegetation",
+    "timestep_test",
+);
+!ispath(savedir) && mkpath(savedir)
+
+# Create plot with statistics
+# Compare T state computed with small vs large dt
+fig = Figure()
+ax = Axis(
+    fig[1, 1],
+    xlabel = "Timestep (minutes)",
+    ylabel = "Temperature (K)",
+    xscale = log10,
+    yscale = log10,
+    title = "Error in T over $(sim_time / 24) day sim, dts in [$(dts[1]), $(dts[end])]",
+)
+dts = dts[2:end] ./ 60
+lines!(ax, dts, FT.(mean_err), label = "Mean Error")
+lines!(ax, dts, FT.(p95_err), label = "95th% Error")
+lines!(ax, dts, FT.(p99_err), label = "99th% Error")
+axislegend(ax)
+save(joinpath(savedir, "errors.png"), fig)
+
+# Create convergence plot
+fig2 = Figure()
+ax2 = Axis(
+    fig2[1, 1],
+    xlabel = "log(dt)",
+    ylabel = "log(|T[end] - T_ref[end]|)",
+    xscale = log10,
+    yscale = log10,
+    title = "Convergence of T; sim time = $(sim_time / 24) days, dts in [$(dts[1]), $(dts[end])]",
+)
+scatter!(ax2, dts, FT.(sol_err))
+lines!(ax2, dts, dts / 1e3)
+save(joinpath(savedir, "convergence.png"), fig2)
+
+# Plot T throughout full simulation for each run
+fig3 = Figure()
+ax3 = Axis(
+    fig3[1, 1],
+    xlabel = "time (hr)",
+    ylabel = "T (K)",
+    title = "T throughout simulation; length = $(sim_time / 24) days, dts in [$(dts[1]), $(dts[end])]",
+)
+times = times ./ 3600.0 # hours
+for i in 1:length(times)
+    lines!(ax3, times[i], T_states[i], label = "dt $(dts[i]) s")
+end
+axislegend(ax3, position = :rt)
+save(joinpath(savedir, "states.png"), fig3)

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -169,9 +169,15 @@ function default_diagnostics(
             # "pwc", # return a Tuple
             "si",
             "sie",
+            "swo",
+            "lwo",
+            "er",
+            "et",
+            "sr",
         ]
     elseif output_vars == :short
-        soilcanopy_diagnostics = ["gpp", "ct", "lai", "swc", "si"]
+        soilcanopy_diagnostics =
+            ["gpp", "ct", "lai", "swc", "si", "swo", "lwo", "et", "er", "sr"]
     end
 
     if average_period == :hourly

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -149,7 +149,7 @@ function define_diagnostics!(land_model)
 
     ## Canopy Module ##
 
-    ### Canopy - Solar Induced Fluorescence 
+    ### Canopy - Solar Induced Fluorescence
     # Solar Induced Fluorescence
     add_diagnostic_variable!(
         short_name = "sif",
@@ -256,7 +256,7 @@ function define_diagnostics!(land_model)
     )
     =#
 
-    # Root flux per ground area 
+    # Root flux per ground area
     add_diagnostic_variable!(
         short_name = "far",
         long_name = "Root flux per ground area",
@@ -724,6 +724,60 @@ function define_diagnostics!(land_model)
         comments = "The production of CO2 by microbes in the soil. Vary by layers of soil depth. (depth resolved)",
         compute! = (out, Y, p, t) ->
             compute_soilco2_source_microbe!(out, Y, p, t, land_model),
+    )
+
+    ## Other ##
+    # Longwave out
+    add_diagnostic_variable!(
+        short_name = "lwo",
+        long_name = "Longwave Radiation Out",
+        standard_name = "longwave radiation out",
+        units = "W m^-2",
+        comments = "Longwave radiation going out of the land surface.",
+        compute! = (out, Y, p, t) -> compute_lw_out!(out, Y, p, t, land_model),
+    )
+
+    # Shortwave out
+    add_diagnostic_variable!(
+        short_name = "swo",
+        long_name = "Shortwave Radiation Out",
+        standard_name = "shortwave radiation out",
+        units = "W m^-2",
+        comments = "Shortwave radiation going out of the land surface.",
+        compute! = (out, Y, p, t) -> compute_sw_out!(out, Y, p, t, land_model),
+    )
+
+    # Evapotranspiration
+    add_diagnostic_variable!(
+        short_name = "et",
+        long_name = "Evapotranspiration",
+        standard_name = "evapotranspiration",
+        units = "kg m^-2 s^-1",
+        comments = "Total flux of water mass out of the surface.",
+        compute! = (out, Y, p, t) ->
+            compute_evapotranspiration!(out, Y, p, t, land_model),
+    )
+
+    # Ecosystem respiration
+    add_diagnostic_variable!(
+        short_name = "er",
+        long_name = "Ecosystem Respiration",
+        standard_name = "ecosystem respiration",
+        units = "mol CO2 m^-2 s^-1",
+        comments = "Total respiration flux out of the surface.",
+        compute! = (out, Y, p, t) ->
+            compute_total_respiration!(out, Y, p, t, land_model),
+    )
+
+    # Surface runoff
+    add_diagnostic_variable!(
+        short_name = "sr",
+        long_name = "Surface Runoff",
+        standard_name = "surface_runoff",
+        units = "m s^-1",
+        comments = "Water runoff at the surface, this is the water flowing horizontally above the ground.",
+        compute! = (out, Y, p, t) ->
+            compute_surface_runoff!(out, Y, p, t, land_model),
     )
 
     ## Stored in Y (prognostic or state variables) ##

--- a/src/shared_utilities/implicit_timestepping.jl
+++ b/src/shared_utilities/implicit_timestepping.jl
@@ -1,5 +1,6 @@
 using ClimaCore.MatrixFields
 import ClimaCore.MatrixFields: @name, ⋅
+using ClimaCore: Spaces
 import LinearAlgebra
 import LinearAlgebra: I
 
@@ -107,53 +108,57 @@ to the `explicit_names` tuple.
 """
 function ImplicitEquationJacobian(Y::ClimaCore.Fields.FieldVector)
     FT = eltype(Y)
-    center_space = axes(Y.soil.ϑ_l)
-
-    # Construct a tridiagonal matrix that will be used as the Jacobian
-    tridiag_type = MatrixFields.TridiagonalMatrixRow{FT}
-    # Create a field containing a `TridiagonalMatrixRow` at each point
-    tridiag_field = Fields.Field(tridiag_type, center_space)
-    fill!(parent(tridiag_field), NaN)
-
     # Only add jacobian blocks for fields that are in Y for this model
-    is_in_Y(name) = MatrixFields.has_field(Y, name)
+    is_in_Y(var) = MatrixFields.has_field(Y, var)
 
     # Define the implicit and explicit variables of any model we use
-    implicit_names = (@name(soil.ϑ_l), @name(soil.ρe_int))
-    explicit_names = (
+    implicit_vars =
+        (@name(soil.ϑ_l), @name(soil.ρe_int), @name(canopy.energy.T))
+    explicit_vars = (
         @name(soilco2.C),
         @name(soil.θ_i),
         @name(canopy.hydraulics.ϑ_l),
-        @name(canopy.energy.T),
         @name(snow.S),
         @name(snow.U)
     )
 
     # Filter out the variables that are not in this model's state, `Y`
-    available_implicit_names =
-        MatrixFields.unrolled_filter(is_in_Y, implicit_names)
-    available_explicit_names =
-        MatrixFields.unrolled_filter(is_in_Y, explicit_names)
+    available_implicit_vars =
+        MatrixFields.unrolled_filter(is_in_Y, implicit_vars)
+    available_explicit_vars =
+        MatrixFields.unrolled_filter(is_in_Y, explicit_vars)
 
+    get_jac_type(
+        space::Union{
+            Spaces.FiniteDifferenceSpace,
+            Spaces.ExtrudedFiniteDifferenceSpace,
+        },
+        FT,
+    ) = MatrixFields.TridiagonalMatrixRow{FT}
+    get_jac_type(
+        space::Union{Spaces.PointSpace, Spaces.SpectralElementSpace2D},
+        FT,
+    ) = MatrixFields.DiagonalMatrixRow{FT}
+
+    get_j_field(space, FT) = zeros(get_jac_type(space, FT), space)
+
+    implicit_blocks = MatrixFields.unrolled_map(
+        var ->
+            (var, var) =>
+                get_j_field(axes(MatrixFields.get_field(Y, var)), FT),
+        available_implicit_vars,
+    )
     # For explicitly-stepped variables, use the negative identity matrix
     # Note: We have to use FT(-1) * I instead of -I because inv(-1) == -1.0,
     # which means that multiplying inv(-1) by a Float32 will yield a Float64.
-    identity_blocks = MatrixFields.unrolled_map(
-        name -> (name, name) => FT(-1) * I,
-        available_explicit_names,
+    explicit_blocks = MatrixFields.unrolled_map(
+        var -> (var, var) => FT(-1) * I,
+        available_explicit_vars,
     )
 
-    # For implicitly-stepped variables, use a tridiagonal matrix
-    tridiagonal_blocks = MatrixFields.unrolled_map(
-        name ->
-            (name, name) => Fields.Field(
-                tridiag_type,
-                axes(MatrixFields.get_field(Y, name)),
-            ),
-        available_implicit_names,
-    )
 
-    matrix = MatrixFields.FieldMatrix(identity_blocks..., tridiagonal_blocks...)
+
+    matrix = MatrixFields.FieldMatrix(implicit_blocks..., explicit_blocks...)
 
     # Set up block diagonal solver for block Jacobian
     alg = MatrixFields.BlockDiagonalSolve()

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -603,6 +603,15 @@ struct AtmosDrivenFluxBC{
     prognostic_land_components::C
 end
 
+function AtmosDrivenFluxBC(
+    atmos,
+    radiation,
+    runoff;
+    prognostic_land_components = (:soil,),
+)
+    args = (atmos, radiation, runoff, prognostic_land_components)
+    return AtmosDrivenFluxBC{typeof.(args)...}(args...)
+end
 
 function AtmosDrivenFluxBC(
     atmos,

--- a/src/standalone/Vegetation/canopy_energy.jl
+++ b/src/standalone/Vegetation/canopy_energy.jl
@@ -10,12 +10,28 @@ abstract type AbstractCanopyEnergyModel{FT} <: AbstractCanopyComponent{FT} end
 ClimaLand.name(model::AbstractCanopyEnergyModel) = :energy
 
 
-ClimaLand.auxiliary_vars(model::AbstractCanopyEnergyModel) =
-    (:shf, :lhf, :fa_energy_roots, :r_ae)
+ClimaLand.auxiliary_vars(model::AbstractCanopyEnergyModel) = (
+    :shf,
+    :lhf,
+    :fa_energy_roots,
+    :r_ae,
+    :∂SHF∂Tc,
+    :∂LHF∂qc,
+    :∂LW_n∂Tc,
+    :∂qc∂Tc,
+)
 ClimaLand.auxiliary_types(model::AbstractCanopyEnergyModel{FT}) where {FT} =
-    (FT, FT, FT, FT)
-ClimaLand.auxiliary_domain_names(model::AbstractCanopyEnergyModel) =
-    (:surface, :surface, :surface, :surface)
+    (FT, FT, FT, FT, FT, FT, FT, FT)
+ClimaLand.auxiliary_domain_names(model::AbstractCanopyEnergyModel) = (
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+)
 
 """
     PrescribedCanopyTempModel{FT} <: AbstractCanopyEnergyModel{FT}
@@ -87,11 +103,11 @@ where the canopy temperature is modeled prognostically.
 canopy_temperature(model::BigLeafEnergyModel, canopy, Y, p, t) =
     Y.canopy.energy.T
 
-function make_compute_exp_tendency(
+function make_compute_imp_tendency(
     model::BigLeafEnergyModel{FT},
     canopy,
 ) where {FT}
-    function compute_exp_tendency!(dY, Y, p, t)
+    function compute_imp_tendency!(dY, Y, p, t)
         area_index = p.canopy.hydraulics.area_index
         ac_canopy = model.parameters.ac_canopy
         # Energy Equation:
@@ -117,7 +133,7 @@ function make_compute_exp_tendency(
                 p.canopy.energy.lhf - p.canopy.energy.fa_energy_roots
             ) / c_per_ground_area
     end
-    return compute_exp_tendency!
+    return compute_imp_tendency!
 end
 
 """
@@ -153,4 +169,68 @@ function root_energy_flux_per_ground_area!(
     t,
 ) where {FT}
     fa_energy .= FT(0)
+end
+
+function ClimaLand.make_compute_jacobian(
+    model::BigLeafEnergyModel{FT},
+    canopy,
+) where {FT}
+    function compute_jacobian!(jacobian::ImplicitEquationJacobian, Y, p, dtγ, t)
+        (; matrix) = jacobian
+
+        # The derivative of the residual with respect to the prognostic variable
+        ∂Tres∂T = matrix[@name(canopy.energy.T), @name(canopy.energy.T)]
+        ∂LHF∂qc = p.canopy.energy.∂LHF∂qc
+        ∂SHF∂Tc = p.canopy.energy.∂SHF∂Tc
+        ∂LW_n∂Tc = p.canopy.energy.∂LW_n∂Tc
+        ∂qc∂Tc = p.canopy.energy.∂qc∂Tc
+        ϵ_c = p.canopy.radiative_transfer.ϵ
+        area_index = p.canopy.hydraulics.area_index
+        ac_canopy = model.parameters.ac_canopy
+        earth_param_set = canopy.parameters.earth_param_set
+        _T_freeze = LP.T_freeze(earth_param_set)
+        _σ = LP.Stefan(earth_param_set)
+        @. ∂LW_n∂Tc = -2 * 4 * _σ * ϵ_c * Y.canopy.energy.T^3 # ≈ ϵ_ground = 1
+        @. ∂qc∂Tc = partial_q_sat_partial_T_liq(
+            p.drivers.P,
+            Y.canopy.energy.T - _T_freeze,
+        )# use atmos air pressure as approximation for surface air pressure
+        @. ∂Tres∂T =
+            dtγ * MatrixFields.DiagonalMatrixRow(
+                (∂LW_n∂Tc - ∂SHF∂Tc - ∂LHF∂qc * ∂qc∂Tc) /
+                (ac_canopy * max(area_index.leaf + area_index.stem, eps(FT))),
+            ) - (I,)
+    end
+    return compute_jacobian!
+end
+
+"""
+    partial_q_sat_partial_T_liq(P::FT, T::FT) where {FT}
+
+Computes the quantity ∂q_sat∂T at temperature T and pressure P,
+over liquid water. The temperature must be in Celsius.
+
+Uses the polynomial approximation from Flatau et al. (1992).
+"""
+function partial_q_sat_partial_T_liq(P::FT, T::FT) where {FT}
+    esat = FT(
+        6.11213476e2 +
+        4.44007856e1 * T +
+        1.43064234 * T^2 +
+        2.64461437e-2 * T^3 +
+        3.05903558e-4 * T^4 +
+        1.96237241e-6 * T^5 +
+        8.92344772e-9 * T^6 - 3.73208410e-11 * T^7 + 2.09339997e-14 * T^8,
+    )
+    desatdT = FT(
+        4.44017302e1 +
+        2.86064092 * T +
+        7.94683137e-2 * T^2 +
+        1.21211669e-3 * T^3 +
+        1.03354611e-5 * T^4 +
+        4.04125005e-8 * T^5 - 7.88037859e-11 * T^6 - 1.14596802e-12 * T^7 +
+        3.81294516e-15 * T^8,
+    )
+
+    return FT(0.622) * P / (P - FT(0.378) * esat)^2 * desatdT
 end

--- a/src/standalone/Vegetation/component_models.jl
+++ b/src/standalone/Vegetation/component_models.jl
@@ -123,11 +123,50 @@ may be needed and passed in (via the `canopy` model itself).
 The right hand side for the entire canopy model can make use of
 these functions for the individual components.
 """
-function ClimaLand.make_compute_exp_tendency(::AbstractCanopyComponent, canopy)
-    function compute_exp_tendency!(dY, Y, p, t) end
+function ClimaLand.make_compute_exp_tendency(
+    component::AbstractCanopyComponent,
+    canopy,
+)
+    function compute_exp_tendency!(dY, Y, p, t)
+        vars = prognostic_vars(component)
+        dY_canopy = getproperty(dY, name(canopy))
+        if !isempty(vars)
+            getproperty(dY_canopy, name(component)) .= 0
+        end
+    end
     return compute_exp_tendency!
 end
 
+"""
+     ClimaLand.make_compute_imp_tendency(component::AbstractCanopyComponent, canopy)
+
+Creates the compute_imp_tendency!(dY,Y,p,t) function for the canopy `component`.
+
+Since component models are not standalone models, other information
+may be needed and passed in (via the `canopy` model itself).
+The right hand side for the entire canopy model can make use of
+these functions for the individual components.
+"""
+function ClimaLand.make_compute_imp_tendency(
+    component::AbstractCanopyComponent,
+    canopy,
+)
+    function compute_imp_tendency!(dY, Y, p, t)
+        vars = prognostic_vars(component)
+        dY_canopy = getproperty(dY, name(canopy))
+        if !isempty(vars)
+            getproperty(dY_canopy, name(component)) .= 0
+        end
+
+    end
+    return compute_imp_tendency!
+end
+
+
+function make_compute_jacobian(component::AbstractCanopyComponent, canopy)
+    function compute_jacobian!(W, Y, p, dtγ, t) end
+    return compute_jacobian!
+end
 
 """
      set_canopy_prescribed_field!(component::AbstractCanopyComponent,

--- a/test/shared_utilities/variable_types.jl
+++ b/test/shared_utilities/variable_types.jl
@@ -78,8 +78,14 @@ end
 
 @testset "Default canopy component" begin
     FT = Float64
+    struct DefaultCanopy{FT} <: AbstractImExModel{FT} end
+    ClimaLand.name(::DefaultCanopy) where {FT} = :canopy
+    dc = DefaultCanopy{FT}()
+
     struct DefaultCanopyComponent{FT} <: AbstractCanopyComponent{FT} end
+    ClimaLand.name(::DefaultCanopyComponent) where {FT} = :component
     dcc = DefaultCanopyComponent{FT}()
+
     @test ClimaLand.prognostic_vars(dcc) == ()
     @test ClimaLand.prognostic_types(dcc) == ()
     @test ClimaLand.prognostic_domain_names(dcc) == ()
@@ -88,10 +94,9 @@ end
     @test ClimaLand.auxiliary_types(dcc) == ()
     @test ClimaLand.auxiliary_domain_names(dcc) == ()
 
-    x = [0, 1, 2, 3]
-    dcc_compute_exp_tendency! = make_compute_exp_tendency(dcc, nothing)
+    x = [(canopy = (component = [1],),), 1, 2, 3]
+    dcc_compute_exp_tendency! = make_compute_exp_tendency(dcc, dc)
     @test dcc_compute_exp_tendency!(x[1], x[2], x[3], x[4]) == nothing
-    @test x == [0, 1, 2, 3]
 
     @test_throws MethodError make_compute_imp_tendency(dcc)
 end

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -13,7 +13,7 @@ using ClimaLand.Canopy
 using ClimaLand.Canopy.PlantHydraulics
 using ClimaLand.Domains: Point
 import Insolation
-
+using ClimaCore.MatrixFields: @name
 import ClimaLand
 import ClimaLand.Parameters as LP
 import ClimaParams
@@ -43,7 +43,6 @@ import ClimaParams
             RTparams = BeerLambertParameters(FT)
             photosynthesis_params = FarquharParameters(FT, is_c3; Vcmax25)
             stomatal_g_params = MedlynConductanceParameters(FT; g1)
-
             AR_model = AutotrophicRespirationModel{FT}(AR_params)
             stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
             photosynthesis_model = FarquharModel{FT}(photosynthesis_params)
@@ -245,6 +244,14 @@ import ClimaParams
             parent(Y.canopy.hydraulics.ϑ_l) .= plant_ν
             set_initial_cache! = make_set_initial_cache(canopy)
             exp_tendency! = make_exp_tendency(canopy)
+            imp_tendency! = ClimaLand.make_imp_tendency(canopy)
+            jacobian! = ClimaLand.make_jacobian(canopy)
+            # set up jacobian info
+            jac_kwargs = (;
+                jac_prototype = ImplicitEquationJacobian(Y),
+                Wfact = jacobian!,
+            )
+
             t0 = FT(0.0)
             dY = similar(Y)
             set_initial_cache!(p, Y, t0)
@@ -658,6 +665,7 @@ end
                 θs = zenith_angle,
             )
 
+
             # Plant Hydraulics
             RAI = FT(1)
             SAI = FT(0)
@@ -780,6 +788,14 @@ end
             t0 = FT(0.0)
             set_initial_cache!(p, Y, t0)
             exp_tendency! = make_exp_tendency(canopy)
+            imp_tendency! = ClimaLand.make_imp_tendency(canopy)
+            jacobian! = ClimaLand.make_jacobian(canopy)
+            # set up jacobian info
+            jac_kwargs = (;
+                jac_prototype = ImplicitEquationJacobian(Y),
+                Wfact = jacobian!,
+            )
+
             dY = similar(Y)
             exp_tendency!(dY, Y, p, t0)
             turb_fluxes =
@@ -809,6 +825,276 @@ end
                 ) .== FT(289),
             )
         end
+    end
+end
+
+@testset "Jacobian for Temperature" begin
+    for FT in (Float32, Float64)
+        domain = Point(; z_sfc = FT(0.0))
+
+        g1 = FT(790)
+        Vcmax25 = FT(9e-5)
+        is_c3 = FT(1)
+        RTparams = BeerLambertParameters(FT)
+        photosynthesis_params = FarquharParameters(FT, is_c3; Vcmax25)
+        stomatal_g_params = MedlynConductanceParameters(FT; g1)
+
+        stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
+        photosynthesis_model = FarquharModel{FT}(photosynthesis_params)
+        rt_model = BeerLambertModel{FT}(RTparams)
+        energy_model = BigLeafEnergyModel{FT}(BigLeafEnergyParameters{FT}())
+        earth_param_set = LP.LandParameters(FT)
+        LAI = FT(8.0) # m2 [leaf] m-2 [ground]
+        z_0m = FT(2.0) # m, Roughness length for momentum - value from tall forest ChatGPT
+        z_0b = FT(0.1) # m, Roughness length for scalars - value from tall forest ChatGPT
+        h_int = FT(30.0) # m, "where measurements would be taken at a typical flux tower of a 20m canopy"
+        shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
+            z_0m,
+            z_0b,
+            earth_param_set,
+        )
+        lat = FT(0.0) # degree
+        long = FT(-180) # degree
+
+        function zenith_angle(
+            t,
+            start_date;
+            latitude = lat,
+            longitude = long,
+            insol_params = earth_param_set.insol_params,
+        )
+            current_datetime = start_date + Dates.Second(round(t))
+            d, δ, η_UTC =
+                FT.(
+                    Insolation.helper_instantaneous_zenith_angle(
+                        current_datetime,
+                        start_date,
+                        insol_params,
+                    )
+                )
+            return Insolation.instantaneous_zenith_angle(
+                d,
+                δ,
+                η_UTC,
+                longitude,
+                latitude,
+            )[1]
+        end
+
+        function shortwave_radiation(
+            t;
+            latitude = lat,
+            longitude = long,
+            insol_params = earth_param_set.insol_params,
+        )
+            return 1000 # W/m^2
+        end
+
+        function longwave_radiation(t)
+            return 200 # W/m^2
+        end
+
+        u_atmos = t -> 10 #m.s-1
+
+        liquid_precip = (t) -> 0 # m
+        snow_precip = (t) -> 0 # m
+        T_atmos = t -> 290 # Kelvin
+        q_atmos = t -> 0.001 # kg/kg
+        P_atmos = t -> 1e5 # Pa
+        h_atmos = h_int # m
+        c_atmos = (t) -> 4.11e-4 # mol/mol
+        start_date = DateTime(2005)
+        atmos = PrescribedAtmosphere(
+            TimeVaryingInput(liquid_precip),
+            TimeVaryingInput(snow_precip),
+            TimeVaryingInput(T_atmos),
+            TimeVaryingInput(u_atmos),
+            TimeVaryingInput(q_atmos),
+            TimeVaryingInput(P_atmos),
+            start_date,
+            h_atmos,
+            earth_param_set;
+            c_co2 = TimeVaryingInput(c_atmos),
+        )
+        radiation = PrescribedRadiativeFluxes(
+            FT,
+            TimeVaryingInput(shortwave_radiation),
+            TimeVaryingInput(longwave_radiation),
+            start_date;
+            θs = zenith_angle,
+        )
+
+        # Plant Hydraulics
+        RAI = FT(1)
+        SAI = FT(0)
+        lai_fun = t -> LAI
+        ai_parameterization = PlantHydraulics.PrescribedSiteAreaIndex{FT}(
+            TimeVaryingInput(lai_fun),
+            SAI,
+            RAI,
+        )
+        K_sat_plant = FT(1.8e-8) # m/s
+        ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value
+        Weibull_param = FT(4) # unitless, Holtzman's original c param value
+        a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
+        plant_ν = FT(0.7) # m3/m3
+        plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
+        conductivity_model =
+            PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+        retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
+        root_depths = SVector{10, FT}(-(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0) # 1st element is the deepest root depth
+        rooting_depth = FT(0.5)
+        param_set = PlantHydraulics.PlantHydraulicsParameters(;
+            ai_parameterization = ai_parameterization,
+            ν = plant_ν,
+            S_s = plant_S_s,
+            rooting_depth = rooting_depth,
+            conductivity_model = conductivity_model,
+            retention_model = retention_model,
+        )
+        Δz = FT(1.0) # height of compartments
+        n_stem = Int64(0) # number of stem elements
+        n_leaf = Int64(1) # number of leaf elements
+        compartment_centers =
+            FT.(
+                Vector(
+                    range(
+                        start = Δz / 2,
+                        step = Δz,
+                        stop = Δz * (n_stem + n_leaf) - (Δz / 2),
+                    ),
+                ),
+            )
+        compartment_faces =
+            FT.(
+                Vector(
+                    range(
+                        start = 0.0,
+                        step = Δz,
+                        stop = Δz * (n_stem + n_leaf),
+                    ),
+                )
+            )
+
+        ψ_soil0 = FT(0.0)
+        T_soil0 = FT(290)
+        soil_driver = PrescribedSoil(
+            root_depths,
+            (t) -> ψ_soil0,
+            (t) -> T_soil0,
+            FT(0.2),
+            FT(0.4),
+            FT(0.98),
+        )
+
+        plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
+            parameters = param_set,
+            n_stem = n_stem,
+            n_leaf = n_leaf,
+            compartment_surfaces = compartment_faces,
+            compartment_midpoints = compartment_centers,
+        )
+        autotrophic_parameters = AutotrophicRespirationParameters(FT)
+        autotrophic_respiration_model =
+            AutotrophicRespirationModel{FT}(autotrophic_parameters)
+
+        canopy = ClimaLand.Canopy.CanopyModel{FT}(;
+            parameters = shared_params,
+            domain = domain,
+            radiative_transfer = rt_model,
+            photosynthesis = photosynthesis_model,
+            conductance = stomatal_model,
+            autotrophic_respiration = autotrophic_respiration_model,
+            energy = energy_model,
+            hydraulics = plant_hydraulics,
+            soil_driver = soil_driver,
+            atmos = atmos,
+            radiation = radiation,
+        )
+
+        Y, p, coords = ClimaLand.initialize(canopy)
+
+        Y.canopy.hydraulics .= plant_ν
+        Y.canopy.energy.T = FT(289)
+
+        set_initial_cache! = make_set_initial_cache(canopy)
+        t0 = FT(0.0)
+        imp_tendency! = ClimaLand.make_imp_tendency(canopy)
+        jacobian! = ClimaLand.make_jacobian(canopy)
+
+        set_initial_cache!(p, Y, t0)
+        T_sfc = ClimaLand.surface_temperature(canopy, Y, p, t0)
+        ρ_sfc =
+            ClimaLand.surface_air_density(canopy.atmos, canopy, Y, p, t0, T_sfc)
+        q_sfc = ClimaLand.surface_specific_humidity(canopy, Y, p, T_sfc, ρ_sfc)
+        dY = similar(Y)
+        imp_tendency!(dY, Y, p, t0)
+        jac = ImplicitEquationJacobian(Y)
+        jacobian!(jac, Y, p, FT(1), t0)
+        jac_value =
+            parent(jac.matrix[@name(canopy.energy.T), @name(canopy.energy.T)])
+        ΔT = FT(0.01)
+
+        Y_2 = deepcopy(Y)
+        Y_2.canopy.energy.T = FT(289 + ΔT)
+        p_2 = deepcopy(p)
+        set_initial_cache!(p_2, Y_2, t0)
+        T_sfc2 = ClimaLand.surface_temperature(canopy, Y_2, p_2, t0)
+        ρ_sfc2 = ClimaLand.surface_air_density(
+            canopy.atmos,
+            canopy,
+            Y_2,
+            p_2,
+            t0,
+            T_sfc2,
+        )
+        q_sfc2 = ClimaLand.surface_specific_humidity(
+            canopy,
+            Y_2,
+            p_2,
+            T_sfc2,
+            ρ_sfc2,
+        )
+        dY_2 = similar(Y_2)
+        imp_tendency!(dY_2, Y_2, p_2, t0)
+
+        finitediff_LW =
+            (
+                p_2.canopy.radiative_transfer.LW_n .-
+                p.canopy.radiative_transfer.LW_n
+            ) ./ ΔT
+        estimated_LW = p.canopy.energy.∂LW_n∂Tc
+        @test parent(abs.(finitediff_LW .- estimated_LW) ./ finitediff_LW)[1] <
+              0.01
+
+        finitediff_SHF = (p_2.canopy.energy.shf .- p.canopy.energy.shf) ./ ΔT
+        estimated_SHF = p.canopy.energy.∂SHF∂Tc
+        @test parent(abs.(finitediff_SHF .- estimated_SHF) ./ finitediff_SHF)[1] <
+              0.05
+
+        finitediff_LHF = (p_2.canopy.energy.lhf .- p.canopy.energy.lhf) ./ ΔT
+        estimated_LHF = p.canopy.energy.∂LHF∂qc .* p.canopy.energy.∂qc∂Tc
+        @test parent(abs.(finitediff_LHF .- estimated_LHF) ./ finitediff_LHF)[1] <
+              0.5
+
+        # Error in `q` derivative is large
+        finitediff_q = (q_sfc2 .- q_sfc) ./ ΔT
+        estimated_q = p.canopy.energy.∂qc∂Tc
+        @test parent(abs.(finitediff_q .- estimated_q) ./ finitediff_q)[1] <
+              0.25
+
+        # Im not sure why this is not smaller! There must be an error in ∂LHF∂qc also.
+        estimated_LHF_with_correct_q = p.canopy.energy.∂LHF∂qc .* finitediff_q
+        @test parent(
+            abs.(finitediff_LHF .- estimated_LHF_with_correct_q) ./
+            finitediff_LHF,
+        )[1] < 0.5
+
+        # Recall jac = ∂Ṫ∂T - 1 [dtγ = 1]
+        ∂Ṫ∂T = jac_value .+ 1
+        @test (abs.(
+            parent((dY_2.canopy.energy.T .- dY.canopy.energy.T) ./ ΔT) - ∂Ṫ∂T
+        ) / ∂Ṫ∂T)[1] < 0.25 # Error propagates here from ∂LHF∂T
     end
 end
 


### PR DESCRIPTION
## Purpose 
Add implicit tendency for canopy temperature
Address #696 

Previously, all canopy variables were stepped explicitly. Now temperature
is stepped implicitly in both standalone CanopyModel runs and integrated
SoilCanopyModel runs. Changes include adding a jacobian and implicit 
tendency for the CanopyModel, and updating scripts to use ImEx steppers.
We've also added scripts to test convergence behavior of the standalone
and integrated cases, which are output as plots on buildkite.

This change increases the stability of our global
SoilCanopyModel runs, decreasing the number of NaNs we see, and allows
us to take timesteps of 450s.


### Notes
There are two things we dont understand about this change:
- there seem to be some times during the simultation where the error is always large, and a smaller dt doesnt help. For example, the 99th percentile error curve dips below the mean error for small dt, which indicates there are outliers that are very large in the top 1% error
  - update 9/18: it's possible this may happen during times in the simulation where temperature is changing a lot, e.g. shortly after a driver update, as opposed to when the temperature is in equilibrium. See plots in comments for more information
- the derivative of SHF with respect to temperature is correct to a few percent, but the derivative of LHF with respect to temeperature is ~30% wrong. This is partly due to d_qsat/d_T errors (but Ive double checked that I entered the formula correct), but seems like it is also due to d_LHF/d_qsat. I think I have followed CLM exactly. Not sure why the error is large.

These two questions will be investigated in a later PR - see https://github.com/CliMA/ClimaLand.jl/issues/782

## Results
With an explicit stepper, RK4, a test script at the Ozark site with the canopy alone permits dt = 60 [ac_canopy = 1e3]. Time to solution = 114 seconds - see kd/canopy_explicit_tests branch. Using dt = 180 fails.
With an implicit stepper ARS111, updated jacobian every newton iteration, max_iters = 6, the same simulation can be run with dt=3600. Time to solution = 16 seconds. Using only a single iteration failed.

Accuracy as a function of timestep (ref solution = dt = 6, implicit solver)
Float 32:
![errors_f32](https://github.com/user-attachments/assets/925c7c39-d59e-44bd-bb36-6de9917916c3)
Float64:
![errors_f64](https://github.com/user-attachments/assets/0a528162-4529-4ee4-b47c-dd8996c2ff43)

In the global long run, on this branch: [kd/canopy_explicit_global_nans](https://buildkite.com/clima/climaland-long-runs/builds?branch=kd%2Fcanopy_explicit_global_nans) I just changed the value of ac_canopy but left everything else the same as #main - i.e. using an explicit solver. The resulting map is almost entirely NaN [ look at time 86400]

On the implicit branch (this PR), we have no NaNs after one day. [ look at time 86400]

## To-do
- [X] Merge ClimaCore Branch
- [X] Test timestep improvement
- [X] Unit test Jacobian
- [x] Cleanup canopy timestep_test.jl
- [x] Add script to show soil/canopy convergence (analogous to canopy timestep_test.jl) - add to buildkite pipeline
- [x] Rebase
- [x] Check longruns
  - requires https://github.com/CliMA/ClimaCore.jl/pull/2016 for GPU compatibility
- [x] Review



## Content
- Adds canopy temp to the list of implicitly stepped variables
- Adds the canopy jacobian
- Adds the canopy implicit tendency
- updates scripts and some timesteps
- adds a script testing timestep convergence, adds to buildkite
- update docs Manifest to ClimaCore 0.14.11


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
