### PR TITLE
Extend Vcmax to support SpaceVaryingInput

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,3 +1,6 @@
+[clm_data]
+git-tree-sha1 = "9d6f7207023958b74c1b2079cb29e4f17e19a196"
+
 [era5_land_forcing_data2021]
 git-tree-sha1 = "ec424296df6b60cfe273ac8f981701fbbed0bd8a"
 

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -369,7 +369,16 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     g1 = FT(141) # Wang et al: 141 sqrt(Pa) for Medlyn model; Natan used 300.
 
     #Photosynthesis model
-    Vcmax25 = FT(9e-5) # from Yujie's paper 4.5e-5 , Natan used 9e-5
+    clm_artifact_path = ClimaLand.Artifacts.clm_data_folder_path(; context)
+    # vcmax is read in units of umol CO2/m^2/s and then converted to mol CO2/m^2/s
+    Vcmax25 = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "vcmx25",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+        file_reader_kwargs = (; preprocess_func = (data) -> data / 1_000_000,),
+    )
 
     # Plant Hydraulics and general plant parameters
     SAI = FT(0.0) # m2/m2

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -369,7 +369,16 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     g1 = FT(141) # Wang et al: 141 sqrt(Pa) for Medlyn model; Natan used 300.
 
     #Photosynthesis model
-    Vcmax25 = FT(9e-5) # from Yujie's paper 4.5e-5 , Natan used 9e-5
+    clm_artifact_path = ClimaLand.Artifacts.clm_data_folder_path(; context)
+    # vcmax is read in units of umol CO2/m^2/s and then converted to mol CO2/m^2/s
+    Vcmax25 = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "vcmx25",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+        file_reader_kwargs = (; preprocess_func = (data) -> data / 1_000_000,),
+    )
 
     # Plant Hydraulics and general plant parameters
     SAI = FT(0.0) # m2/m2

--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -106,19 +106,19 @@ end
 
 """
     function FarquharParameters(
-        FT, 
+        FT,
         mechanism::AbstractPhotosynthesisMechanism;
         Vcmax25 = FT(5e-5),
         kwargs...  # For individual parameter overrides
     )
 
     function FarquharParameters(
-        toml_dict::CP.AbstractTOMLDict, 
+        toml_dict::CP.AbstractTOMLDict,
         mechanism::AbstractPhotosynthesisMechanism;
         Vcmax25 = FT(5e-5),
         kwargs...  # For individual parameter overrides
     )
-    
+
 Constructors for the FarquharParameters struct. Two variants:
 1. Pass in the float-type and retrieve parameter values from the default TOML dict.
 2. Pass in a TOML dictionary to retrieve parameter values.Possible calls:
@@ -183,7 +183,7 @@ end
     )
 
     function OptimalityFarquharParameters(
-        toml_dict::CP.AbstractTOMLDict, 
+        toml_dict::CP.AbstractTOMLDict,
         kwargs...  # For individual parameter overrides
     )
 
@@ -262,7 +262,7 @@ end
 EnergyHydrologyParameters has two constructors: float-type and toml dict based.
 Additional parameters must be added manually: ν, ν_ss_om, ν_ss_quartz, ν_ss_gravel, hydrology_cm, K_sat, S_s, and θ_r
 All parameters can be manually overriden via keyword arguments. Note, however,
-that certain parameters must have the same type (e.g, if a field is 
+that certain parameters must have the same type (e.g, if a field is
 supplied for porosity, it must be supplied for all other parameters
 defined in the interior of the domain). Some parameters are defined only
 on the surface of the domain (e.g albedo), while other are defined everywhere

--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -166,7 +166,9 @@ function FarquharParameters(
     parameters = CP.get_parameter_values(toml_dict, name_map, "Land")
     FT = CP.float_type(toml_dict)
     MECH = typeof(mechanism)
-    return FarquharParameters{FT, MECH}(;
+    Vcmax25 = FT.(Vcmax25)
+    VC = typeof(Vcmax25)
+    return FarquharParameters{FT, MECH, VC}(;
         mechanism,
         Vcmax25,
         parameters...,

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -15,6 +15,15 @@ function era5_land_forcing_data2021_folder_path(; context = nothing)
 end
 
 """
+    clm_data__folder_path(; context)
+
+Return the path to the folder that contains the clm data.
+"""
+function clm_data_folder_path(; context = nothing)
+    return @clima_artifact("clm_data", context)
+end
+
+"""
     soil_params_artifact_path(; context)
 
 Return the path to the folder that contains the soil parameters.

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -43,9 +43,9 @@ Return the path to the file that contains a year of fluxnet data
 corresponding to a `site_ID` in the set (US-MOz, US-NR1, US-Ha1, US-Var).
 
 Site publications and licenses:
-US-Ha1: 
+US-Ha1:
 
-Urbanski, S., Barford, C., Wofsy, S., Kucharik, C., Pyle, E., Budney, J., McKain, K., Fitzjarrald, D., Czikowsky, M., Munger, J. W. 2007. Factors Controlling CO2 Exchange On Timescales From Hourly To Decadal At Harvard Forest, Journal Of Geophysical Research, 112:G2, . 
+Urbanski, S., Barford, C., Wofsy, S., Kucharik, C., Pyle, E., Budney, J., McKain, K., Fitzjarrald, D., Czikowsky, M., Munger, J. W. 2007. Factors Controlling CO2 Exchange On Timescales From Hourly To Decadal At Harvard Forest, Journal Of Geophysical Research, 112:G2, .
 
 AmeriFlux FLUXNET: https://doi.org/10.17190/AMF/1871137
 Citation: J. William Munger (2022), AmeriFlux FLUXNET-1F US-Ha1 Harvard Forest EMS Tower (HFR1), Ver. 3-5, AmeriFlux AMP, (Dataset). https://doi.org/10.17190/AMF/1871137
@@ -54,7 +54,7 @@ AmeriFlux CC-BY-4.0 Policy
 
 US-MOz
 
-Gu, L., Pallardy, S. G., Yang, B., Hosman, K. P., Mao, J., Ricciuto, D., Shi, X., Sun, Y. 2016. Testing a Land Model In Ecosystem Functional Space via a Comparison of Observed and Modeled Ecosystem Responses to Precipitation Regimes and Associated Stresses in a Central U.S. Forest, Journal Of Geophysical Research: Biogeosciences, 121:7, 1884-1902. 
+Gu, L., Pallardy, S. G., Yang, B., Hosman, K. P., Mao, J., Ricciuto, D., Shi, X., Sun, Y. 2016. Testing a Land Model In Ecosystem Functional Space via a Comparison of Observed and Modeled Ecosystem Responses to Precipitation Regimes and Associated Stresses in a Central U.S. Forest, Journal Of Geophysical Research: Biogeosciences, 121:7, 1884-1902.
 
 AmeriFlux FLUXNET: https://doi.org/10.17190/AMF/1854370
 Citation: Jeffrey Wood, Lianhong Gu (2021), AmeriFlux FLUXNET-1F US-MOz Missouri Ozark Site, Ver. 3-5, AmeriFlux AMP, (Dataset). https://doi.org/10.17190/AMF/1854370
@@ -63,7 +63,7 @@ AmeriFlux CC-BY-4.0 Policy
 
 US-NR1
 
-Burns, S. P., Blanken, P. D., Turnipseed, A. A., Hu, J., Monson, R. K. 2015. The Influence Of Warm-Season Precipitation On The Diel Cycle Of The Surface Energy Balance And Carbon Dioxide At A Colorado Subalpine Forest Site, Biogeosciences, 12:23, 7349-7377. 
+Burns, S. P., Blanken, P. D., Turnipseed, A. A., Hu, J., Monson, R. K. 2015. The Influence Of Warm-Season Precipitation On The Diel Cycle Of The Surface Energy Balance And Carbon Dioxide At A Colorado Subalpine Forest Site, Biogeosciences, 12:23, 7349-7377.
 
 AmeriFlux FLUXNET: https://doi.org/10.17190/AMF/1871141
 Citation: Peter D. Blanken, Russel K. Monson, Sean P. Burns, David R. Bowling, Andrew A. Turnipseed (2022), AmeriFlux FLUXNET-1F US-NR1 Niwot Ridge Forest (LTER NWT1), Ver. 3-5, AmeriFlux AMP, (Dataset). https://doi.org/10.17190/AMF/1871141
@@ -186,7 +186,7 @@ end
 Returns the path to the file which contains the necessary information for the TOPMODEL
 runoff parameterization at 2.5 degrees resolution.
 
-This file was created with 
+This file was created with
 https://github.com/CliMA/ClimaLand.jl/blob/main/src/standalone/Soil/Runoff/preprocess_topographic_index_simple.jl
 
 using the data provided by
@@ -219,8 +219,8 @@ end
 Local path to file containing measured evaporation rate as a function of time
 for bare soil.
 
-Data was originally collected by Lehmann, Peter, Shmuel Assouline, 
-and Dani Or. "Characteristic lengths affecting evaporative drying of 
+Data was originally collected by Lehmann, Peter, Shmuel Assouline,
+and Dani Or. "Characteristic lengths affecting evaporative drying of
 porous media." Physical Review E 77.5 (2008): 056309 and presented
 in Figure 8 of that work.
 
@@ -243,13 +243,13 @@ end
 """
     huang_et_al2011_soil_van_genuchten_data(; context=nothing)
 
-Local path to file containing soil van Genuchten parameters as a 
+Local path to file containing soil van Genuchten parameters as a
 function of depth for soil
 from site SV62 in Fort McMurray, Alberta, Canada.
 
-Data was originally collected by Huang, Mingbin, et al. 
-"Infiltration and drainage processes in multi-layered coarse soils." 
-Canadian Journal of Soil Science 91.2 (2011): 169-183 
+Data was originally collected by Huang, Mingbin, et al.
+"Infiltration and drainage processes in multi-layered coarse soils."
+Canadian Journal of Soil Science 91.2 (2011): 169-183
 and presented in Table 1b of that work.
 
 https://doi.org/10.4141/cjss09118
@@ -268,18 +268,18 @@ end
 """
     mizoguchi1990_soil_freezing_data(; context=nothing)
 
-Local path to file containing soil volumetric content as a function 
-of depth and time during a freezing 
+Local path to file containing soil volumetric content as a function
+of depth and time during a freezing
 soil column experiment.
 
-Data was originally collected in Mizoguchi, M. 1990. Water, heat and 
-salt transport in freezing soil, Ph.D. thesis. (In Japanese.) 
+Data was originally collected in Mizoguchi, M. 1990. Water, heat and
+salt transport in freezing soil, Ph.D. thesis. (In Japanese.)
 University of Tokyo, Tokyo.
 
-Data was obtained by us from Figure 4 of Hansson, Klas, et al. 
-"Water flow and heat transport in frozen soil: Numerical solution 
-and freeze–thaw applications." Vadose Zone Journal 3.2 (2004): 693-704 
-using a plot digitizer; we did not quantify uncertainties introduced 
+Data was obtained by us from Figure 4 of Hansson, Klas, et al.
+"Water flow and heat transport in frozen soil: Numerical solution
+and freeze–thaw applications." Vadose Zone Journal 3.2 (2004): 693-704
+using a plot digitizer; we did not quantify uncertainties introduced
 in this process.
 """
 function mizoguchi1990_soil_freezing_data(; context = nothing)

--- a/src/standalone/Vegetation/photosynthesis.jl
+++ b/src/standalone/Vegetation/photosynthesis.jl
@@ -17,7 +17,11 @@ struct C4 <: AbstractPhotosynthesisMechanism end
 
 abstract type AbstractPhotosynthesisModel{FT} <: AbstractCanopyComponent{FT} end
 """
-    FarquharParameters{FT<:AbstractFloat, MECH <: AbstractPhotosynthesisMechanism}
+    FarquharParameters{
+        FT<:AbstractFloat,
+        MECH <: AbstractPhotosynthesisMechanism,
+        VC <: Union{FT, ClimaCore.Fields.Field},
+    }
 
 The required parameters for the Farquhar photosynthesis model.
 $(DocStringExtensions.FIELDS)
@@ -25,9 +29,10 @@ $(DocStringExtensions.FIELDS)
 Base.@kwdef struct FarquharParameters{
     FT <: AbstractFloat,
     MECH <: AbstractPhotosynthesisMechanism,
+    VC <: Union{FT, ClimaCore.Fields.Field},
 }
     "Vcmax at 25 °C (mol CO2/m^2/s)"
-    Vcmax25::FT
+    Vcmax25::VC
     "Γstar at 25 °C (mol/mol)"
     Γstar25::FT
     "Michaelis-Menten parameter for CO2 at 25 °C (mol/mol)"
@@ -93,26 +98,23 @@ function photosynthesis_at_a_point_Farquhar(
     c_co2,
     medlyn_factor,
     R,
-    parameters,
+    Vcmax25,
+    Γstar25,
+    ΔHJmax,
+    ΔHVcmax,
+    ΔHΓstar,
+    f,
+    ΔHRd,
+    To,
+    θj,
+    ϕ,
+    mechanism,
+    oi,
+    Kc25,
+    Ko25,
+    ΔHkc,
+    ΔHko,
 )
-    (;
-        Vcmax25,
-        Γstar25,
-        ΔHJmax,
-        ΔHVcmax,
-        ΔHΓstar,
-        f,
-        ΔHRd,
-        To,
-        θj,
-        ϕ,
-        mechanism,
-        oi,
-        Kc25,
-        Ko25,
-        ΔHkc,
-        ΔHko,
-    ) = parameters
     Jmax = max_electron_transport(Vcmax25, ΔHJmax, T, To, R)
     J = electron_transport(APAR, Jmax, θj, ϕ)
     Vcmax = compute_Vcmax(Vcmax25, T, To, R, ΔHVcmax)
@@ -156,8 +158,27 @@ function update_photosynthesis!(
     c_co2,
     R,
 )
-    (; Vcmax25, f, ΔHRd, To) = model.parameters
-
+    (;
+        Vcmax25,
+        f,
+        ΔHRd,
+        To,
+        Γstar25,
+        ΔHJmax,
+        ΔHVcmax,
+        ΔHΓstar,
+        f,
+        ΔHRd,
+        To,
+        θj,
+        ϕ,
+        mechanism,
+        oi,
+        Kc25,
+        Ko25,
+        ΔHkc,
+        ΔHko,
+    ) = model.parameters
     @. Rd = dark_respiration(Vcmax25, β, f, ΔHRd, T, To, R)
     @. An = photosynthesis_at_a_point_Farquhar(
         T,
@@ -167,7 +188,22 @@ function update_photosynthesis!(
         c_co2,
         medlyn_factor,
         R,
-        model.parameters,
+        Vcmax25,
+        Γstar25,
+        ΔHJmax,
+        ΔHVcmax,
+        ΔHΓstar,
+        f,
+        ΔHRd,
+        To,
+        θj,
+        ϕ,
+        mechanism,
+        oi,
+        Kc25,
+        Ko25,
+        ΔHkc,
+        ΔHko,
     )
     Vcmax25field .= Vcmax25
 end

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -22,10 +22,11 @@ import ClimaParams
 @testset "Canopy software pipes" begin
     for FT in (Float32, Float64)
         domain = Point(; z_sfc = FT(0.0))
-
+        # create new field with constant value everywhere
+        Vcmax25 = fill(FT(9e-5), domain.space.surface)
         AR_params = AutotrophicRespirationParameters(FT)
         RTparams = BeerLambertParameters(FT)
-        photosynthesis_params = FarquharParameters(FT, C3())
+        photosynthesis_params = FarquharParameters(FT, C3(); Vcmax25 = Vcmax25)
         stomatal_g_params = MedlynConductanceParameters(FT)
 
         AR_model = AutotrophicRespirationModel{FT}(AR_params)
@@ -515,9 +516,10 @@ end
 @testset "Canopy software pipes with energy model" begin
     for FT in (Float32, Float64)
         domain = Point(; z_sfc = FT(0.0))
-
+        # create new field with constant value everywhere
+        Vcmax25 = fill(FT(9e-5), domain.space.surface)
         RTparams = BeerLambertParameters(FT)
-        photosynthesis_params = FarquharParameters(FT, C3())
+        photosynthesis_params = FarquharParameters(FT, C3(); Vcmax25 = Vcmax25)
         stomatal_g_params = MedlynConductanceParameters(FT)
 
         stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
@@ -765,7 +767,8 @@ end
 @testset "Zero LAI;" begin
     for FT in (Float32, Float64)
         domain = Point(; z_sfc = FT(0.0))
-
+        # create new field with constant value everywhere
+        Vcmax25 = fill(FT(9e-5), domain.space.surface)
         BeerLambertparams = BeerLambertParameters(FT)
         # TwoStreamModel parameters
         Ω = FT(0.69)
@@ -787,7 +790,7 @@ end
             τ_NIR_leaf,
             G_Function,
         )
-        photosynthesis_params = FarquharParameters(FT, C3())
+        photosynthesis_params = FarquharParameters(FT, C3(); Vcmax25 = Vcmax25)
         stomatal_g_params = MedlynConductanceParameters(FT)
 
         stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

FarquharParameters now also supports Vcmax25 of type ClimaCore.Fields.Field. In relevant tests, Vcmax25 is changed from a float to a field that contains the previous Vcmax25 value everywhere. Both longrun and benchmark Land.jl now use the Vcmax map from clm_data.
Closes #723  

PR also contains whitespace removal.



## To-do
- Add VCmax map to ClimaArtifacts



## Content
- `FarquharParameters` takes a `Vcmax25` of type `F <: Union{<: AbstractFloat, ClimaCore.Field}`
- `Land.jl` benchmark and long run uses the vcmax map from clm_data. Map can be seen below. 
![vc](https://github.com/user-attachments/assets/68bf767f-b657-44b1-a6f2-561c315c676d)
- Relevant tests now use field of constant values for `Vcmax25`. 

### Example output of `experiments/long_runs/land.jl`
#### Previously:
![Day6Prev](https://github.com/user-attachments/assets/7f0b067a-3af2-47ca-a6cb-2965a28a29ba)
#### After changing Vcmax25 to the clm_data map:
![gpp_518400 0](https://github.com/user-attachments/assets/88c520e9-da20-4dba-9997-da177d359dee)




<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
