### PR TITLE
Increasing phase change timescale for soil

### DIFF
--- a/test/shared_utilities/domains.jl
+++ b/test/shared_utilities/domains.jl
@@ -43,7 +43,7 @@ FT = Float32
     face_space = obtain_face_space(shell.space.subsurface)
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     @test shell.fields.z_sfc == top_face_to_surface(z_face, shell.space.surface)
-    Δz_top, Δz_bottom = get_Δz(shell.fields.z)
+    Δz_top, Δz_bottom, Δz = get_Δz(shell.fields.z)
     @test shell.fields.Δz_top == Δz_top
     @test shell.fields.Δz_bottom == Δz_bottom
     @test shell.radius == radius
@@ -109,7 +109,7 @@ FT = Float32
     face_space = obtain_face_space(box.space.subsurface)
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     @test box.fields.z_sfc == top_face_to_surface(z_face, box.space.surface)
-    Δz_top, Δz_bottom = get_Δz(box.fields.z)
+    Δz_top, Δz_bottom, Δz = get_Δz(box.fields.z)
     @test box.fields.Δz_top == Δz_top
     @test box.fields.Δz_bottom == Δz_bottom
     box_coords = coordinates(box).subsurface
@@ -260,7 +260,9 @@ FT = Float32
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     @test z_column.fields.z_sfc ==
           top_face_to_surface(z_face, z_column.space.surface)
-    Δz_top, Δz_bottom = get_Δz(z_column.fields.z)
+    Δz_top, Δz_bottom, Δz = get_Δz(z_column.fields.z)
+    z = ClimaCore.Fields.coordinate_field(z_column.space.subsurface).z
+    @test z_column.fields.z == z
     @test z_column.fields.Δz_top == Δz_top
     @test z_column.fields.Δz_bottom == Δz_bottom
     column_coords = coordinates(z_column).subsurface


### PR DESCRIPTION
## Purpose 
The phase change term is a relaxation term which requires a timescale. Our current code uses the thermal timescale of the first layer, i.e. dz_top^2*specific_heat/conductivity. This modifies the timescale to be the thermal time per layer, which requires dz of each layer. These are different since the layers are smaller near the top of the domain.

## To-do
Review
## Content
Add dz to domain.fields
Use in phase change computation

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
