### PR TITLE
LAI lower threshold for nonzero LAI

### DIFF
--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -473,21 +473,12 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
         )
     )
     # Set up plant hydraulics
-    # Note that we clip all values of LAI below 0.05 to zero.
-    # This is because we currently run into issues when LAI is
-    # of order eps(FT) in the SW radiation code.
-    # Please see Issue #644
-    # or PR #645 for details.
-    # For now, this clipping is similar to what CLM does.
     LAIfunction = TimeVaryingInput(
         joinpath(era5_artifact_path, "era5_lai_2021_0.9x1.25_clima.nc"),
         "lai",
         surface_space;
         reference_date = start_date,
         regridder_type,
-        file_reader_kwargs = (;
-            preprocess_func = (data) -> data > 0.05 ? data : 0.0,
-        ),
     )
     ai_parameterization =
         Canopy.PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -226,16 +226,12 @@ photosynthesis_args = (;
     parameters = Canopy.FarquharParameters(FT, Canopy.C3(); Vcmax25 = Vcmax25)
 )
 # Set up plant hydraulics
-# Not ideal
 LAIfunction = TimeVaryingInput(
     joinpath(era5_artifact_path, "era5_lai_2021_0.9x1.25_clima.nc"),
     "lai",
     surface_space;
     reference_date = start_date,
     regridder_type,
-    file_reader_kwargs = (;
-        preprocess_func = (data) -> data > 0.05 ? data : 0.0,
-    ),
 )
 ai_parameterization = Canopy.PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
 

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -483,21 +483,12 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     )
     # Set up plant hydraulics
 
-    # Note that we clip all values of LAI below 0.05 to zero.
-    # This is because we currently run into issues when LAI is
-    # of order eps(FT) in the SW radiation code.
-    # Please see Issue #644
-    # or PR #645 for details.
-    # For now, this clipping is similar to what CLM does.
     LAIfunction = TimeVaryingInput(
         joinpath(era5_artifact_path, "era5_lai_2021_0.9x1.25_clima.nc"),
         "lai",
         surface_space;
         reference_date = start_date,
         regridder_type,
-        file_reader_kwargs = (;
-            preprocess_func = (data) -> data > 0.05 ? data : 0.0,
-        ),
         method = time_interpolation_method,
     )
     ai_parameterization =

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -68,7 +68,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
         depth = depth,
         nelements = nelements,
         npolynomial = 1,
-        dz_tuple = FT.((10.0, 0.05)),# top layer should ideally be only a few cm!
+        dz_tuple = FT.((10.0, 0.05)),
     )
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -483,21 +483,12 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
     )
     # Set up plant hydraulics
 
-    # Note that we clip all values of LAI below 0.05 to zero.
-    # This is because we currently run into issues when LAI is
-    # of order eps(FT) in the SW radiation code.
-    # Please see Issue #644
-    # or PR #645 for details.
-    # For now, this clipping is similar to what CLM does.
     LAIfunction = TimeVaryingInput(
         joinpath(era5_artifact_path, "era5_lai_2021_0.9x1.25_clima.nc"),
         "lai",
         surface_space;
         reference_date = start_date,
         regridder_type,
-        file_reader_kwargs = (;
-            preprocess_func = (data) -> data > 0.05 ? data : 0.0,
-        ),
         method = time_interpolation_method,
     )
     ai_parameterization =

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -623,7 +623,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
         start_date;
         output_writer = nc_writer,
         output_vars = :short,
-        average_period = :monthly,
+        average_period = :daily,
     )
 
     diagnostic_handler =
@@ -638,7 +638,7 @@ end
 function setup_and_solve_problem(; greet = false)
 
     t0 = 0.0
-    tf = 60 * 60.0 * 24 * 365
+    tf = 60 * 60.0 * 24 * 30
     Δt = 900.0
     nelements = (10, 10, 15)
     if greet

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -623,7 +623,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
         start_date;
         output_writer = nc_writer,
         output_vars = :short,
-        average_period = :daily,
+        average_period = :monthly,
     )
 
     diagnostic_handler =
@@ -638,7 +638,7 @@ end
 function setup_and_solve_problem(; greet = false)
 
     t0 = 0.0
-    tf = 60 * 60.0 * 24 * 30
+    tf = 60 * 60.0 * 24 * 365
     Δt = 900.0
     nelements = (10, 10, 15)
     if greet

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -316,6 +316,13 @@ end
 
 Sets the canopy prescribed fields pertaining to the PlantHydraulics
 component (the area indices) with their values at time t.
+
+Note that we clip all values of LAI below 0.05 to zero.
+This is because we currently run into issues when LAI is
+of order eps(FT) in the SW radiation code.
+Please see Issue #644
+or PR #645 for details.
+For now, this clipping is similar to what CLM and NOAH MP do.
 """
 function ClimaLand.Canopy.set_canopy_prescribed_field!(
     component::PlantHydraulicsModel{FT},

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -304,7 +304,9 @@ ClimaLand.auxiliary_types(model::PlantHydraulicsModel{FT}) where {FT} = (
 ClimaLand.auxiliary_domain_names(::PlantHydraulicsModel) =
     (:surface, :surface, :surface, :surface, :surface)
 
-
+function clip(x::FT, threshold::FT) where {FT}
+    x > threshold ? x : FT(0)
+end
 """
     set_canopy_prescribed_field!(component::PlantHydraulics{FT},
                                  p,
@@ -322,6 +324,8 @@ function ClimaLand.Canopy.set_canopy_prescribed_field!(
 ) where {FT}
     (; LAIfunction, SAI, RAI) = component.parameters.ai_parameterization
     evaluate!(p.canopy.hydraulics.area_index.leaf, LAIfunction, floor(t))
+    p.canopy.hydraulics.area_index.leaf .=
+        clip.(p.canopy.hydraulics.area_index.leaf, FT(0.05))
     @. p.canopy.hydraulics.area_index.stem = SAI
     @. p.canopy.hydraulics.area_index.root = RAI
 end

--- a/test/shared_utilities/domains.jl
+++ b/test/shared_utilities/domains.jl
@@ -43,7 +43,7 @@ FT = Float32
     face_space = obtain_face_space(shell.space.subsurface)
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     @test shell.fields.z_sfc == top_face_to_surface(z_face, shell.space.surface)
-    Δz_top, Δz_bottom = get_Δz(shell.fields.z)
+    Δz_top, Δz_bottom, Δz = get_Δz(shell.fields.z)
     @test shell.fields.Δz_top == Δz_top
     @test shell.fields.Δz_bottom == Δz_bottom
     @test shell.radius == radius
@@ -109,7 +109,7 @@ FT = Float32
     face_space = obtain_face_space(box.space.subsurface)
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     @test box.fields.z_sfc == top_face_to_surface(z_face, box.space.surface)
-    Δz_top, Δz_bottom = get_Δz(box.fields.z)
+    Δz_top, Δz_bottom, Δz = get_Δz(box.fields.z)
     @test box.fields.Δz_top == Δz_top
     @test box.fields.Δz_bottom == Δz_bottom
     box_coords = coordinates(box).subsurface
@@ -260,7 +260,9 @@ FT = Float32
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     @test z_column.fields.z_sfc ==
           top_face_to_surface(z_face, z_column.space.surface)
-    Δz_top, Δz_bottom = get_Δz(z_column.fields.z)
+    Δz_top, Δz_bottom, Δz = get_Δz(z_column.fields.z)
+    z = ClimaCore.Fields.coordinate_field(z_column.space.subsurface).z
+    @test z_column.fields.z == z
     @test z_column.fields.Δz_top == Δz_top
     @test z_column.fields.Δz_bottom == Δz_bottom
     column_coords = coordinates(z_column).subsurface

--- a/test/shared_utilities/domains.jl
+++ b/test/shared_utilities/domains.jl
@@ -43,7 +43,7 @@ FT = Float32
     face_space = obtain_face_space(shell.space.subsurface)
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     @test shell.fields.z_sfc == top_face_to_surface(z_face, shell.space.surface)
-    Δz_top, Δz_bottom, Δz = get_Δz(shell.fields.z)
+    Δz_top, Δz_bottom = get_Δz(shell.fields.z)
     @test shell.fields.Δz_top == Δz_top
     @test shell.fields.Δz_bottom == Δz_bottom
     @test shell.radius == radius
@@ -109,7 +109,7 @@ FT = Float32
     face_space = obtain_face_space(box.space.subsurface)
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     @test box.fields.z_sfc == top_face_to_surface(z_face, box.space.surface)
-    Δz_top, Δz_bottom, Δz = get_Δz(box.fields.z)
+    Δz_top, Δz_bottom = get_Δz(box.fields.z)
     @test box.fields.Δz_top == Δz_top
     @test box.fields.Δz_bottom == Δz_bottom
     box_coords = coordinates(box).subsurface
@@ -260,9 +260,7 @@ FT = Float32
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     @test z_column.fields.z_sfc ==
           top_face_to_surface(z_face, z_column.space.surface)
-    Δz_top, Δz_bottom, Δz = get_Δz(z_column.fields.z)
-    z = ClimaCore.Fields.coordinate_field(z_column.space.subsurface).z
-    @test z_column.fields.z == z
+    Δz_top, Δz_bottom = get_Δz(z_column.fields.z)
     @test z_column.fields.Δz_top == Δz_top
     @test z_column.fields.Δz_bottom == Δz_bottom
     column_coords = coordinates(z_column).subsurface

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -498,7 +498,10 @@ end
         set_canopy_prescribed_field!(plant_hydraulics, p, FT(200))
         @test all(
             Array(parent(p.canopy.hydraulics.area_index.leaf)) .==
-            FT(LAI * sin(200 * 2π / 365)),
+            ClimaLand.Canopy.PlantHydraulics.clip(
+                FT(LAI * sin(200 * 2π / 365)),
+                FT(0.05),
+            ),
         )
 
         set_canopy_prescribed_field!(Default{FT}(), p, t0)
@@ -506,7 +509,10 @@ end
         # Test that they are unchanged
         @test all(
             parent(p.canopy.hydraulics.area_index.leaf) .==
-            FT(LAI * sin(200 * 2π / 365)),
+            ClimaLand.Canopy.PlantHydraulics.clip(
+                FT(LAI * sin(200 * 2π / 365)),
+                FT(0.05),
+            ),
         )
         @test all(
             Array(parent(p.canopy.hydraulics.area_index.stem)) .== FT(1.0),


### PR DESCRIPTION
## Purpose 
We set LAI to be zero if it is below 0.05. This is what CLM does. 

Do we need to do this? Our fluxes should tend to zero as LAI -> 0, and our tendency for the canopy temperature is a sum of fluxes/max(LAI*height of canopy, eps(FT)). Therefore, for small LAI, everything should be well behaved.  That said, there was a roundoff bug for very small LAI: https://github.com/CliMA/ClimaLand.jl/issues/645, and, empirically, small values of LAI leads to NaNs (see below). 

I had thought our clipping of LAI was happening in the TimeVaryingInput preprocessfunction, but that is applied prior to any linear interpolation. This could cause issues near the coastline and also inland in regions where LAI is very small

While it would be good to understand the issues at small LAI better, this PR makes it so we are doing what we already thought we are doing. 
## To-do



## Content
Previous Main:
![image](https://github.com/user-attachments/assets/6e4f5aa5-7e59-4cb2-bdcc-fcb9bf66e16f)

After fix:
![image](https://github.com/user-attachments/assets/97506a19-c44b-4ef4-9a95-f8108749abfe)


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
