### PR TITLE
lateral flow defaults to false in energy hydrology

### DIFF
--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -116,7 +116,7 @@ end
         domain::D,
         boundary_conditions::NamedTuple,
         sources::Tuple,
-        lateral_flow::Bool = true
+        lateral_flow::Bool = false
     ) where {FT, D, PS}
 
 A constructor for a `EnergyHydrology` model, which sets the default value
@@ -127,8 +127,9 @@ function EnergyHydrology{FT}(;
     domain::D,
     boundary_conditions::NamedTuple,
     sources::Tuple,
-    lateral_flow::Bool = true,
+    lateral_flow::Bool = false,
 ) where {FT, D, PSE}
+    @assert !lateral_flow
     top_bc = boundary_conditions.top
     if typeof(top_bc) <: AtmosDrivenFluxBC
         # If the top BC indicates atmospheric conditions are driving the model


### PR DESCRIPTION
## Purpose 
The lateral_flow flag should be set to false, but it was still defaulting to true for the EnergyHydrology model.


## To-do



## Content


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
