### PR TITLE
remove two not-needed functions

### DIFF
--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -81,8 +81,6 @@ ClimaLand.turbulent_fluxes_at_a_point
 ClimaLand.radiative_fluxes_at_a_point
 ClimaLand.set_atmos_ts!
 ClimaLand.surface_air_density
-ClimaLand.liquid_precipitation
-ClimaLand.snow_precipitation
 ClimaLand.surface_temperature
 ClimaLand.surface_resistance
 ClimaLand.surface_specific_humidity

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -20,8 +20,6 @@ export AbstractAtmosphericDrivers,
     turbulent_fluxes,
     net_radiation,
     turbulent_fluxes_at_a_point,
-    liquid_precipitation,
-    snow_precipitation,
     vapor_pressure_deficit,
     displacement_height,
     relative_humidity,
@@ -479,25 +477,6 @@ function ClimaLand.net_radiation(
     model_name = ClimaLand.name(model)
     model_cache = getproperty(p, model_name)
     return model_cache.R_n
-end
-
-
-"""
-    liquid_precipitation(atmos::AbstractAtmosphericDrivers, p, t)
-
-Returns the liquid precipitation (m/s) at the surface.
-"""
-function liquid_precipitation(atmos::AbstractAtmosphericDrivers, p, t)
-    return p.drivers.P_liq
-end
-
-"""
-    snow_precipitation(atmos::AbstractAtmosphericDrivers, p, t)
-
-Returns the precipitation in snow (m of liquid water/s) at the surface.
-"""
-function snow_precipitation(atmos::AbstractAtmosphericDrivers, p, t)
-    return p.drivers.P_snow
 end
 
 """

--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -22,8 +22,6 @@ import ClimaLand.Domains: coordinates, SphericalShell
 using ClimaLand:
     AbstractAtmosphericDrivers,
     AbstractRadiativeDrivers,
-    liquid_precipitation,
-    snow_precipitation,
     turbulent_fluxes,
     net_radiation,
     compute_ρ_sfc,
@@ -379,8 +377,8 @@ function make_compute_exp_tendency(model::BucketModel{FT}) where {FT}
         # Positive infiltration -> net (negative) flux into soil
         @. dY.bucket.W = -p.bucket.infiltration # Equation (2) of the text.
 
-        liquid_precip = liquid_precipitation(model.atmos, p, t) # always negative
-        snow_precip = snow_precipitation(model.atmos, p, t)
+        liquid_precip = p.drivers.P_liq
+        snow_precip = p.drivers.P_snow
 
         dY.bucket.Ws = @. -(
             liquid_precip +
@@ -480,7 +478,7 @@ function make_update_aux(model::BucketModel{FT}) where {FT}
             p.bucket.snow_cover_fraction # Equation 22
 
         # Partition water fluxes
-        liquid_precip = liquid_precipitation(model.atmos, p, t) # always negative
+        liquid_precip = p.drivers.P_liq
         # F_melt is negative as it is a downward welling flux warming the snow
         @.p.bucket.snow_melt = p.bucket.partitioned_fluxes.F_melt / _ρLH_f0 # defined after Equation (22)
 

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -244,7 +244,7 @@ for FT in (Float32, Float64)
                   p.bucket.snow_cover_fraction
             @test p.bucket.snow_melt ==
                   p.bucket.partitioned_fluxes.F_melt ./ _ρLH_f0
-            liquid_precip = ClimaLand.liquid_precipitation(model.atmos, p, t0)
+            liquid_precip = p.drivers.P_liq
 
             @test p.bucket.infiltration ==
                   ClimaLand.Bucket.infiltration_at_point.(


### PR DESCRIPTION
## Purpose 
These functions are not needed because (1) they are extremely simply (just returning something) and (2) we do not have multiple methods and do not have a need to specialize.


## To-do



## Content
Remove `ClimaLand.liquid_precipitation` and `ClimaLand.snow_precipitation`.


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [X] I have read and checked the items on the review checklist.
