### PR TITLE
Update clm_data artifact

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,5 +1,9 @@
 [clm_data]
-git-tree-sha1 = "9d6f7207023958b74c1b2079cb29e4f17e19a196"
+git-tree-sha1 = "5fcb868a751f4a2e32181612bb0c123e9a8e7e97"
+
+    [[clm_data.download]]
+    sha256 = "bd8b53d691507e746e1de6dd2cc97178510c1d8944df1c23e4737bbb7ac7f8dd"
+    url = "https://caltech.box.com/shared/static/hbi0w0hbz8chaab4ym3kdpthc0d1blfc.gz"
 
 [era5_land_forcing_data2021]
 git-tree-sha1 = "ec424296df6b60cfe273ac8f981701fbbed0bd8a"

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -382,7 +382,7 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     )
     # photosynthesis mechanism is read as a float, where 1.0 indicates c3 and 0.0 c4
     is_c3 = SpaceVaryingInput(
-        joinpath(clm_artifact_path, "mechanism_map.nc"),
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "c3_dominant",
         surface_space;
         regridder_type,

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -391,7 +391,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     )
     # photosynthesis mechanism is read as a float, where 1.0 indicates c3 and 0.0 c4
     is_c3 = SpaceVaryingInput(
-        joinpath(clm_artifact_path, "mechanism_map.nc"),
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "c3_dominant",
         surface_space;
         regridder_type,

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -392,7 +392,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
 
     # c3 is read in as a float
     is_c3 = SpaceVaryingInput(
-        joinpath(clm_artifact_path, "mechanism_map.nc"),
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "c3_dominant",
         surface_space;
         regridder_type,


### PR DESCRIPTION
## Purpose 
Update Artifacts.toml to use updated clm_data.

Change calls that used mechanism_map.nc to use vegetation_properties_map.nc because
mechanism_map.nc is deleted in the new clm_data artifact.

See the artifact changes [here](https://github.com/CliMA/ClimaArtifacts/pull/40)





## Content
- Update artifacts.toml
- Update artifact usage in benchmark/land.jl, longruns/land.jl, and landa_regional.jl

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
