### PR TITLE
All CO2 fluxes in mol CO2 m-2 s-1

### DIFF
--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -96,8 +96,7 @@ function AutotrophicRespirationParameters(
         :live_stem_wood_coeff => :ηsl,
         :specific_leaf_density => :σl,
         :root_leaf_nitrogen_ratio => :μr,
-        :mol_CO2_to_kg_C_factor => :f1,
-        :relative_contribution_factor => :f2,
+        :relative_contribution_factor => :Rel,
         :stem_leaf_nitrogen_ratio => :μs,
     )
     parameters = CP.get_parameter_values(toml_dict, name_map, "Land")

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Ha1/US-Ha1_parameters.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Ha1/US-Ha1_parameters.jl
@@ -60,10 +60,9 @@ function auto_resp_harvard(;
     σl = FT(0.05),
     μr = FT(1.0),
     μs = FT(0.1),
-    f1 = FT(0.012),
-    f2 = FT(0.25),
+    Rel = FT(0.25),
 )
-    return AutotrophicRespirationParameters(ne, ηsl, σl, μr, μs, f1, f2)
+    return AutotrophicRespirationParameters(ne, ηsl, σl, μr, μs, Rel)
 end
 
 function soil_harvard(;

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-MOz/US-MOz_parameters.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-MOz/US-MOz_parameters.jl
@@ -60,10 +60,9 @@ function auto_resp_ozark(;
     σl = FT(0.05),
     μr = FT(1.0),
     μs = FT(0.1),
-    f1 = FT(0.012),
-    f2 = FT(0.25),
+    Rel = FT(0.25),
 )
-    return AutotrophicRespirationParameters(ne, ηsl, σl, μr, μs, f1, f2)
+    return AutotrophicRespirationParameters(ne, ηsl, σl, μr, μs, Rel)
 end
 
 function soil_ozark(; # Function that returns the src function, but with ozark default args

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-NR1/US-NR1_parameters.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-NR1/US-NR1_parameters.jl
@@ -60,10 +60,9 @@ function auto_resp_niwotridge(;
     σl = FT(0.05),
     μr = FT(1.0),
     μs = FT(0.1),
-    f1 = FT(0.012),
-    f2 = FT(0.25),
+    Rel = FT(0.25),
 )
-    return AutotrophicRespirationParameters(ne, ηsl, σl, μr, μs, f1, f2)
+    return AutotrophicRespirationParameters(ne, ηsl, σl, μr, μs, Rel)
 end
 
 function soil_niwotridge(;

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Var/US-Var_parameters.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_sites/US-Var/US-Var_parameters.jl
@@ -60,10 +60,9 @@ function auto_resp_vairaranch(;
     σl = FT(0.05),
     μr = FT(1.0),
     μs = FT(0.1),
-    f1 = FT(0.012),
-    f2 = FT(0.25),
+    Rel = FT(0.25),
 )
-    return AutotrophicRespirationParameters(ne, ηsl, σl, μr, μs, f1, f2)
+    return AutotrophicRespirationParameters(ne, ηsl, σl, μr, μs, Rel)
 end
 
 function soil_vairaranch(;

--- a/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
@@ -95,8 +95,7 @@ function run_fluxnet(
             σl = params.auto_resp.σl,
             μr = params.auto_resp.μr,
             μs = params.auto_resp.μs,
-            f1 = params.auto_resp.f1,
-            f2 = params.auto_resp.f2,
+            Rel = params.auto_resp.Rel,
         )
     )
     # Set up radiative transfer

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -167,7 +167,7 @@ function define_diagnostics!(land_model)
         short_name = "ra",
         long_name = "Autotrophic Respiration",
         standard_name = "autotrophic_respiration",
-        units = "kg C m^-2 s^-1",
+        units = "mol CO2 m^-2 s^-1",
         comments = "The canopy autotrophic respiration, the sum of leaves, stems and roots respiration.",
         compute! = (out, Y, p, t) ->
             compute_autotrophic_respiration!(out, Y, p, t, land_model),
@@ -720,7 +720,7 @@ function define_diagnostics!(land_model)
         short_name = "scms",
         long_name = "Soil CO2 Microbial Source",
         standard_name = "soil_co2_microbial_source",
-        units = "kg C m^-2 s^-1",
+        units = "kg C m^-3 s^-1",
         comments = "The production of CO2 by microbes in the soil. Vary by layers of soil depth.",
         compute! = (out, Y, p, t) ->
             compute_soilco2_source_microbe!(out, Y, p, t, land_model),

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -139,7 +139,22 @@ end
 @diagnostic_compute "vapor_flux" SoilCanopyModel p.soil.turbulent_fluxes.vapor_flux
 
 # Soil - SoilCO2
-@diagnostic_compute "heterotrophic_respiration" SoilCanopyModel p.soilco2.top_bc
+function compute_heterotrophic_respiration!(
+    out,
+    Y,
+    p,
+    t,
+    land_model::SoilCanopyModel{FT},
+) where {FT}
+    if isnothing(out)
+        return p.soilco2.top_bc .* FT(83.26)
+    else
+        out .= p.soilco2.top_bc .* FT(83.26)
+    end
+end # Convert from kg C to mol CO2. 
+# To convert from kg C to mol CO2, we need to multiply by:
+# [3.664 kg CO2/ kg C] x [10^3 g CO2/ kg CO2] x [1 mol CO2/44.009 g CO2] = 83.26 mol CO2/kg C
+
 @diagnostic_compute "soilco2_diffusivity" SoilCanopyModel p.soilco2.D
 @diagnostic_compute "soilco2_source_microbe" SoilCanopyModel p.soilco2.Sm
 

--- a/src/standalone/Vegetation/autotrophic_respiration.jl
+++ b/src/standalone/Vegetation/autotrophic_respiration.jl
@@ -22,10 +22,8 @@ Base.@kwdef struct AutotrophicRespirationParameters{FT <: AbstractFloat}
     μr::FT
     "Ratio stem nitrogen to top leaf nitrogen (-), typical value 0.1"
     μs::FT
-    "Factor to convert from mol CO2 to kg C"
-    f1::FT
-    "Factor of relative contribution or Rgrowth (-)"
-    f2::FT
+    "Relative contribution or Rgrowth (-)"
+    Rel::FT
 end
 
 Base.eltype(::AutotrophicRespirationParameters{FT}) where {FT} = FT
@@ -73,7 +71,7 @@ ClimaLand.auxiliary_domain_names(::AutotrophicRespirationModel) = (:surface,)
                                   h,
                                  )
 
-Computes the autotrophic respiration as the sum of the plant maintenance
+Computes the autotrophic respiration (mol co2 m^-2 s^-1) as the sum of the plant maintenance
 and growth respirations, according to the JULES model.
 
 Clark, D. B., et al. "The Joint UK Land Environment Simulator (JULES), model description–Part 2: carbon fluxes and vegetation dynamics." Geoscientific Model Development 4.3 (2011): 701-722.
@@ -92,11 +90,11 @@ function compute_autrophic_respiration(
     h,
 )
 
-    (; ne, ηsl, σl, μr, μs, f1, f2) = model.parameters
+    (; ne, ηsl, σl, μr, μs, Rel) = model.parameters
     Nl, Nr, Ns =
         nitrogen_content(ne, Vcmax25, LAI, SAI, RAI, ηsl, h, σl, μr, μs)
-    Rpm = plant_respiration_maintenance(Rd, β, Nl, Nr, Ns, f1)
-    Rg = plant_respiration_growth(f2, An, Rpm)
+    Rpm = plant_respiration_maintenance(Rd, β, Nl, Nr, Ns)
+    Rg = plant_respiration_growth(Rel, An, Rpm)
     Ra = Rpm + Rg
     return Ra * (1 - exp(-K * LAI * Ω)) / (K * Ω) # adjust to canopy level
 end

--- a/src/standalone/Vegetation/canopy_parameterizations.jl
+++ b/src/standalone/Vegetation/canopy_parameterizations.jl
@@ -1007,7 +1007,6 @@ end
         Nl::FT, # Nitrogen content of leafs
         Nr::FT, # Nitrogen content of roots
         Ns::FT, # Nitrogen content of stems
-        f::FT # Factor to convert from mol CO2 to kg C
         ) where {FT}
 
 Computes plant maintenance respiration as a function of dark respiration (Rd),
@@ -1020,24 +1019,23 @@ function plant_respiration_maintenance(
     Nl::FT, # Nitrogen content of leafs
     Nr::FT, # Nitrogen content of roots
     Ns::FT, # Nitrogen content of stems
-    f1::FT, # Factor to convert from mol CO2 to kg C
 ) where {FT}
     # When LAI is zero, Nl = 0
-    Rpm = f1 * Rd * (β + (Nr + Ns) / max(Nl, eps(FT)))
+    Rpm = Rd * (β + (Nr + Ns) / max(Nl, eps(FT)))
     return Rpm
 end
 
 """
     plant_respiration_growth(
-        f::FT, # Factor of relative contribution
+        Rel::FT, # Factor of relative contribution
         An::FT, # Net photosynthesis
         Rpm::FT # Plant maintenance respiration
         ) where {FT}
 
 Computes plant growth respiration as a function of net photosynthesis (An),
-plant maintenance respiration (Rpm), and a relative contribution factor, f.
+plant maintenance respiration (Rpm), and a relative contribution factor, Rel.
 """
-function plant_respiration_growth(f2::FT, An::FT, Rpm::FT) where {FT}
-    Rg = f2 * (An - Rpm)
+function plant_respiration_growth(Rel::FT, An::FT, Rpm::FT) where {FT}
+    Rg = Rel * (An - Rpm)
     return Rg
 end

--- a/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
+++ b/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
@@ -291,8 +291,8 @@ for FT in (Float32, Float64)
             ARparams.μr,
             ARparams.μs,
         )
-        Rpm = plant_respiration_maintenance(Rd, β, Nl, Nr, Ns, ARparams.f1)
-        Rg = plant_respiration_growth.(ARparams.f2, An, Rpm)
+        Rpm = plant_respiration_maintenance(Rd, β, Nl, Nr, Ns)
+        Rg = plant_respiration_growth.(ARparams.Rel, An, Rpm)
 
         @test Nl ==
               photosynthesisparams.Vcmax25 / ARparams.ne * ARparams.σl * LAI
@@ -306,8 +306,8 @@ for FT in (Float32, Float64)
               h_canopy *
               LAI *
               ClimaLand.heaviside(SAI)# == gives a very small error
-        @test Rpm == ARparams.f1 * Rd * (β + (Nr + Ns) / Nl)
-        @test all(@.(Rg ≈ ARparams.f2 * (An - Rpm)))
+        @test Rpm == Rd * (β + (Nr + Ns) / Nl)
+        @test all(@.(Rg ≈ ARparams.Rel * (An - Rpm)))
 
     end
 end


### PR DESCRIPTION
There was some inconsistencies, as well as some bug in the code, because of sometimes expressing CO2 fluxes in gC m-2 s-1, and sometimes in mol CO2 m-2 s-1.
In this PR, we express all CO2 fluxes in mol CO2 m-2 s-1. Note: the parameter "f1" (:mol_CO2_to_kg_C_factor) from AutotrophicRespirationParameters has been removed, and the parameter "f2" (:relative_contribution_factor) renamed to "Rel". This change is also happening in [ClimaParams.jl PR #205](https://github.com/CliMA/ClimaParams.jl/pull/205)