### PR TITLE
Kd/rb/ar/basic sif refactor

### DIFF
--- a/docs/src/APIs/canopy/Photosynthesis.md
+++ b/docs/src/APIs/canopy/Photosynthesis.md
@@ -7,6 +7,7 @@ CurrentModule = ClimaLand.Canopy
 ## Parameters
 
 ```@docs
+ClimaLand.Canopy.SIFParameters
 ClimaLand.Canopy.FarquharParameters
 ClimaLand.Canopy.OptimalityFarquharParameters
 ```

--- a/lib/ClimaLandSimulations/src/utilities/climaland_output_dataframe.jl
+++ b/lib/ClimaLandSimulations/src/utilities/climaland_output_dataframe.jl
@@ -57,6 +57,7 @@ function make_output_df(
         collect(map(i -> (i, :soil, :T), 1:20)), # 20 shouldn't be hard-coded, but an arg, equal to n layers
         collect(map(i -> (i, :soil, :θ_l), 1:20)),
         (1, :soil, :turbulent_fluxes, :vapor_flux),
+        (1, :canopy, :sif, :SIF),
     )
 
     output_vectors = [getoutput(sv, args...) for args in output_list]

--- a/lib/ClimaLandSimulations/src/utilities/makie_plots.jl
+++ b/lib/ClimaLandSimulations/src/utilities/makie_plots.jl
@@ -401,8 +401,9 @@ function diurnals_fig(inputs, climaland, earth_param_set; dashboard = false) # w
         ylabel = L"\text{CO}_{2} \, (\mu\text{mol m}^{-2} \, \text{s}^{-1})",
     ) # C fluxes
     ax_W = Axis(fig[2, 1], ylabel = L"\text{H}_{2}\text{O} \, \text{(mm)}") # h2o fluxes
+    ax_SIF = Axis(fig[3, 1], ylabel = L"\text{SIF}") # SIF
     ax_E = Axis(
-        fig[3, 1],
+        fig[4, 1],
         ylabel = L"\text{Radiation} \, (\text{W} \, \text{m}^{-2})",
         xlabel = L"\text{Hour of the day}",
         xgridvisible = false,
@@ -456,6 +457,11 @@ function diurnals_fig(inputs, climaland, earth_param_set; dashboard = false) # w
         linestyle = :dot,
     )
 
+    # SIF
+    p_SIF_m =
+        diurnal_plot!(fig, ax_SIF, climaland.DateTime, climaland.SIF, :black)
+
+
     # Energy fluxes
     # model
     # diurnal_plot!(fig, ax_E, climaland.DateTime, climaland.LW_out, :red)
@@ -472,7 +478,7 @@ function diurnals_fig(inputs, climaland, earth_param_set; dashboard = false) # w
         linestyle = :dot,
     )
 
-    [xlims!(axes, (0, 24)) for axes in [ax_C, ax_W, ax_E]]
+    [xlims!(axes, (0, 24)) for axes in [ax_C, ax_W, ax_SIF, ax_E]]
 
     axislegend(
         ax_C,
@@ -491,6 +497,14 @@ function diurnals_fig(inputs, climaland, earth_param_set; dashboard = false) # w
         orientation = :vertical,
     )
     axislegend(
+        ax_SIF,
+        [p_SIF_m],
+        ["SIF model"],
+        "",
+        position = :rt,
+        orientation = :vertical,
+    )
+    axislegend(
         ax_E,
         [p_SWout_d, p_SWout_m],
         ["SWout obs.", "SWout model"],
@@ -501,6 +515,7 @@ function diurnals_fig(inputs, climaland, earth_param_set; dashboard = false) # w
 
     hidexdecorations!(ax_C)
     hidexdecorations!(ax_W)
+    hidexdecorations!(ax_SIF)
 
     fig
     return fig

--- a/src/standalone/Vegetation/solar_induced_fluorescence.jl
+++ b/src/standalone/Vegetation/solar_induced_fluorescence.jl
@@ -1,0 +1,117 @@
+export SIFParameters, Lee2015SIFModel
+
+abstract type AbstractSIFModel{FT} <: AbstractCanopyComponent{FT} end
+
+"""
+    SIFParameters{FT<:AbstractFloat}
+
+The required parameters for the SIF parameterisation 
+Lee et al, 2015. Global Change Biology 21, 3469-3477, doi:10.1111/gcb.12948.
+$(DocStringExtensions.FIELDS)
+"""
+@kwdef struct SIFParameters{FT <: AbstractFloat}
+    "The rate coefficient for florescence, unitless"
+    kf::FT = FT(0.05)
+    "Parameter used to compute the rate coefficient for heat loss in dark-adapted conditions, Tol et al. 2014, unitless"
+    kd_p1::FT = FT(0.03)
+    "Parameter used to compute the rate coefficient for heat loss in dark-adapted conditions, Tol et al. 2014, unitless"
+    kd_p2::FT = FT(0.0273)
+    "Parameter used to compute the rate coefficient for heat loss in dark-adapted conditions, Tol et al. 2014, unitless"
+    min_kd::FT = FT(0.087)
+    "Parameter used to compute the rate coefficient for heat loss in light-adapted conditions, Lee et al 2013 (unitless)"
+    kn_p1::FT = FT(6.2473)
+    "Parameter used to compute the rate coefficient for heat loss in light-adapted conditions, Lee et al 2013 (unitless)"
+    kn_p2::FT = FT(0.5944)
+    "Rate coefficient for photochemical quenching"
+    kp::FT = FT(4.0)
+    "Slope of line relating leaf-level fluorescence to spectrometer-observed fluorescence as a function of Vcmax 25. Lee et al 2015."
+    kappa_p1::FT = FT(0.045)
+    "Intercept of line relating leaf-level fluorescence to spectrometer-observed fluorescence as a function of Vcmax 25.  Lee et al 2015."
+    kappa_p2::FT = FT(7.85)
+end
+
+Base.eltype(::SIFParameters{FT}) where {FT} = FT
+
+struct Lee2015SIFModel{FT, SP <: SIFParameters{FT}} <: AbstractSIFModel{FT}
+    parameters::SP
+    function Lee2015SIFModel{FT}() where {FT}
+        parameters = SIFParameters{FT}()
+        new{FT, typeof(parameters)}(parameters)
+    end
+end
+
+ClimaLand.name(model::AbstractSIFModel) = :sif
+ClimaLand.auxiliary_vars(model::Lee2015SIFModel) = (:SIF,)
+ClimaLand.auxiliary_types(model::Lee2015SIFModel{FT}) where {FT} = (FT,)
+ClimaLand.auxiliary_domain_names(::Lee2015SIFModel) = (:surface,)
+
+
+# 4 Solar Induced Fluorescence (SIF)
+
+# call function below inside photosynthesis.jl p
+
+"""
+    update_SIF!(
+        SIF::FT,
+        sif_model::Lee2015SIFModel,
+        APAR::FT,
+        Tc::FT,
+        Vcmax25::FT,
+        R::FT,
+        T_freeze::FT,
+        photosynthesis_parameters,
+    ) where {FT}
+
+Updates observed SIF at 755 nm in W/m^2. Note that Tc is in Kelvin, and photo
+synthetic rates are in mol/m^2/s, and APAR is in PPFD.
+Lee et al, 2015. Global Change Biology 21, 3469-3477, doi:10.1111/gcb.12948
+"""
+function update_SIF!(
+    SIF,
+    sif_model::Lee2015SIFModel,
+    APAR,
+    Tc,
+    Vcmax25,
+    R,
+    T_freeze,
+    photosynthesis_parameters,
+)
+    sif_parameters = sif_model.parameters
+    @. SIF = compute_SIF_at_a_point(
+        APAR,
+        Tc,
+        Vcmax25,
+        R,
+        T_freeze,
+        photosynthesis_parameters,
+        sif_parameters,
+    )
+end
+
+Base.broadcastable(m::SIFParameters) = tuple(m)
+function compute_SIF_at_a_point(
+    APAR::FT,
+    Tc::FT,
+    Vcmax25::FT,
+    R::FT,
+    T_freeze::FT,
+    photosynthesis_parameters,
+    sif_parameters,
+) where {FT}
+    (; ΔHJmax, To, θj, ϕ) = photosynthesis_parameters
+    Jmax = max_electron_transport(Vcmax25, ΔHJmax, Tc, To, R)
+    J = electron_transport(APAR, Jmax, θj, ϕ)
+    (; kf, kd_p1, kd_p2, min_kd, kn_p1, kn_p2, kp, kappa_p1, kappa_p2) =
+        sif_parameters
+    kd = max(kd_p1 * (Tc - T_freeze) + kd_p2, min_kd)
+    x = 1 - J / Jmax
+    kn = (kn_p1 * x - kn_p2) * x
+    ϕp0 = kp / (kf + kp + kn)
+    ϕp = J / Jmax * ϕp0
+    ϕf = kf / (kf + kd + kn) * (1 - ϕp)
+    κ = kappa_p1 * Vcmax25 * FT(1e6) + kappa_p2 # formula expects Vcmax25 in μmol/m^2/s
+    F = APAR * ϕf
+    SIF_755 = F / κ
+
+    return SIF_755
+end


### PR DESCRIPTION
Implements a simple SIF model, `Lee2015SIFModel`, in `AbstractSIFModel` within the `Canopy` module. 

@braghiere as you suggested, we made a new AbstractSIFModel, independent from others components of the Canopy module (where we now have photosynthesis, stomatal conductance, radiative transfer, autotrophic respiration, solar induced fluorescence, etc.). We named this first simple sif model "Lee2015SIFModel", if you have a better name let us know. This implementation allows to easily dispatch on other sif models in the future. Can you check the equations and units? Thanks!