### PR TITLE
Site level runoff

### DIFF
--- a/docs/src/APIs/Soil.md
+++ b/docs/src/APIs/Soil.md
@@ -65,6 +65,7 @@ ClimaLand.Soil.soil_tortuosity
 
 ```@docs
 ClimaLand.Soil.NoRunoff
+ClimaLand.Soil.SurfaceRunoff
 ClimaLand.Soil.TOPMODELRunoff
 ClimaLand.Soil.TOPMODELSubsurfaceRunoff
 ClimaLand.Soil.subsurface_runoff_source

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -231,7 +231,12 @@ shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
 canopy_model_args = (; parameters = shared_params, domain = canopy_domain)
 
 # Integrated plant hydraulics and soil model
-land_input = (atmos = atmos, radiation = radiation, soil_organic_carbon = Csom)
+land_input = (
+    atmos = atmos,
+    radiation = radiation,
+    soil_organic_carbon = Csom,
+    runoff = ClimaLand.Soil.Runoff.SurfaceRunoff(),
+)
 land = SoilCanopyModel{FT}(;
     soilco2_type = soilco2_type,
     soilco2_args = soilco2_args,

--- a/experiments/integrated/performance/profile_allocations.jl
+++ b/experiments/integrated/performance/profile_allocations.jl
@@ -308,7 +308,12 @@ shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
 canopy_model_args = (; parameters = shared_params, domain = canopy_domain)
 
 # Integrated plant hydraulics and soil model
-land_input = (atmos = atmos, radiation = radiation, soil_organic_carbon = Csom)
+land_input = (
+    atmos = atmos,
+    radiation = radiation,
+    soil_organic_carbon = Csom,
+    runoff = ClimaLand.Soil.Runoff.SurfaceRunoff(),
+)
 land = SoilCanopyModel{FT}(;
     soilco2_type = soilco2_type,
     soilco2_args = soilco2_args,

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -142,8 +142,8 @@ for FT in (Float32, Float64)
                 :ice_frac,
                 :R_n,
                 :top_bc,
-                :infiltration,
                 :sfc_scratch,
+                :infiltration,
                 :bottom_bc,
             )
             function init_soil!(Y, z, params)

--- a/test/standalone/Soil/runoff.jl
+++ b/test/standalone/Soil/runoff.jl
@@ -3,11 +3,16 @@ import ClimaComms
 import ClimaUtilities
 import ClimaUtilities.TimeVaryingInputs: TimeVaryingInput
 using ClimaLand
+
 using Test
 using ClimaCore, NCDatasets
 FT = Float32
 @testset "Base runoff functionality, FT = $FT" begin
     runoff = ClimaLand.Soil.Runoff.NoRunoff()
+    @test ClimaLand.Soil.Runoff.runoff_vars(runoff) == (:infiltration,)
+    @test ClimaLand.Soil.Runoff.runoff_var_domain_names(runoff) == (:surface,)
+    @test ClimaLand.Soil.Runoff.runoff_var_types(runoff, FT) == (FT,)
+
     precip = 5.0
     @test ClimaLand.Soil.Runoff.subsurface_runoff_source(runoff) == nothing
     struct Foo{FT} <: ClimaLand.Soil.Runoff.AbstractSoilSource{FT} end
@@ -92,6 +97,13 @@ end
         f_max = f_max,
         R_sb = R_sb,
     )
+    @test ClimaLand.Soil.Runoff.runoff_vars(runoff_model) ==
+          (:infiltration, :is_saturated, :R_s, :R_ss, :h∇, :subsfc_scratch)
+    @test ClimaLand.Soil.Runoff.runoff_var_domain_names(runoff_model) ==
+          (:surface, :subsurface, :surface, :surface, :surface, :subsurface)
+    @test ClimaLand.Soil.Runoff.runoff_var_types(runoff_model, FT) ==
+          (FT, FT, FT, FT, FT, FT)
+
     @test runoff_model.f_over == f_over
     @test runoff_model.f_max == f_max
     @test runoff_model.subsurface_source ==
@@ -138,6 +150,8 @@ end
     @test :R_ss ∈ propertynames(p.soil)
     @test :h∇ ∈ propertynames(p.soil)
     @test :infiltration ∈ propertynames(p.soil)
+    @test :is_saturated ∈ propertynames(p.soil)
+    @test :subsfc_scratch ∈ propertynames(p.soil)
 
     # set initial conditions
     z = ClimaCore.Fields.coordinate_field(domain.space.subsurface).z
@@ -169,4 +183,86 @@ end
         precip_field,
     )
     @test p.soil.R_s == abs.(precip_field .- p.soil.infiltration)
+
+end
+
+
+@testset "Richards model, Site level runoff FT =$FT" begin
+    domain = ClimaLand.Domains.SphericalShell(;
+        radius = FT(6300e3),
+        depth = FT(50.0),
+        nelements = (101, 15),
+        npolynomial = 1,
+        dz_tuple = FT.((5.0, 0.05)),
+    )
+    surface_space = domain.space.surface
+    subsurface_space = domain.space.subsurface
+    runoff_model = ClimaLand.Soil.Runoff.SurfaceRunoff()
+    @test ClimaLand.Soil.Runoff.runoff_vars(runoff_model) ==
+          (:is_saturated, :R_s, :infiltration, :subsfc_scratch)
+    @test ClimaLand.Soil.Runoff.runoff_var_domain_names(runoff_model) ==
+          (:subsurface, :surface, :surface, :subsurface)
+    @test ClimaLand.Soil.Runoff.runoff_var_types(runoff_model, FT) ==
+          (FT, FT, FT, FT)
+
+
+    @test runoff_model.subsurface_source == nothing
+
+    vg_α = ClimaCore.Fields.ones(subsurface_space) .* FT(0.2)
+    hydrology_cm = map(vg_α) do (α)
+        FT = typeof(α)
+        ClimaLand.Soil.vanGenuchten{FT}(; α = α, n = α + FT(2))
+    end
+    θ_r = ClimaCore.Fields.zeros(subsurface_space)
+    ν = ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.5)
+    K_sat = ClimaCore.Fields.zeros(subsurface_space) .+ FT(1e-6)
+    S_s = ClimaCore.Fields.zeros(subsurface_space) .+ FT(1e-3)
+    soil_params = ClimaLand.Soil.RichardsParameters(;
+        hydrology_cm = hydrology_cm,
+        ν = ν,
+        K_sat = K_sat,
+        S_s = S_s,
+        θ_r = θ_r,
+    )
+    lat = ClimaCore.Fields.coordinate_field(surface_space).lat
+    precip_field = @. FT(-1e-6) + FT(5e-7) * sin(lat / FT(90.0 * 2π))
+    function precip_function(t; fieldvals = precip_field)
+        return fieldvals
+    end
+
+    precip = TimeVaryingInput(precip_function)
+    atmos = ClimaLand.PrescribedPrecipitation{FT, typeof(precip)}(precip)
+
+    noflux = ClimaLand.Soil.WaterFluxBC((p, t) -> 0.0)
+    bc = (;
+        top = ClimaLand.Soil.RichardsAtmosDrivenFluxBC(atmos, runoff_model),
+        bottom = noflux,
+    )
+    model = ClimaLand.Soil.RichardsModel{FT}(;
+        parameters = soil_params,
+        domain = domain,
+        boundary_conditions = bc,
+        sources = (),
+    )
+    Y, p, t = initialize(model)
+    @test :R_s ∈ propertynames(p.soil)
+    @test :infiltration ∈ propertynames(p.soil)
+    @test :is_saturated ∈ propertynames(p.soil)
+
+    # set initial conditions
+    z = ClimaCore.Fields.coordinate_field(domain.space.subsurface).z
+    Y.soil.ϑ_l .= FT(0.6) .- FT(0.3 / 50) .* (z .+ FT(50))
+    evaluate!(p.drivers.P_liq, atmos.liquid_precip, FT(0))
+    set_initial_cache! = make_set_initial_cache(model)
+    set_initial_cache!(p, Y, FT(0))
+    ic = ClimaLand.Soil.Runoff.soil_infiltration_capacity(model, Y, p)
+    @test ic == ClimaCore.Fields.zeros(surface_space) .- FT(1e-6) #Ksat
+    @test p.soil.infiltration ==
+          ClimaLand.Soil.Runoff.surface_infiltration.(
+        ic,
+        precip_field,
+        ClimaLand.Domains.top_center_to_surface(p.soil.is_saturated),
+    )
+    @test p.soil.R_s == abs.(precip_field .- p.soil.infiltration)
+
 end


### PR DESCRIPTION
## Purpose 
Restart of PR https://github.com/CliMA/ClimaLand.jl/pull/544/files from the current main
co-authored by @AlexisRenchon @braghiere 

Small change adding simple surface runoff (if soil surface is saturated -> all runs off, if soil is not saturated, runoff is created if the input is > infiltration capacity). No subsurface runoff is computed.

At the same time, since this is a new type of runoff with new cache variables, I introduced "runoff_var" functions that it is easier to create the cache variables without specific methods for each runoff type


## To-do

## Content
[1] New runoff type for sites
[2] New methods for adding variables depending on runoff model type
[3] unit tests
[4] usage in ozark pft and profile_allocations fluxnet site runs

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [x] I have read and checked the items on the review checklist.
