### PR TITLE
Generalize runoff fn to take any input rather than hardcoded to P_liq

### DIFF
--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -421,7 +421,7 @@ function soil_boundary_fluxes!(
 ) where {FT}
     bc = soil.boundary_conditions.top
     p.soil.turbulent_fluxes .= turbulent_fluxes(bc.atmos, soil, Y, p, t)
-    Soil.Runoff.update_runoff!(p, bc.runoff, Y, t, soil)
+    Soil.Runoff.update_runoff!(p, bc.runoff, p.drivers.P_liq, Y, t, soil)
     @. p.soil.top_bc.water =
         p.soil.infiltration + p.soil.turbulent_fluxes.vapor_flux_liq
     @. p.soil.top_bc.heat =

--- a/src/standalone/Soil/Runoff/Runoff.jl
+++ b/src/standalone/Soil/Runoff/Runoff.jl
@@ -61,13 +61,13 @@ struct NoRunoff <: AbstractRunoffModel
 end
 
 """
-    update_runoff!(p, runoff::NoRunoff, _...)
+    update_runoff!(p, runoff::NoRunoff, input, _...)
 
 Updates the runoff variables in the cache `p.soil` in place
 in the case of NoRunoff: sets infiltration = precipitation.
 """
-function update_runoff!(p, runoff::NoRunoff, _...)
-    p.soil.infiltration .= p.drivers.P_liq
+function update_runoff!(p, runoff::NoRunoff, input, _...)
+    p.soil.infiltration .= input
 end
 
 runoff_vars(::NoRunoff) = (:infiltration,)
@@ -112,6 +112,7 @@ end
     update_runoff!(
         p,
         runoff::SurfaceRunoff,
+        input,
         Y,
         t,
         model::AbstractSoilModel,
@@ -128,6 +129,7 @@ p.soil.infiltration
 function update_runoff!(
     p,
     runoff::SurfaceRunoff,
+    input,
     Y,
     t,
     model::AbstractSoilModel,
@@ -142,9 +144,8 @@ function update_runoff!(
     is_saturated_sfc =
         ClimaLand.Domains.top_center_to_surface(p.soil.is_saturated) # a view
 
-    @. p.soil.infiltration =
-        surface_infiltration(ic, p.drivers.P_liq, is_saturated_sfc)
-    @. p.soil.R_s = abs(p.drivers.P_liq .- p.soil.infiltration)
+    @. p.soil.infiltration = surface_infiltration(ic, input, is_saturated_sfc)
+    @. p.soil.R_s = abs(input .- p.soil.infiltration)
 end
 
 runoff_vars(::SurfaceRunoff) =
@@ -204,7 +205,7 @@ end
 
 
 """
-    update_runoff!(p, runoff::TOPMODELRunoff, Y,t, model::AbstractSoilModel)
+    update_runoff!(p, runoff::TOPMODELRunoff, input, Y,t, model::AbstractSoilModel)
 
 Updates the runoff model variables in place in `p.soil` for the TOPMODELRunoff
 parameterization:
@@ -216,6 +217,7 @@ p.soil.infiltration
 function update_runoff!(
     p,
     runoff::TOPMODELRunoff,
+    input,
     Y,
     t,
     model::AbstractSoilModel,
@@ -239,9 +241,9 @@ function update_runoff!(
         runoff.f_over,
         model.domain.fields.depth - p.soil.h∇,
         ic,
-        precip,
+        input,
     )
-    @. p.soil.R_s = abs(precip - p.soil.infiltration)
+    @. p.soil.R_s = abs(input - p.soil.infiltration)
 
 end
 

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -198,7 +198,7 @@ function boundary_flux(
     p::NamedTuple,
     t,
 )::ClimaCore.Fields.Field
-    update_runoff!(p, bc.runoff, Y, t, model)
+    update_runoff!(p, bc.runoff, p.drivers.P_liq, Y, t, model)
     return p.soil.infiltration
 end
 
@@ -763,7 +763,7 @@ function soil_boundary_fluxes!(
 )
     p.soil.turbulent_fluxes .= turbulent_fluxes(bc.atmos, model, Y, p, t)
     p.soil.R_n .= net_radiation(bc.radiation, model, Y, p, t)
-    update_runoff!(p, bc.runoff, Y, t, model)
+    update_runoff!(p, bc.runoff, p.drivers.P_liq, Y, t, model)
     # We do not model the energy flux from infiltration.
     @. p.soil.top_bc.water =
         p.soil.infiltration + p.soil.turbulent_fluxes.vapor_flux_liq


### PR DESCRIPTION
## Purpose 
Our runoff function was hardcoded to compute runoff using P_liq as the liquid water reaching the soil. This generalizes it to use any input flux (which could be P_liq for bare soil). However, when snow is melting, the input flux reaching the soil should be P_liq + Melt. For soil under canopy, we at some point will compute interception, and then the flux reaching the soil surface would be P_liq - Interception.


## To-do


## Content
Pass in the input 

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
