### PR TITLE
Consistent naming for radiation, land properties for radiation

### DIFF
--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -396,12 +396,12 @@ else
     )
 end
 
-# SW_OUT
-SW_out_model = [parent(sv.saveval[k].SW_out)[1] for k in 1:length(sv.saveval)]
+# Upwelling shortwave radiation - referred to as "outgoing" in the data
+SW_u_model = [parent(sv.saveval[k].SW_u)[1] for k in 1:length(sv.saveval)]
 if drivers.SW_OUT.status == absent
     plot_daily_avg(
-        "SW OUT",
-        SW_out_model,
+        "SW_up",
+        SW_u_model,
         dt_save,
         num_days,
         "w/m^2",
@@ -409,14 +409,14 @@ if drivers.SW_OUT.status == absent
         "model",
     )
 else
-    SW_out_data = FT.(drivers.SW_OUT.values)[Int64(t_spinup ÷ DATA_DT):Int64(
+    SW_u_data = FT.(drivers.SW_OUT.values)[Int64(t_spinup ÷ DATA_DT):Int64(
         tf ÷ DATA_DT,
     )]
     plot_avg_comp(
-        "SW OUT",
-        SW_out_model,
+        "SW up",
+        SW_u_model,
         dt_save,
-        SW_out_data,
+        SW_u_data,
         FT(DATA_DT),
         num_days,
         drivers.SW_OUT.units,
@@ -424,12 +424,12 @@ else
     )
 end
 
-# LW_OUT
-LW_out_model = [parent(sv.saveval[k].LW_out)[1] for k in 1:length(sv.saveval)]
+# Upwelling longwave radiation - referred to as "outgoing" in the data
+LW_u_model = [parent(sv.saveval[k].LW_u)[1] for k in 1:length(sv.saveval)]
 if drivers.LW_OUT.status == absent
     plot_daily_avg(
-        "LW OUT",
-        LW_out_model,
+        "LW up",
+        LW_u_model,
         dt_save,
         num_days,
         "w/m^2",
@@ -437,14 +437,14 @@ if drivers.LW_OUT.status == absent
         "model",
     )
 else
-    LW_out_data = FT.(drivers.LW_OUT.values)[Int64(t_spinup ÷ DATA_DT):Int64(
+    LW_u_data = FT.(drivers.LW_OUT.values)[Int64(t_spinup ÷ DATA_DT):Int64(
         tf ÷ DATA_DT,
     )]
     plot_avg_comp(
-        "LW OUT",
-        LW_out_model,
+        "LW up",
+        LW_u_model,
         dt_save,
-        LW_out_data,
+        LW_u_data,
         FT(DATA_DT),
         num_days,
         drivers.LW_OUT.units,

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -340,12 +340,12 @@ else
     )
 end
 
-# SW_OUT
-SW_out_model = [parent(sv.saveval[k].SW_out)[1] for k in 1:length(sv.saveval)]
+# Upwelling shortwave radiation is referred to as outgoing in the data
+SW_u_model = [parent(sv.saveval[k].SW_u)[1] for k in 1:length(sv.saveval)]
 if drivers.SW_OUT.status == absent
     plot_daily_avg(
-        "SW OUT",
-        SW_out_model,
+        "SW up",
+        SW_u_model,
         dt_save,
         num_days,
         "w/m^2",
@@ -353,14 +353,14 @@ if drivers.SW_OUT.status == absent
         "model",
     )
 else
-    SW_out_data = FT.(drivers.SW_OUT.values)[Int64(t_spinup ÷ DATA_DT):Int64(
+    SW_u_data = FT.(drivers.SW_OUT.values)[Int64(t_spinup ÷ DATA_DT):Int64(
         tf ÷ DATA_DT,
     )]
     plot_avg_comp(
-        "SW OUT",
-        SW_out_model,
+        "SW up",
+        SW_u_model,
         dt_save,
-        SW_out_data,
+        SW_u_data,
         FT(DATA_DT),
         num_days,
         drivers.SW_OUT.units,
@@ -368,12 +368,12 @@ else
     )
 end
 
-# LW_OUT
-LW_out_model = [parent(sv.saveval[k].LW_out)[1] for k in 1:length(sv.saveval)]
+# Upwelling longwave radiation is referred to outgoing in the data
+LW_u_model = [parent(sv.saveval[k].LW_u)[1] for k in 1:length(sv.saveval)]
 if drivers.LW_OUT.status == absent
     plot_daily_avg(
-        "LW OUT",
-        LW_out_model,
+        "LW up",
+        LW_u_model,
         dt_save,
         num_days,
         "w/m^2",
@@ -381,14 +381,14 @@ if drivers.LW_OUT.status == absent
         "model",
     )
 else
-    LW_out_data = FT.(drivers.LW_OUT.values)[Int64(t_spinup ÷ DATA_DT):Int64(
+    LW_u_data = FT.(drivers.LW_OUT.values)[Int64(t_spinup ÷ DATA_DT):Int64(
         tf ÷ DATA_DT,
     )]
     plot_avg_comp(
-        "LW OUT",
-        LW_out_model,
+        "LW up",
+        LW_u_model,
         dt_save,
-        LW_out_data,
+        LW_u_data,
         FT(DATA_DT),
         num_days,
         drivers.LW_OUT.units,

--- a/experiments/long_runs/bucket.jl
+++ b/experiments/long_runs/bucket.jl
@@ -166,7 +166,7 @@ setup_and_solve_problem(; greet = true);
 #### ClimaAnalysis ####
 simdir = ClimaAnalysis.SimDir(outdir)
 short_names =
-    ["alpha", "rn", "tsfc", "qsfc", "lhf", "shf", "wsoil", "wsfc", "ssfc"]
+    ["swa", "rn", "tsfc", "qsfc", "lhf", "shf", "wsoil", "wsfc", "ssfc"]
 for short_name in short_names
     var = get(simdir; short_name)
     times = ClimaAnalysis.times(var)

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -583,7 +583,7 @@ setup_and_solve_problem(; greet = true);
 # read in diagnostics and make some plots!
 #### ClimaAnalysis ####
 simdir = ClimaAnalysis.SimDir(outdir)
-short_names = ["gpp", "ct", "lai", "swc", "si", "swo", "lwo", "et", "er", "sr"]
+short_names = ["gpp", "ct", "lai", "swc", "si", "swa", "lwu", "et", "er", "sr"]
 for short_name in short_names
     var = get(simdir; short_name)
     times = ClimaAnalysis.times(var)

--- a/experiments/standalone/Bucket/global_bucket_function.jl
+++ b/experiments/standalone/Bucket/global_bucket_function.jl
@@ -193,7 +193,7 @@ sol = ClimaComms.@time ClimaComms.device() SciMLBase.solve(
 # all
 simdir = ClimaAnalysis.SimDir(output_dir)
 short_names_2D = [
-    "alpha",
+    "swa",
     "rn",
     "tsfc",
     "qsfc",

--- a/experiments/standalone/Vegetation/no_vegetation.jl
+++ b/experiments/standalone/Vegetation/no_vegetation.jl
@@ -217,11 +217,11 @@ resp = [
     parent(sv.saveval[k].canopy.autotrophic_respiration.Ra)[1] * 1e6 for
     k in 1:length(sol.t)
 ]
-SW_abs = [
+SW_n = [
     parent(sv.saveval[k].canopy.radiative_transfer.SW_n)[1] for
     k in 1:length(sol.t)
 ]
-LW_abs = [
+LW_n = [
     parent(sv.saveval[k].canopy.radiative_transfer.LW_n)[1] for
     k in 1:length(sol.t)
 ]
@@ -249,8 +249,8 @@ axislegend(ax)
 save(joinpath(savedir, "no_veg_state.png"), fig)
 fig2 = Figure()
 ax = Axis(fig2[1, 1], xlabel = "Time (days)", ylabel = "Energy Fluxes")
-lines!(ax, sol.t ./ 24 ./ 3600, SW_abs, label = "SW")
-lines!(ax, sol.t ./ 24 ./ 3600, LW_abs, label = "LW")
+lines!(ax, sol.t ./ 24 ./ 3600, SW_n, label = "SW")
+lines!(ax, sol.t ./ 24 ./ 3600, LW_n, label = "LW")
 lines!(ax, sol.t ./ 24 ./ 3600, SHF, label = "SHF")
 lines!(ax, sol.t ./ 24 ./ 3600, LHF, label = "LHF")
 lines!(ax, sol.t ./ 24 ./ 3600, RE, label = "RE")

--- a/experiments/standalone/Vegetation/varying_lai.jl
+++ b/experiments/standalone/Vegetation/varying_lai.jl
@@ -217,11 +217,11 @@ resp = [
     parent(sv.saveval[k].canopy.autotrophic_respiration.Ra)[1] * 1e6 for
     k in 1:length(sol.t)
 ]
-SW_abs = [
+SW_n = [
     parent(sv.saveval[k].canopy.radiative_transfer.SW_n)[1] for
     k in 1:length(sol.t)
 ]
-LW_abs = [
+LW_n = [
     parent(sv.saveval[k].canopy.radiative_transfer.LW_n)[1] for
     k in 1:length(sol.t)
 ]
@@ -249,8 +249,8 @@ axislegend(ax)
 save(joinpath(savedir, "varying_lai_state.png"), fig)
 fig2 = Figure()
 ax = Axis(fig2[1, 1], xlabel = "Time (days)", ylabel = "Energy Fluxes")
-lines!(ax, sol.t ./ 24 ./ 3600, SW_abs, label = "SW")
-lines!(ax, sol.t ./ 24 ./ 3600, LW_abs, label = "LW")
+lines!(ax, sol.t ./ 24 ./ 3600, SW_n, label = "SW_n")
+lines!(ax, sol.t ./ 24 ./ 3600, LW_n, label = "LW_n")
 lines!(ax, sol.t ./ 24 ./ 3600, SHF, label = "SHF")
 lines!(ax, sol.t ./ 24 ./ 3600, LHF, label = "LHF")
 lines!(ax, sol.t ./ 24 ./ 3600, RE, label = "RE")

--- a/experiments/standalone/Vegetation/varying_lai_with_stem.jl
+++ b/experiments/standalone/Vegetation/varying_lai_with_stem.jl
@@ -225,11 +225,11 @@ resp = [
     parent(sv.saveval[k].canopy.autotrophic_respiration.Ra)[1] * 1e6 for
     k in 1:length(sol.t)
 ]
-SW_abs = [
+SW_n = [
     parent(sv.saveval[k].canopy.radiative_transfer.SW_n)[1] for
     k in 1:length(sol.t)
 ]
-LW_abs = [
+LW_n = [
     parent(sv.saveval[k].canopy.radiative_transfer.LW_n)[1] for
     k in 1:length(sol.t)
 ]
@@ -260,8 +260,8 @@ axislegend(ax)
 save(joinpath(savedir, "varying_lai_with_stem_state.png"), fig)
 fig2 = Figure()
 ax = Axis(fig2[1, 1], xlabel = "Time (days)", ylabel = "Energy Fluxes")
-lines!(ax, sol.t ./ 24 ./ 3600, SW_abs, label = "SW")
-lines!(ax, sol.t ./ 24 ./ 3600, LW_abs, label = "LW")
+lines!(ax, sol.t ./ 24 ./ 3600, SW_n, label = "SW_n")
+lines!(ax, sol.t ./ 24 ./ 3600, LW_n, label = "LW_n")
 lines!(ax, sol.t ./ 24 ./ 3600, SHF, label = "SHF")
 lines!(ax, sol.t ./ 24 ./ 3600, LHF, label = "LHF")
 lines!(ax, sol.t ./ 24 ./ 3600, RE, label = "RE")

--- a/lib/ClimaLandSimulations/src/utilities/climaland_output_dataframe.jl
+++ b/lib/ClimaLandSimulations/src/utilities/climaland_output_dataframe.jl
@@ -8,7 +8,7 @@ By default, get output from sv.saveval, but user can specify e.g., result = sol.
 By default, get surface value, but user can specify depth for e.g., soil temperature
 
 example 1: 
-julia> getoutput(sv, 1, :SW_out)
+julia> getoutput(sv, 1, :SW_u)
 
 example 2: 
 julia> getoutput(sv, 1, :canopy, :conductance, :gs)
@@ -30,7 +30,7 @@ function getoutput(
 end
 
 """
-    make_output_df(sv, inputs)
+    make_ouput_df(sv, inputs)
 
 Return a dataframe containing climaland outputs
 """
@@ -43,8 +43,8 @@ function make_output_df(
 )
     # List of output that we want
     output_list = vcat(
-        (1, :SW_out),
-        (1, :LW_out),
+        (1, :SW_u),
+        (1, :LW_u),
         (1, :canopy, :conductance, :gs),
         (1, :canopy, :conductance, :transpiration),
         (1, :canopy, :autotrophic_respiration, :Ra),

--- a/lib/ClimaLandSimulations/src/utilities/makie_plots.jl
+++ b/lib/ClimaLandSimulations/src/utilities/makie_plots.jl
@@ -18,7 +18,7 @@ export timeseries_fluxes_fig,
 # 9. Wavelet coherence
 # to do in another script: animations
 
-# 1. Time series of GPP, ET and SW_OUT
+# 1. Time series of GPP, ET and SW_u
 function timeseries_fluxes_fig(
     inputs,
     climaland,
@@ -43,10 +43,8 @@ function timeseries_fluxes_fig(
         ylabel = L"\text{GPP} \, (\mu\text{mol m}^{-2} \, \text{s}^{-1})",
     ) # C fluxes
     ax_W = Axis(fig[2, 1], ylabel = L"\text{ET (mm)}") # h2o fluxes
-    ax_SWOUT = Axis(
-        fig[3, 1],
-        ylabel = L"\text{SW OUT} \, (\text{W} \, \text{m}^{-2})",
-    ) # shortwave out
+    ax_SW_up =
+        Axis(fig[3, 1], ylabel = L"\text{SW up} \, (\text{W} \, \text{m}^{-2})") # shortwave up
     # ax_T = Axis(fig[4, 1]) # air, canopy, and soil temperature
 
     # for time series, CairoMakie should allow DateTime type soon (but not yet)
@@ -84,15 +82,15 @@ function timeseries_fluxes_fig(
         color = :black,
     ) # not sure units
 
-    # ax_SW_OUT
-    p_SWOUT_m = lines!(
-        ax_SWOUT,
+    # ax_SW_up
+    p_SW_up_m = lines!(
+        ax_SW_up,
         datetime2unix.(climaland.DateTime),
-        climaland.SW_out,
+        climaland.SW_u,
         color = :blue,
     )
-    p_SWOUT_d = lines!(
-        ax_SWOUT,
+    p_SW_up_d = lines!(
+        ax_SW_up,
         datetime2unix.(inputs.DateTime[index_t_start:index_t_end]),
         inputs.SW_OUT[index_t_start:index_t_end],
         color = :black,
@@ -103,7 +101,7 @@ function timeseries_fluxes_fig(
         (datetime2unix.(dateticks), Dates.format.(dateticks, "mm/dd"))
     ax_W.xticks[] =
         (datetime2unix.(dateticks), Dates.format.(dateticks, "mm/dd"))
-    ax_SWOUT.xticks[] =
+    ax_SW_up.xticks[] =
         (datetime2unix.(dateticks), Dates.format.(dateticks, "mm/dd"))
 
     axislegend(
@@ -117,7 +115,7 @@ function timeseries_fluxes_fig(
 
     ylims!(ax_C, (0, 40))
     ylims!(ax_W, (0, 30))
-    ylims!(ax_SWOUT, (0, 200))
+    ylims!(ax_SW_up, (0, 200))
 
     [
         xlims!(
@@ -126,7 +124,7 @@ function timeseries_fluxes_fig(
                 datetime2unix(climaland.DateTime[1]),
                 datetime2unix(climaland.DateTime[end]),
             ),
-        ) for axes in [ax_C, ax_W, ax_SWOUT]
+        ) for axes in [ax_C, ax_W, ax_SW_up]
     ]
 
     fig
@@ -237,7 +235,7 @@ function timeseries_H2O_fig(
 
     #ylims!(ax_C, (0, 40))
     #ylims!(ax_W, (0, 30))
-    #ylims!(ax_SWOUT, (0, 200))
+    #ylims!(ax_SW_up, (0, 200))
 
     [
         xlims!(
@@ -407,7 +405,7 @@ function diurnals_fig(inputs, climaland, earth_param_set; dashboard = false) # w
         ylabel = L"\text{Radiation} \, (\text{W} \, \text{m}^{-2})",
         xlabel = L"\text{Hour of the day}",
         xgridvisible = false,
-    ) # shortwave out
+    ) # shortwave up
 
     # CO2 fluxes
     # model
@@ -464,11 +462,11 @@ function diurnals_fig(inputs, climaland, earth_param_set; dashboard = false) # w
 
     # Energy fluxes
     # model
-    # diurnal_plot!(fig, ax_E, climaland.DateTime, climaland.LW_out, :red)
-    p_SWout_m =
-        diurnal_plot!(fig, ax_E, climaland.DateTime, climaland.SW_out, :red)
+    # diurnal_plot!(fig, ax_E, climaland.DateTime, climaland.LW_u, :red)
+    p_SW_up_m =
+        diurnal_plot!(fig, ax_E, climaland.DateTime, climaland.SW_u, :red)
     # data
-    p_SWout_d = diurnal_plot!(
+    p_SW_up_d = diurnal_plot!(
         fig,
         ax_E,
         inputs.DateTime[index_t_start:index_t_end],
@@ -506,8 +504,8 @@ function diurnals_fig(inputs, climaland, earth_param_set; dashboard = false) # w
     )
     axislegend(
         ax_E,
-        [p_SWout_d, p_SWout_m],
-        ["SWout obs.", "SWout model"],
+        [p_SW_up_d, p_SW_up_m],
+        ["SWup obs.", "SWup model"],
         "",
         position = :rt,
         orientation = :vertical,

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -60,7 +60,7 @@ function default_diagnostics(
     define_diagnostics!(land_model)
 
     bucket_diagnostics = [
-        "alpha",
+        "swa",
         "rn",
         "tsfc",
         "qsfc",
@@ -114,6 +114,7 @@ function default_diagnostics(
 
     if output_vars == :long
         soilcanopy_diagnostics = [
+            "swa",
             "sif",
             "ra",
             "gs",
@@ -169,15 +170,15 @@ function default_diagnostics(
             # "pwc", # return a Tuple
             "si",
             "sie",
-            "swo",
-            "lwo",
+            "swu",
+            "lwu",
             "er",
             "et",
             "sr",
         ]
     elseif output_vars == :short
         soilcanopy_diagnostics =
-            ["gpp", "ct", "lai", "swc", "si", "swo", "lwo", "et", "er", "sr"]
+            ["gpp", "ct", "lai", "swc", "si", "swa", "lwu", "et", "er", "sr"]
     end
 
     if average_period == :hourly

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -10,14 +10,15 @@ function define_diagnostics!(land_model)
 
     ## Stored in p (diagnostics variables stored in the cache) ##
 
-    # Albedo
+    # Shortwave Albedo
     add_diagnostic_variable!(
-        short_name = "alpha",
-        long_name = "Albedo",
-        standard_name = "albedo",
+        short_name = "swa",
+        long_name = "Shortwave Albedo",
+        standard_name = "sw_albedo",
         units = "",
-        comments = "The fraction of incoming radiation reflected by the land surface.",
-        compute! = (out, Y, p, t) -> compute_albedo!(out, Y, p, t, land_model),
+        comments = "The fraction of downwelling shortwave radiation reflected by the land surface.",
+        compute! = (out, Y, p, t) ->
+            compute_sw_albedo!(out, Y, p, t, land_model),
     )
 
     # Net radiation
@@ -26,7 +27,7 @@ function define_diagnostics!(land_model)
         long_name = "Net Radiation",
         standard_name = "net_radiation",
         units = "W m^-2",
-        comments = "Difference between incoming and outgoing shortwave and longwave radiation at the land surface.",
+        comments = "Difference between downwelling and upwelling shortwave and longwave radiation at the land surface.",
         compute! = (out, Y, p, t) ->
             compute_net_radiation!(out, Y, p, t, land_model),
     )
@@ -486,7 +487,7 @@ function define_diagnostics!(land_model)
         long_name = "Net Longwave Radiation",
         standard_name = "net_longwave_radiation",
         units = "W m^-2",
-        comments = "The net (in minus out) longwave radiation at the surface.",
+        comments = "The net (down minus up) longwave radiation at the surface.",
         compute! = (out, Y, p, t) ->
             compute_radiation_longwave_net!(out, Y, p, t, land_model),
     )
@@ -497,7 +498,7 @@ function define_diagnostics!(land_model)
         long_name = "Net Shortwave Radiation",
         standard_name = "net_shortwave_radiation",
         units = "W m^-2",
-        comments = "The net (in minus out) shortwave radiation at the surface.",
+        comments = "The net (down minus up) shortwave radiation at the surface.",
         compute! = (out, Y, p, t) ->
             compute_radiation_shortwave_net!(out, Y, p, t, land_model),
     )
@@ -542,7 +543,7 @@ function define_diagnostics!(land_model)
         long_name = "Down Longwave Radiation",
         standard_name = "down_longwave_radiation",
         units = "W m^-2",
-        comments = "The down (in) longwave radiation at the surface.",
+        comments = "The downwelling longwave radiation at the surface.",
         compute! = (out, Y, p, t) ->
             compute_radiation_longwave_down!(out, Y, p, t, land_model),
     )
@@ -553,7 +554,7 @@ function define_diagnostics!(land_model)
         long_name = "Short Longwave Radiation",
         standard_name = "short_longwave_radiation",
         units = "W m^-2",
-        comments = "The short (in) longwave radiation at the surface.",
+        comments = "The downwelling shortwave radiation at the surface.",
         compute! = (out, Y, p, t) ->
             compute_radiation_shortwave_down!(out, Y, p, t, land_model),
     )
@@ -729,22 +730,22 @@ function define_diagnostics!(land_model)
     ## Other ##
     # Longwave out
     add_diagnostic_variable!(
-        short_name = "lwo",
-        long_name = "Longwave Radiation Out",
-        standard_name = "longwave radiation out",
+        short_name = "lwu",
+        long_name = "Longwave Radiation Up",
+        standard_name = "longwave_radiation_up",
         units = "W m^-2",
-        comments = "Longwave radiation going out of the land surface.",
-        compute! = (out, Y, p, t) -> compute_lw_out!(out, Y, p, t, land_model),
+        comments = "Upwelling longwave radiation.",
+        compute! = (out, Y, p, t) -> compute_lw_up!(out, Y, p, t, land_model),
     )
 
     # Shortwave out
     add_diagnostic_variable!(
-        short_name = "swo",
-        long_name = "Shortwave Radiation Out",
-        standard_name = "shortwave radiation out",
+        short_name = "swu",
+        long_name = "Shortwave Radiation Up",
+        standard_name = "shortwave_radiation_up",
         units = "W m^-2",
-        comments = "Shortwave radiation going out of the land surface.",
-        compute! = (out, Y, p, t) -> compute_sw_out!(out, Y, p, t, land_model),
+        comments = "Upwelling shortwave radiation",
+        compute! = (out, Y, p, t) -> compute_sw_up!(out, Y, p, t, land_model),
     )
 
     # Evapotranspiration

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -46,7 +46,7 @@ end
 
 # variables stored in p (diagnostics variables stored in the cache)
 @diagnostic_compute "aerodynamic_resistance" BucketModel p.bucket.turbulent_fluxes.r_ae
-@diagnostic_compute "albedo" BucketModel p.bucket.α_sfc
+@diagnostic_compute "sw_albedo" BucketModel p.bucket.α_sfc
 @diagnostic_compute "latent_heat_flux" BucketModel p.bucket.turbulent_fluxes.lhf
 @diagnostic_compute "net_radiation" BucketModel p.bucket.R_n
 @diagnostic_compute "sensible_heat_flux" BucketModel p.bucket.turbulent_fluxes.shf
@@ -159,9 +159,9 @@ end # Convert from kg C to mol CO2.
 @diagnostic_compute "soilco2_source_microbe" SoilCanopyModel p.soilco2.Sm
 
 ## Other ##
-
-@diagnostic_compute "lw_out" SoilCanopyModel p.LW_out
-@diagnostic_compute "sw_out" SoilCanopyModel p.SW_out
+@diagnostic_compute "sw_albedo" SoilCanopyModel p.α_sfc
+@diagnostic_compute "lw_up" SoilCanopyModel p.LW_u
+@diagnostic_compute "sw_up" SoilCanopyModel p.SW_u
 @diagnostic_compute "surface_runoff" SoilCanopyModel p.soil.R_s
 
 function compute_evapotranspiration!(


### PR DESCRIPTION
## Purpose 
Address inconsistencies in naming for radiation: upwelling/downwelling vs in/out

Store the albedo, emissivity, and effective temperature of the land

Partially addresses OKR2.3.8

## To-do



## Content
We now follow the convention everywhere:
- downwelling "_d" fluxes are positive if down
- upwelling "_u" fluxes are positive if up
- store alpha_sfc, epsilon_sfc, and T_sfc in the cache. These are computed using SW_u, SW_d, LW_u, and the Stefan-Boltzmann constant.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
