### PR TITLE
Misc fixes to regional domain, long run scripts

### DIFF
--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -68,7 +68,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
         depth = depth,
         nelements = nelements,
         npolynomial = 1,
-        dz_tuple = FT.((10.0, 0.5)),# top layer should ideally be only a few cm!
+        dz_tuple = FT.((10.0, 0.05)),# top layer should ideally be only a few cm!
     )
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface

--- a/src/shared_utilities/Domains.jl
+++ b/src/shared_utilities/Domains.jl
@@ -235,7 +235,7 @@ Example: `longlat = (FT(-118.14452), FT(34.14778))`. `longlat` is in degrees, wi
 is not accounted for. We compute `xlim` and `ylim` as
 
 ```julia
-xlim = (long - xlim[1] / (2radius_earth), long + xlim[2] / (2radius_earth))
+xlim = (long - xlim[1] / (2π*radius_earth) * 360, long + xlim[2] / (2π*radius_earth) * 360)
 ```
 """
 function Plane(;
@@ -271,11 +271,13 @@ function Plane(;
         dylim = ylim # lat bounds
         # Now make x refer to lat, and y refer to long,
         # for compatibility with ClimaCore
-        xlim =
-            (lat - dylim[1] / (2radius_earth), lat + dylim[2] / (2radius_earth))
+        xlim = (
+            lat - dylim[1] / FT(2π * radius_earth) * 360,
+            lat + dylim[2] / FT(2π * radius_earth) * 360,
+        )
         ylim = (
-            long - dxlim[1] / (2radius_earth),
-            long + dxlim[2] / (2radius_earth),
+            long - dxlim[1] / FT(2π * radius_earth) * 360,
+            long + dxlim[2] / FT(2π * radius_earth) * 360,
         )
         @assert xlim[1] < xlim[2]
         @assert ylim[1] < ylim[2]
@@ -390,7 +392,7 @@ globe centered around the `long` and `lat`. In this case, the radius of Earth is
 assumed to be `6.378e6` meters and curvature is not included. We compute `xlim` and `ylim` as
 
 ```julia
-xlim = (long - xlim[1] / (2radius_earth), long + xlim[2] / (2radius_earth))
+xlim = (long - xlim[1] / (2π*radius_earth) * 360, long + xlim[2] / (2π*radius_earth) * 360)
 ```
 
 Using `ClimaCore` tools, the coordinate

--- a/test/shared_utilities/domains.jl
+++ b/test/shared_utilities/domains.jl
@@ -177,12 +177,12 @@ FT = Float32
     longlat = (FT(-118.14452), FT(34.14778))
     radius_earth = FT(6.378e6)
     xlim_longlat = (
-        longlat[2] - dylim[1] / 2radius_earth,
-        longlat[2] + dylim[2] / 2radius_earth,
+        longlat[2] - dylim[1] / FT(2π * radius_earth) * 360,
+        longlat[2] + dylim[2] / FT(2π * radius_earth) * 360,
     )
     ylim_longlat = (
-        longlat[1] - dxlim[1] / 2radius_earth,
-        longlat[1] + dxlim[2] / 2radius_earth,
+        longlat[1] - dxlim[1] / FT(2π * radius_earth) * 360,
+        longlat[1] + dxlim[2] / FT(2π * radius_earth) * 360,
     )
 
     longlat_plane = Plane(;


### PR DESCRIPTION
## Purpose 
- We should convert from meters D to degrees as: D/(2piR_earth)*360
- Increase resolution in soil model in land long runs
- g1 spatially varying in land_region


## To-do



## Content
Update Domains.jl and test
g1 spatially varying in land_region.jl
dz_tuple -> (10, 0.05) in land.jl and land_region.jl

## Results

On the cluster, we have for the long land.jl run with dz_top = 5cm:
![swc_3 1536e7](https://github.com/user-attachments/assets/43beb4a6-9dbf-4809-acfd-5c6035adeaed)

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
