### PR TITLE
fix buildkite run so that unit tests run on GPU

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 agents:
   queue: new-central
-  slurm_mem: 8G
+  slurm_mem: 12G
   modules: climacommon/2024_10_09
 
 env:
@@ -26,7 +26,7 @@ steps:
       - "julia --project=.buildkite -e 'using Pkg; Pkg.status()'"
 
       - echo "--- Instantiate test"
-      - "julia --project=test -e 'using Pkg; Pkg.develop(;path=\".\"); Pkg.instantiate(;verbose=true)'"
+      - "julia --project=test -e 'using Pkg; Pkg.develop(;path=\".\"); Pkg.add(\"MPI\"); Pkg.add(\"CUDA\"); Pkg.instantiate(;verbose=true)'"
       - "julia --project=test -e 'using Pkg; Pkg.status()'"
 
       - echo "--- Instantiate lib/ClimaLandSimulations"
@@ -68,15 +68,6 @@ steps:
       - label: "Richards comparison to Bonan"
         command: "julia --color=yes --project=.buildkite experiments/standalone/Soil/richards_comparison.jl"
         artifact_paths: "experiments/standalone/Soil/cpu/output_active/comparison*png"
-
-      - label: "Richards comparison to Bonan: GPU"
-        command: "julia --color=yes --project=.buildkite experiments/standalone/Soil/richards_comparison.jl"
-        artifact_paths: "experiments/standalone/Soil/gpu/output_active/comparison*png"
-        agents:
-          slurm_ntasks: 1
-          slurm_gpus: 1
-        env:
-          CLIMACOMMS_DEVICE: "CUDA"
 
       - label: "vaira_test"
         command: "julia --color=yes --project=.buildkite experiments/integrated/fluxnet/run_fluxnet.jl US-Var"
@@ -144,6 +135,15 @@ steps:
         env:
           CLIMACOMMS_DEVICE: "CUDA"
 
+      - label: "Richards comparison to Bonan: GPU"
+        command: "julia --color=yes --project=.buildkite experiments/standalone/Soil/richards_comparison.jl"
+        artifact_paths: "experiments/standalone/Soil/gpu/output_active/comparison*png"
+        agents:
+          slurm_ntasks: 1
+          slurm_gpus: 1
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+
   - group: "ClimaLandSimulations"
     steps:
       - label: "Ozark figures Makie"
@@ -188,6 +188,8 @@ steps:
         agents:
           slurm_ntasks: 1
           slurm_gpus: 1
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
 
       - label: "Global Bucket on GPU (functional albedo)"
         key: "global_bucket_function_gpu"

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,9 @@ ClimaLand.jl Release Notes
 
 main
 --------
-
+- Run unit tests on GPU, and update code for GPU compatibility
+  (including workaround for ClimaCore type inference failure)
+  PR[#739](https://github.com/CliMA/ClimaLand.jl/pull/739)
 
 v0.15.6
 -------

--- a/experiments/integrated/performance/integrated_timestep_test.jl
+++ b/experiments/integrated/performance/integrated_timestep_test.jl
@@ -104,8 +104,9 @@ function set_initial_conditions(land, t0)
         )
 
     for i in 1:2
+        S_l = S_l_ini[i]
         Y.canopy.hydraulics.ϑ_l.:($i) .=
-            augmented_liquid_fraction.(canopy_params.ν, S_l_ini[i])
+            augmented_liquid_fraction.(canopy_params.ν, S_l)
     end
 
     Y.canopy.energy.T = FT(297.5)
@@ -176,14 +177,14 @@ function zenith_angle(
     t,
     start_date;
     cd_field = sfc_cds,
-    insol_params::Insolation.Parameters.InsolationParameters{FT} = earth_param_set.insol_params,
-) where {FT}
+    insol_params::Insolation.Parameters.InsolationParameters{_FT} = earth_param_set.insol_params,
+) where {_FT}
     # This should be time in UTC
     current_datetime = start_date + Dates.Second(round(t))
 
     # Orbital Data uses Float64, so we need to convert to our sim FT
     d, δ, η_UTC =
-        FT.(
+        _FT.(
             Insolation.helper_instantaneous_zenith_angle(
                 current_datetime,
                 start_date,

--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -66,7 +66,6 @@ function LP.LandParameters(toml_dict::CP.AbstractTOMLDict)
         insol_params,
     )
 end
-Base.broadcastable(ps::LP.LandParameters) = tuple(ps)
 
 """
     AutotrophicRespirationParameters(FT; kwargs...)

--- a/src/shared_utilities/Parameters.jl
+++ b/src/shared_utilities/Parameters.jl
@@ -28,6 +28,7 @@ Base.@kwdef struct LandParameters{FT, TP, SFP, IP} <: ALP
 end
 
 Base.eltype(::LandParameters{FT}) where {FT} = FT
+Base.broadcastable(ps::LandParameters) = tuple(ps)
 
 # wrapper methods:
 P_ref(ps::ALP) = ps.MSLP

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -623,6 +623,11 @@ function ClimaLand.source!(
     _ρ_l = FT(LP.ρ_cloud_liq(earth_param_set))
     _ρ_i = FT(LP.ρ_cloud_ice(earth_param_set))
     Δz = model.domain.fields.Δz # center face distance
+
+    # Wrap hydrology and earth parameters in one struct to avoid type inference failure
+    hydrology_earth_params =
+        ClimaLand.Soil.HydrologyEarthParameters.(hydrology_cm, earth_param_set)
+
     @. dY.soil.ϑ_l +=
         -phase_change_source(
             p.soil.θ_l,
@@ -640,8 +645,7 @@ function ClimaLand.source!(
             ),
             ν,
             θ_r,
-            hydrology_cm,
-            earth_param_set,
+            hydrology_earth_params,
         )
     @. dY.soil.θ_i +=
         (_ρ_l / _ρ_i) * phase_change_source(
@@ -660,11 +664,9 @@ function ClimaLand.source!(
             ),
             ν,
             θ_r,
-            hydrology_cm,
-            earth_param_set,
+            hydrology_earth_params,
         )
 end
-
 
 """
     SoilSublimation{FT} <: AbstractSoilSource{FT}

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -23,7 +23,7 @@ struct ConstantGFunction{F <: Union{AbstractFloat, ClimaCore.Fields.Field}} <:
 end
 
 # Make the ConstantGFunction broadcastable
-Base.broadcastable(G::ConstantGFunction) = Ref(G)
+Base.broadcastable(G::ConstantGFunction) = tuple(G)
 
 """
     CLMGFunction
@@ -38,7 +38,7 @@ struct CLMGFunction{F <: Union{AbstractFloat, ClimaCore.Fields.Field}} <:
 end
 
 # Make the CLMGFunction broadcastable
-Base.broadcastable(G::CLMGFunction) = Ref(G)
+Base.broadcastable(G::CLMGFunction) = tuple(G)
 
 """
     BeerLambertParameters{FT <: AbstractFloat}

--- a/test/standalone/Soil/soil_parameterizations.jl
+++ b/test/standalone/Soil/soil_parameterizations.jl
@@ -307,6 +307,10 @@ for FT in (Float32, Float64)
         vg_n = FT(1.4)
         hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
 
+        # Wrap hydrology and earth parameters in one struct to avoid type inference failure
+        hydrology_earth_params =
+            ClimaLand.Soil.HydrologyEarthParameters(hcm, param_set)
+
         K_sat = FT(1e-5)
         ν_ss_om = FT(0.1)
         ν_ss_gravel = FT(0.1)
@@ -336,11 +340,26 @@ for FT in (Float32, Float64)
         ρc_s = volumetric_heat_capacity.(θ_l, θ_i, parameters.ρc_ds, param_set)
         τ = thermal_time.(ρc_s, Δz, parameters.κ_dry)
         @test (
-            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, hcm, param_set) ≈
-            (θ_l .- θ_star) ./ τ
+            phase_change_source.(
+                θ_l,
+                θ_i,
+                T,
+                τ,
+                ν,
+                θ_r,
+                hydrology_earth_params,
+            ) ≈ (θ_l .- θ_star) ./ τ
         )
         @test sum(
-            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, hcm, param_set) .> 0.0,
+            phase_change_source.(
+                θ_l,
+                θ_i,
+                T,
+                τ,
+                ν,
+                θ_r,
+                hydrology_earth_params,
+            ) .> 0.0,
         ) == 3
         # try θ_l = 0.1
 
@@ -354,8 +373,15 @@ for FT in (Float32, Float64)
         ρc_s = volumetric_heat_capacity.(θ_l, θ_i, parameters.ρc_ds, param_set)
         τ = thermal_time.(ρc_s, Δz, parameters.κ_dry)
         @test (
-            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, hcm, param_set) ≈
-            zeros(FT, 3)
+            phase_change_source.(
+                θ_l,
+                θ_i,
+                T,
+                τ,
+                ν,
+                θ_r,
+                hydrology_earth_params,
+            ) ≈ zeros(FT, 3)
         )
         @test (θ_star ≈ θ_l)
 
@@ -370,11 +396,26 @@ for FT in (Float32, Float64)
         ρc_s = volumetric_heat_capacity.(θ_l, θ_i, parameters.ρc_ds, param_set)
         τ = thermal_time.(ρc_s, Δz, parameters.κ_dry)
         @test (
-            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, hcm, param_set) ≈
-            (θ_l .- θ_star) ./ τ
+            phase_change_source.(
+                θ_l,
+                θ_i,
+                T,
+                τ,
+                ν,
+                θ_r,
+                hydrology_earth_params,
+            ) ≈ (θ_l .- θ_star) ./ τ
         )
         @test sum(
-            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, hcm, param_set) .< 0.0,
+            phase_change_source.(
+                θ_l,
+                θ_i,
+                T,
+                τ,
+                ν,
+                θ_r,
+                hydrology_earth_params,
+            ) .< 0.0,
         ) == 2
 
 
@@ -388,11 +429,26 @@ for FT in (Float32, Float64)
         ρc_s = volumetric_heat_capacity.(θ_l, θ_i, parameters.ρc_ds, param_set)
         τ = thermal_time.(ρc_s, Δz, parameters.κ_dry)
         @test (
-            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, hcm, param_set) ≈
-            (θ_l .- θ_star) ./ τ
+            phase_change_source.(
+                θ_l,
+                θ_i,
+                T,
+                τ,
+                ν,
+                θ_r,
+                hydrology_earth_params,
+            ) ≈ (θ_l .- θ_star) ./ τ
         )
         @test sum(
-            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, hcm, param_set) .> 0.0,
+            phase_change_source.(
+                θ_l,
+                θ_i,
+                T,
+                τ,
+                ν,
+                θ_r,
+                hydrology_earth_params,
+            ) .> 0.0,
         ) == 2
     end
 end

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -514,7 +514,7 @@ end
         set_canopy_prescribed_field!(Default{FT}(), p, t0)
         # Test that they are unchanged
         @test all(
-            parent(p.canopy.hydraulics.area_index.leaf) .==
+            Array(parent(p.canopy.hydraulics.area_index.leaf)) .==
             ClimaLand.Canopy.PlantHydraulics.clip(
                 FT(LAI * sin(200 * 2π / 365)),
                 FT(0.05),
@@ -1059,8 +1059,7 @@ end
         imp_tendency!(dY, Y, p, t0)
         jac = ImplicitEquationJacobian(Y)
         jacobian!(jac, Y, p, FT(1), t0)
-        jac_value =
-            parent(jac.matrix[@name(canopy.energy.T), @name(canopy.energy.T)])
+        jac_value = jac.matrix[@name(canopy.energy.T), @name(canopy.energy.T)]
         ΔT = FT(0.01)
 
         Y_2 = deepcopy(Y)
@@ -1092,8 +1091,9 @@ end
                 p.canopy.radiative_transfer.LW_n
             ) ./ ΔT
         estimated_LW = p.canopy.energy.∂LW_n∂Tc
-        @test parent(abs.(finitediff_LW .- estimated_LW) ./ finitediff_LW)[1] <
-              0.01
+        @test Array(
+            parent(abs.(finitediff_LW .- estimated_LW) ./ finitediff_LW),
+        )[1] < 0.01
 
         finitediff_SHF =
             (
@@ -1101,8 +1101,9 @@ end
                 p.canopy.energy.turbulent_fluxes.shf
             ) ./ ΔT
         estimated_SHF = p.canopy.energy.turbulent_fluxes.∂SHF∂Tc
-        @test parent(abs.(finitediff_SHF .- estimated_SHF) ./ finitediff_SHF)[1] <
-              0.15
+        @test Array(
+            parent(abs.(finitediff_SHF .- estimated_SHF) ./ finitediff_SHF),
+        )[1] < 0.15
 
         finitediff_LHF =
             (
@@ -1111,27 +1112,32 @@ end
             ) ./ ΔT
         estimated_LHF =
             p.canopy.energy.turbulent_fluxes.∂LHF∂qc .* p.canopy.energy.∂qc∂Tc
-        @test parent(abs.(finitediff_LHF .- estimated_LHF) ./ finitediff_LHF)[1] <
-              0.3
+        @test Array(
+            parent(abs.(finitediff_LHF .- estimated_LHF) ./ finitediff_LHF),
+        )[1] < 0.3
 
         # Error in `q` derivative is large
         finitediff_q = (q_sfc2 .- q_sfc) ./ ΔT
         estimated_q = p.canopy.energy.∂qc∂Tc
-        @test parent(abs.(finitediff_q .- estimated_q) ./ finitediff_q)[1] <
-              0.25
+        @test Array(
+            parent(abs.(finitediff_q .- estimated_q) ./ finitediff_q),
+        )[1] < 0.25
 
         # Im not sure why this is not smaller! There must be an error in ∂LHF∂qc also.
         estimated_LHF_with_correct_q =
             p.canopy.energy.turbulent_fluxes.∂LHF∂qc .* finitediff_q
-        @test parent(
-            abs.(finitediff_LHF .- estimated_LHF_with_correct_q) ./
-            finitediff_LHF,
+        @test Array(
+            parent(
+                abs.(finitediff_LHF .- estimated_LHF_with_correct_q) ./
+                finitediff_LHF,
+            ),
         )[1] < 0.5
 
         # Recall jac = ∂Ṫ∂T - 1 [dtγ = 1]
-        ∂Ṫ∂T = jac_value .+ 1
+        ∂Ṫ∂T = Array(parent(jac_value)) .+ 1
         @test (abs.(
-            parent((dY_2.canopy.energy.T .- dY.canopy.energy.T) ./ ΔT) - ∂Ṫ∂T
+            Array(parent((dY_2.canopy.energy.T .- dY.canopy.energy.T) ./ ΔT)) -
+            ∂Ṫ∂T
         ) / ∂Ṫ∂T)[1] < 0.25 # Error propagates here from ∂LHF∂T
     end
 end
@@ -1389,24 +1395,42 @@ end
                 t0 = FT(0.0)
                 set_initial_cache!(p, Y, t0)
 
-                @test all(parent(p.canopy.hydraulics.fa.:1) .== FT(0))
+                @test all(Array(parent(p.canopy.hydraulics.fa.:1)) .== FT(0))
                 @test all(
-                    parent(p.canopy.energy.turbulent_fluxes.lhf) .== FT(0),
-                )
-                @test all(
-                    parent(p.canopy.energy.turbulent_fluxes.shf) .== FT(0),
-                )
-                @test all(parent(p.canopy.energy.fa_energy_roots) .== FT(0))
-                @test all(parent(p.canopy.hydraulics.fa_roots) .== FT(0))
-                @test all(
-                    parent(p.canopy.energy.turbulent_fluxes.transpiration) .==
+                    Array(parent(p.canopy.energy.turbulent_fluxes.lhf)) .==
                     FT(0),
                 )
-                @test all(parent(p.canopy.radiative_transfer.LW_n) .== FT(0))
-                @test all(parent(p.canopy.radiative_transfer.SW_n) .== FT(0))
-                @test all(parent(p.canopy.radiative_transfer.par.abs) .== FT(0))
-                @test all(parent(p.canopy.radiative_transfer.nir.abs) .== FT(0))
-                @test all(parent(p.canopy.autotrophic_respiration.Ra) .== FT(0))
+                @test all(
+                    Array(parent(p.canopy.energy.turbulent_fluxes.shf)) .==
+                    FT(0),
+                )
+                @test all(
+                    Array(parent(p.canopy.energy.fa_energy_roots)) .== FT(0),
+                )
+                @test all(Array(parent(p.canopy.hydraulics.fa_roots)) .== FT(0))
+                @test all(
+                    Array(
+                        parent(p.canopy.energy.turbulent_fluxes.transpiration),
+                    ) .== FT(0),
+                )
+                @test all(
+                    Array(parent(p.canopy.radiative_transfer.LW_n)) .== FT(0),
+                )
+                @test all(
+                    Array(parent(p.canopy.radiative_transfer.SW_n)) .== FT(0),
+                )
+                @test all(
+                    Array(parent(p.canopy.radiative_transfer.par.abs)) .==
+                    FT(0),
+                )
+                @test all(
+                    Array(parent(p.canopy.radiative_transfer.nir.abs)) .==
+                    FT(0),
+                )
+                @test all(
+                    Array(parent(p.canopy.autotrophic_respiration.Ra)) .==
+                    FT(0),
+                )
             end
         end
     end


### PR DESCRIPTION
## Purpose 
Some of our buildkite runs were not running on GPU. Update buildkite so that they are.

closes #860 

## Content
- Run tests on GPU (we thought we were doing this before but were not), and make some GPU-compatibility fixes
- Use Array(parent(...)) in tests for GPU compatibility.
This is required to enable GPU compatibility. Generally the pattern
`Array(parent(...))` is discouraged, but using it to check analytic
values in tests is okay.
- Add workaround to avoid type inference failure (initial bug described below)
This is required as a workaround to the type inference failure detailed 
in https://github.com/CliMA/ClimaCore.jl/issues/2065. The failure appears
when a function is broadcast over one field and two structs; the types
are too complex and inference fails. This workaround introduces a wrapper
struct to contain the two struct inputs, so that the function is broadcast
over one field and only one struct, and the types are easier to infer.

## Initial bug reported
1. Fix bug in `experiments/integrated/performance/profile_allocations.jl`. Note that the same code runs on the Clima cluster on GPU. This is the error message:
```
(base) [kdeck@hpc-22-32 ClimaLand.jl]$ julia --project=.buildkite  experiments/integrated/performance/profile_allocations.jl
[ Info: ProfileCanvas found, running with profiler
ERROR: LoadError: InvalidIRError: compiling MethodInstance for ClimaCoreCUDAExt.knl_copyto!(::ClimaCore.DataLayouts.VIJFH{Float64, 5, 2, 600, CUDA.CuDeviceArray{Float64, 5, 1}}, ::Base.Broadcast.Broadcasted{ClimaCore.DataLayouts.VIJFHStyle{5, 2, 600, CUDA.CuArray{Float64, N, CUDA.DeviceMemory} where N}, NTuple{5, Base.OneTo{Int64}}, typeof(ClimaCore.RecursiveApply.radd), Tuple{ClimaCore.DataLayouts.VIJFH{Float64, 5, 2, 600, CUDA.CuDeviceArray{Float64, 5, 1}}, Base.Broadcast.Broadcasted{ClimaCore.DataLayouts.VIJFHStyle{5, 2, 600, CUDA.CuArray{Float64, N, CUDA.DeviceMemory} where N}, Nothing, typeof(ClimaCore.RecursiveApply.rsub), Tuple{Base.Broadcast.Broadcasted{ClimaCore.DataLayouts.VIJFHStyle{5, 2, 600, CUDA.CuArray{Float64, N, CUDA.DeviceMemory} where N}, Nothing, typeof(phase_change_source), Tuple{ClimaCore.DataLayouts.VIJFH{Float64, 5, 2, 600, CUDA.CuDeviceArray{Float64, 5, 1}}, ClimaCore.DataLayouts.VIJFH{Float64, 5, 2, 600, CUDA.CuDeviceArray{Float64, 5, 1}}, ClimaCore.DataLayouts.VIJFH{Float64, 5, 2, 600, CUDA.CuDeviceArray{Float64, 5, 1}}, Base.Broadcast.Broadcasted{ClimaCore.DataLayouts.VIJFHStyle{5, 2, 600, CUDA.CuArray{Float64, N, CUDA.DeviceMemory} where N}, Nothing, typeof(thermal_time), Tuple{Base.Broadcast.Broadcasted{ClimaCore.DataLayouts.VIJFHStyle{5, 2, 600, CUDA.CuArray{Float64, N, CUDA.DeviceMemory} where N}, Nothing, typeof(volumetric_heat_capacity), Tuple{ClimaCore.DataLayouts.VIJFH{Float64, 5, 2, 600, CUDA.CuDeviceArray{Float64, 5, 1}}, ClimaCore.DataLayouts.VIJFH{Float64, 5, 2, 600, CUDA.CuDeviceArray{Float64, 5, 1}}, Float64, Tuple{ClimaLand.Parameters.LandParameters{Float64, Thermodynamics.Parameters.ThermodynamicsParameters{Float64}, SurfaceFluxes.Parameters.SurfaceFluxesParameters{Float64, SurfaceFluxes.UniversalFunctions.BusingerParams{Float64}, Thermodynamics.Parameters.ThermodynamicsParameters{Float64}}, Insolation.Parameters.InsolationParameters{Float64}}}}}, ClimaCore.DataLayouts.VIJFH{Float64, 5, 2, 600, SubArray{Float64, 5, CUDA.CuDeviceArray{Float64, 5, 1}, Tuple{Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}, UnitRange{Int64}, Base.Slice{Base.OneTo{Int64}}}, false}}, ClimaCore.DataLayouts.VIJFH{Float64, 5, 2, 600, CUDA.CuDeviceArray{Float64, 5, 1}}}}, Float64, Float64, Tuple{vanGenuchten{Float64}}, Tuple{ClimaLand.Parameters.LandParameters{Float64, Thermodynamics.Parameters.ThermodynamicsParameters{Float64}, SurfaceFluxes.Parameters.SurfaceFluxesParameters{Float64, SurfaceFluxes.UniversalFunctions.BusingerParams{Float64}, Thermodynamics.Parameters.ThermodynamicsParameters{Float64}}, Insolation.Parameters.InsolationParameters{Float64}}}}}}}}}) resulted in invalid LLVM IR
Reason: unsupported dynamic function invocation (call to getindex(t::Tuple, i::Int64) @ Base tuple.jl:31)
Stacktrace:
 [1] _getindex (repeats 7 times)
   @ ./broadcast.jl:705
 [2] _broadcast_getindex
   @ ./broadcast.jl:681
 [3] _getindex
   @ ./broadcast.jl:706
 [4] _broadcast_getindex
   @ ./broadcast.jl:681
 [5] _getindex
   @ ./broadcast.jl:706
 [6] _getindex
   @ ./broadcast.jl:705
 [7] _broadcast_getindex
   @ ./broadcast.jl:681
 [8] getindex
   @ ./broadcast.jl:636
 [9] knl_copyto!
   @ ~/.julia/packages/ClimaCore/Zoz8z/ext/cuda/data_layouts_copyto.jl:13
Reason: unsupported dynamic function invocation (call to matric_potential)
Stacktrace:
  [1] phase_change_source
    @ /central/home/kdeck/ClimaLand.jl/src/standalone/Soil/soil_heat_parameterizations.jl:65
```

 /central/home/kdeck/ClimaLand.jl/src/standalone/Soil/soil_heat_parameterizations.jl:65:
```
function phase_change_source(
    θ_l::FT,
    θ_i::FT,
    T::FT,
    τ::FT,
    ν::FT,
    θ_r::FT,
    hydrology_cm::C,
    earth_param_set::EP,
) where {FT, EP, C}
    _ρ_i = FT(LP.ρ_cloud_ice(earth_param_set))
    _ρ_l = FT(LP.ρ_cloud_liq(earth_param_set))
    _LH_f0 = FT(LP.LH_f0(earth_param_set))
    _T_freeze = FT(LP.T_freeze(earth_param_set))
    _grav = FT(LP.grav(earth_param_set))
    # According to Dall'Amico (text above equation 1), ψw0 corresponds
    # to the matric potential corresponding to the total water content (liquid and ice).
    θtot = min(_ρ_i / _ρ_l * θ_i + θ_l, ν)
    # This is consistent with Equation (22) of Dall'Amico
    ψw0 = matric_potential(hydrology_cm, effective_saturation(ν, θtot, θ_r)) # <---- Line 65

    ψT = _LH_f0 / _T_freeze / _grav * (T - _T_freeze) * heaviside(_T_freeze - T)
    # Equation (23) of Dall'Amico
    θstar = inverse_matric_potential(hydrology_cm, ψw0 + ψT) * (ν - θ_r) + θ_r

    return (θ_l - θstar) / τ
end
```

Called by:
```
    params = model.parameters
    (; ν, ρc_ds, θ_r, hydrology_cm, earth_param_set) = params
    _ρ_l = FT(LP.ρ_cloud_liq(earth_param_set))
    _ρ_i = FT(LP.ρ_cloud_ice(earth_param_set))
    Δz = model.domain.fields.Δz # center face distance
    @. dY.soil.ϑ_l +=
        -phase_change_source(
            p.soil.θ_l,
            Y.soil.θ_i,
            p.soil.T,
            thermal_time(
                volumetric_heat_capacity(
                    p.soil.θ_l,
                    Y.soil.θ_i,
                    ρc_ds,
                    earth_param_set,
                ),
                Δz,
                p.soil.κ,
            ),
            ν,
            θ_r,
            hydrology_cm,
            earth_param_set,
        )
```

Note that `typeof(hydrology_cm) <: AbstractSoilHydrologyClosure` and we have set `Base.broadcastable(x::AbstractSoilHydrologyClosure) = tuple(x)`


## Content



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
