### PR TITLE
conv checker

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ main
 --------
 Improve Performance of soil canopy model
 - PR [#666]
+- PR [#677] Remove norm condition
 Add base global soil canopy run to benchmark and experiments
 - PR [#591] adds benchmark run
 - PR [#669] adds topmodel runoff

--- a/docs/tutorials/standalone/Soil/layered_soil.jl
+++ b/docs/tutorials/standalone/Soil/layered_soil.jl
@@ -10,7 +10,6 @@
 
 using Plots
 import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
-import NCDatasets
 import SciMLBase
 import ClimaTimeSteppers as CTS
 using ClimaCore
@@ -117,7 +116,7 @@ conv_checker = CTS.ConvergenceChecker(norm_condition = convergence_cond)
 ode_algo = CTS.IMEXAlgorithm(
     stepper,
     CTS.NewtonsMethod(
-        max_iters = 50,
+        max_iters = 10,
         update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
         convergence_checker = conv_checker,
     ),

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -17,8 +17,7 @@
 # Simulation duration: 6 hours
 # Timestep: 180 s
 # Timestepper: ARS343
-# Maximum iterations: 1
-# Convergence criterion: 1e-8
+# Fixed number of iterations: 1
 # Jacobian update: Every Newton iteration
 # Precipitation data update: every timestep
 import SciMLBase
@@ -622,14 +621,11 @@ function setup_and_solve_problem(; greet = false)
 
     # Define timestepper and ODE algorithm
     stepper = CTS.ARS343()
-    norm_condition = CTS.MaximumError(FT(1e-8))
-    conv_checker = CTS.ConvergenceChecker(; norm_condition = norm_condition)
     ode_algo = CTS.IMEXAlgorithm(
         stepper,
         CTS.NewtonsMethod(
             max_iters = 1,
             update_j = CTS.UpdateEvery(CTS.NewTimeStep),
-            convergence_checker = conv_checker,
         ),
     )
 

--- a/experiments/benchmarks/richards.jl
+++ b/experiments/benchmarks/richards.jl
@@ -18,8 +18,7 @@
 # Simulation duration: 7 days
 # Timestep: 1800 s (30 min)
 # Timestepper: ARS111
-# Maximum iterations: 2
-# Convergence criterion: 1e-8
+# Fixed number of iterations: 2
 # Jacobian update: Every Newton iteration
 # Precipitation data update: every timestep
 
@@ -303,14 +302,11 @@ function setup_and_solve_problem(; greet = false)
 
     # Define timestepper and ODE algorithm
     stepper = CTS.ARS111()
-    norm_condition = CTS.MaximumError(FT(1e-8))
-    conv_checker = CTS.ConvergenceChecker(; norm_condition = norm_condition)
     ode_algo = CTS.IMEXAlgorithm(
         stepper,
         CTS.NewtonsMethod(
             max_iters = 2,
             update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
-            convergence_checker = conv_checker,
         ),
     )
 

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -341,14 +341,11 @@ imp_tendency! = ClimaLand.make_imp_tendency(land);
 tendency_jacobian! = ClimaLand.make_tendency_jacobian(land);
 set_initial_cache!(p, Y, t0)
 stepper = CTS.ARS343()
-norm_condition = CTS.MaximumError(FT(1e-8))
-conv_checker = CTS.ConvergenceChecker(; norm_condition = norm_condition)
 ode_algo = CTS.IMEXAlgorithm(
     stepper,
     CTS.NewtonsMethod(
         max_iters = 1,
         update_j = CTS.UpdateEvery(CTS.NewTimeStep),
-        convergence_checker = conv_checker,
     ),
 )
 

--- a/experiments/standalone/Soil/richards_runoff.jl
+++ b/experiments/standalone/Soil/richards_runoff.jl
@@ -220,14 +220,11 @@ tendency_jacobian! = ClimaLand.make_tendency_jacobian(model);
 
 set_initial_cache!(p, Y, t0)
 stepper = CTS.ARS111()
-norm_condition = CTS.MaximumError(FT(1e-8))
-conv_checker = CTS.ConvergenceChecker(; norm_condition = norm_condition)
 ode_algo = CTS.IMEXAlgorithm(
     stepper,
     CTS.NewtonsMethod(
         max_iters = 2,
         update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
-        convergence_checker = conv_checker,
     ),
 )
 


### PR DESCRIPTION
## Purpose 
Remove convergence checker from select simulations, since we set max_iters = 1 or 2 anyways


## To-do


## Content
I kept the convergence checker in the following:
`./experiments/standalone/Soil/richards_comparison.jl` [more accurate better for comparison?]
`./experiments/standalone/Soil/water_conservation.jl` [testing limit of performance of jacobian approx]
`./experiments/integrated/performance/conservation/ozark_conservation_setup.jl` [perhaps for conservation we want convergence]
`./docs/tutorials/standalone/Soil/layered_soil.jl` [not sure, but this had a very high number of max_iters, so the convergence checker may matter]

I removed it from all global runs, though


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
