### PR TITLE
use method in Domains only

### DIFF
--- a/experiments/standalone/Soil/richards_runoff.jl
+++ b/experiments/standalone/Soil/richards_runoff.jl
@@ -320,9 +320,8 @@ if context.device isa ClimaComms.CPUSingleThreaded
 
     θ_sfc_end = ClimaCore.Remapping.interpolate(
         remapper,
-        ClimaLand.Soil.get_top_surface_field(
+        ClimaLand.Domains.top_center_to_surface(
             oceans_to_zero.(field_to_error.(sol.u[end].soil.ϑ_l), mask),
-            surface_space,
         ),
     )
 
@@ -339,12 +338,11 @@ if context.device isa ClimaComms.CPUSingleThreaded
 
     Δθ_sfc = ClimaCore.Remapping.interpolate(
         remapper,
-        ClimaLand.Soil.get_top_surface_field(
+        ClimaLand.Domains.top_center_to_surface(
             oceans_to_zero.(
                 field_to_error.(sol.u[end].soil.ϑ_l .- sol.u[1].soil.ϑ_l),
                 mask,
             ),
-            surface_space,
         ),
     )
     ax2 = Axis(fig[1, 3], xlabel = "Longitude", title = "θ_sfc Δ")

--- a/src/shared_utilities/Domains.jl
+++ b/src/shared_utilities/Domains.jl
@@ -718,6 +718,37 @@ function linear_interpolation_to_surface!(sfc_field, center_field, z, Δz_top)
 end
 
 """
+    bottom_center_to_surface(center_field::ClimaCore.Fields.Field)
+
+Creates and returns a ClimaCore.Fields.Field defined on the space
+corresponding to the bottom surface of the space on which `center_field`
+is defined, with values equal to the those at the level of the bottom
+center.
+
+For example, given a `center_field` defined on 1D center finite difference space,
+this would return a field defined on the Point space of the bottom surface of
+the column. The value would be the value of the original `center_field`
+at the bottommost location. Given a `center_field` defined on a 3D
+extruded center finite difference space, this would return a 2D field
+corresponding to the bottom surface, with values equal to the bottommost level.
+"""
+function bottom_center_to_surface(center_field::ClimaCore.Fields.Field)
+    center_space = axes(center_field)
+    surface_space = obtain_surface_space(center_space)
+    return ClimaCore.Fields.Field(
+        ClimaCore.Fields.field_values(ClimaCore.Fields.level(center_field, 1)),
+        surface_space,
+    )
+end
+
+"""
+    bottom_center_to_surface(val)
+
+When `val` is a scalar (e.g. a single float or struct), returns `val`.
+"""
+bottom_center_to_surface(val) = val
+
+"""
     get_Δz(z::ClimaCore.Fields.Field)
 
 A function to return a tuple containing the distance between the top boundary
@@ -792,6 +823,7 @@ export coordinates,
     obtain_face_space,
     obtain_surface_space,
     top_center_to_surface,
+    bottom_center_to_surface,
     top_face_to_surface,
     obtain_surface_domain,
     linear_interpolation_to_surface!,

--- a/src/standalone/Soil/Runoff/Runoff.jl
+++ b/src/standalone/Soil/Runoff/Runoff.jl
@@ -230,12 +230,8 @@ Computes the soil infiltration capacity on the surface space
 Currently approximates i_c = -K_sat at the surface.
 """
 function soil_infiltration_capacity(model::RichardsModel, Y, p)
-    surface_space = model.domain.space.surface
     @. p.soil.subsfc_scratch = -1 * model.parameters.K_sat
-    return ClimaLand.Soil.get_top_surface_field(
-        p.soil.subsfc_scratch,
-        surface_space,
-    )
+    return ClimaLand.Domains.top_center_to_surface(p.soil.subsfc_scratch)
 end
 
 """
@@ -258,10 +254,7 @@ function soil_infiltration_capacity(model::EnergyHydrology, Y, p)
             Ω,
         ) *
         ClimaLand.Soil.viscosity_factor(p.soil.T, γ, γT_ref)
-    return ClimaLand.Soil.get_top_surface_field(
-        p.soil.subsfc_scratch,
-        surface_space,
-    )
+    return ClimaLand.Domains.top_center_to_surface(p.soil.subsfc_scratch)
 end
 
 

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -846,11 +846,11 @@ function ClimaLand.surface_specific_humidity(
             Thermodynamics.Liquid(),
         ) .* (@. exp(g * ψ_sfc * M_w / (R * T_sfc)))
     ice_frac = p.soil.ice_frac
-    surface_space = model.domain.space.surface
-    ν_sfc = get_top_surface_field(model.parameters.ν, surface_space)
-    θ_r_sfc = get_top_surface_field(model.parameters.θ_r, surface_space)
-    S_c_sfc =
-        get_top_surface_field(model.parameters.hydrology_cm.S_c, surface_space)
+    ν_sfc = ClimaLand.Domains.top_center_to_surface(model.parameters.ν)
+    θ_r_sfc = ClimaLand.Domains.top_center_to_surface(model.parameters.θ_r)
+    S_c_sfc = ClimaLand.Domains.top_center_to_surface(
+        model.parameters.hydrology_cm.S_c,
+    )
     θ_l_sfc = ClimaLand.Domains.top_center_to_surface(p.soil.θ_l)
     θ_i_sfc = ClimaLand.Domains.top_center_to_surface(Y.soil.θ_i)
     @. ice_frac = ice_fraction(θ_l_sfc, θ_i_sfc, ν_sfc, θ_r_sfc)


### PR DESCRIPTION
## Purpose 
Removes functionality in Soil which is duplicated by functionality in Domains.
Closes #615 

## To-do



## Content
Adds bottom_center_to_surface to Domains.jl
Removes two methods (top_surface_field and bottom_surface_field) from Soil, we now use the version in Domains


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
