### PR TITLE
SOC can be spatially varying only

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ ClimaLand.jl Release Notes
 
 main
 --------
+- Allow for simple spatially varying prescribed organic carbon, rather than require temporal variation as well.
+  PR[#705](https://github.com/CliMA/ClimaLand.jl/pull/705)
 
 v0.14.0
 --------

--- a/docs/tutorials/integrated/soil_canopy_tutorial.jl
+++ b/docs/tutorials/integrated/soil_canopy_tutorial.jl
@@ -176,8 +176,12 @@ soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
 
 soilco2_ps = SoilCO2ModelParameters(FT);
 
-# soil microbes args
-Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
+# Specify the spatially varying soil organic carbon as a ClimaCore field.
+# One can also specify SOC using a TimeVaryingInput, or SpaceVaryingInput (reading data from files)
+subsurface_space = soil_domain.space.subsurface
+Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(
+    ClimaCore.Fields.zeros(subsurface_space) .+ 5,
+)
 
 soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
 soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> 0.0);

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -409,7 +409,9 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
 
     # soil microbes args
-    Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
+    Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(
+        ClimaCore.Fields.zeros(subsurface_space) .+ 5,
+    )
 
     # Set the soil CO2 BC to being atmospheric CO2
     soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -136,8 +136,10 @@ soil_model_type = Soil.EnergyHydrology{FT}
 soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
 
 soilco2_ps = SoilCO2ModelParameters(FT)
-
-Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
+subsurface_space = soil_domain.space.subsurface
+Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(
+    ClimaCore.Fields.zeros(subsurface_space) .+ 5,
+)
 
 # Set the soil CO2 BC to being atmospheric CO2
 soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -95,8 +95,10 @@ soil_model_type = Soil.EnergyHydrology{FT}
 soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
 
 soilco2_ps = SoilCO2ModelParameters(FT)
-
-Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
+subsurface_space = soil_domain.space.subsurface
+Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(
+    ClimaCore.Fields.zeros(subsurface_space) .+ 5,
+)
 
 # Set the soil CO2 BC to being atmospheric CO2
 soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -181,7 +181,9 @@ soil_model_type = Soil.EnergyHydrology{FT}
 soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
 
 # soil microbes args
-Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
+Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(
+    ClimaCore.Fields.zeros(subsurface_space) .+ 5,
+)
 
 # Set the soil CO2 BC to being atmospheric CO2
 soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()

--- a/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
+++ b/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
@@ -82,7 +82,10 @@ soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
 soilco2_ps = SoilCO2ModelParameters(FT)
 
 # soil microbes args
-Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
+subsurface_space = soil_domain.space.subsurface
+Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(
+    ClimaCore.Fields.zeros(subsurface_space) .+ 5,
+)
 
 # Set the soil CO2 BC to being atmospheric CO2
 soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()

--- a/experiments/integrated/performance/profile_allocations.jl
+++ b/experiments/integrated/performance/profile_allocations.jl
@@ -229,7 +229,10 @@ soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
 soilco2_ps = SoilCO2ModelParameters(FT)
 
 # soil microbes args
-Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
+subsurface_space = soil_domain.space.subsurface
+Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(
+    ClimaCore.Fields.zeros(subsurface_space) .+ 5,
+)
 
 # Set the soil CO2 BC to being atmospheric CO2
 soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -408,7 +408,9 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
 
     # soil microbes args
-    Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
+    Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(
+        ClimaCore.Fields.zeros(subsurface_space) .+ 5,
+    )
 
     # Set the soil CO2 BC to being atmospheric CO2
     soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()

--- a/test/shared_utilities/drivers.jl
+++ b/test/shared_utilities/drivers.jl
@@ -162,4 +162,13 @@ end
     soc_p = (; drivers = ClimaLand.initialize_drivers((soc_driver,), coords))
     soc_update!(soc_p, 0.0)
     @test soc_p.drivers.soc == [FT(1.0), FT(1.0)]
+
+    column = ClimaLand.Domains.Column(; zlim = (FT(-1), FT(0)), nelements = 10)
+    soc = ClimaCore.Fields.ones(column.space.subsurface)
+    soc_driver = ClimaLand.PrescribedSoilOrganicCarbon{FT}(soc)
+    soc_update! = ClimaLand.make_update_drivers((soc_driver,))
+    coords = ClimaLand.Domains.coordinates(column)
+    soc_p = (; drivers = ClimaLand.initialize_drivers((soc_driver,), coords))
+    soc_update!(soc_p, 0.0)
+    @test soc_p.drivers.soc == soc
 end


### PR DESCRIPTION
## Purpose 
Our goal is to prescribed soil organic carbon from time varying data. We added this in, but our only use case currently was TimeVaryingInput((t) -> constant). Since SOC is a 3d field, I think the allocations in regridded_snapshot! led to a big slowdown with this change.
Before that PR:
https://buildkite.com/clima/climaland-benchmark/builds/709#0190a29f-b2ff-40e3-9dae-a007eae845c4 (10 seconds)
After.: https://buildkite.com/clima/climaland-benchmark/builds/744#0190b780-87fb-493d-ad30-3ee2aabf1d30 (25 seconds)

For now, I added the option to have SOC be only a spatially varying field and not use TimeVaryingInput (and hence not need regridded_snapshot!). this should speed things up for us, and also be relevant for shorter runs where SOC is not varying much, or for runs where we do not have time-varying data.

The time per simulation is now back to 10 seconds.


## To-do

## Content
Allow for the prescribed SOC driver to be a field, and not a TimeVaryingInput. In this case, set p.drivers.soc = the field each evaluate step, intead of evaluating the TimeVaryingInput object at a specific time.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
