### PR TITLE
Extend two stream parameters to space varying

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -6,11 +6,11 @@ git-tree-sha1 = "316096635acaa8102477820f480ca02fe66eb828"
     url = "https://caltech.box.com/shared/static/awz2lku3ngoto6t78muktzfk3kjloxsw.gz"
 
 [clm_data]
-git-tree-sha1 = "5fcb868a751f4a2e32181612bb0c123e9a8e7e97"
+git-tree-sha1 = "459bca9591a26a48864240d2a37de8b5eb66530d"
 
     [[clm_data.download]]
-    sha256 = "bd8b53d691507e746e1de6dd2cc97178510c1d8944df1c23e4737bbb7ac7f8dd"
-    url = "https://caltech.box.com/shared/static/hbi0w0hbz8chaab4ym3kdpthc0d1blfc.gz"
+    sha256 = "dc3c0fc1c84935faf0770ba5e2b85ee7cf943d68f14783b29919c8ef44470fe3"
+    url = "https://caltech.box.com/shared/static/6pu2f6c99g29qawvjjh3j56drkonpd3z.gz"
 
 [era5_land_forcing_data2021]
 git-tree-sha1 = "ec424296df6b60cfe273ac8f981701fbbed0bd8a"

--- a/docs/src/APIs/canopy/RadiativeTransfer.md
+++ b/docs/src/APIs/canopy/RadiativeTransfer.md
@@ -14,7 +14,8 @@ ClimaLand.Canopy.BeerLambertParameters
 
 ```@docs
 ClimaLand.Canopy.compute_absorbances
-ClimaLand.Canopy.plant_absorbed_pfd
+ClimaLand.Canopy.plant_absorbed_pfd_beer_lambert
+ClimaLand.Canopy.plant_absorbed_pfd_two_stream
 ClimaLand.Canopy.extinction_coeff
 ClimaLand.Canopy.extinction_coeff
 ClimaLand.Canopy.canopy_radiant_energy_fluxes!

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -344,20 +344,43 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
         R_sb = R_sb,
     )
 
+    # Energy Balance model
+    ac_canopy = FT(2.5e3)
+
+    #clm_data is used for g1, vcmax, rooting, and two_stream param maps
+    clm_artifact_path = ClimaLand.Artifacts.clm_data_folder_path(; context)
 
     # TwoStreamModel parameters
     Ω = FT(0.69)
     ld = FT(0.5)
-    α_PAR_leaf = FT(0.1)
-    τ_PAR_leaf = FT(0.05)
-    α_NIR_leaf = FT(0.45)
-    τ_NIR_leaf = FT(0.25)
-
-    # Energy Balance model
-    ac_canopy = FT(2.5e3)
-
-    #clm_data is used for g1 and vcmax maps
-    clm_artifact_path = ClimaLand.Artifacts.clm_data_folder_path(; context)
+    α_PAR_leaf = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "rholvis",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    τ_PAR_leaf = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "taulvis",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    α_NIR_leaf = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "rholnir",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    τ_NIR_leaf = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "taulnir",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
 
     # Conductance Model
     # g1 is read in units of sqrt(kPa) and then converted to sqrt(Pa)

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -352,7 +352,14 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
 
     # TwoStreamModel parameters
     Ω = FT(0.69)
-    ld = FT(0.5)
+    χl = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "xl",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    G_Function = CLMGFunction(χl)
     α_PAR_leaf = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "rholvis",
@@ -496,6 +503,7 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
             τ_PAR_leaf,
             α_NIR_leaf,
             τ_NIR_leaf,
+            G_Function,
         )
     )
     # Set up conductance

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -353,21 +353,43 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
         R_sb = R_sb,
     )
 
+    # Energy Balance model
+    ac_canopy = FT(2.5e3)
+
+    #clm_data is used for g1, vcmax, rooting, and two_stream param maps
+    clm_artifact_path = ClimaLand.Artifacts.clm_data_folder_path(; context)
 
     # TwoStreamModel parameters
     Ω = FT(0.69)
     ld = FT(0.5)
-    α_PAR_leaf = FT(0.1)
-    τ_PAR_leaf = FT(0.05)
-    α_NIR_leaf = FT(0.45)
-    τ_NIR_leaf = FT(0.25)
-
-    # Energy Balance model
-    ac_canopy = FT(2.5e3)
-
-    #clm_data is used for g1 and vcmax maps
-    clm_artifact_path = ClimaLand.Artifacts.clm_data_folder_path(; context)
-
+    α_PAR_leaf = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "rholvis",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    τ_PAR_leaf = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "taulvis",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    α_NIR_leaf = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "rholnir",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    τ_NIR_leaf = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "taulnir",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
     # Conductance Model
     # g1 is read in units of sqrt(kPa) and then converted to sqrt(Pa)
     g1 = SpaceVaryingInput(

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -361,7 +361,14 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
 
     # TwoStreamModel parameters
     Ω = FT(0.69)
-    ld = FT(0.5)
+    χl = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "xl",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    G_Function = CLMGFunction(χl)
     α_PAR_leaf = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "rholvis",
@@ -503,6 +510,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
             τ_PAR_leaf,
             α_NIR_leaf,
             τ_NIR_leaf,
+            G_Function,
         )
     )
     # Set up conductance

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -364,7 +364,14 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
 
     # TwoStreamModel parameters
     Ω = FT(0.69)
-    ld = FT(0.5)
+    χl = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "xl",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    G_Function = CLMGFunction(χl)
     α_PAR_leaf = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "rholvis",
@@ -508,6 +515,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
             τ_PAR_leaf,
             α_NIR_leaf,
             τ_NIR_leaf,
+            G_Function,
         )
     )
     # Set up conductance

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -357,18 +357,43 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
         R_sb = R_sb,
     )
 
+    # Energy Balance model
+    ac_canopy = FT(2.5e4) # this will likely be 10x smaller!
+    #clm_data is used for g1, vcmax, rooting, and two_stream param maps
+    clm_artifact_path = ClimaLand.Artifacts.clm_data_folder_path(; context)
 
     # TwoStreamModel parameters
     Ω = FT(0.69)
     ld = FT(0.5)
-    α_PAR_leaf = FT(0.1)
-    τ_PAR_leaf = FT(0.05)
-    α_NIR_leaf = FT(0.45)
-    τ_NIR_leaf = FT(0.25)
+    α_PAR_leaf = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "rholvis",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    τ_PAR_leaf = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "taulvis",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    α_NIR_leaf = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "rholnir",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    τ_NIR_leaf = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "taulnir",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
 
-    # Energy Balance model
-    ac_canopy = FT(2.5e4) # this will likely be 10x smaller!
-    clm_artifact_path = ClimaLand.Artifacts.clm_data_folder_path(; context)
     # Conductance Model
     # g1 is read in units of sqrt(kPa) and then converted to sqrt(Pa)
     g1 = SpaceVaryingInput(

--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -600,7 +600,20 @@ function TwoStreamParameters(
 
     parameters = CP.get_parameter_values(toml_dict, name_map, "Land")
     FT = CP.float_type(toml_dict)
-    return TwoStreamParameters{FT, typeof(G_Function)}(;
+    # default value for keyword args must be converted manually
+    # automatic conversion not possible to Union types
+    α_PAR_leaf = FT.(α_PAR_leaf)
+    τ_PAR_leaf = FT.(τ_PAR_leaf)
+    α_NIR_leaf = FT.(α_NIR_leaf)
+    τ_NIR_leaf = FT.(τ_NIR_leaf)
+    return TwoStreamParameters{
+        FT,
+        typeof(G_Function),
+        typeof(α_PAR_leaf),
+        typeof(τ_PAR_leaf),
+        typeof(α_NIR_leaf),
+        typeof(τ_NIR_leaf),
+    }(;
         G_Function,
         α_PAR_leaf,
         τ_PAR_leaf,
@@ -651,7 +664,16 @@ function BeerLambertParameters(
 
     parameters = CP.get_parameter_values(toml_dict, name_map, "Land")
     FT = CP.float_type(toml_dict)
-    return BeerLambertParameters{FT, typeof(G_Function)}(;
+    # default value for keyword args must be converted manually
+    # automatic conversion not possible to Union types
+    α_PAR_leaf = FT.(α_PAR_leaf)
+    α_NIR_leaf = FT.(α_NIR_leaf)
+    return BeerLambertParameters{
+        FT,
+        typeof(G_Function),
+        typeof(α_PAR_leaf),
+        typeof(α_NIR_leaf),
+    }(;
         G_Function,
         α_PAR_leaf,
         α_NIR_leaf,

--- a/ext/CreateParametersExt.jl
+++ b/ext/CreateParametersExt.jl
@@ -584,14 +584,14 @@ TwoStreamParameters(::Type{FT}; kwargs...) where {FT <: AbstractFloat} =
 function TwoStreamParameters(
     toml_dict::CP.AbstractTOMLDict;
     G_Function = ConstantGFunction(CP.float_type(toml_dict)(0.5)),
-    α_PAR_leaf = 0.3,
-    τ_PAR_leaf = 0.2,
-    α_NIR_leaf = 0.4,
-    τ_NIR_leaf = 0.25,
+    α_PAR_leaf::F = 0.3,
+    τ_PAR_leaf::F = 0.2,
+    α_NIR_leaf::F = 0.4,
+    τ_NIR_leaf::F = 0.25,
     Ω = 1,
     n_layers = UInt64(20),
     kwargs...,
-)
+) where {F}
     name_map = (;
         :wavelength_per_PAR_photon => :λ_γ_PAR,
         :wavelength_per_NIR_photon => :λ_γ_NIR,
@@ -606,14 +606,7 @@ function TwoStreamParameters(
     τ_PAR_leaf = FT.(τ_PAR_leaf)
     α_NIR_leaf = FT.(α_NIR_leaf)
     τ_NIR_leaf = FT.(τ_NIR_leaf)
-    return TwoStreamParameters{
-        FT,
-        typeof(G_Function),
-        typeof(α_PAR_leaf),
-        typeof(τ_PAR_leaf),
-        typeof(α_NIR_leaf),
-        typeof(τ_NIR_leaf),
-    }(;
+    return TwoStreamParameters{FT, typeof(G_Function), typeof(α_PAR_leaf)}(;
         G_Function,
         α_PAR_leaf,
         τ_PAR_leaf,
@@ -651,11 +644,11 @@ BeerLambertParameters(::Type{FT}; kwargs...) where {FT <: AbstractFloat} =
 function BeerLambertParameters(
     toml_dict::CP.AbstractTOMLDict;
     G_Function = ConstantGFunction(CP.float_type(toml_dict)(0.5)),
-    α_PAR_leaf = 0.1,
-    α_NIR_leaf = 0.4,
+    α_PAR_leaf::F = 0.1,
+    α_NIR_leaf::F = 0.4,
     Ω = 1,
     kwargs...,
-)
+) where {F}
     name_map = (;
         :wavelength_per_PAR_photon => :λ_γ_PAR,
         :wavelength_per_NIR_photon => :λ_γ_NIR,
@@ -668,12 +661,7 @@ function BeerLambertParameters(
     # automatic conversion not possible to Union types
     α_PAR_leaf = FT.(α_PAR_leaf)
     α_NIR_leaf = FT.(α_NIR_leaf)
-    return BeerLambertParameters{
-        FT,
-        typeof(G_Function),
-        typeof(α_PAR_leaf),
-        typeof(α_NIR_leaf),
-    }(;
+    return BeerLambertParameters{FT, typeof(G_Function), typeof(α_PAR_leaf)}(;
         G_Function,
         α_PAR_leaf,
         α_NIR_leaf,

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -463,7 +463,8 @@ function ClimaLand.make_update_aux(
         RT = canopy.radiative_transfer
         compute_PAR!(inc_par, RT, canopy.radiation, p, t)
         compute_NIR!(inc_nir, RT, canopy.radiation, p, t)
-        K = extinction_coeff.(p.canopy.radiative_transfer.G, θs)
+        K = p.canopy.radiative_transfer.K
+        @. K = extinction_coeff(p.canopy.radiative_transfer.G, θs)
         DOY = Dates.dayofyear(
             canopy.atmos.start_date + Dates.Second(floor(Int64, t)),
         )

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -459,10 +459,11 @@ function ClimaLand.make_update_aux(
         @. p.canopy.radiative_transfer.ϵ =
             canopy.radiative_transfer.parameters.ϵ_canopy *
             (1 - exp(-(LAI + SAI))) #from CLM 5.0, Tech note 4.20
+        p.canopy.radiative_transfer.G .= compute_G(G_Function, θs)
         RT = canopy.radiative_transfer
         compute_PAR!(inc_par, RT, canopy.radiation, p, t)
         compute_NIR!(inc_nir, RT, canopy.radiation, p, t)
-        K = extinction_coeff.(G_Function, θs)
+        K = extinction_coeff.(p.canopy.radiative_transfer.G, θs)
         DOY = Dates.dayofyear(
             canopy.atmos.start_date + Dates.Second(floor(Int64, t)),
         )

--- a/src/standalone/Vegetation/canopy_parameterizations.jl
+++ b/src/standalone/Vegetation/canopy_parameterizations.jl
@@ -1,5 +1,6 @@
 using ..ClimaLand.Canopy
-export plant_absorbed_pfd,
+export plant_absorbed_pfd_beer_lambert,
+    plant_absorbed_pfd_two_stream,
     extinction_coeff,
     arrhenius_function,
     intercellular_co2,
@@ -95,16 +96,16 @@ function compute_absorbances!(
     _...,
 ) where {FT}
     RTP = RT.parameters
-    @. p.canopy.radiative_transfer.par = plant_absorbed_pfd(
-        RT,
+    @. p.canopy.radiative_transfer.par = plant_absorbed_pfd_beer_lambert(
+        RTP.Ω,
         PAR / (N_a * energy_per_photon_PAR),
         RTP.α_PAR_leaf,
         LAI,
         K,
         α_soil_PAR,
     )
-    @. p.canopy.radiative_transfer.nir = plant_absorbed_pfd(
-        RT,
+    @. p.canopy.radiative_transfer.nir = plant_absorbed_pfd_beer_lambert(
+        RTP.Ω,
         NIR / (N_a * energy_per_photon_NIR),
         RTP.α_NIR_leaf,
         LAI,
@@ -157,8 +158,10 @@ function compute_absorbances!(
     frac_diff,
 ) where {FT}
     RTP = RT.parameters
-    @. p.canopy.radiative_transfer.par = plant_absorbed_pfd(
-        RT,
+    @. p.canopy.radiative_transfer.par = plant_absorbed_pfd_two_stream(
+        RTP.G_Function,
+        RTP.Ω,
+        RTP.n_layers,
         PAR / (energy_per_photon_PAR * N_a),
         RTP.α_PAR_leaf,
         RTP.τ_PAR_leaf,
@@ -168,8 +171,10 @@ function compute_absorbances!(
         α_soil_PAR,
         frac_diff,
     )
-    @. p.canopy.radiative_transfer.nir = plant_absorbed_pfd(
-        RT,
+    @. p.canopy.radiative_transfer.nir = plant_absorbed_pfd_two_stream(
+        RTP.G_Function,
+        RTP.Ω,
+        RTP.n_layers,
         NIR / (energy_per_photon_NIR * N_a),
         RTP.α_NIR_leaf,
         RTP.τ_NIR_leaf,
@@ -182,8 +187,8 @@ function compute_absorbances!(
 end
 
 """
-    plant_absorbed_pfd(
-        RT::BeerLambertModel{FT},
+    plant_absorbed_pfd_beer_lambert(
+        Ω::FT,
         SW_IN:FT,
         α_leaf::FT,
         LAI::FT,
@@ -203,31 +208,33 @@ and the albedo of the soil (`α_soil`).
 Returns a tuple of reflected, absorbed, and transmitted radiation in
 mol photons/m^2/s.
 """
-function plant_absorbed_pfd(
-    RT::BeerLambertModel{FT},
+function plant_absorbed_pfd_beer_lambert(
+    Ω::FT,
     SW_IN::FT,
     α_leaf::FT,
     LAI::FT,
     K::FT,
     α_soil::FT,
 ) where {FT}
-    RTP = RT.parameters
-    AR = SW_IN * (1 - α_leaf) * (1 - exp(-K * LAI * RTP.Ω)) * (1 - α_soil)
-    TR = SW_IN * exp(-K * LAI * RTP.Ω)
+    AR = SW_IN * (1 - α_leaf) * (1 - exp(-K * LAI * Ω)) * (1 - α_soil)
+    TR = SW_IN * exp(-K * LAI * Ω)
     RR = SW_IN - AR - TR * (1 - α_soil)
     return (; abs = AR, refl = RR, trans = TR)
 end
 
 """
-    plant_absorbed_pfd(
-        RT::TwoStreamModel{FT},
-        α_leaf,
+    plant_absorbed_pfd_two_stream(
+        G_Function::Union{ConstantGFunction, CLMGFunction},
+        Ω::FT,
+        n_layers::UInt64,
         SW_IN::FT,
+        α_leaf::FT,
+        τ_leaf::FT,
         LAI::FT,
         K::FT,
-        τ_leaf,
         θs::FT,
         α_soil::FT,
+        frac_diff::FT,
     )
 
 Computes the absorbed, transmitted, and reflected  photon flux density
@@ -242,8 +249,10 @@ canopy soil_driver, solar zenith angle, and τ.
 Returns a tuple of reflected, absorbed, and transmitted radiation in
 mol photons/m^2/s.
 """
-function plant_absorbed_pfd(
-    RT::TwoStreamModel{FT},
+function plant_absorbed_pfd_two_stream(
+    G_Function::Union{ConstantGFunction, CLMGFunction},
+    Ω::FT,
+    n_layers::UInt64,
     SW_IN::FT,
     α_leaf::FT,
     τ_leaf::FT,
@@ -253,8 +262,6 @@ function plant_absorbed_pfd(
     α_soil::FT,
     frac_diff::FT,
 ) where {FT}
-
-    (; G_Function, Ω, n_layers) = RT.parameters
 
     # Get the current leaf angular distribution value based on the solar zenith angle
     G = compute_G(G_Function, θs)
@@ -344,6 +351,7 @@ function plant_absorbed_pfd(
     I_dir_dn_prev = 0
     I_dif_up_prev = 0
     I_dif_dn_prev = 0
+
 
     # Compute F_abs in each canopy layer
     while i <= n_layers

--- a/src/standalone/Vegetation/canopy_parameterizations.jl
+++ b/src/standalone/Vegetation/canopy_parameterizations.jl
@@ -30,28 +30,28 @@ export plant_absorbed_pfd_beer_lambert,
 
 """
     compute_G(
-        G::ConstantGFunction{FT},
-        _::FT,
+        G::ConstantGFunction,
+        _,
     )
 
 Returns the constant leaf angle distribution value for the given G function.
 Takes in an arbitrary value for the solar zenith angle, which is not used.
 """
-function compute_G(G::ConstantGFunction, _::FT) where {FT}
+function compute_G(G::ConstantGFunction, _)
     return G.ld
 end
 
 """
     compute_G(
-        G::CLMGFunction{FT},
-        θs::FT,
+        G::CLMGFunction,
+        θs,
     )
 
 Returns the leaf angle distribution value for CLM G function as a function of the
 solar zenith angle and the leaf orientation index. See section 3.1 of
 https://www2.cesm.ucar.edu/models/cesm2/land/CLM50_Tech_Note.pdf
 """
-function compute_G(G::CLMGFunction, θs::FT) where {FT}
+function compute_G(G::CLMGFunction, θs)
     return compute_G_CLMG.(G.χl, θs)
 end
 
@@ -61,8 +61,8 @@ end
         θs::FT,
     )
 
-Returns the leaf angle distribution value for CLM G function as a function of the
-solar zenith angle and the leaf orientation index. See section 3.1 of
+Returns the leaf angle distribution value for CLM G function at a point as a function of the
+solar zenith angle at the point and the leaf orientation index at the point. See section 3.1 of
 https://www2.cesm.ucar.edu/models/cesm2/land/CLM50_Tech_Note.pdf
 """
 function compute_G_CLMG(χl::FT, θs::FT) where {FT}
@@ -483,7 +483,7 @@ end
                      θs::FT) where {FT}
 
 Computes the vegetation extinction coefficient (`K`), as a function
-of the sun zenith angle (`θs`), and the leaf angle distribution (`ld`).
+of the sun zenith angle (`θs`), and the leaf angle distribution (`G`).
 """
 function extinction_coeff(G::FT, θs::FT) where {FT}
     K = G / max(cos(θs), eps(FT))

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -18,9 +18,10 @@ abstract type AbstractGFunction{FT} end
 A type for a constant G function, which is used to represent the leaf angle
 distribution function in the radiative transfer models.
 """
-struct ConstantGFunction{FT} <: AbstractGFunction{FT}
+struct ConstantGFunction{F <: Union{AbstractFloat, ClimaCore.Fields.Field}} <:
+       AbstractGFunction{F}
     "Leaf angle distribution value (unitless)"
-    ld::FT
+    ld::F
 end
 
 # Make the ConstantGFunction broadcastable
@@ -32,9 +33,10 @@ Base.broadcastable(G::ConstantGFunction) = Ref(G)
 A type for a G function that is parameterized by the solar zenith angle,
 following the CLM approach to parameterizing the leaf angle distribution function.
 """
-struct CLMGFunction{FT} <: AbstractGFunction{FT}
+struct CLMGFunction{F <: Union{AbstractFloat, ClimaCore.Fields.Field}} <:
+       AbstractGFunction{F}
     "Leaf orientation index (unitless)"
-    χl::FT
+    χl::F
 end
 
 # Make the CLMGFunction broadcastable
@@ -48,7 +50,7 @@ $(DocStringExtensions.FIELDS)
 """
 Base.@kwdef struct BeerLambertParameters{
     FT <: AbstractFloat,
-    G <: AbstractGFunction{FT},
+    G <: AbstractGFunction,
     F <: Union{FT, ClimaCore.Fields.Field},
 }
     "PAR leaf reflectance (unitless)"
@@ -88,7 +90,7 @@ $(DocStringExtensions.FIELDS)
 """
 Base.@kwdef struct TwoStreamParameters{
     FT <: AbstractFloat,
-    G <: AbstractGFunction{FT},
+    G <: AbstractGFunction,
     F <: Union{FT, ClimaCore.Fields.Field},
 }
     "PAR leaf reflectance (unitless)"
@@ -180,7 +182,7 @@ Base.broadcastable(RT::AbstractRadiationModel) = tuple(RT)
 
 ClimaLand.name(model::AbstractRadiationModel) = :radiative_transfer
 ClimaLand.auxiliary_vars(model::Union{BeerLambertModel, TwoStreamModel}) =
-    (:inc_nir, :inc_par, :nir, :par, :LW_n, :SW_n, :ϵ, :frac_diff)
+    (:inc_nir, :inc_par, :nir, :par, :LW_n, :SW_n, :ϵ, :frac_diff, :G)
 ClimaLand.auxiliary_types(
     model::Union{BeerLambertModel{FT}, TwoStreamModel{FT}},
 ) where {FT} = (
@@ -192,8 +194,10 @@ ClimaLand.auxiliary_types(
     FT,
     FT,
     FT,
+    FT,
 )
 ClimaLand.auxiliary_domain_names(::Union{BeerLambertModel, TwoStreamModel}) = (
+    :surface,
     :surface,
     :surface,
     :surface,

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -182,7 +182,7 @@ Base.broadcastable(RT::AbstractRadiationModel) = tuple(RT)
 
 ClimaLand.name(model::AbstractRadiationModel) = :radiative_transfer
 ClimaLand.auxiliary_vars(model::Union{BeerLambertModel, TwoStreamModel}) =
-    (:inc_nir, :inc_par, :nir, :par, :LW_n, :SW_n, :ϵ, :frac_diff, :G)
+    (:inc_nir, :inc_par, :nir, :par, :LW_n, :SW_n, :ϵ, :frac_diff, :G, :K)
 ClimaLand.auxiliary_types(
     model::Union{BeerLambertModel{FT}, TwoStreamModel{FT}},
 ) where {FT} = (
@@ -195,8 +195,10 @@ ClimaLand.auxiliary_types(
     FT,
     FT,
     FT,
+    FT,
 )
 ClimaLand.auxiliary_domain_names(::Union{BeerLambertModel, TwoStreamModel}) = (
+    :surface,
     :surface,
     :surface,
     :surface,

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -49,11 +49,13 @@ $(DocStringExtensions.FIELDS)
 Base.@kwdef struct BeerLambertParameters{
     FT <: AbstractFloat,
     G <: AbstractGFunction{FT},
+    APAR <: Union{FT, ClimaCore.Fields.Field},
+    ANIR <: Union{FT, ClimaCore.Fields.Field},
 }
     "PAR leaf reflectance (unitless)"
-    α_PAR_leaf::FT
+    α_PAR_leaf::APAR
     "NIR leaf reflectance"
-    α_NIR_leaf::FT
+    α_NIR_leaf::ANIR
     "Emissivity of the canopy"
     ϵ_canopy::FT
     "Clumping index following Braghiere (2021) (unitless)"
@@ -88,15 +90,19 @@ $(DocStringExtensions.FIELDS)
 Base.@kwdef struct TwoStreamParameters{
     FT <: AbstractFloat,
     G <: AbstractGFunction{FT},
+    APAR <: Union{FT, ClimaCore.Fields.Field},
+    TPAR <: Union{FT, ClimaCore.Fields.Field},
+    ANIR <: Union{FT, ClimaCore.Fields.Field},
+    TNIR <: Union{FT, ClimaCore.Fields.Field},
 }
     "PAR leaf reflectance (unitless)"
-    α_PAR_leaf::FT
+    α_PAR_leaf::APAR
     "PAR leaf element transmittance"
-    τ_PAR_leaf::FT
+    τ_PAR_leaf::TPAR
     "NIR leaf reflectance"
-    α_NIR_leaf::FT
+    α_NIR_leaf::ANIR
     "NIR leaf element transmittance"
-    τ_NIR_leaf::FT
+    τ_NIR_leaf::TNIR
     "Emissivity of the canopy"
     ϵ_canopy::FT
     "Clumping index following Braghiere 2021 (unitless)"
@@ -106,7 +112,7 @@ Base.@kwdef struct TwoStreamParameters{
     "Typical wavelength per NIR photon (m)"
     λ_γ_NIR::FT
     "Number of layers to partition the canopy into when integrating the
-    absorption over the canopy vertically. Unrelated to the number of layers in 
+    absorption over the canopy vertically. Unrelated to the number of layers in
     the vertical discretization of the canopy for the plant hydraulics model.
     (Constant, and should eventually move to ClimaParams)"
     n_layers::UInt64

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -49,13 +49,12 @@ $(DocStringExtensions.FIELDS)
 Base.@kwdef struct BeerLambertParameters{
     FT <: AbstractFloat,
     G <: AbstractGFunction{FT},
-    APAR <: Union{FT, ClimaCore.Fields.Field},
-    ANIR <: Union{FT, ClimaCore.Fields.Field},
+    F <: Union{FT, ClimaCore.Fields.Field},
 }
     "PAR leaf reflectance (unitless)"
-    α_PAR_leaf::APAR
+    α_PAR_leaf::F
     "NIR leaf reflectance"
-    α_NIR_leaf::ANIR
+    α_NIR_leaf::F
     "Emissivity of the canopy"
     ϵ_canopy::FT
     "Clumping index following Braghiere (2021) (unitless)"
@@ -90,19 +89,16 @@ $(DocStringExtensions.FIELDS)
 Base.@kwdef struct TwoStreamParameters{
     FT <: AbstractFloat,
     G <: AbstractGFunction{FT},
-    APAR <: Union{FT, ClimaCore.Fields.Field},
-    TPAR <: Union{FT, ClimaCore.Fields.Field},
-    ANIR <: Union{FT, ClimaCore.Fields.Field},
-    TNIR <: Union{FT, ClimaCore.Fields.Field},
+    F <: Union{FT, ClimaCore.Fields.Field},
 }
     "PAR leaf reflectance (unitless)"
-    α_PAR_leaf::APAR
+    α_PAR_leaf::F
     "PAR leaf element transmittance"
-    τ_PAR_leaf::TPAR
+    τ_PAR_leaf::F
     "NIR leaf reflectance"
-    α_NIR_leaf::ANIR
+    α_NIR_leaf::F
     "NIR leaf element transmittance"
-    τ_NIR_leaf::TNIR
+    τ_NIR_leaf::F
     "Emissivity of the canopy"
     ϵ_canopy::FT
     "Clumping index following Braghiere 2021 (unitless)"

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -37,10 +37,21 @@ import ClimaParams
         Vcmax25_cases = (FT(9e-5), fill(FT(9e-5), domain.space.surface))
         mechanism_cases = (FT(1), mechanism_field)
         rooting_cases = (FT(0.5), fill(FT(0.5), domain.space.surface))
-        zipped = zip(g1_cases, Vcmax25_cases, mechanism_cases, rooting_cases)
-        for (g1, Vcmax25, is_c3, rooting_depth) in zipped
+        # test default values as field
+        α_PAR_leaf_cases = (FT(0.1), fill(FT(0.1), domain.space.surface))
+        α_NIR_leaf_cases = (FT(0.4), fill(FT(0.4), domain.space.surface))
+        zipped_params = zip(
+            g1_cases,
+            Vcmax25_cases,
+            mechanism_cases,
+            rooting_cases,
+            α_PAR_leaf_cases,
+            α_NIR_leaf_cases,
+        )
+        for (g1, Vcmax25, is_c3, rooting_depth, α_PAR_leaf, α_NIR_leaf) in
+            zipped_params
             AR_params = AutotrophicRespirationParameters(FT)
-            RTparams = BeerLambertParameters(FT)
+            RTparams = BeerLambertParameters(FT; α_PAR_leaf, α_NIR_leaf)
             photosynthesis_params = FarquharParameters(FT, is_c3; Vcmax25)
             stomatal_g_params = MedlynConductanceParameters(FT; g1)
             AR_model = AutotrophicRespirationModel{FT}(AR_params)
@@ -574,9 +585,20 @@ end
         Vcmax25_cases = (FT(9e-5), fill(FT(9e-5), domain.space.surface))
         mechanism_cases = (FT(1), mechanism_field)
         rooting_cases = (FT(0.5), fill(FT(0.5), domain.space.surface))
-        zipped = zip(g1_cases, Vcmax25_cases, mechanism_cases, rooting_cases)
-        for (g1, Vcmax25, is_c3, rooting_depth) in zipped
-            RTparams = BeerLambertParameters(FT)
+        # test default values as field
+        α_PAR_leaf_cases = (FT(0.1), fill(FT(0.1), domain.space.surface))
+        α_NIR_leaf_cases = (FT(0.4), fill(FT(0.4), domain.space.surface))
+        zipped_params = zip(
+            g1_cases,
+            Vcmax25_cases,
+            mechanism_cases,
+            rooting_cases,
+            α_PAR_leaf_cases,
+            α_NIR_leaf_cases,
+        )
+        for (g1, Vcmax25, is_c3, rooting_depth, α_PAR_leaf, α_NIR_leaf) in
+            zipped_params
+            RTparams = BeerLambertParameters(FT; α_PAR_leaf, α_NIR_leaf)
             photosynthesis_params = FarquharParameters(FT, is_c3; Vcmax25)
             stomatal_g_params = MedlynConductanceParameters(FT; g1)
 
@@ -1117,20 +1139,45 @@ end
         Vcmax25_cases = (FT(9e-5), fill(FT(9e-5), domain.space.surface))
         mechanism_cases = (FT(1), mechanism_field)
         rooting_cases = (FT(0.5), fill(FT(0.5), domain.space.surface))
-        zipped = zip(g1_cases, Vcmax25_cases, mechanism_cases, rooting_cases)
-        for (g1, Vcmax25, is_c3, rooting_depth) in zipped
+        α_PAR_leaf_cases = (FT(0.1), fill(FT(0.1), domain.space.surface))
+        τ_PAR_leaf_cases = (FT(0.05), fill(FT(0.05), domain.space.surface))
+        α_NIR_leaf_cases = (FT(0.45), fill(FT(0.45), domain.space.surface))
+        τ_NIR_leaf_cases = (FT(0.25), fill(FT(0.25), domain.space.surface))
+        zipped_params = zip(
+            g1_cases,
+            Vcmax25_cases,
+            mechanism_cases,
+            rooting_cases,
+            α_PAR_leaf_cases,
+            τ_PAR_leaf_cases,
+            α_NIR_leaf_cases,
+            τ_NIR_leaf_cases,
+        )
+        for (
+            g1,
+            Vcmax25,
+            is_c3,
+            rooting_depth,
+            α_PAR_leaf,
+            τ_PAR_leaf,
+            α_NIR_leaf,
+            τ_NIR_leaf,
+        ) in zipped_params
             BeerLambertparams = BeerLambertParameters(FT)
             # TwoStreamModel parameters
             Ω = FT(0.69)
             χl = FT(0.1)
             G_Function = CLMGFunction(χl)
-            α_PAR_leaf = FT(0.1)
             λ_γ_PAR = FT(5e-7)
             λ_γ_NIR = FT(1.65e-6)
-            τ_PAR_leaf = FT(0.05)
-            α_NIR_leaf = FT(0.45)
-            τ_NIR_leaf = FT(0.25)
             ϵ_canopy = FT(0.97)
+            BeerLambertparams = BeerLambertParameters(
+                FT;
+                α_PAR_leaf,
+                α_NIR_leaf,
+                λ_γ_PAR,
+                λ_γ_NIR,
+            )
             TwoStreamparams = TwoStreamParameters(
                 FT;
                 Ω,

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -40,6 +40,7 @@ import ClimaParams
         # test default values as field
         α_PAR_leaf_cases = (FT(0.1), fill(FT(0.1), domain.space.surface))
         α_NIR_leaf_cases = (FT(0.4), fill(FT(0.4), domain.space.surface))
+        ld_cases = (FT(0.5), fill(FT(0.5), domain.space.surface))
         zipped_params = zip(
             g1_cases,
             Vcmax25_cases,
@@ -47,11 +48,14 @@ import ClimaParams
             rooting_cases,
             α_PAR_leaf_cases,
             α_NIR_leaf_cases,
+            ld_cases,
         )
-        for (g1, Vcmax25, is_c3, rooting_depth, α_PAR_leaf, α_NIR_leaf) in
+        for (g1, Vcmax25, is_c3, rooting_depth, α_PAR_leaf, α_NIR_leaf, ld) in
             zipped_params
             AR_params = AutotrophicRespirationParameters(FT)
-            RTparams = BeerLambertParameters(FT; α_PAR_leaf, α_NIR_leaf)
+            G_Function = ConstantGFunction(ld)
+            RTparams =
+                BeerLambertParameters(FT; α_PAR_leaf, α_NIR_leaf, G_Function)
             photosynthesis_params = FarquharParameters(FT, is_c3; Vcmax25)
             stomatal_g_params = MedlynConductanceParameters(FT; g1)
             AR_model = AutotrophicRespirationModel{FT}(AR_params)
@@ -588,6 +592,7 @@ end
         # test default values as field
         α_PAR_leaf_cases = (FT(0.1), fill(FT(0.1), domain.space.surface))
         α_NIR_leaf_cases = (FT(0.4), fill(FT(0.4), domain.space.surface))
+        ld_cases = (FT(0.5), fill(FT(0.5), domain.space.surface))
         zipped_params = zip(
             g1_cases,
             Vcmax25_cases,
@@ -595,10 +600,13 @@ end
             rooting_cases,
             α_PAR_leaf_cases,
             α_NIR_leaf_cases,
+            ld_cases,
         )
-        for (g1, Vcmax25, is_c3, rooting_depth, α_PAR_leaf, α_NIR_leaf) in
+        for (g1, Vcmax25, is_c3, rooting_depth, α_PAR_leaf, α_NIR_leaf, ld) in
             zipped_params
-            RTparams = BeerLambertParameters(FT; α_PAR_leaf, α_NIR_leaf)
+            G_Function = ConstantGFunction(ld)
+            RTparams =
+                BeerLambertParameters(FT; α_PAR_leaf, α_NIR_leaf, G_Function)
             photosynthesis_params = FarquharParameters(FT, is_c3; Vcmax25)
             stomatal_g_params = MedlynConductanceParameters(FT; g1)
 
@@ -1143,6 +1151,7 @@ end
         τ_PAR_leaf_cases = (FT(0.05), fill(FT(0.05), domain.space.surface))
         α_NIR_leaf_cases = (FT(0.45), fill(FT(0.45), domain.space.surface))
         τ_NIR_leaf_cases = (FT(0.25), fill(FT(0.25), domain.space.surface))
+        χl_cases = (FT(0.1), fill(FT(0.1), domain.space.surface))
         zipped_params = zip(
             g1_cases,
             Vcmax25_cases,
@@ -1152,6 +1161,7 @@ end
             τ_PAR_leaf_cases,
             α_NIR_leaf_cases,
             τ_NIR_leaf_cases,
+            χl_cases,
         )
         for (
             g1,
@@ -1162,11 +1172,11 @@ end
             τ_PAR_leaf,
             α_NIR_leaf,
             τ_NIR_leaf,
+            χl,
         ) in zipped_params
             BeerLambertparams = BeerLambertParameters(FT)
             # TwoStreamModel parameters
             Ω = FT(0.69)
-            χl = FT(0.1)
             G_Function = CLMGFunction(χl)
             λ_γ_PAR = FT(5e-7)
             λ_γ_NIR = FT(1.65e-6)

--- a/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
+++ b/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
@@ -104,8 +104,8 @@ for FT in (Float32, Float64)
         K_c = extinction_coeff.(RTparams.G_Function, θs)
         α_soil_PAR = FT(0.2)
         output =
-            plant_absorbed_pfd.(
-                RT,
+            plant_absorbed_pfd_beer_lambert.(
+                RTparams.Ω,
                 PAR,
                 RTparams.α_PAR_leaf,
                 LAI,

--- a/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
+++ b/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
@@ -101,7 +101,8 @@ for FT in (Float32, Float64)
         θs = FT.(Array(0:0.1:(π / 2)))
         SW(θs) = cos.(θs) * FT.(500) # W/m^2
         PAR = SW(θs) ./ (energy_per_photon * N_a) # convert 500 W/m^2 to mol of photons per m^2/s
-        K_c = extinction_coeff.(RTparams.G_Function, θs)
+        G = compute_G(RTparams.G_Function, θs)
+        K_c = extinction_coeff.(G, θs)
         α_soil_PAR = FT(0.2)
         output =
             plant_absorbed_pfd_beer_lambert.(

--- a/test/standalone/Vegetation/test_two_stream.jl
+++ b/test/standalone/Vegetation/test_two_stream.jl
@@ -12,6 +12,7 @@ ClimaComms.@import_required_backends
 using ClimaLand.Canopy
 using DelimitedFiles
 using ArtifactWrappers
+using ClimaLand.Domains: Point
 
 # Get the test data
 data_file = ArtifactWrapper(
@@ -34,48 +35,64 @@ for FT in (Float32, Float64)
         θs = acos.(FT.(test_set[2:end, column_names .== "mu"]))
         LAI = FT.(test_set[2:end, column_names .== "LAI"])
         lds = FT.(test_set[2:end, column_names .== "ld"])
-        α_PAR_leaf = FT.(test_set[2:end, column_names .== "rho"])
-        τ = FT.(test_set[2:end, column_names .== "tau"])
         a_soil = FT.(test_set[2:end, column_names .== "a_soil"])
         n_layers = UInt64.(test_set[2:end, column_names .== "n_layers"])
         PropDif = FT.(test_set[2:end, column_names .== "prop_diffuse"])
 
-        # Read the result for each setup from the Python output
-        py_FAPAR = FT.(test_set[2:end, column_names .== "FAPAR"])
+        # setup spatially varying params as both float and spatially varying
+        domain = Point(; z_sfc = FT(0.0))
+        α_PAR_leaf_scalars = FT.(test_set[2:end, column_names .== "rho"])
+        α_PAR_leaf_fields =
+            map(x -> fill(x, domain.space.surface), α_PAR_leaf_scalars)
+        τ_scalars = FT.(test_set[2:end, column_names .== "tau"])
+        τ_fields = map(x -> fill(x, domain.space.surface), τ_scalars)
+        # loop through once with params as floats, then with params as fields
+        α_PAR_leaf_cases = (α_PAR_leaf_scalars, α_PAR_leaf_fields)
+        τ_cases = (τ_scalars, τ_scalars)
+        zipped_params = zip(α_PAR_leaf_cases, τ_cases)
+        for (α_PAR_leaf, τ) in zipped_params
+            # Read the result for each setup from the Python output
+            py_FAPAR = FT.(test_set[2:end, column_names .== "FAPAR"])
 
-        # Python code does not use clumping index, and λ_γ does not impact FAPAR
-        # Test over all rows in the stored output from the Python module
-        for i in 2:(size(test_set, 1) - 1)
+            # Python code does not use clumping index, and λ_γ does not impact FAPAR
+            # Test over all rows in the stored output from the Python module
+            for i in 2:(size(test_set, 1) - 1)
 
-            # Set the parameters based on the setup read from the file
-            RT_params = TwoStreamParameters(
-                FT;
-                G_Function = ConstantGFunction(FT(lds[i])),
-                α_PAR_leaf = α_PAR_leaf[i],
-                τ_PAR_leaf = τ[i],
-                Ω = FT(1),
-                n_layers = n_layers[i],
-            )
+                # Set the parameters based on the setup read from the file
+                RT_params = TwoStreamParameters(
+                    FT;
+                    G_Function = ConstantGFunction(FT(lds[i])),
+                    α_PAR_leaf = α_PAR_leaf[i],
+                    τ_PAR_leaf = τ[i],
+                    Ω = FT(1),
+                    n_layers = n_layers[i],
+                )
 
-            # Initialize the TwoStream model
-            RT = TwoStreamModel(RT_params)
+                # Initialize the TwoStream model
+                RT = TwoStreamModel(RT_params)
 
-            # Compute the predicted FAPAR using the ClimaLand TwoStream implementation
-            K = extinction_coeff(RT_params.G_Function, θs[i])
-            output = plant_absorbed_pfd(
-                RT,
-                FT(1),
-                RT_params.α_PAR_leaf,
-                RT_params.τ_PAR_leaf,
-                LAI[i],
-                K,
-                θs[i],
-                a_soil[i],
-                PropDif[i],
-            )
-            FAPAR = output.abs
-            # Check that the predictions are app. equivalent to the Python model
-            @test isapprox(py_FAPAR[i], FAPAR, atol = 0.005)
+                # Compute the predicted FAPAR using the ClimaLand TwoStream implementation
+                K = extinction_coeff(RT_params.G_Function, θs[i])
+                output =
+                    plant_absorbed_pfd.(
+                        Ref(RT),
+                        FT(1),
+                        RT_params.α_PAR_leaf,
+                        RT_params.τ_PAR_leaf,
+                        LAI[i],
+                        K,
+                        θs[i],
+                        a_soil[i],
+                        PropDif[i],
+                    )
+                FAPAR = output.abs
+                # Check that the predictions are app. equivalent to the Python model
+                # Create a field of the expect value because isapprox cannot be broadcast
+                # over a field of floats. The domain is a point, so it makes no difference
+                # to the error when FAPAR is a float
+                expected_output = fill(py_FAPAR[i], domain.space.surface)
+                @test isapprox(0, sum(FAPAR .- expected_output), atol = 0.005)
+            end
         end
     end
 end

--- a/test/standalone/Vegetation/test_two_stream.jl
+++ b/test/standalone/Vegetation/test_two_stream.jl
@@ -48,9 +48,16 @@ for FT in (Float32, Float64)
         τ_fields = map(x -> fill(x, domain.space.surface), τ_scalars)
         # loop through once with params as floats, then with params as fields
         α_PAR_leaf_cases = (α_PAR_leaf_scalars, α_PAR_leaf_fields)
-        τ_cases = (τ_scalars, τ_scalars)
-        zipped_params = zip(α_PAR_leaf_cases, τ_cases)
-        for (α_PAR_leaf, τ) in zipped_params
+        τ_PAR_leaf_cases = (τ_scalars, τ_fields)
+        α_NIR_leaf_cases = (FT(0.4), fill(FT(0.4), domain.space.surface))
+        τ_NIR_leaf_cases = (FT(0.25), fill(FT(0.24), domain.space.surface))
+        zipped_params = zip(
+            α_PAR_leaf_cases,
+            τ_PAR_leaf_cases,
+            α_NIR_leaf_cases,
+            τ_NIR_leaf_cases,
+        )
+        for (α_PAR_leaf, τ_PAR_leaf, α_NIR_leaf, τ_NIR_leaf) in zipped_params
             # Read the result for each setup from the Python output
             py_FAPAR = FT.(test_set[2:end, column_names .== "FAPAR"])
 
@@ -63,7 +70,9 @@ for FT in (Float32, Float64)
                     FT;
                     G_Function = ConstantGFunction(FT(lds[i])),
                     α_PAR_leaf = α_PAR_leaf[i],
-                    τ_PAR_leaf = τ[i],
+                    τ_PAR_leaf = τ_PAR_leaf[i],
+                    α_NIR_leaf = α_NIR_leaf,
+                    τ_NIR_leaf = τ_NIR_leaf,
                     Ω = FT(1),
                     n_layers = n_layers[i],
                 )

--- a/test/standalone/Vegetation/test_two_stream.jl
+++ b/test/standalone/Vegetation/test_two_stream.jl
@@ -74,8 +74,10 @@ for FT in (Float32, Float64)
                 # Compute the predicted FAPAR using the ClimaLand TwoStream implementation
                 K = extinction_coeff(RT_params.G_Function, θs[i])
                 output =
-                    plant_absorbed_pfd.(
-                        Ref(RT),
+                    plant_absorbed_pfd_two_stream.(
+                        RT_params.G_Function,
+                        RT_params.Ω,
+                        RT_params.n_layers,
                         FT(1),
                         RT_params.α_PAR_leaf,
                         RT_params.τ_PAR_leaf,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Towards spatially varying canopy parameters
Closes #784 

G_function can now support its parameters as floats or fields of floats.
A variable G was added to the Radiation
model's auxilliary vars. G is now calculated only once during
update_aux!. Previously, G was calculated once in extinction_coeff
and once  in plant_absorbed_pfd, which are both called during
update_aux.

G was added to the auxilliary vars because it is not possible
to broadcast on a struct containing a field. This means G needs
to be calculated before extinction_coeff and plant_absorbed_pfd
are called, and then passed in as an argument.

α_PAR_leaf, τ_PAR_leaf, α_NIR_leaf, and τ_NIR_leaf in TwoStreamParameters
support fields. α_PAR_leaf and α_NIR_leaf in BeerLambertParameters also
support fields. Both constructors changed to match the new structs.
The tests that used TwoStructParameters and BeerLambartParameters
now test functionality when the parameters are a float, and then as a field
of constants. This is a straight forwards change for all tests except
test_two_stream.jl, where a workaround is used to  avoid broadcasting
isapprox over a field of floats. This results in an error because
it tries to convert bools to floats.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
- alphas and taus extended to support fields in both TwoStreamParameters and BeerLambertParameters
- created maps for alpha and added to clima artifacts (see below)
- changes to tests
![rholnir_map](https://github.com/user-attachments/assets/7c042499-32f6-4295-aeb8-f5a85e2faa5a)

![rholvis_map](https://github.com/user-attachments/assets/d6307b51-d9a4-4ffd-bfb6-7f9c3cf7ad61)

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
