### PR TITLE
Generalize domain depth

### DIFF
--- a/src/shared_utilities/Domains.jl
+++ b/src/shared_utilities/Domains.jl
@@ -910,10 +910,39 @@ function get_additional_domain_fields(subsurface_space)
     face_space = obtain_face_space(subsurface_space)
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     z_sfc = top_face_to_surface(z_face, surface_space)
-    fields = (; z = z, Δz_top = Δz_top, Δz_bottom = Δz_bottom, z_sfc = z_sfc)
+    d = depth(subsurface_space)
+    fields = (;
+        z = z,
+        Δz_top = Δz_top,
+        Δz_bottom = Δz_bottom,
+        z_sfc = z_sfc,
+        depth = d,
+    )
     return fields
 end
 
+"""
+    depth(space::Union{ClimaCore.Spaces.CenterFiniteDifferenceSpace,
+                       ClimaCore.Spaces.CenterExtrudedFiniteDifferenceSpace}) 
+
+Returns the depth of the domain as a scalar. Note that these functions
+will need to be modified upon the introduction of 
+- topography at surface
+- depth to bedrock (topography at bottom)
+
+Since the depth will be a field in this case, it should be allocated and
+stored in domain.fields, which is why we store it there now even though it is not a field.
+"""
+depth(space::ClimaCore.Spaces.CenterExtrudedFiniteDifferenceSpace) =
+    (
+        space.grid.vertical_grid.topology.mesh.domain.coord_max -
+        space.grid.vertical_grid.topology.mesh.domain.coord_min
+    ).z
+depth(space::ClimaCore.Spaces.CenterFiniteDifferenceSpace) =
+    (
+        space.grid.topology.mesh.domain.coord_max -
+        space.grid.topology.mesh.domain.coord_min
+    ).z
 
 export AbstractDomain
 export Column, Plane, HybridBox, Point, SphericalShell, SphericalSurface

--- a/src/standalone/Soil/Runoff/Runoff.jl
+++ b/src/standalone/Soil/Runoff/Runoff.jl
@@ -228,7 +228,7 @@ function update_runoff!(
     @. p.soil.R_ss = topmodel_ss_flux(
         runoff.subsurface_source.R_sb,
         runoff.f_over,
-        model.domain.depth - p.soil.h∇,
+        model.domain.fields.depth - p.soil.h∇,
     )
     ic = soil_infiltration_capacity(model, Y, p) # should be non-allocating
 
@@ -237,7 +237,7 @@ function update_runoff!(
         p.soil.h∇,
         runoff.f_max,
         runoff.f_over,
-        model.domain.depth - p.soil.h∇,
+        model.domain.fields.depth - p.soil.h∇,
         ic,
         precip,
     )

--- a/test/shared_utilities/domains.jl
+++ b/test/shared_utilities/domains.jl
@@ -37,6 +37,7 @@ FT = Float32
         nelements = n_elements_sphere,
         npolynomial = npoly_sphere,
     )
+    @test shell.fields.depth == depth
     @test shell.fields.z ==
           ClimaCore.Fields.coordinate_field(shell.space.subsurface).z
     face_space = obtain_face_space(shell.space.subsurface)
@@ -102,6 +103,7 @@ FT = Float32
         nelements = nelements,
         npolynomial = 0,
     )
+    @test box.fields.depth == zlim[2] - zlim[1]
     @test box.fields.z ==
           ClimaCore.Fields.coordinate_field(box.space.subsurface).z
     face_space = obtain_face_space(box.space.subsurface)
@@ -210,6 +212,7 @@ FT = Float32
         nelements = nelements,
         npolynomial = 0,
     )
+    @test longlat_box.fields.depth == zlim[2] - zlim[1]
     @test longlat_box.fields.z ==
           ClimaCore.Fields.coordinate_field(longlat_box.space.subsurface).z
     face_space = obtain_face_space(longlat_box.space.subsurface)
@@ -252,6 +255,7 @@ FT = Float32
     z_column = Column(; zlim = zlim, nelements = nelements[3])
     @test z_column.fields.z ==
           ClimaCore.Fields.coordinate_field(z_column.space.subsurface).z
+    @test z_column.fields.depth == zlim[2] - zlim[1]
     face_space = obtain_face_space(z_column.space.subsurface)
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     @test z_column.fields.z_sfc ==


### PR DESCRIPTION
## Purpose 
In global runs (spherical shell domain), the depth is used to compute TOPMODEL runoff. When we carry out regional simulations (hydrid box domain), we also require the depth, then. However, we were accessing the depth of the domain in a manner specific to the spherical shell.

This generalizes and stores the depth in domain.fields. I added a column method for completeness, even though we may not need it.


## To-do


## Content

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
