### PR TITLE
renaming

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,9 @@ Add base global soil canopy run to benchmark and experiments
 - PR [#669] adds topmodel runoff
 Soil implicit solver
 - PR [#678] updates Jacobian for soil energy
-
+Misc
+- PR [#685] Renames jacobian update functions to align with our convention
+            for tendency functions
 v0.12.4
 --------
 - Fix various canopy flux bugs

--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -60,8 +60,8 @@ ClimaLand.diffusive_flux
 ClimaLand.boundary_vars
 ClimaLand.boundary_var_domain_names
 ClimaLand.boundary_var_types
-ClimaLand.make_tendency_jacobian
-ClimaLand.make_update_jacobian
+ClimaLand.make_jacobian
+ClimaLand.make_compute_jacobian
 ClimaLand.set_dfluxBCdY!
 ClimaLand.get_drivers
 ```

--- a/docs/tutorials/integrated/soil_canopy_tutorial.jl
+++ b/docs/tutorials/integrated/soil_canopy_tutorial.jl
@@ -327,11 +327,9 @@ land = SoilCanopyModel{FT}(;
 Y, p, coords = initialize(land);
 exp_tendency! = make_exp_tendency(land);
 imp_tendency! = make_imp_tendency(land);
-tendency_jacobian! = make_tendency_jacobian(land);
-jac_kwargs = (;
-    jac_prototype = ClimaLand.ImplicitEquationJacobian(Y),
-    Wfact = tendency_jacobian!,
-);
+jacobian! = make_jacobian(land);
+jac_kwargs =
+    (; jac_prototype = ClimaLand.ImplicitEquationJacobian(Y), Wfact = jacobian!);
 
 # We need to provide initial conditions for the soil and canopy hydraulics
 # models:

--- a/docs/tutorials/standalone/Soil/evaporation.jl
+++ b/docs/tutorials/standalone/Soil/evaporation.jl
@@ -181,9 +181,8 @@ set_initial_cache!(p, Y, t0);
 # Define the tendency functions
 exp_tendency! = make_exp_tendency(soil)
 imp_tendency! = make_imp_tendency(soil);
-tendency_jacobian! = ClimaLand.make_tendency_jacobian(soil);
-jac_kwargs =
-    (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = tendency_jacobian!);
+jacobian! = ClimaLand.make_jacobian(soil);
+jac_kwargs = (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!);
 
 timestepper = CTS.ARS111();
 ode_algo = CTS.IMEXAlgorithm(

--- a/docs/tutorials/standalone/Soil/evaporation_gilat_loess.jl
+++ b/docs/tutorials/standalone/Soil/evaporation_gilat_loess.jl
@@ -168,9 +168,8 @@ set_initial_cache!(p, Y, t0);
 # Timestepping:
 exp_tendency! = make_exp_tendency(soil)
 imp_tendency! = make_imp_tendency(soil);
-tendency_jacobian! = ClimaLand.make_tendency_jacobian(soil);
-jac_kwargs =
-    (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = tendency_jacobian!);
+jacobian! = ClimaLand.make_jacobian(soil);
+jac_kwargs = (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!);
 
 timestepper = CTS.ARS111();
 ode_algo = CTS.IMEXAlgorithm(
@@ -224,7 +223,7 @@ set_initial_cache!(p, Y, t0)
 soil_exp_tendency! = make_exp_tendency(soil)
 exp_tendency! = make_exp_tendency(soil)
 imp_tendency! = make_imp_tendency(soil);
-tendency_jacobian! = ClimaLand.make_tendency_jacobian(soil);
+jacobian! = ClimaLand.make_jacobian(soil);
 timestepper = CTS.ARS111();
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
@@ -233,8 +232,7 @@ ode_algo = CTS.IMEXAlgorithm(
         update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
     ),
 );
-jac_kwargs =
-    (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = tendency_jacobian!);
+jac_kwargs = (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!);
 prob = SciMLBase.ODEProblem(
     CTS.ClimaODEFunction(
         T_exp! = exp_tendency!,
@@ -290,7 +288,7 @@ set_initial_cache! = make_set_initial_cache(soil)
 set_initial_cache!(p, Y, t0)
 exp_tendency! = make_exp_tendency(soil)
 imp_tendency! = make_imp_tendency(soil);
-tendency_jacobian! = ClimaLand.make_tendency_jacobian(soil);
+jacobian! = ClimaLand.make_jacobian(soil);
 timestepper = CTS.ARS111();
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
@@ -299,8 +297,7 @@ ode_algo = CTS.IMEXAlgorithm(
         update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
     ),
 );
-jac_kwargs =
-    (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = tendency_jacobian!);
+jac_kwargs = (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!);
 prob = SciMLBase.ODEProblem(
     CTS.ClimaODEFunction(
         T_exp! = exp_tendency!,

--- a/docs/tutorials/standalone/Soil/freezing_front.jl
+++ b/docs/tutorials/standalone/Soil/freezing_front.jl
@@ -211,9 +211,8 @@ set_initial_cache!(p, Y, t0);
 # Create the tendency function, and choose a timestep, and timestepper:
 exp_tendency! = make_exp_tendency(soil)
 imp_tendency! = make_imp_tendency(soil);
-tendency_jacobian! = ClimaLand.make_tendency_jacobian(soil);
-jac_kwargs =
-    (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = tendency_jacobian!);
+jacobian! = ClimaLand.make_jacobian(soil);
+jac_kwargs = (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!);
 
 dt = Float64(100)
 

--- a/docs/tutorials/standalone/Soil/layered_soil.jl
+++ b/docs/tutorials/standalone/Soil/layered_soil.jl
@@ -123,10 +123,9 @@ ode_algo = CTS.IMEXAlgorithm(
 )
 exp_tendency! = make_exp_tendency(soil)
 imp_tendency! = make_imp_tendency(soil)
-tendency_jacobian! = make_tendency_jacobian(soil)
+jacobian! = make_jacobian(soil)
 
-jac_kwargs =
-    (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = tendency_jacobian!)
+jac_kwargs = (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!)
 prob = SciMLBase.ODEProblem(
     CTS.ClimaODEFunction(
         T_exp! = exp_tendency!,

--- a/docs/tutorials/standalone/Soil/richards_equation.jl
+++ b/docs/tutorials/standalone/Soil/richards_equation.jl
@@ -140,7 +140,7 @@ soil = Soil.RichardsModel{FT}(;
 # We also create the function which is used to update our Jacobian.
 exp_tendency! = make_exp_tendency(soil);
 imp_tendency! = ClimaLand.make_imp_tendency(soil);
-tendency_jacobian! = ClimaLand.make_tendency_jacobian(soil);
+jacobian! = ClimaLand.make_jacobian(soil);
 
 # # Set up the simulation
 # We can now initialize the prognostic and auxiliary variable vectors, and take
@@ -185,8 +185,7 @@ ode_algo = CTS.IMEXAlgorithm(
 );
 
 # Here we set up the information used for our Jacobian.
-jac_kwargs =
-    (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = tendency_jacobian!);
+jac_kwargs = (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!);
 
 # And then we can solve the system of equations, using
 # [SciMLBase.jl](https://github.com/SciML/SciMLBase.jl) and

--- a/docs/tutorials/standalone/Soil/soil_energy_hydrology.jl
+++ b/docs/tutorials/standalone/Soil/soil_energy_hydrology.jl
@@ -185,7 +185,7 @@ soil = Soil.EnergyHydrology{FT}(;
 # We also create the function which is used to update our Jacobian.
 exp_tendency! = make_exp_tendency(soil);
 imp_tendency! = make_imp_tendency(soil);
-tendency_jacobian! = ClimaLand.make_tendency_jacobian(soil);
+jacobian! = ClimaLand.make_jacobian(soil);
 
 # # Set up the simulation
 # We can now initialize the prognostic and auxiliary variable vectors, and take
@@ -261,8 +261,7 @@ ode_algo = CTS.IMEXAlgorithm(
     ),
 );
 
-jac_kwargs =
-    (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = tendency_jacobian!);
+jac_kwargs = (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!);
 
 prob = SciMLBase.ODEProblem(
     CTS.ClimaODEFunction(

--- a/docs/tutorials/standalone/Soil/sublimation.jl
+++ b/docs/tutorials/standalone/Soil/sublimation.jl
@@ -167,9 +167,8 @@ set_initial_cache!(p, Y, t0);
 # Timestepping functions:
 exp_tendency! = make_exp_tendency(soil)
 imp_tendency! = make_imp_tendency(soil)
-tendency_jacobian! = ClimaLand.make_tendency_jacobian(soil)
-jac_kwargs =
-    (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = tendency_jacobian!)
+jacobian! = ClimaLand.make_jacobian(soil)
+jac_kwargs = (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!)
 
 timestepper = CTS.ARS111()
 ode_algo = CTS.IMEXAlgorithm(

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -577,14 +577,12 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     set_initial_cache! = make_set_initial_cache(land)
     exp_tendency! = make_exp_tendency(land)
     imp_tendency! = ClimaLand.make_imp_tendency(land)
-    tendency_jacobian! = ClimaLand.make_tendency_jacobian(land)
+    jacobian! = ClimaLand.make_jacobian(land)
     set_initial_cache!(p, Y, t0)
 
     # set up jacobian info
-    jac_kwargs = (;
-        jac_prototype = ImplicitEquationJacobian(Y),
-        Wfact = tendency_jacobian!,
-    )
+    jac_kwargs =
+        (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!)
 
     prob = SciMLBase.ODEProblem(
         CTS.ClimaODEFunction(

--- a/experiments/benchmarks/richards.jl
+++ b/experiments/benchmarks/richards.jl
@@ -44,7 +44,7 @@ using ClimaLand:
     make_update_aux,
     make_exp_tendency,
     make_imp_tendency,
-    make_tendency_jacobian,
+    make_jacobian,
     make_set_initial_cache
 
 import Profile, ProfileCanvas
@@ -256,14 +256,14 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     set_initial_cache! = make_set_initial_cache(model)
     exp_tendency! = make_exp_tendency(model)
     imp_tendency! = make_imp_tendency(model)
-    tendency_jacobian! = make_tendency_jacobian(model)
+    jacobian! = make_jacobian(model)
 
     set_initial_cache!(p, Y, t0)
 
     # set up jacobian info
     jac_kwargs = (;
         jac_prototype = ClimaLand.Soil.ImplicitEquationJacobian(Y),
-        Wfact = tendency_jacobian!,
+        Wfact = jacobian!,
     )
 
     prob = SciMLBase.ODEProblem(

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -256,11 +256,9 @@ land = SoilCanopyModel{FT}(;
 Y, p, cds = initialize(land)
 exp_tendency! = make_exp_tendency(land)
 imp_tendency! = make_imp_tendency(land);
-tendency_jacobian! = make_tendency_jacobian(land);
-jac_kwargs = (;
-    jac_prototype = ClimaLand.ImplicitEquationJacobian(Y),
-    Wfact = tendency_jacobian!,
-);
+jacobian! = make_jacobian(land);
+jac_kwargs =
+    (; jac_prototype = ClimaLand.ImplicitEquationJacobian(Y), Wfact = jacobian!);
 
 #Initial conditions
 Y.soil.ϑ_l =

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -213,11 +213,9 @@ land = SoilCanopyModel{FT}(;
 Y, p, cds = initialize(land)
 exp_tendency! = make_exp_tendency(land)
 imp_tendency! = make_imp_tendency(land)
-tendency_jacobian! = make_tendency_jacobian(land);
-jac_kwargs = (;
-    jac_prototype = ClimaLand.ImplicitEquationJacobian(Y),
-    Wfact = tendency_jacobian!,
-);
+jacobian! = make_jacobian(land);
+jac_kwargs =
+    (; jac_prototype = ClimaLand.ImplicitEquationJacobian(Y), Wfact = jacobian!);
 
 #Initial conditions
 Y.soil.ϑ_l =

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -338,7 +338,7 @@ evaluate!(Y.canopy.energy.T, atmos.T, t0)
 set_initial_cache! = make_set_initial_cache(land)
 exp_tendency! = make_exp_tendency(land);
 imp_tendency! = ClimaLand.make_imp_tendency(land);
-tendency_jacobian! = ClimaLand.make_tendency_jacobian(land);
+jacobian! = ClimaLand.make_jacobian(land);
 set_initial_cache!(p, Y, t0)
 stepper = CTS.ARS343()
 ode_algo = CTS.IMEXAlgorithm(
@@ -350,8 +350,7 @@ ode_algo = CTS.IMEXAlgorithm(
 )
 
 # set up jacobian info
-jac_kwargs =
-    (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = tendency_jacobian!)
+jac_kwargs = (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!)
 
 prob = SciMLBase.ODEProblem(
     CTS.ClimaODEFunction(

--- a/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
+++ b/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
@@ -193,13 +193,11 @@ land = SoilCanopyModel{FT}(;
 )
 exp_tendency! = make_exp_tendency(land)
 imp_tendency! = make_imp_tendency(land);
-tendency_jacobian! = make_tendency_jacobian(land);
+jacobian! = make_jacobian(land);
 set_initial_cache! = make_set_initial_cache(land)
 Y, p, cds = initialize(land)
-jac_kwargs = (;
-    jac_prototype = ClimaLand.ImplicitEquationJacobian(Y),
-    Wfact = tendency_jacobian!,
-);
+jac_kwargs =
+    (; jac_prototype = ClimaLand.ImplicitEquationJacobian(Y), Wfact = jacobian!);
 
 #Initial conditions
 Y.soil.ϑ_l = drivers.SWC.values[1 + Int(round(t0 / 1800))] # Get soil water content at t0

--- a/experiments/integrated/performance/profile_allocations.jl
+++ b/experiments/integrated/performance/profile_allocations.jl
@@ -330,7 +330,7 @@ land = SoilCanopyModel{FT}(;
 # Define explicit and implicit tendencies, and the jacobian
 exp_tendency! = make_exp_tendency(land)
 imp_tendency! = make_imp_tendency(land);
-tendency_jacobian! = make_tendency_jacobian(land);
+jacobian! = make_jacobian(land);
 
 # Set up timestepping and simulation callbacks
 dt = Float64(150)
@@ -352,10 +352,8 @@ driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
 Y, p = set_initial_conditions(land, t0)
 
 # Set up jacobian info
-jac_kwargs = (;
-    jac_prototype = ClimaLand.ImplicitEquationJacobian(Y),
-    Wfact = tendency_jacobian!,
-);
+jac_kwargs =
+    (; jac_prototype = ClimaLand.ImplicitEquationJacobian(Y), Wfact = jacobian!);
 
 # Solve simulation
 prob = SciMLBase.ODEProblem(

--- a/experiments/standalone/Soil/richards_comparison.jl
+++ b/experiments/standalone/Soil/richards_comparison.jl
@@ -77,7 +77,7 @@ outdir = joinpath(
         Y.soil.ϑ_l .= FT(0.24)
         exp_tendency! = make_exp_tendency(soil)
         imp_tendency! = ClimaLand.make_imp_tendency(soil)
-        tendency_jacobian! = ClimaLand.make_tendency_jacobian(soil)
+        jacobian! = ClimaLand.make_jacobian(soil)
         set_initial_cache!(p, Y, t0)
 
         stepper = CTS.ARS111()
@@ -93,10 +93,8 @@ outdir = joinpath(
         )
 
         # set up jacobian info
-        jac_kwargs = (;
-            jac_prototype = ImplicitEquationJacobian(Y),
-            Wfact = tendency_jacobian!,
-        )
+        jac_kwargs =
+            (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!)
 
         prob = SciMLBase.ODEProblem(
             CTS.ClimaODEFunction(
@@ -173,7 +171,7 @@ end
         Y.soil.ϑ_l .= FT(0.1)
         exp_tendency! = make_exp_tendency(soil)
         imp_tendency! = ClimaLand.make_imp_tendency(soil)
-        tendency_jacobian! = ClimaLand.make_tendency_jacobian(soil)
+        jacobian! = ClimaLand.make_jacobian(soil)
         set_initial_cache!(p, Y, t0)
 
         stepper = CTS.ARS111()
@@ -188,10 +186,8 @@ end
             ),
         )
         # set up jacobian info
-        jac_kwargs = (;
-            jac_prototype = ImplicitEquationJacobian(Y),
-            Wfact = tendency_jacobian!,
-        )
+        jac_kwargs =
+            (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!)
 
         prob = SciMLBase.ODEProblem(
             CTS.ClimaODEFunction(

--- a/experiments/standalone/Soil/richards_runoff.jl
+++ b/experiments/standalone/Soil/richards_runoff.jl
@@ -216,7 +216,7 @@ Y.soil.ϑ_l .= hydrostatic_profile.(lat, z, ν, θ_r, vg_α, vg_n, S_s, f_max)
 set_initial_cache! = make_set_initial_cache(model)
 exp_tendency! = make_exp_tendency(model);
 imp_tendency! = ClimaLand.make_imp_tendency(model);
-tendency_jacobian! = ClimaLand.make_tendency_jacobian(model);
+jacobian! = ClimaLand.make_jacobian(model);
 
 set_initial_cache!(p, Y, t0)
 stepper = CTS.ARS111()
@@ -229,8 +229,7 @@ ode_algo = CTS.IMEXAlgorithm(
 )
 
 # set up jacobian info
-jac_kwargs =
-    (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = tendency_jacobian!)
+jac_kwargs = (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!)
 
 prob = SciMLBase.ODEProblem(
     CTS.ClimaODEFunction(

--- a/experiments/standalone/Soil/water_conservation.jl
+++ b/experiments/standalone/Soil/water_conservation.jl
@@ -84,7 +84,7 @@ for FT in (Float32, Float64)
     exp_tendency! = make_exp_tendency(soil)
     set_initial_cache! = make_set_initial_cache(soil)
     imp_tendency! = make_imp_tendency(soil)
-    tendency_jacobian! = make_tendency_jacobian(soil)
+    jacobian! = make_jacobian(soil)
 
     rmses = Array{FT}(undef, length(dts))
     mass_errors = Array{FT}(undef, length(dts))
@@ -95,10 +95,8 @@ for FT in (Float32, Float64)
         @. Y.soil.ϑ_l = FT(0.24)
         set_initial_cache!(p, Y, FT(0.0))
 
-        jac_kwargs = (;
-            jac_prototype = ImplicitEquationJacobian(Y),
-            Wfact = tendency_jacobian!,
-        )
+        jac_kwargs =
+            (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!)
 
         prob = SciMLBase.ODEProblem(
             CTS.ClimaODEFunction(
@@ -195,7 +193,7 @@ for FT in (Float32, Float64)
     exp_tendency! = make_exp_tendency(soil_dirichlet)
     set_initial_cache! = make_set_initial_cache(soil_dirichlet)
     imp_tendency! = make_imp_tendency(soil_dirichlet)
-    tendency_jacobian! = make_tendency_jacobian(soil_dirichlet)
+    jacobian! = make_jacobian(soil_dirichlet)
     update_aux! = make_update_aux(soil_dirichlet)
 
     rmses_dirichlet = Array{FT}(undef, length(dts))
@@ -207,10 +205,8 @@ for FT in (Float32, Float64)
         @. Y.soil.ϑ_l = FT(0.24)
         set_initial_cache!(p, Y, FT(0.0))
 
-        jac_kwargs = (;
-            jac_prototype = ImplicitEquationJacobian(Y),
-            Wfact = tendency_jacobian!,
-        )
+        jac_kwargs =
+            (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!)
 
         prob = SciMLBase.ODEProblem(
             CTS.ClimaODEFunction(

--- a/experiments/standalone/Soil/water_energy_conservation.jl
+++ b/experiments/standalone/Soil/water_energy_conservation.jl
@@ -62,7 +62,7 @@ soil = Soil.EnergyHydrology{FT}(;
 
 exp_tendency! = make_exp_tendency(soil);
 imp_tendency! = make_imp_tendency(soil);
-tendency_jacobian! = ClimaLand.make_tendency_jacobian(soil);
+jacobian! = ClimaLand.make_jacobian(soil);
 
 
 function init_soil!(Y, z, Trange, params)
@@ -138,10 +138,8 @@ for experiment in [no_phase_change, phase_change]
     Y, p, coords = initialize(soil)
     init_soil!(Y, coords.subsurface.z, Trange, soil.parameters)
     set_initial_cache!(p, Y, t0)
-    jac_kwargs = (;
-        jac_prototype = ImplicitEquationJacobian(Y),
-        Wfact = tendency_jacobian!,
-    )
+    jac_kwargs =
+        (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!)
 
     prob = SciMLBase.ODEProblem(
         CTS.ClimaODEFunction(
@@ -166,10 +164,8 @@ for experiment in [no_phase_change, phase_change]
         Y, p, coords = initialize(soil)
         init_soil!(Y, coords.subsurface.z, Trange, soil.parameters)
         set_initial_cache!(p, Y, t0)
-        jac_kwargs = (;
-            jac_prototype = ImplicitEquationJacobian(Y),
-            Wfact = tendency_jacobian!,
-        )
+        jac_kwargs =
+            (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!)
 
         prob = SciMLBase.ODEProblem(
             CTS.ClimaODEFunction(

--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -188,16 +188,16 @@ function make_update_boundary_fluxes(land::AbstractLandModel)
     return update_boundary_fluxes!
 end
 
-function make_update_jacobian(land::AbstractLandModel)
+function make_compute_jacobian(land::AbstractLandModel)
     components = land_components(land)
-    update_jacobian_function_list =
-        map(x -> make_update_jacobian(getproperty(land, x)), components)
-    function update_jacobian!(jacobian, Y, p, dtγ, t)
-        for f! in update_jacobian_function_list
+    compute_jacobian_function_list =
+        map(x -> make_compute_jacobian(getproperty(land, x)), components)
+    function compute_jacobian!(jacobian, Y, p, dtγ, t)
+        for f! in compute_jacobian_function_list
             f!(jacobian, Y, p, dtγ, t)
         end
     end
-    return update_jacobian!
+    return compute_jacobian!
 end
 
 """

--- a/src/shared_utilities/implicit_timestepping.jl
+++ b/src/shared_utilities/implicit_timestepping.jl
@@ -4,12 +4,12 @@ import UnrolledUtilities
 import LinearAlgebra
 import LinearAlgebra: I
 
-export make_tendency_jacobian,
-    make_update_jacobian, set_dfluxBCdY!, ImplicitEquationJacobian
+export make_jacobian,
+    make_compute_jacobian, set_dfluxBCdY!, ImplicitEquationJacobian
 
 
 """
-   make_tendency_jacobian(model::AbstractModel)
+   make_jacobian(model::AbstractModel)
 
 Creates and returns a function which updates the auxiliary
 variables `p` in place and then updates the entries of the
@@ -18,25 +18,25 @@ Jacobian matrix `W` for the `model` in place.
 The default is that no updates are required, no implicit tendency is
 present, and hence the timestepping is entirely explicit.
 
-Note that the returned function `tendency_jacobian!` should be
+Note that the returned function `jacobian!` should be
 used as `Wfact!` in `ClimaTimeSteppers.jl` and `SciMLBase.jl`.
 """
-function make_tendency_jacobian(model::AbstractModel)
+function make_jacobian(model::AbstractModel)
     update_aux! = make_update_aux(model)
     update_boundary_fluxes! = make_update_boundary_fluxes(model)
-    update_jacobian! = make_update_jacobian(model)
-    function tendency_jacobian!(W, Y, p, dtγ, t)
+    compute_jacobian! = make_compute_jacobian(model)
+    function jacobian!(W, Y, p, dtγ, t)
         update_aux!(p, Y, t)
         update_boundary_fluxes!(p, Y, t)
-        update_jacobian!(W, Y, p, dtγ, t)
+        compute_jacobian!(W, Y, p, dtγ, t)
     end
-    return tendency_jacobian!
+    return jacobian!
 end
 
 """
-    make_update_jacobian(model::AbstractModel)
+    make_compute_jacobian(model::AbstractModel)
 
-Creates and returns a function which updates the entries
+Creates and returns a function which computes the entries
 of the Jacobian matrix `W` in place.
 
 If the implicit tendency function is given by
@@ -48,9 +48,9 @@ and `T!_i` is the implicit tendency of the `i-th` state variable.
 The default is that no updates are required, but this function
 must be extended for models that use implicit timestepping.
 """
-function make_update_jacobian(model::AbstractModel)
-    function update_jacobian!(W, Y, p, dtγ, t) end
-    return update_jacobian!
+function make_compute_jacobian(model::AbstractModel)
+    function compute_jacobian!(W, Y, p, dtγ, t) end
+    return compute_jacobian!
 end
 
 """

--- a/src/standalone/Soil/Soil.jl
+++ b/src/standalone/Soil/Soil.jl
@@ -73,7 +73,7 @@ import ClimaLand:
     make_compute_exp_tendency,
     make_compute_imp_tendency,
     make_update_boundary_fluxes,
-    make_update_jacobian,
+    make_compute_jacobian,
     prognostic_vars,
     auxiliary_vars,
     prognostic_domain_names,

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -278,16 +278,16 @@ function ClimaLand.make_compute_imp_tendency(
 end
 
 """
-    ClimaLand.make_update_jacobian(model::EnergyHydrology{FT}) where {FT}
+    ClimaLand.make_compute_jacobian(model::EnergyHydrology{FT}) where {FT}
 
-Creates and returns the update_jacobian! function for the EnergyHydrology model.
+Creates and returns the compute_jacobian! function for the EnergyHydrology model.
 This updates the contribution for the soil liquid water content only.
 
 Using this Jacobian with a backwards Euler timestepper is equivalent
 to using the modified Picard scheme of Celia et al. (1990).
 """
-function ClimaLand.make_update_jacobian(model::EnergyHydrology{FT}) where {FT}
-    function update_jacobian!(jacobian::ImplicitEquationJacobian, Y, p, dtγ, t)
+function ClimaLand.make_compute_jacobian(model::EnergyHydrology{FT}) where {FT}
+    function compute_jacobian!(jacobian::ImplicitEquationJacobian, Y, p, dtγ, t)
         (; matrix) = jacobian
         (; ν, hydrology_cm, S_s, θ_r, ρc_ds, earth_param_set) = model.parameters
 
@@ -374,7 +374,7 @@ function ClimaLand.make_update_jacobian(model::EnergyHydrology{FT}) where {FT}
                 )
             ) - (I,)
     end
-    return update_jacobian!
+    return compute_jacobian!
 end
 
 """

--- a/src/standalone/Soil/rre.jl
+++ b/src/standalone/Soil/rre.jl
@@ -342,16 +342,16 @@ function ClimaLand.make_update_aux(model::RichardsModel)
 end
 
 """
-    ClimaLand.make_update_jacobian(model::RichardsModel{FT}) where {FT}
+    ClimaLand.make_compute_jacobian(model::RichardsModel{FT}) where {FT}
 
-Creates and returns the update_jacobian! function for RichardsModel.
+Creates and returns the compute_jacobian! function for RichardsModel.
 This updates the contribution for the soil liquid water content.
 
 Using this Jacobian with a backwards Euler timestepper is equivalent
 to using the modified Picard scheme of Celia et al. (1990).
 """
-function ClimaLand.make_update_jacobian(model::RichardsModel{FT}) where {FT}
-    function update_jacobian!(jacobian::ImplicitEquationJacobian, Y, p, dtγ, t)
+function ClimaLand.make_compute_jacobian(model::RichardsModel{FT}) where {FT}
+    function compute_jacobian!(jacobian::ImplicitEquationJacobian, Y, p, dtγ, t)
         (; matrix) = jacobian
         (; ν, hydrology_cm, S_s, θ_r) = model.parameters
 
@@ -425,7 +425,7 @@ function ClimaLand.make_update_jacobian(model::RichardsModel{FT}) where {FT}
                 ) - (I,)
         end
     end
-    return update_jacobian!
+    return compute_jacobian!
 end
 
 """

--- a/test/shared_utilities/implicit_timestepping/energy_hydrology_model.jl
+++ b/test/shared_utilities/implicit_timestepping/energy_hydrology_model.jl
@@ -78,7 +78,7 @@ for FT in (Float32, Float64)
         )
         # We do not set the initial aux state here because we want to test that it is updated correctly in the jacobian correctly.
         jacobian = ImplicitEquationJacobian(Y)
-        jac_tendency! = make_tendency_jacobian(soil)
+        jac_tendency! = make_jacobian(soil)
         dtγ = FT(1.0)
         jac_tendency!(jacobian, Y, p, dtγ, FT(0.0))
 

--- a/test/shared_utilities/implicit_timestepping/richards_model.jl
+++ b/test/shared_utilities/implicit_timestepping/richards_model.jl
@@ -54,7 +54,7 @@ for FT in (Float32, Float64)
             # we want to test that it is updated correctly in
             # the jacobian correctly.
             jacobian = ImplicitEquationJacobian(Y)
-            jac_tendency! = make_tendency_jacobian(soil)
+            jac_tendency! = make_jacobian(soil)
             dtγ = FT(1.0)
             jac_tendency!(jacobian, Y, p, dtγ, FT(0.0))
 
@@ -180,7 +180,7 @@ for FT in (Float32, Float64)
             # we want to test that it is updated correctly in
             # the jacobian correctly.
             jacobian = ImplicitEquationJacobian(Y)
-            jacobian_tendency! = make_tendency_jacobian(soil)
+            jacobian_tendency! = make_jacobian(soil)
             dtγ = FT(1.0)
             jacobian_tendency!(jacobian, Y, p, dtγ, FT(0.0))
 


### PR DESCRIPTION
## Purpose 
Close #660 

We have the function `imp_tendency!`, which calls `update_aux!`, `update_boundary_fluxes!`, and `compute_imp_tendency!` (where the actual tendency computation is done). We also have the explicit analogs.

Similarly, we have `tendency_jacobian!`, which calls `update_aux!`, `update_boundary_fluxes!`, and `update_jacobian!` (where the actual tendency computation is done).

## To-do


## Content
Renames two functions
`update_jacobian -> compute_jacobian` (analog is `compute_imp_tendency`)
`tendency_jacobian -> jacobian` (analog is `imp_tendency`)

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
