### PR TITLE
Add support for regional simulations

### DIFF
--- a/.buildkite/Manifest.toml
+++ b/.buildkite/Manifest.toml
@@ -5,9 +5,9 @@ manifest_format = "2.0"
 project_hash = "ec4f7d2c4723052ebe1d11f9619ed44dcedb650c"
 
 [[deps.ADTypes]]
-git-tree-sha1 = "aa4d425271a914d8c4af6ad9fccb6eb3aec662c7"
+git-tree-sha1 = "6778bcc27496dae5723ff37ee30af451db8b35fe"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
-version = "1.6.1"
+version = "1.6.2"
 weakdeps = ["ChainRulesCore", "EnzymeCore"]
 
     [deps.ADTypes.extensions]
@@ -371,9 +371,9 @@ version = "0.5.6"
     GeoMakie = "db073c08-6b98-4ee5-b6a4-5efafb3259c6"
 
 [[deps.ClimaComms]]
-git-tree-sha1 = "2ca8c9ca6131a7be8ca262e6db79bc7aa94ab597"
+git-tree-sha1 = "ec303a4a66dc0a0ebe15a639a7e685afeaa0daef"
 uuid = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
-version = "0.6.3"
+version = "0.6.4"
 weakdeps = ["CUDA", "MPI"]
 
     [deps.ClimaComms.extensions]
@@ -446,9 +446,9 @@ version = "0.7.33"
 
 [[deps.ClimaUtilities]]
 deps = ["Artifacts", "Dates"]
-git-tree-sha1 = "2e171face2f5ee218ebaa9aee7b5e14a28b14366"
+git-tree-sha1 = "f516cf47cf12eaade1e326e7566738147a2e924a"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
-version = "0.1.10"
+version = "0.1.11"
 
     [deps.ClimaUtilities.extensions]
     ClimaUtilitiesClimaCommsCUDAExt = ["ClimaComms", "CUDA"]
@@ -636,6 +636,12 @@ version = "1.0.0"
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
+[[deps.Dbus_jll]]
+deps = ["Artifacts", "Expat_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "fc173b380865f70627d7dd1190dc2fce6cc105af"
+uuid = "ee1fde0b-3d02-5ea6-8484-8dfef6360eab"
+version = "1.14.10+0"
+
 [[deps.DefineSingletons]]
 git-tree-sha1 = "0fba8b706d0178b4dc7fd44a96a92382c9065c2c"
 uuid = "244e2a9f-e319-4986-a169-4d1fe445cd52"
@@ -655,9 +661,9 @@ version = "1.9.1"
 
 [[deps.DiffEqBase]]
 deps = ["ArrayInterface", "ConcreteStructs", "DataStructures", "DocStringExtensions", "EnumX", "EnzymeCore", "FastBroadcast", "FastClosures", "ForwardDiff", "FunctionWrappers", "FunctionWrappersWrappers", "LinearAlgebra", "Logging", "Markdown", "MuladdMacro", "Parameters", "PreallocationTools", "PrecompileTools", "Printf", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLOperators", "Setfield", "Static", "StaticArraysCore", "Statistics", "Tricks", "TruncatedStacktraces"]
-git-tree-sha1 = "a49034d21181e6ed3c2ae0ab5a586d7f0a4ee912"
+git-tree-sha1 = "72950e082d2241a1da1c924147943e2918471af9"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
-version = "6.152.1"
+version = "6.152.2"
 
     [deps.DiffEqBase.extensions]
     DiffEqBaseCUDAExt = "CUDA"
@@ -1065,19 +1071,19 @@ version = "0.1.3"
 
 [[deps.Functors]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "8a66c07630d6428eaab3506a0eabfcf4a9edea05"
+git-tree-sha1 = "64d8e93700c7a3f28f717d265382d52fac9fa1c1"
 uuid = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
-version = "0.4.11"
+version = "0.4.12"
 
 [[deps.Future]]
 deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
 [[deps.GLFW_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Libglvnd_jll", "Xorg_libXcursor_jll", "Xorg_libXi_jll", "Xorg_libXinerama_jll", "Xorg_libXrandr_jll", "xkbcommon_jll"]
-git-tree-sha1 = "3f74912a156096bd8fdbef211eff66ab446e7297"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libglvnd_jll", "Xorg_libXcursor_jll", "Xorg_libXi_jll", "Xorg_libXinerama_jll", "Xorg_libXrandr_jll", "libdecor_jll", "xkbcommon_jll"]
+git-tree-sha1 = "532f9126ad901533af1d4f5c198867227a7bb077"
 uuid = "0656b61e-2033-5cc2-a64a-77c0f6c09b89"
-version = "3.4.0+0"
+version = "3.4.0+1"
 
 [[deps.GPUArrays]]
 deps = ["Adapt", "GPUArraysCore", "LLVM", "LinearAlgebra", "Printf", "Random", "Reexport", "Serialization", "Statistics"]
@@ -2222,9 +2228,9 @@ version = "1.4.3"
 
 [[deps.PreallocationTools]]
 deps = ["Adapt", "ArrayInterface", "ForwardDiff"]
-git-tree-sha1 = "406c29a7f46706d379a3bce45671b4e3a39ddfbc"
+git-tree-sha1 = "d7f3f63331c7c8c81245b4ee2815b7d496365833"
 uuid = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
-version = "0.4.22"
+version = "0.4.23"
 
     [deps.PreallocationTools.extensions]
     PreallocationToolsReverseDiffExt = "ReverseDiff"
@@ -2467,9 +2473,9 @@ version = "0.1.0"
 
 [[deps.SciMLBase]]
 deps = ["ADTypes", "Accessors", "ArrayInterface", "CommonSolve", "ConstructionBase", "Distributed", "DocStringExtensions", "EnumX", "Expronicon", "FunctionWrappersWrappers", "IteratorInterfaceExtensions", "LinearAlgebra", "Logging", "Markdown", "PrecompileTools", "Preferences", "Printf", "RecipesBase", "RecursiveArrayTools", "Reexport", "RuntimeGeneratedFunctions", "SciMLOperators", "SciMLStructures", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface", "Tables"]
-git-tree-sha1 = "b316ed5e5e71a6414b0c0e0c9f334afcc701ebf8"
+git-tree-sha1 = "7f0e208db50f5fee2386b6d8dc9608d580059331"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "2.48.0"
+version = "2.48.1"
 
     [deps.SciMLBase.extensions]
     SciMLBaseChainRulesCoreExt = "ChainRulesCore"
@@ -2498,9 +2504,9 @@ version = "0.3.8"
 
 [[deps.SciMLStructures]]
 deps = ["ArrayInterface"]
-git-tree-sha1 = "cfdd1200d150df1d3c055cc72ee6850742e982d7"
+git-tree-sha1 = "20ad3e7c137156c50c93c888d0f2bc5b7883c729"
 uuid = "53ae85a6-f571-4167-b2af-e1d143709226"
-version = "1.4.1"
+version = "1.4.2"
 
 [[deps.Scratch]]
 deps = ["Dates"]
@@ -3246,6 +3252,12 @@ version = "0.15.1+0"
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
 version = "5.8.0+1"
+
+[[deps.libdecor_jll]]
+deps = ["Artifacts", "Dbus_jll", "JLLWrappers", "Libdl", "Libglvnd_jll", "Pango_jll", "Wayland_jll", "xkbcommon_jll"]
+git-tree-sha1 = "9bf7903af251d2050b467f76bdbe57ce541f7f4f"
+uuid = "1183f4f0-6f2a-5f1a-908b-139f9cdfea6f"
+version = "0.2.2+0"
 
 [[deps.libevdev_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -150,9 +150,16 @@ steps:
           - "experiments/global_bucket_function/output_active/*.png"
 
       - label: "Global Bucket on CPU (static map albedo)"
-        key: "global_bucket_staticmap_cpu"
-        command: "julia --color=yes --project=.buildkite experiments/standalone/Bucket/global_bucket_staticmap.jl"
+        key: "bucket_era5_cpu"
+        command: "julia --color=yes --project=.buildkite experiments/standalone/Bucket/bucket_era5.jl"
         artifact_paths: "experiments/standalone/Bucket/artifacts_staticmap/*cpu*"
+
+      - label: "Regional Bucket on CPU (static map albedo)"
+        key: "regional_bucket_era5_cpu"
+        command: "julia --color=yes --project=.buildkite experiments/standalone/Bucket/bucket_era5.jl"
+        artifact_paths: "experiments/standalone/Bucket/artifacts_staticmap_regional/*cpu*"
+        env:
+          CLIMALAND_CI_REGIONAL_BUCKET: true
 
       - label: "Global Bucket on CPU (temporal map albedo)"
         key: "global_bucket_temporalmap_cpu"
@@ -185,8 +192,8 @@ steps:
         artifact_paths: "experiments/standalone/Bucket/artifacts/*gpu*"
 
       - label: "Global Bucket on GPU (static map albedo)"
-        key: "global_bucket_staticmap_gpu"
-        command: "julia --color=yes --project=.buildkite experiments/standalone/Bucket/global_bucket_staticmap.jl"
+        key: "bucket_era5_gpu"
+        command: "julia --color=yes --project=.buildkite experiments/standalone/Bucket/bucket_era5.jl"
         agents:
           slurm_ntasks: 1
           slurm_gres: "gpu:p100:1"
@@ -211,7 +218,7 @@ steps:
         depends_on:
           - "global_bucket_function_cpu"
           - "global_bucket_function_gpu"
-          - "global_bucket_staticmap_cpu"
-          - "global_bucket_staticmap_gpu"
+          - "bucket_era5_cpu"
+          - "bucket_era5_gpu"
           - "global_bucket_temporalmap_cpu"
           - "global_bucket_temporalmap_gpu"

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,14 +10,8 @@ main
 
 v0.14.1
 --------
-- Site level runoff
+- Add simple model for single-column surface runoff
   PR[#702](https://github.com/CliMA/ClimaLand.jl/pull/702)
-- Snowmip sites
-  PR[#694](https://github.com/CliMA/ClimaLand.jl/pull/694)
-- Soil long run 
-  PR[#700](https://github.com/CliMA/ClimaLand.jl/pull/700)
-- Boundary flux for snow
-  PR[#701](https://github.com/CliMA/ClimaLand.jl/pull/701)
 
 v0.14.0
 --------

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@ ClimaLand.jl Release Notes
 main
 --------
 
+- Add support for regional simulations, box runs centered around a given
+  longitude and latitude.
+  PR [#710](https://github.com/CliMA/ClimaLand.jl/pull/710)
+
 v0.14.1
 --------
 - Site level runoff

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="logo-white.svg">
   <source media="(prefers-color-scheme: light)" srcset="logo.svg">
-  <img alt="Shows the logo of ClimaLand, with a drop and three leaves" src="logo.svg">
+  <img alt="Shows the logo of ClimaLand, with a water drop and three leaves" src="logo.svg">
 </picture>
 <p align="center">
   <strong>Create and run  land models in integrated (multi-
@@ -23,6 +23,7 @@ component) or standalone (single component) modes.  </strong>
 
 This is the repository of the CliMA land model code. Here are some notable features:
 - ClimaLand has a modular design, models can be run as standalone (e.g., soil moisture only) or integrated (e.g., soil moisture and energy AND canopy AND snow, etc.)
+- ClimaLand can simulate single columns, regional boxes, and global runs
 - ClimaLand is CPU and GPU compatible
 - ClimaLand welcome contributions: please feel free to reach out to us with questions about how to get started, create a branch, and extend our code. For example, a modeler might want to test a new stomatal conductance model. 
 - ClimaLand provides APIs and UIs at multiple levels. 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -34,10 +34,6 @@ tutorials = [
         "Integrated soil+canopy modeling" => [
             "Coupled Canopy and Soil" => "integrated/soil_canopy_tutorial.jl",
         ],
-        "Bucket LSM" => [
-            "standalone/Bucket/bucket_tutorial.jl",
-            "standalone/Bucket/coupled_bucket.jl",
-        ],
         "Snow Modeling" => [
             "standalone/Snow/base_tutorial.jl",
             "standalone/Snow/data_tutorial.jl",

--- a/docs/src/folderstructure.md
+++ b/docs/src/folderstructure.md
@@ -2,7 +2,7 @@
 
 [ClimaLand](https://github.com/CliMA/ClimaLand.jl) home directory has 5 main folders:
 
-- docs: contains files to generate [the documentation website](clima.github.io/ClimaLand.jl/).  
+- docs: contains files to generate [the documentation website](clima.github.io/ClimaLand.jl/).
 - experiments: contains simple runs of `ClimaLand` models. 
 - parameters: contains a file to retrieve constants such as avogadro's number, the speed of light, etc. 
 - src: contains the code of `ClimaLand` models. 
@@ -45,7 +45,7 @@ For example, `/experiments/LSM/ozark/` contains:
 
 The `/src` folder contains the source code of `ClimaLand` models. It contains 3 folders:
 - shared_utilities: This is a core folder that defines functions and data structures used across all modules and models types of `ClimaLand`. For example, `shared_utilities/models.jl` defines and export the function `make_update_aux` which will be used to create a function which updates the auxiliary parameters, stored in the vector `p`, `shared_utilities/boundary_conditions.jl` defines functions for setting boundary condition for PDE domains, etc.
-- standalone: This folder contains standalone models, which are submodels that can be run independently of each other. This is an important aspect of `ClimaLand` code design: to maximise modularity, sub-models can be run alone, and many different methods of the same sub-model can be defined via Julia multiple-disptach. The standalone folder is independent from the integrated folder. 
+- standalone: This folder contains standalone models, which are submodels that can be run independently of each other. This is an important aspect of `ClimaLand` code design: to maximize modularity, sub-models can be run alone, and many different methods of the same sub-model can be defined via Julia multiple dispatch. The standalone folder is independent from the integrated folder. 
 - integrated: This folder contains integrated models. It assembles standalone models together, as one would assemble pieces of a puzzle. Thanks to the modularity of `ClimaLand` design, many configuration of LSM can be assembled in integrated models. The same functions (`update_aux!`, `exp_tendency!`, etc.) can be used for standalone and integrated models, and an can be stepped  in the same way.
 
 As well as one file:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,1 +1,4 @@
 # ClimaLand.jl
+
+`ClimaLand.jl` is a [Julia](https://julialang.org/) toolkit for land surface
+modeling.

--- a/experiments/standalone/Bucket/bucket_era5.jl
+++ b/experiments/standalone/Bucket/bucket_era5.jl
@@ -1,7 +1,7 @@
-# # Global bucket run using spatial map albedo
+# # Global/regional bucket run using spatial map albedo
 
 # The code sets up and runs the bucket for 7 days using albedo read in from
-# a file containing static data over the globe, and analytic atmospheric and
+# a file containing static data over the globe or on a region, and ERA5 atmospheric and
 # radiative forcings.
 # Moving forward, this driver will serve as our more complex global bucket run,
 # eventually running for a longer time period (1+ year) and using temporally
@@ -64,7 +64,6 @@ function compute_clims(v)
 end
 
 anim_plots = true
-
 # Set to true if you want to run a regional simulation. By default, it is false,
 # unless the `CLIMALAND_CI_REGIONAL_BUCKET` environment variable is defined.
 regional_simulation = haskey(ENV, "CLIMALAND_CI_REGIONAL_BUCKET")
@@ -76,19 +75,34 @@ context = ClimaComms.context()
 earth_param_set = LP.LandParameters(FT);
 outdir = joinpath(
     pkgdir(ClimaLand),
-    "experiments/standalone/Bucket/artifacts_staticmap",
+    "experiments/standalone/Bucket/artifacts_staticmap$(regional_str)",
 )
 !ispath(outdir) && mkpath(outdir)
 
 # Set up simulation domain
 soil_depth = FT(3.5);
-bucket_domain = ClimaLand.Domains.SphericalShell(;
-    radius = FT(6.3781e6),
-    depth = soil_depth,
-    nelements = (30, 10),
-    npolynomial = 1,
-    dz_tuple = FT.((1.0, 0.05)),
-);
+if regional_simulation
+    @info "Running regional simulation"
+    center_long, center_lat = FT(-118.14452), FT(34.14778)
+    # Half size of the grid in meters
+    delta_m = FT(50_000)
+    bucket_domain = ClimaLand.Domains.HybridBox(;
+        xlim = (delta_m, delta_m),
+        ylim = (delta_m, delta_m),
+        zlim = (-soil_depth, FT(0.0)),
+        longlat = (center_long, center_lat),
+        nelements = (30, 30, 10),
+        npolynomial = 1,
+    )
+else
+    bucket_domain = ClimaLand.Domains.SphericalShell(;
+        radius = FT(6.3781e6),
+        depth = soil_depth,
+        nelements = (30, 10),
+        npolynomial = 1,
+        dz_tuple = FT.((1.0, 0.05)),
+    )
+end
 ref_time = DateTime(2021);
 
 # Set up parameters
@@ -264,8 +278,38 @@ sol = ClimaComms.@time ClimaComms.device() SciMLBase.solve(
 
 # Interpolate to grid
 space = axes(coords.surface)
-longpts = range(-180.0, 180.0, 21)
-latpts = range(-90.0, 90.0, 21)
+num_pts = 21
+if regional_simulation
+    radius_earth = FT(6.378e6)
+    xlim = (
+        center_long - delta_m / (2radius_earth),
+        center_long + delta_m / (2radius_earth),
+    )
+    ylim = (
+        center_lat - delta_m / (2radius_earth),
+        center_lat + delta_m / (2radius_earth),
+    )
+    longpts = range(xlim[1], xlim[2], num_pts)
+    latpts = range(ylim[1], ylim[2], num_pts)
+
+    # Temporary monkey patch until we use the new diagnostics.
+    # This is used somewhere internally by the remapper.
+    # TODO: Remove this and use ClimaDiagnostics instead
+    ClimaCore.Geometry._coordinate(
+        pt::ClimaCore.Geometry.LatLongPoint,
+        ::Val{1},
+    ) = ClimaCore.Geometry.LongPoint(pt.long)
+    ClimaCore.Geometry._coordinate(
+        pt::ClimaCore.Geometry.LatLongPoint,
+        ::Val{2},
+    ) = ClimaCore.Geometry.LatPoint(pt.lat)
+
+else
+    longpts = range(-180.0, 180.0, num_pts)
+    latpts = range(-90.0, 90.0, num_pts)
+    hcoords =
+        [Geometry.LatLongPoint(lat, long) for long in longpts, lat in latpts]
+end
 hcoords = [Geometry.LatLongPoint(lat, long) for long in longpts, lat in latpts]
 remapper = Remapping.Remapper(space, hcoords)
 

--- a/experiments/standalone/Bucket/global_bucket_staticmap.jl
+++ b/experiments/standalone/Bucket/global_bucket_staticmap.jl
@@ -64,6 +64,12 @@ function compute_clims(v)
 end
 
 anim_plots = true
+
+# Set to true if you want to run a regional simulation. By default, it is false,
+# unless the `CLIMALAND_CI_REGIONAL_BUCKET` environment variable is defined.
+regional_simulation = haskey(ENV, "CLIMALAND_CI_REGIONAL_BUCKET")
+regional_str = regional_simulation ? "_regional" : ""
+
 regridder_type = :InterpolationsRegridder
 FT = Float64;
 context = ClimaComms.context()

--- a/test/shared_utilities/domains.jl
+++ b/test/shared_utilities/domains.jl
@@ -128,6 +128,7 @@ FT = Float32
     @test obtain_surface_domain(box) == Plane{FT}(
         xlim,
         ylim,
+        nothing,
         nelements[1:2],
         (true, true),
         0,
@@ -169,24 +170,82 @@ FT = Float32
           ClimaCore.Spaces.SpectralElementSpace2D
 
     # Plane latlong
+    dxlim = (FT(-50_000), FT(80_000))
+    dylim = (FT(-30_000), FT(40_000))
+    longlat = (FT(-118.14452), FT(34.14778))
+    radius_earth = FT(6.378e6)
+    xlim_longlat = (
+        longlat[1] - dxlim[1] / 2radius_earth,
+        longlat[1] + dxlim[2] / 2radius_earth,
+    )
+    ylim_longlat = (
+        longlat[2] - dylim[1] / 2radius_earth,
+        longlat[2] + dylim[2] / (2radius_earth),
+    )
+
     longlat_plane = Plane(;
-        xlim = xlim,
-        ylim = ylim,
-        longlat = (FT(-118.14452), FT(34.14778)),
+        xlim = dxlim,
+        ylim = dylim,
+        longlat,
         nelements = nelements[1:2],
         npolynomial = 0,
     )
     plane_coords = coordinates(longlat_plane).surface
-    @test eltype(plane_coords) == ClimaCore.Geometry.LongLatPoint{FT}
+    @test eltype(plane_coords) == ClimaCore.Geometry.LatLongPoint{FT}
     @test typeof(plane_coords) <: ClimaCore.Fields.Field
-    @test xy_plane.xlim == FT.(xlim)
-    @test xy_plane.ylim == FT.(ylim)
-    @test xy_plane.nelements == nelements[1:2]
-    @test xy_plane.npolynomial == 0
-    @test xy_plane.periodic == (false, false)
-    @test typeof(xy_plane.space.surface) <:
+    @test longlat_plane.xlim == FT.(xlim_longlat)
+    @test longlat_plane.ylim == FT.(ylim_longlat)
+    @test longlat_plane.nelements == nelements[1:2]
+    @test longlat_plane.npolynomial == 0
+    @test longlat_plane.periodic == (false, false)
+    @test typeof(longlat_plane.space.surface) <:
           ClimaCore.Spaces.SpectralElementSpace2D
 
+    # Box latlong
+    longlat_box = HybridBox(;
+        xlim = dxlim,
+        ylim = dylim,
+        zlim = zlim,
+        longlat,
+        nelements = nelements,
+        npolynomial = 0,
+    )
+    @test longlat_box.fields.z ==
+          ClimaCore.Fields.coordinate_field(longlat_box.space.subsurface).z
+    face_space = obtain_face_space(longlat_box.space.subsurface)
+    z_face = ClimaCore.Fields.coordinate_field(face_space).z
+    @test longlat_box.fields.z_sfc ==
+          top_face_to_surface(z_face, longlat_box.space.surface)
+    Δz_top, Δz_bottom = get_Δz(longlat_box.fields.z)
+    @test longlat_box.fields.Δz_top == Δz_top
+    @test longlat_box.fields.Δz_bottom == Δz_bottom
+    longlat_box_coords = coordinates(longlat_box).subsurface
+    @test eltype(longlat_box_coords) == ClimaCore.Geometry.LatLongZPoint{FT}
+    @test typeof(longlat_box_coords) <: ClimaCore.Fields.Field
+    @test longlat_box.xlim == FT.(xlim_longlat)
+    @test longlat_box.ylim == FT.(ylim_longlat)
+    @test longlat_box.zlim == FT.(zlim)
+    @test longlat_box.nelements == nelements
+    @test longlat_box.npolynomial == 0
+    @test longlat_box.periodic == (false, false)
+    @test typeof(
+        ClimaCore.Spaces.horizontal_space(longlat_box.space.subsurface),
+    ) <: ClimaCore.Spaces.SpectralElementSpace2D
+    @test typeof(longlat_box.space.subsurface) <:
+          ClimaCore.Spaces.CenterExtrudedFiniteDifferenceSpace
+    @test typeof(longlat_box.space.surface) <:
+          ClimaCore.Spaces.SpectralElementSpace2D
+    @test obtain_surface_space(longlat_box.space.subsurface) ==
+          longlat_box.space.surface
+    @test obtain_surface_domain(longlat_box) == Plane{FT}(
+        xlim_longlat,
+        ylim_longlat,
+        longlat,
+        nelements[1:2],
+        (false, false),
+        0,
+        (; surface = longlat_box.space.surface),
+    )
 
     # Column
 

--- a/test/shared_utilities/domains.jl
+++ b/test/shared_utilities/domains.jl
@@ -168,6 +168,25 @@ FT = Float32
     @test typeof(xy_plane.space.surface) <:
           ClimaCore.Spaces.SpectralElementSpace2D
 
+    # Plane latlong
+    longlat_plane = Plane(;
+        xlim = xlim,
+        ylim = ylim,
+        longlat = (FT(-118.14452), FT(34.14778)),
+        nelements = nelements[1:2],
+        npolynomial = 0,
+    )
+    plane_coords = coordinates(longlat_plane).surface
+    @test eltype(plane_coords) == ClimaCore.Geometry.LongLatPoint{FT}
+    @test typeof(plane_coords) <: ClimaCore.Fields.Field
+    @test xy_plane.xlim == FT.(xlim)
+    @test xy_plane.ylim == FT.(ylim)
+    @test xy_plane.nelements == nelements[1:2]
+    @test xy_plane.npolynomial == 0
+    @test xy_plane.periodic == (false, false)
+    @test typeof(xy_plane.space.surface) <:
+          ClimaCore.Spaces.SpectralElementSpace2D
+
 
     # Column
 


### PR DESCRIPTION
This PR adds support for regional simulations, box simulations centered around a specific long/lat. Regional simulations are useful for all sorts of reasons, including debugging. Here, I use the fact that there is no later information exchange and set up a box domain. 

Closes #709 