### PR TITLE
Extend plant hydraulics rooting depth to support fields

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,8 +9,6 @@ main
 v0.15.0
 --------
 - Add regional simulation example PR [#757](https://github.com/CliMA/ClimaLand.jl/pull/757)
-- ![][badge-💥breaking] Extend photosynthesis mechanism parameter to support fields.
-  PR[#774](https://github.com/CliMA/ClimaLand.jl/pull/774)
 - Reduced number of dependencies, leading to faster instantiation and import time,
 - Improved compatibility of ClimaLand with older versions of packages.
   PR[#749](https://github.com/CliMA/ClimaLand.jl/pull/749)
@@ -19,6 +17,9 @@ v0.15.0
   PR[#759](https://github.com/CliMA/ClimaLand.jl/pull/759)
 - Added a regional run example.
   PR[#757](https://github.com/CliMA/ClimaLand.jl/pull/757)
+- ![breaking change][badge-💥breaking] Extend photosynthesis mechanism parameter to support fields.
+PR[#774](https://github.com/CliMA/ClimaLand.jl/pull/774)
+  - C3/C4 structs are removed. Now C3 is represented by a float of 1.0 and C4 by a float of 0.0
 
 v0.14.3
 --------

--- a/deprecated_features.md
+++ b/deprecated_features.md
@@ -1,0 +1,9 @@
+# Deprecated Features List
+
+This file lists deprecated features and the recommended alternative practice
+
+- ## `root_distribution`
+
+    The `root_distribution` in `PlantHydraulicsParameters` is replaced by `rooting_depth`.
+    If using a `root_distribution` function of the form P(x) = 1/d e^(z/d), then `rooting_depth`
+    is equivalent to d.

--- a/docs/tutorials/integrated/soil_canopy_tutorial.jl
+++ b/docs/tutorials/integrated/soil_canopy_tutorial.jl
@@ -239,9 +239,6 @@ K_sat_plant = FT(1.8e-8)
 RAI = (SAI + maxLAI) * f_root_to_shoot;
 # Note: LAIfunction was determined from data in the script we included above.
 ai_parameterization = PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
-function root_distribution(z::T; rooting_depth = FT(1.0)) where {T}
-    return T(1.0 / rooting_depth) * exp(z / T(rooting_depth)) # 1/m
-end
 
 ψ63 = FT(-4 / 0.0098)
 Weibull_param = FT(4)
@@ -259,7 +256,7 @@ plant_hydraulics_ps = PlantHydraulics.PlantHydraulicsParameters(;
     ai_parameterization = ai_parameterization,
     ν = plant_ν,
     S_s = plant_S_s,
-    root_distribution = root_distribution,
+    rooting_depth = FT(1.0),
     conductivity_model = conductivity_model,
     retention_model = retention_model,
 )

--- a/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -197,11 +197,6 @@ ai_parameterization =
     PrescribedSiteAreaIndex{FT}(TimeVaryingInput(LAIfunction), SAI, RAI)
 rooting_depth = FT(1.0);
 
-# Define the root distribution function p(z):
-
-function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
-    return T(1.0 / rooting_depth) * exp(z / T(rooting_depth))
-end;
 
 # Create the component conductivity and retention models of the hydraulics
 # model. In ClimaLand, a Weibull parameterization is used for the conductivity as
@@ -226,7 +221,7 @@ plant_hydraulics_ps = PlantHydraulics.PlantHydraulicsParameters(;
     ai_parameterization = ai_parameterization,
     ν = ν,
     S_s = S_s,
-    root_distribution = root_distribution,
+    rooting_depth = rooting_depth,
     conductivity_model = conductivity_model,
     retention_model = retention_model,
 );

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -403,7 +403,7 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     plant_ν = FT(1.44e-4)
     plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
     rooting_depth = SpaceVaryingInput(
-        joinpath(clm_artifact_path, "root_map.nc"),
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "rooting_depth",
         surface_space;
         regridder_type,

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -402,7 +402,13 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     retention_model = Canopy.PlantHydraulics.LinearRetentionCurve{FT}(a)
     plant_ν = FT(1.44e-4)
     plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
-    rooting_depth = FT(0.5) # from Natan
+    rooting_depth = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "root_map.nc"),
+        "rooting_depth",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
     n_stem = 0
     n_leaf = 1
     h_stem = FT(0.0)

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -486,15 +486,11 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     ai_parameterization =
         Canopy.PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
 
-    function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
-        return T(1.0 / rooting_depth) * exp(z / T(rooting_depth)) # 1/m
-    end
-
     plant_hydraulics_ps = Canopy.PlantHydraulics.PlantHydraulicsParameters(;
         ai_parameterization = ai_parameterization,
         ν = plant_ν,
         S_s = plant_S_s,
-        root_distribution = root_distribution,
+        rooting_depth = rooting_depth,
         conductivity_model = conductivity_model,
         retention_model = retention_model,
     )

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -190,15 +190,11 @@ photosynthesis_args =
 # Set up plant hydraulics
 ai_parameterization = PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
 
-function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
-    return T(1.0 / rooting_depth) * exp(z / T(rooting_depth)) # 1/m
-end
-
 plant_hydraulics_ps = PlantHydraulics.PlantHydraulicsParameters(;
     ai_parameterization = ai_parameterization,
     ν = plant_ν,
     S_s = plant_S_s,
-    root_distribution = root_distribution,
+    rooting_depth = rooting_depth,
     conductivity_model = conductivity_model,
     retention_model = retention_model,
 )

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -147,15 +147,11 @@ photosynthesis_args =
 # Set up plant hydraulics
 ai_parameterization = PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
 
-function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
-    return T(1.0 / rooting_depth) * exp(z / T(rooting_depth)) # 1/m
-end
-
 plant_hydraulics_ps = PlantHydraulics.PlantHydraulicsParameters(;
     ai_parameterization = ai_parameterization,
     ν = plant_ν,
     S_s = plant_S_s,
-    root_distribution = root_distribution,
+    rooting_depth = rooting_depth,
     conductivity_model = conductivity_model,
     retention_model = retention_model,
 )

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -235,15 +235,11 @@ LAIfunction = TimeVaryingInput(
 )
 ai_parameterization = Canopy.PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
 
-function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
-    return T(1.0 / rooting_depth) * exp(z / T(rooting_depth)) # 1/m
-end
-
 plant_hydraulics_ps = Canopy.PlantHydraulics.PlantHydraulicsParameters(;
     ai_parameterization = ai_parameterization,
     ν = plant_ν,
     S_s = plant_S_s,
-    root_distribution = root_distribution,
+    rooting_depth = rooting_depth,
     conductivity_model = conductivity_model,
     retention_model = retention_model,
 )

--- a/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
+++ b/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
@@ -135,15 +135,11 @@ photosynthesis_args =
 # Set up plant hydraulics
 ai_parameterization = PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
 
-function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
-    return T(1.0 / rooting_depth) * exp(z / T(rooting_depth)) # 1/m
-end
-
 plant_hydraulics_ps = PlantHydraulics.PlantHydraulicsParameters(;
     ai_parameterization = ai_parameterization,
     ν = plant_ν,
     S_s = plant_S_s,
-    root_distribution = root_distribution,
+    rooting_depth = rooting_depth,
     conductivity_model = conductivity_model,
     retention_model = retention_model,
 )

--- a/experiments/integrated/performance/profile_allocations.jl
+++ b/experiments/integrated/performance/profile_allocations.jl
@@ -271,14 +271,11 @@ photosynthesis_args =
     (; parameters = FarquharParameters(FT, is_c3; Vcmax25 = Vcmax25))
 # Set up plant hydraulics
 ai_parameterization = PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
-function root_distribution(z::T) where {T}
-    return T(1.0 / 0.5 * exp(z / 0.5)) # 1/m
-end
 plant_hydraulics_ps = PlantHydraulics.PlantHydraulicsParameters(;
     ai_parameterization = ai_parameterization,
     ν = plant_ν,
     S_s = plant_S_s,
-    root_distribution = root_distribution,
+    rooting_depth = FT(0.5),
     conductivity_model = conductivity_model,
     retention_model = retention_model,
 )

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -411,7 +411,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     plant_ν = FT(1.44e-4)
     plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
     rooting_depth = SpaceVaryingInput(
-        joinpath(clm_artifact_path, "root_map.nc"),
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "rooting_depth",
         surface_space;
         regridder_type,

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -410,7 +410,13 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     retention_model = Canopy.PlantHydraulics.LinearRetentionCurve{FT}(a)
     plant_ν = FT(1.44e-4)
     plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
-    rooting_depth = FT(0.5) # from Natan
+    rooting_depth = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "root_map.nc"),
+        "rooting_depth",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
     n_stem = 0
     n_leaf = 1
     h_stem = FT(0.0)

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -496,15 +496,11 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     ai_parameterization =
         Canopy.PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
 
-    function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
-        return T(1.0 / rooting_depth) * exp(z / T(rooting_depth)) # 1/m
-    end
-
     plant_hydraulics_ps = Canopy.PlantHydraulics.PlantHydraulicsParameters(;
         ai_parameterization = ai_parameterization,
         ν = plant_ν,
         S_s = plant_S_s,
-        root_distribution = root_distribution,
+        rooting_depth = rooting_depth,
         conductivity_model = conductivity_model,
         retention_model = retention_model,
     )

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -412,7 +412,13 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
     retention_model = Canopy.PlantHydraulics.LinearRetentionCurve{FT}(a)
     plant_ν = FT(1.44e-4)
     plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
-    rooting_depth = FT(0.5) # from Natan
+    rooting_depth = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "root_map.nc"),
+        "rooting_depth",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
     n_stem = 0
     n_leaf = 1
     h_stem = FT(0.0)

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -498,15 +498,11 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
     ai_parameterization =
         Canopy.PrescribedSiteAreaIndex{FT}(LAIfunction, SAI, RAI)
 
-    function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
-        return T(1.0 / rooting_depth) * exp(z / T(rooting_depth)) # 1/m
-    end
-
     plant_hydraulics_ps = Canopy.PlantHydraulics.PlantHydraulicsParameters(;
         ai_parameterization = ai_parameterization,
         ν = plant_ν,
         S_s = plant_S_s,
-        root_distribution = root_distribution,
+        rooting_depth = rooting_depth,
         conductivity_model = conductivity_model,
         retention_model = retention_model,
     )

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -413,7 +413,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
     plant_ν = FT(1.44e-4)
     plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
     rooting_depth = SpaceVaryingInput(
-        joinpath(clm_artifact_path, "root_map.nc"),
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "rooting_depth",
         surface_space;
         regridder_type,

--- a/experiments/standalone/Vegetation/no_vegetation.jl
+++ b/experiments/standalone/Vegetation/no_vegetation.jl
@@ -108,10 +108,6 @@ ai_parameterization =
     PrescribedSiteAreaIndex{FT}(TimeVaryingInput(fakeLAIfunction), SAI, RAI)
 rooting_depth = FT(1.0);
 
-function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
-    return T(1.0 / rooting_depth) * exp(z / T(rooting_depth))
-end;
-
 K_sat_plant = FT(1.8e-8)
 ψ63 = FT(-4 / 0.0098)
 Weibull_param = FT(4)
@@ -129,7 +125,7 @@ plant_hydraulics_ps = PlantHydraulics.PlantHydraulicsParameters(;
     ai_parameterization = ai_parameterization,
     ν = ν,
     S_s = S_s,
-    root_distribution = root_distribution,
+    rooting_depth = rooting_depth,
     conductivity_model = conductivity_model,
     retention_model = retention_model,
 );

--- a/experiments/standalone/Vegetation/varying_lai.jl
+++ b/experiments/standalone/Vegetation/varying_lai.jl
@@ -108,10 +108,6 @@ ai_parameterization =
     PrescribedSiteAreaIndex{FT}(TimeVaryingInput(fakeLAIfunction), SAI, RAI)
 rooting_depth = FT(1.0);
 
-function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
-    return T(1.0 / rooting_depth) * exp(z / T(rooting_depth))
-end;
-
 K_sat_plant = FT(1.8e-8)
 ψ63 = FT(-4 / 0.0098)
 Weibull_param = FT(4)
@@ -129,7 +125,7 @@ plant_hydraulics_ps = PlantHydraulics.PlantHydraulicsParameters(;
     ai_parameterization = ai_parameterization,
     ν = ν,
     S_s = S_s,
-    root_distribution = root_distribution,
+    rooting_depth = rooting_depth,
     conductivity_model = conductivity_model,
     retention_model = retention_model,
 );

--- a/experiments/standalone/Vegetation/varying_lai_with_stem.jl
+++ b/experiments/standalone/Vegetation/varying_lai_with_stem.jl
@@ -107,10 +107,6 @@ ai_parameterization =
     PrescribedSiteAreaIndex{FT}(TimeVaryingInput(fakeLAIfunction2), SAI, RAI)
 rooting_depth = FT(1.0);
 
-function root_distribution(z::T; rooting_depth = rooting_depth) where {T}
-    return T(1.0 / rooting_depth) * exp(z / T(rooting_depth))
-end;
-
 K_sat_plant = FT(1.8e-6)
 ψ63 = FT(-4 / 0.0098)
 Weibull_param = FT(4)
@@ -128,7 +124,7 @@ plant_hydraulics_ps = PlantHydraulics.PlantHydraulicsParameters(;
     ai_parameterization = ai_parameterization,
     ν = ν,
     S_s = S_s,
-    root_distribution = root_distribution,
+    rooting_depth = rooting_depth,
     conductivity_model = conductivity_model,
     retention_model = retention_model,
 );

--- a/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
@@ -154,18 +154,12 @@ function run_fluxnet(
         drivers.RAI,
     )
 
-    function root_distribution(
-        z::T;
-        rooting_depth = params.plant_hydraulics.rooting_depth,
-    ) where {T}
-        return T(1.0 / rooting_depth) * exp(z / T(rooting_depth)) # 1/m
-    end
 
     plant_hydraulics_ps = PlantHydraulics.PlantHydraulicsParameters(;
         ai_parameterization = ai_parameterization,
         ν = drivers.plant_ν,
         S_s = params.plant_hydraulics.S_s,
-        root_distribution = root_distribution,
+        rooting_depth = params.plant_hydraulics.rooting_depth,
         conductivity_model = params.plant_hydraulics.conductivity_model,
         retention_model = params.plant_hydraulics.retention_model,
     )

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -261,7 +261,11 @@ function make_update_boundary_fluxes(
         # Note that in `PrescribedSoil` mode, we compute the flux using K_soil = K_plant(ψ_soil)
         # and K_canopy = K_plant(ψ_canopy). In `PrognosticSoil` mode here, we compute the flux using
         # K_soil = K_soil(ψ_soil) and K_canopy = K_plant(ψ_canopy).
-
+        # if rooting_depth param is not nothing, use root_distribution from source
+        # otherwise use root_distribution from params
+        root_likelihood(z::FT, rd::Union{FT, Nothing}) =
+            !isnothing(rd) ? root_distribution(z, rd) :
+            model.parameters.root_distribution(z)
         @. p.root_extraction =
             above_ground_area_index *
             PlantHydraulics.water_flux(
@@ -275,7 +279,7 @@ function make_update_boundary_fluxes(
                     p.canopy.hydraulics.ψ.:1,
                 ),
             ) *
-            (ClimaLand.Canopy.PlantHydraulics.root_distribution(
+            (root_likelihood(
                 z,
                 land.canopy.hydraulics.parameters.rooting_depth,
             ))

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -224,7 +224,7 @@ lsm_aux_domain_names(m::SoilCanopyModel) =
 A method which makes a function; the returned function
 updates the additional auxiliary variables for the integrated model,
 as well as updates the boundary auxiliary variables for all component
-models. 
+models.
 
 This function is called each ode function evaluation, prior to the tendency function
 evaluation.
@@ -275,7 +275,10 @@ function make_update_boundary_fluxes(
                     p.canopy.hydraulics.ψ.:1,
                 ),
             ) *
-            (land.canopy.hydraulics.parameters.root_distribution(z))
+            (ClimaLand.Canopy.PlantHydraulics.root_distribution(
+                z,
+                land.canopy.hydraulics.parameters.rooting_depth,
+            ))
         @. p.root_energy_extraction =
             p.root_extraction * ClimaLand.Soil.volumetric_internal_energy_liq(
                 p.soil.T,

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -157,24 +157,42 @@ function PlantHydraulicsParameters(;
     ai_parameterization::PrescribedSiteAreaIndex{FT},
     ν::FT,
     S_s::FT,
-    rooting_depth::Union{FT, ClimaCore.Fields.Field},
+    rooting_depth::Union{Nothing, FT, ClimaCore.Fields.Field} = nothing,
+    root_distribution::Union{Nothing, Function} = nothing,
     conductivity_model,
     retention_model,
 ) where {FT}
-    return PlantHydraulicsParameters{
-        FT,
-        typeof(ai_parameterization),
-        typeof(conductivity_model),
-        typeof(retention_model),
-        typeof(rooting_depth),
-    }(
-        ai_parameterization,
-        ν,
-        S_s,
-        conductivity_model,
-        retention_model,
-        rooting_depth,
-    )
+    if root_distribution isa Nothing
+        return PlantHydraulicsParameters{
+            FT,
+            typeof(ai_parameterization),
+            typeof(conductivity_model),
+            typeof(retention_model),
+            typeof(rooting_depth),
+        }(
+            ai_parameterization,
+            ν,
+            S_s,
+            conductivity_model,
+            retention_model,
+            rooting_depth,
+        )
+    else
+        return PlantHydraulicsParameters{
+            FT,
+            typeof(ai_parameterization),
+            typeof(conductivity_model),
+            typeof(retention_model),
+            FT,
+        }(
+            ai_parameterization,
+            ν,
+            S_s,
+            conductivity_model,
+            retention_model,
+            FT(1.0 / root_distribution(0.0)),
+        )
+    end
 end
 
 """

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -374,15 +374,15 @@ end
 """
     root_distribution(z::FT, rooting_depth::FT)
 
-Computes value of rooting probabilty density function at `z`.
+Computes value of rooting probability density function at `z`.
 
-The rooting probabilty density function is derived from the
-cumulative distribution function F(z) = 1 - beta^(100z), which is described
+The rooting probability density function is derived from the
+cumulative distribution function F(z) = 1 - β^(100z), which is described
 by Equation 2.23 of
 Bonan, "Climate Change and Terrestrial Ecosystem Modeling", 2019 Cambridge University Press.
 This probability distribution function is equivalent to the derivative of the
 cumulative distribution function with respect to z,
-where `rooting_depth` replaces (-1)/(100ln(beta)).
+where `rooting_depth` replaces (-1)/(100ln(β)) and z is expected to be negative.
 """
 function root_distribution(z::FT, rooting_depth::FT) where {FT <: AbstractFloat}
     return (1 / rooting_depth) * exp(z / rooting_depth) # 1/m

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -187,7 +187,7 @@ function PlantHydraulicsParameters(;
             )
         else
             Base.depwarn(
-                "root_distribution keyword argument is deprecated",
+                "root_distribution keyword argument is deprecated. Use rooting_depth instead.",
                 :PlantHydraulicsParameters,
             )
         end

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -153,6 +153,18 @@ struct PlantHydraulicsParameters{
     rooting_depth::RD
 end
 
+"""
+    PlantHydraulicsParameters(;
+        ai_parameterization::PrescribedSiteAreaIndex{FT},
+        ν::FT,
+        S_s::FT,
+        rooting_depth::Union{FT, ClimaCore.Fields.Field},
+        conductivity_model,
+        retention_model,
+    )
+
+Constructor for PlantHydraulicsParameters.
+"""
 function PlantHydraulicsParameters(;
     ai_parameterization::PrescribedSiteAreaIndex{FT},
     ν::FT,

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -149,7 +149,7 @@ struct PlantHydraulicsParameters{
     conductivity_model::CP
     "Water retention model and parameters"
     retention_model::RP
-    "Rooting depth parameter (m) - used to calculate root_distribution"
+    "Rooting depth parameter (m) - a characteristic depth below which 1/e of the root mass lies"
     rooting_depth::RD
 end
 
@@ -374,10 +374,18 @@ end
 """
     root_distribution(z::FT, rooting_depth::FT)
 
-Compute value of rooting probabilty density function at `z`
+Computes value of rooting probabilty density function at `z`.
+
+The rooting probabilty density function is derived from the
+cumulative distribution function F(z) = 1 - beta^(100z), which is described
+by Equation 2.23 of
+Bonan, "Climate Change and Terrestrial Ecosystem Modeling", 2019 Cambridge University Press.
+This probability distribution function is equivalent to the derivative of the
+cumulative distribution function with respect to z,
+where `rooting_depth` replaces (-1)/(100ln(beta)).
 """
 function root_distribution(z::FT, rooting_depth::FT) where {FT <: AbstractFloat}
-    return FT(1.0 / rooting_depth) * exp(z / FT(rooting_depth)) # 1/m
+    return (1 / rooting_depth) * exp(z / rooting_depth) # 1/m
 end
 
 """

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -157,42 +157,24 @@ function PlantHydraulicsParameters(;
     ai_parameterization::PrescribedSiteAreaIndex{FT},
     ν::FT,
     S_s::FT,
-    rooting_depth::Union{Nothing, FT, ClimaCore.Fields.Field} = nothing,
-    root_distribution::Union{Nothing, Function} = nothing,
+    rooting_depth::Union{FT, ClimaCore.Fields.Field},
     conductivity_model,
     retention_model,
 ) where {FT}
-    if root_distribution isa Nothing
-        return PlantHydraulicsParameters{
-            FT,
-            typeof(ai_parameterization),
-            typeof(conductivity_model),
-            typeof(retention_model),
-            typeof(rooting_depth),
-        }(
-            ai_parameterization,
-            ν,
-            S_s,
-            conductivity_model,
-            retention_model,
-            rooting_depth,
-        )
-    else
-        return PlantHydraulicsParameters{
-            FT,
-            typeof(ai_parameterization),
-            typeof(conductivity_model),
-            typeof(retention_model),
-            FT,
-        }(
-            ai_parameterization,
-            ν,
-            S_s,
-            conductivity_model,
-            retention_model,
-            FT(1.0 / root_distribution(0.0)),
-        )
-    end
+    return PlantHydraulicsParameters{
+        FT,
+        typeof(ai_parameterization),
+        typeof(conductivity_model),
+        typeof(retention_model),
+        typeof(rooting_depth),
+    }(
+        ai_parameterization,
+        ν,
+        S_s,
+        conductivity_model,
+        retention_model,
+        rooting_depth,
+    )
 end
 
 """

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -36,8 +36,9 @@ import ClimaParams
         g1_cases = (FT(790), fill(FT(790), domain.space.surface))
         Vcmax25_cases = (FT(9e-5), fill(FT(9e-5), domain.space.surface))
         mechanism_cases = (FT(1), mechanism_field)
-        zipped = zip(g1_cases, Vcmax25_cases, mechanism_cases)
-        for (g1, Vcmax25, is_c3) in zipped
+        rooting_cases = (FT(0.5), fill(FT(0.5), domain.space.surface))
+        zipped = zip(g1_cases, Vcmax25_cases, mechanism_cases, rooting_cases)
+        for (g1, Vcmax25, is_c3, rooting_depth) in zipped
             AR_params = AutotrophicRespirationParameters(FT)
             RTparams = BeerLambertParameters(FT)
             photosynthesis_params = FarquharParameters(FT, is_c3; Vcmax25)
@@ -149,14 +150,11 @@ import ClimaParams
             retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
             root_depths =
                 SVector{10, FT}(-(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0) # 1st element is the deepest root depth
-            function root_distribution(z::T) where {T}
-                return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
-            end
             param_set = PlantHydraulics.PlantHydraulicsParameters(;
                 ai_parameterization = ai_parameterization,
                 ν = plant_ν,
                 S_s = plant_S_s,
-                root_distribution = root_distribution,
+                rooting_depth = rooting_depth,
                 conductivity_model = conductivity_model,
                 retention_model = retention_model,
             )

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -36,8 +36,9 @@ import ClimaParams
         g1_cases = (FT(790), fill(FT(790), domain.space.surface))
         Vcmax25_cases = (FT(9e-5), fill(FT(9e-5), domain.space.surface))
         mechanism_cases = (FT(1), mechanism_field)
-        zipped = zip(g1_cases, Vcmax25_cases, mechanism_cases)
-        for (g1, Vcmax25, is_c3) in zipped
+        rooting_cases = (FT(0.5), fill(FT(0.5), domain.space.surface))
+        zipped = zip(g1_cases, Vcmax25_cases, mechanism_cases, rooting_cases)
+        for (g1, Vcmax25, is_c3, rooting_depth) in zipped
             AR_params = AutotrophicRespirationParameters(FT)
             RTparams = BeerLambertParameters(FT)
             photosynthesis_params = FarquharParameters(FT, is_c3; Vcmax25)
@@ -149,14 +150,11 @@ import ClimaParams
             retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
             root_depths =
                 SVector{10, FT}(-(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0) # 1st element is the deepest root depth
-            function root_distribution(z::T) where {T}
-                return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
-            end
             param_set = PlantHydraulics.PlantHydraulicsParameters(;
                 ai_parameterization = ai_parameterization,
                 ν = plant_ν,
                 S_s = plant_S_s,
-                root_distribution = root_distribution,
+                rooting_depth = rooting_depth,
                 conductivity_model = conductivity_model,
                 retention_model = retention_model,
             )
@@ -439,14 +437,11 @@ end
             PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
         retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
         root_depths = SVector{10, FT}(-(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0) # 1st element is the deepest root depth
-        function root_distribution(z::T) where {T}
-            return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
-        end
         param_set = PlantHydraulics.PlantHydraulicsParameters(;
             ai_parameterization = ai_parameterization,
             ν = plant_ν,
             S_s = plant_S_s,
-            root_distribution = root_distribution,
+            rooting_depth = FT(0.5),
             conductivity_model = conductivity_model,
             retention_model = retention_model,
         )
@@ -571,8 +566,9 @@ end
         g1_cases = (FT(790), fill(FT(790), domain.space.surface))
         Vcmax25_cases = (FT(9e-5), fill(FT(9e-5), domain.space.surface))
         mechanism_cases = (FT(1), mechanism_field)
-        zipped = zip(g1_cases, Vcmax25_cases, mechanism_cases)
-        for (g1, Vcmax25, is_c3) in zipped
+        rooting_cases = (FT(0.5), fill(FT(0.5), domain.space.surface))
+        zipped = zip(g1_cases, Vcmax25_cases, mechanism_cases, rooting_cases)
+        for (g1, Vcmax25, is_c3, rooting_depth) in zipped
             RTparams = BeerLambertParameters(FT)
             photosynthesis_params = FarquharParameters(FT, is_c3; Vcmax25)
             stomatal_g_params = MedlynConductanceParameters(FT; g1)
@@ -682,14 +678,11 @@ end
             retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
             root_depths =
                 SVector{10, FT}(-(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0) # 1st element is the deepest root depth
-            function root_distribution(z::T) where {T}
-                return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
-            end
             param_set = PlantHydraulics.PlantHydraulicsParameters(;
                 ai_parameterization = ai_parameterization,
                 ν = plant_ν,
                 S_s = plant_S_s,
-                root_distribution = root_distribution,
+                rooting_depth = rooting_depth,
                 conductivity_model = conductivity_model,
                 retention_model = retention_model,
             )
@@ -837,8 +830,9 @@ end
         g1_cases = (FT(790), fill(FT(790), domain.space.surface))
         Vcmax25_cases = (FT(9e-5), fill(FT(9e-5), domain.space.surface))
         mechanism_cases = (FT(1), mechanism_field)
-        zipped = zip(g1_cases, Vcmax25_cases, mechanism_cases)
-        for (g1, Vcmax25, is_c3) in zipped
+        rooting_cases = (FT(0.5), fill(FT(0.5), domain.space.surface))
+        zipped = zip(g1_cases, Vcmax25_cases, mechanism_cases, rooting_cases)
+        for (g1, Vcmax25, is_c3, rooting_depth) in zipped
             BeerLambertparams = BeerLambertParameters(FT)
             # TwoStreamModel parameters
             Ω = FT(0.69)
@@ -971,14 +965,11 @@ end
             retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
             root_depths =
                 SVector{10, FT}(-(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0) # 1st element is the deepest root depth
-            function root_distribution(z::T) where {T}
-                return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
-            end
             param_set = PlantHydraulics.PlantHydraulicsParameters(;
                 ai_parameterization = ai_parameterization,
                 ν = plant_ν,
                 S_s = plant_S_s,
-                root_distribution = root_distribution,
+                rooting_depth = rooting_depth,
                 conductivity_model = conductivity_model,
                 retention_model = retention_model,
             )

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -36,9 +36,8 @@ import ClimaParams
         g1_cases = (FT(790), fill(FT(790), domain.space.surface))
         Vcmax25_cases = (FT(9e-5), fill(FT(9e-5), domain.space.surface))
         mechanism_cases = (FT(1), mechanism_field)
-        rooting_cases = (FT(0.5), fill(FT(0.5), domain.space.surface))
-        zipped = zip(g1_cases, Vcmax25_cases, mechanism_cases, rooting_cases)
-        for (g1, Vcmax25, is_c3, rooting_depth) in zipped
+        zipped = zip(g1_cases, Vcmax25_cases, mechanism_cases)
+        for (g1, Vcmax25, is_c3) in zipped
             AR_params = AutotrophicRespirationParameters(FT)
             RTparams = BeerLambertParameters(FT)
             photosynthesis_params = FarquharParameters(FT, is_c3; Vcmax25)
@@ -150,11 +149,14 @@ import ClimaParams
             retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
             root_depths =
                 SVector{10, FT}(-(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0) # 1st element is the deepest root depth
+            function root_distribution(z::T) where {T}
+                return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
+            end
             param_set = PlantHydraulics.PlantHydraulicsParameters(;
                 ai_parameterization = ai_parameterization,
                 ν = plant_ν,
                 S_s = plant_S_s,
-                rooting_depth = rooting_depth,
+                root_distribution = root_distribution,
                 conductivity_model = conductivity_model,
                 retention_model = retention_model,
             )

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -283,7 +283,7 @@ for FT in (Float32, Float64)
             )
             # Create a system of equations for a given rooting_depth for each cell
             function create_exp_tendency_func(rooting_depth)
-                # Set system to hydrostatic equilibrium state by setting fluxes to zero, and setting LHS of both ODEs to 0
+                # Solve for hydrostatic equilibrium
                 return function initial_compute_exp_tendency!(F, Y)
                     AI = (; leaf = LAI(1.0), root = RAI, stem = SAI)
                     T0A = FT(1e-8) * AI[:leaf]
@@ -339,7 +339,9 @@ for FT in (Float32, Float64)
             must have its own system of equations that is solved for. ClimaCore fields
             cannot hold vectors, so multiple fields must be used to hold the vector solution
             to the system of equations. Here we solve for the steady state of the hydraulics
-            system.
+            system. Then, the solution is used to check that evaluating the
+            tendecy of the model also results in a steady state. This check is repeated using
+            the plant hydraulics model directly.
             =======================#
             # dict to prevent recalculation when returning different index of solution
             solutions_for_rooting_depth = Dict{FT, Vector{FT}}()

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -13,7 +13,6 @@ import ClimaLand
 import ClimaLand.Parameters as LP
 import Insolation
 using Dates
-using Statistics
 
 
 for FT in (Float32, Float64)
@@ -339,7 +338,8 @@ for FT in (Float32, Float64)
             nlsolve does not solve systems of equations that return fields, so each cell
             must have its own system of equations that is solved for. ClimaCore fields
             cannot hold vectors, so multiple fields must be used to hold the vector solution
-            to the system of equations.
+            to the system of equations. Here we solve for the steady state of the hydraulics
+            system.
             =======================#
             # dict to prevent recalculation when returning different index of solution
             solutions_for_rooting_depth = Dict{FT, Vector{FT}}()

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -329,6 +329,7 @@ for FT in (Float32, Float64)
                                     ),
                                 ) * AI[plant_hydraulics.compartment_labels[i]]
                         end
+                        # take the mean because nlsolve does not play well with fields
                         F[i] = mean(fa .- T0A)
                     end
                 end


### PR DESCRIPTION
## Purpose 
Towards spatially varying canopy parameters
Move the root_distribution function to src
Make rooting_depth, an argument to root_distribution, a parameter of PlantHydraulicsParameters
Make rooting depth support ClimaCore fields.
Closes #772 

PlantHydraulicsParameters previously held a root distribution function
that had a default value for rooting depth. This function is
always the same outside testing, so it was removed as a parameter
and placed into src. rooting_depth, an argument to the distribution function
is now a parameters that is either a Float or a field. The tests are changed to
check passing rooting_depth as a float or a field of floats that are the same everywhere.




## To-do
- Add to ClimaArtifacts


## Content
- Rooting_depth map created
- rooting_depth added as parameter
- rooting_distribution moved to source
- all calls to PlantHydraulicsParameters changed accordingly 
- tests changed to also test rooting_depth as a field
- add message in NEWS.md

PlantHydraulicsParameters previously held a root distribution function
that had a default value for rooting depth. This function is
always the same outside testing, so it was removed as a parameter
and placed into src. rooting_depth, an argument to the distribution function
is now a parameters that is either a Float or a field. The tests are changed to
check passing rooting_depth as a float or a field of floats that are the same everywhere.

The rooting_depth map can be seen here:

![rooting_depth](https://github.com/user-attachments/assets/fb446404-2f5c-429f-ac83-dded3c6d1677)



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
