### PR TITLE
add boundary fluxes function for snow

### DIFF
--- a/experiments/standalone/Snow/snow_cdp.jl
+++ b/experiments/standalone/Snow/snow_cdp.jl
@@ -29,7 +29,7 @@ parameters =
 model = ClimaLand.Snow.SnowModel(
     parameters = parameters,
     domain = domain,
-    atmosphere = atmos,
+    atmos = atmos,
     radiation = radiation,
 )
 Y, p, coords = ClimaLand.initialize(model)

--- a/src/shared_utilities/implicit_timestepping.jl
+++ b/src/shared_utilities/implicit_timestepping.jl
@@ -126,6 +126,8 @@ function ImplicitEquationJacobian(Y::ClimaCore.Fields.FieldVector)
         @name(soil.θ_i),
         @name(canopy.hydraulics.ϑ_l),
         @name(canopy.energy.T),
+        @name(snow.S),
+        @name(snow.U)
     )
 
     # Filter out the variables that are not in this model's state, `Y`

--- a/test/standalone/Snow/snow.jl
+++ b/test/standalone/Snow/snow.jl
@@ -46,7 +46,7 @@ import ClimaLand.Parameters as LP
     model = ClimaLand.Snow.SnowModel(
         parameters = parameters,
         domain = domain,
-        atmosphere = atmos,
+        atmos = atmos,
         radiation = rad,
     )
     drivers = ClimaLand.get_drivers(model)
@@ -63,6 +63,9 @@ import ClimaLand.Parameters as LP
         :water_runoff,
         :total_energy_flux,
         :total_water_flux,
+        :applied_energy_flux,
+        :applied_water_flux,
+        :snow_cover_fraction,
     )
 
     Y.snow.S .= FT(0.1)


### PR DESCRIPTION
## Purpose 
This PR simply adds a function which computes boundary fluxes in the same way we already compute them, but within a standalone function specifically for that purpose.

We construct our tendencies in the following fashion:
(1) update "auxiliary vars" of model, stored in cache `p`
(2) update boundary fluxes (also in `p`, but use the values updated in (1))
(3) compute tendency using updated cache values, boundary conditions and `Y`

For standalone models (snow by itself, soil by itself, etc), there is no reason to split (1) and (2). However, when we combine these models, the presence of interactions between the components affect the boundary fluxes each experiences. Because of that, we split the tendency of the land model as
1. update all auxiliary vars in the cache for all components
2. update all the boundary conditions for all the components [ taking into account interactions]
3. compute tendencies for all the components (only use precomputed quantities and Y)

in preparation for the snow model being integrated with soil/canopy, create the boundary_flux function and update the boundary conditions there, rather than in aux or in the tendency itself.


## To-do
Review

## Content
move certain quantities (Rn, turbulent fluxes) computed in update_aux! and in the tendency for snow into boundary_fluxes!


Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [X] I have read and checked the items on the review checklist.
