### PR TITLE
Fix ClimaCoupler downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -32,6 +32,16 @@ jobs:
         with:
           repository: 'CliMA/ClimaCoupler.jl'
           path: ClimaCoupler.jl
+
+        # Hash/links found in ClimaArtifacts
+        # TODO: Remove this when ClimaCoupler can provide a small collections of test files
+      - name: Create SST/SIC artifact folder
+        run: mkdir -p ~/.julia/artifacts/c4f82cd33fb26513ee45bff78330c6b606630fa5
+      - name: Download SST/SIC files
+        run: |
+          wget -q -O ~/.julia/artifacts/c4f82cd33fb26513ee45bff78330c6b606630fa5/MODEL.ICE.HAD187001-198110.OI198111-202206.nc https://gdex.ucar.edu/dataset/158_asphilli/file/MODEL.ICE.HAD187001-198110.OI198111-202206.nc
+          wget -q -O ~/.julia/artifacts/c4f82cd33fb26513ee45bff78330c6b606630fa5/MODEL.SST.HAD187001-198110.OI198111-202206.nc https://gdex.ucar.edu/dataset/158_asphilli/file/MODEL.SST.HAD187001-198110.OI198111-202206.nc
+
       - run: |
           julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ -e 'using Pkg; Pkg.instantiate()'
           julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ -e 'using Pkg; Pkg.develop(; path = ".")'


### PR DESCRIPTION
ClimaCoupler moved to using ClimaArtifacts for SST and SIC. Those are large files, so they are no longer atuomatically downloaded. This commits downloads them for the downstream test.

Hopefully, in the future, ClimaCoupler can provide a smaller dataset for tests
