### PR TITLE
Add a ground heat flux between snow and soil

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ ClimaLand.jl Release Notes
 
 main
 --------
+- Add ground heat flux to snow-soil model PR[#796](https://github.com/CliMA/ClimaLand.jl/pull/796)
+- Add snow-soil model PR [#779](https://github.com/CliMA/ClimaLand.jl/pull/779)
 
 v0.15.0
 --------

--- a/docs/list_tutorials.jl
+++ b/docs/list_tutorials.jl
@@ -9,6 +9,7 @@ tutorials = [
         ],
         "Handling interactions between model components" => [
             "Adjusting boundary conditions for the soil" => "integrated/handling_soil_fluxes.jl",
+            "Adjusting boundary conditions for the snow" => "integrated/handling_snow_fluxes.jl",
         ],
     ],
     "Running standalone component simulations" => [

--- a/docs/src/APIs/Snow.md
+++ b/docs/src/APIs/Snow.md
@@ -23,4 +23,12 @@ ClimaLand.Snow.runoff_timescale
 ClimaLand.Snow.compute_water_runoff	
 ClimaLand.Snow.energy_from_q_l_and_swe
 ClimaLand.Snow.energy_from_T_and_swe
+ClimaLand.Snow.snow_cover_fraction
+```
 
+## Computing fluxes for snow
+
+```@docs
+ClimaLand.Snow.snow_boundary_fluxes!
+ClimaLand.Snow.AtmosDrivenSnowBC
+```

--- a/docs/tutorials/integrated/handling_snow_fluxes.jl
+++ b/docs/tutorials/integrated/handling_snow_fluxes.jl
@@ -1,0 +1,64 @@
+# # Background
+# When solving the system of equations describing the storage of water and energy in snow,
+# "boundary conditions" must be set. These are only true boundary conditions
+# if one considers the equations for water and energy in snow to be discretized PDEs,
+# but they do represent the fluxes at upper boundary (the snow/atmosphere interface) and at
+# the lower boundary (the snow/soil interface), so we refer to them as boundary conditions
+# in order to use a consistent notation with the soil model.
+
+# At present, the only type of boundary condition the snow model supports is
+# `AtmosDrivenSnowBC`, which is an attempt at a compact way of indicating that with this
+# choice, the snow model exchanges water and energy with the atmosphere via sensible, latent, and radiative heat fluxes, and by
+# precipitation and sublimation/evaporation. With this choice, the snow model also has exchange fluxes with the soil (melt water,
+# and a conductive ground heat flux). This boundary condition type includes the atmospheric and radiative
+# forcings, and, importantly, a Tuple which indicates which components of the land are present.
+# The last argument is what we will describe here. For more information on how to supply the prescribed forcing
+# data, please see the tutorial linked [here](@ref shared_utilities/driver_tutorial.jl). For an explanation of the
+# same design implementation for the Soil model, please see [here](@ref integrated/handling_soil_fluxes.jl).
+
+# # Adjusting the boundary conditions for the snow model when run as part of an integrated land model
+
+# The presence of other land components (a canopy, the soil) affects the boundary conditions of the snow
+# and changes them relative to what they would be if only bare snow was interacting with the atmosphere.
+# For example, the canopy absorbs radiation that might otherwise be absorbed by the snow, the
+# canopy intercepts precipitation, and the soil and snow interact thermally at the interface between them.
+# Because of this, we need a way to indicate to the snow model that the boundary conditions must be computed in a different way
+# depending on the components. We do this via the field in the boundary condition of type `AtmosDrivenSnowBC` via
+# a field `prognostic_land_components`,
+# which is a Tuple of the symbols associated with each component in the land model. For example,
+# if you are simulating the snow model in standalone mode, you would set
+
+# `prognostic_land_components = (:snow,)`
+
+# `boundary_condition = ClimaLand.Snow.AtmosDrivenSnowBC(atmos_forcing, radiative_forcing, prognostic_land_components)`
+
+# while, if you are simulating both a prognostic snow and soil model, you would set
+
+# `prognostic_land_components = (:snow, :soil)`
+
+# `boundary_condition = ClimaLand.Snow.AtmosDrivenSnowBC(atmos_forcing, radiative_forcing, prognostic_land_components)`
+
+# Note that the land components are *always* in alphabetical order, and the symbols associated with each
+# land model component are *always* the same as the name of that component, i.e., 
+
+# `ClimaLand.name(snow_model) = :snow`
+
+# `ClimaLand.name(canopy_model) = :canopy`
+
+# `ClimaLand.name(soilco2_model) = :soilco2`
+
+# `ClimaLand.name(soil_model) = :soil`
+
+# Currently, the only supported options are: `(:snow,)`, and `(:snow, :soil)`.
+
+# # How it works
+# When the snow model computes its boundary fluxes, it calls the function
+# `snow_boundary_fluxes!(bc, snow_model, Y, p, t)`, where `bc`
+# is the boundary condition of type `AtmosDrivenSnowBC`.
+# This function then calls `snow_boundary_fluxes!(bc, Val(bc.prognostic_land_components), snow, Y, p, t)`.
+# Here multiple dispatch is used to compute the fluxes correctly according to the value of the `prognostic_land_components`,
+# i.e., based on which components are present.
+
+# # Some important notes
+# When the snow model is run in standalone mode (`prognostic_land_components = (:snow,)`), the ground heat flux is approximate
+# as zero. When the soil and snow model are run together, this flux is computed and affects both the snow and soil.

--- a/experiments/standalone/Snow/snowmip_simulation.jl
+++ b/experiments/standalone/Snow/snowmip_simulation.jl
@@ -50,8 +50,7 @@ parameters =
 model = ClimaLand.Snow.SnowModel(
     parameters = parameters,
     domain = domain,
-    atmos = atmos,
-    radiation = radiation,
+    boundary_conditions = ClimaLand.Snow.AtmosDrivenSnowBC(atmos, radiation),
 )
 Y, p, coords = ClimaLand.initialize(model)
 

--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -303,6 +303,7 @@ import .Soil: soil_boundary_fluxes!, sublimation_source
 import .Soil.Biogeochemistry: soil_temperature, soil_moisture
 include("standalone/Snow/Snow.jl")
 using .Snow
+import .Snow: snow_boundary_fluxes!
 include("standalone/Vegetation/Canopy.jl")
 using .Canopy
 using .Canopy.PlantHydraulics

--- a/src/integrated/soil_snow_model.jl
+++ b/src/integrated/soil_snow_model.jl
@@ -1,4 +1,5 @@
 export LandHydrologyModel
+using ClimaCore.Operators: column_integral_definite!
 
 
 """
@@ -89,8 +90,11 @@ function LandHydrologyModel{FT}(;
         soil_args...,
     )
     snow = snow_model_type(;
-        atmos = atmos,
-        radiation = radiation,
+        boundary_conditions = Snow.AtmosDrivenSnowBC(
+            atmos,
+            radiation,
+            prognostic_land_components,
+        ),
         domain = Domains.obtain_surface_domain(domain),
         snow_args...,
     )
@@ -109,6 +113,11 @@ lsm_aux_vars(m::LandHydrologyModel) = (
     :excess_heat_flux,
     :atmos_energy_flux,
     :atmos_water_flux,
+    :ground_heat_flux,
+    :effective_soil_sfc_T,
+    :sfc_scratch,
+    :subsfc_scratch,
+    :effective_soil_sfc_depth,
 )
 """
     lsm_aux_types(m::LandHydrologyModel)
@@ -116,7 +125,8 @@ lsm_aux_vars(m::LandHydrologyModel) = (
 The types of the additional auxiliary variables that are
 included in the integrated Soil-Snow model.
 """
-lsm_aux_types(m::LandHydrologyModel{FT}) where {FT} = (FT, FT, FT, FT)
+lsm_aux_types(m::LandHydrologyModel{FT}) where {FT} =
+    (FT, FT, FT, FT, FT, FT, FT, FT, FT)
 
 """
     lsm_aux_domain_names(m::LandHydrologyModel)
@@ -124,8 +134,17 @@ lsm_aux_types(m::LandHydrologyModel{FT}) where {FT} = (FT, FT, FT, FT)
 The domain names of the additional auxiliary variables that are
 included in the integrated Soil-Snow model.
 """
-lsm_aux_domain_names(m::LandHydrologyModel) =
-    (:surface, :surface, :surface, :surface)
+lsm_aux_domain_names(m::LandHydrologyModel) = (
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :subsurface,
+    :surface,
+)
 
 """
     make_update_boundary_fluxes(
@@ -143,6 +162,13 @@ models.
 
 This function is called each ode function evaluation, prior to the tendency function
 evaluation.
+
+In this method, we
+1. Compute the ground heat flux between soil and snow. This is required to update the snow and soil boundary fluxes
+2. Update the snow boundary fluxes, which also computes any excess flux of energy or water which occurs when the snow
+completely melts in a step. In this case, that excess must go to the soil for conservation
+3. Update the soil boundary fluxes use precomputed ground heat flux and excess fluxes from snow.
+4. Compute the net flux for the atmosphere, which is useful for assessing conservation.
 """
 function make_update_boundary_fluxes(
     land::LandHydrologyModel{FT, SnM, SoM},
@@ -150,15 +176,30 @@ function make_update_boundary_fluxes(
     update_soil_bf! = make_update_boundary_fluxes(land.soil)
     update_snow_bf! = make_update_boundary_fluxes(land.snow)
     function update_boundary_fluxes!(p, Y, t)
+        earth_param_set = land.soil.parameters.earth_param_set
+        # First compute the ground heat flux in place:
+        update_soil_snow_ground_heat_flux!(
+            p,
+            Y,
+            land.soil.parameters,
+            land.snow.parameters,
+            land.soil.domain,
+            FT,
+        )
+        #Now update snow boundary conditions, which rely on the ground heat flux
         update_snow_bf!(p, Y, t)
         # Now we have access to the actual applied and initially computed fluxes for snow
         @. p.excess_water_flux =
             (p.snow.total_water_flux - p.snow.applied_water_flux)
         @. p.excess_heat_flux =
             (p.snow.total_energy_flux - p.snow.applied_energy_flux)
+        # Now we can update the soil BC, and use the excess fluxes there in order
+        # to conserve energy and water
         update_soil_bf!(p, Y, t)
-        _LH_f0 = FT(LP.LH_f0(land.soil.parameters.earth_param_set))
-        _ρ_liq = FT(LP.ρ_cloud_liq(land.soil.parameters.earth_param_set))
+
+        # compute net flux with atmosphere, this is useful for monitoring conservation
+        _LH_f0 = FT(LP.LH_f0(earth_param_set))
+        _ρ_liq = FT(LP.ρ_cloud_liq(earth_param_set))
         ρe_falling_snow = -_LH_f0 * _ρ_liq # per unit vol of liquid water
         @. p.atmos_energy_flux =
             (1 - p.snow.snow_cover_fraction) * (
@@ -185,8 +226,145 @@ function make_update_boundary_fluxes(
     return update_boundary_fluxes!
 end
 
+"""
+    update_soil_snow_ground_heat_flux!(p, Y, soil_params, snow_params, soil_domain, FT)
+
+Computes and updates `p.ground_heat_flux` with the ground heat flux. We approximate this 
+as
+    F_g =  - κ_eff (T_snow - T_soil)/Δz_eff,
+
+where:
+    κ_eff = κ_soil * κ_snow / (κ_snow * Δz_soil / 2 + κ_soil * Δz_snow / 2)* (Δz_soil + Δz_snow)/2
+    Δz_eff =( Δz_soil + Δz_snow)/2
+
+This is what JULES does to compute the diffusive heat flux between snow and soil, for example, 
+see equation 24 and 25, with k=N, of Best et al, Geosci. Model Dev., 4, 677–699, 2011
+
+However, this is for a multi-layer snow model, with
+T_snow and Δz_snow related to the bottom layer.
+It's not clear this is ideal when we have a single layer snow model. We can revisit this.
+"""
+function update_soil_snow_ground_heat_flux!(
+    p,
+    Y,
+    soil_params,
+    snow_params,
+    soil_domain,
+    FT,
+)
+    # Thermal conductivities
+    κ_snow = p.snow.κ
+    κ_soil = ClimaLand.Domains.top_center_to_surface(p.soil.κ)
+
+    # Depth of snow and soil layers interacting thermally at interface
+    Δz_snow = p.snow.z # Snow depth
+    Δz_soil = p.effective_soil_sfc_depth
+    (; ρc_ds, earth_param_set) = soil_params
+
+    # The snow assumes a thickness D of soil interacts thermally with the snow
+    # but this is specified by a parameter ρcD_g (volumetric heat capacity x depth).
+    # Therefore we infer the depth as D = ρcD_g / ρc_g, where ρc_g is volumetric
+    # heat capacity of the first soil layer
+    @. p.subsfc_scratch =
+        snow_params.ρcD_g /
+        volumetric_heat_capacity(p.soil.θ_l, Y.soil.θ_i, ρc_ds, earth_param_set)
+    Δz_soil .= ClimaLand.Domains.top_center_to_surface(p.subsfc_scratch)
+    # If the soil layers are very large, no layer center may lie within Δz_soil of the snow.
+    # In this case, we take the maximum of the first center layer and the thickness of the layer
+    # interacting with the snow, plus a small amount
+    @. Δz_soil = max(Δz_soil, soil_domain.fields.Δz_top) + sqrt(eps(FT))
+
+    # Find average temperature of soil in depth D
+    ∫H_dz = p.sfc_scratch
+    ∫H_T_dz = p.soil.sfc_scratch
+
+    H = p.subsfc_scratch
+    @. H = ClimaLand.heaviside(
+        soil_domain.fields.z_sfc - soil_domain.fields.z,
+        Δz_soil,
+    )
+    column_integral_definite!(∫H_dz, H)
+
+    H_T = p.subsfc_scratch
+    @. H_T =
+        ClimaLand.heaviside(
+            soil_domain.fields.z_sfc - soil_domain.fields.z,
+            Δz_soil,
+        ) * p.soil.T
+    column_integral_definite!(∫H_T_dz, H_T)
+
+    T_soil = p.effective_soil_sfc_T
+
+    @. T_soil = ∫H_T_dz / ∫H_dz
+
+    # Snow temperature
+    T_snow = p.snow.T
+
+    # compute the flux
+    @. p.ground_heat_flux =
+        -κ_soil * κ_snow / (κ_snow * Δz_soil / 2 + κ_soil * Δz_snow / 2) *
+        (T_snow - T_soil)
+end
+
 
 ### Extensions of existing functions to account for prognostic soil/snow
+"""
+    snow_boundary_fluxes!(
+        bc::AtmosDrivenSnowBC,
+        prognostic_land_components::Val{(:snow, :soil)},
+        model::SnowModel{FT},
+        Y,
+        p,
+        t,
+    ) where {FT}
+
+A method of `snow_boundary_fluxes!` which computes 
+the boundary fluxes for the snow model accounting
+for a heat flux between the soil and snow.
+
+The snow surface is 
+assumed to be bare (no vegetation).
+
+Currently this is almost identical to the method for snow alone,
+except for the inclusion of the ground heat flux (precomputed by 
+the integrated land model). However, this will change more if e.g.
+we allow for transmission of radiation through the snowpack.
+"""
+function snow_boundary_fluxes!(
+    bc::Snow.AtmosDrivenSnowBC,
+    prognostic_land_components::Val{(:snow, :soil)},
+    model::SnowModel{FT},
+    Y,
+    p,
+    t,
+) where {FT}
+    p.snow.turbulent_fluxes .= turbulent_fluxes(bc.atmos, model, Y, p, t)
+    p.snow.R_n .= net_radiation(bc.radiation, model, Y, p, t)
+    # How does rain affect the below?
+    P_snow = p.drivers.P_snow
+
+    @. p.snow.total_water_flux =
+        P_snow +
+        (p.snow.turbulent_fluxes.vapor_flux - p.snow.water_runoff) *
+        p.snow.snow_cover_fraction
+
+    # I think we want dU/dt to include energy of falling snow.
+    # otherwise snow can fall but energy wont change
+    # We are assuming that the sensible heat portion of snow is negligible.
+    _LH_f0 = FT(LP.LH_f0(model.parameters.earth_param_set))
+    _ρ_liq = FT(LP.ρ_cloud_liq(model.parameters.earth_param_set))
+    ρe_falling_snow = -_LH_f0 * _ρ_liq # per unit vol of liquid water
+
+    # positive fluxes are TOWARDS atmos
+    @. p.snow.total_energy_flux =
+        P_snow * ρe_falling_snow +
+        (
+            p.snow.turbulent_fluxes.lhf +
+            p.snow.turbulent_fluxes.shf +
+            p.snow.R_n - p.snow.energy_runoff - p.ground_heat_flux
+        ) * p.snow.snow_cover_fraction
+end
+
 """
     soil_boundary_fluxes!(
         bc::AtmosDrivenFluxBC{<:PrescribedAtmosphere, <:PrescribedRadiativeFluxes},
@@ -232,7 +410,9 @@ function soil_boundary_fluxes!(
             p.soil.R_n +
             p.soil.turbulent_fluxes.lhf +
             p.soil.turbulent_fluxes.shf
-        ) + p.excess_heat_flux
+        ) +
+        p.excess_heat_flux +
+        p.snow.snow_cover_fraction * p.ground_heat_flux
 end
 
 function ClimaLand.Soil.sublimation_source(::Val{(:snow, :soil)}, FT)
@@ -277,5 +457,8 @@ function ClimaLand.source!(
 end
 
 function ClimaLand.get_drivers(model::LandHydrologyModel)
-    return (model.snow.atmos, model.snow.radiation)
+    return (
+        model.snow.boundary_conditions.atmos,
+        model.snow.boundary_conditions.radiation,
+    )
 end

--- a/src/shared_utilities/utils.jl
+++ b/src/shared_utilities/utils.jl
@@ -6,10 +6,20 @@ export FTfromY
 """
      heaviside(x::FT)::FT where {FT}
 
-Computes the heaviside function.
+Computes the heaviside function H(x) = 1 (x ≥0), 0 (x < 0)
 """
 function heaviside(x::FT)::FT where {FT}
-    if x > eps(FT)
+    heaviside(x, FT(0))
+end
+
+"""
+     heaviside(x::FT, a::FT)::FT where {FT}
+
+Computes the heaviside function H(y) = 1 (y ≥0), 0 (y < 0),
+where y = x-a.
+"""
+function heaviside(x::FT, a::FT)::FT where {FT}
+    if x - a > eps(FT)
         return FT(1.0)
     else
         return FT(0.0)

--- a/src/standalone/Snow/boundary_fluxes.jl
+++ b/src/standalone/Snow/boundary_fluxes.jl
@@ -1,0 +1,129 @@
+"""
+    AbstractSnowBC <: ClimaLand.AbstractBC
+
+An abstract type for boundary conditions for the snow model.
+"""
+abstract type AbstractSnowBC <: ClimaLand.AbstractBC end
+
+"""
+    AtmosDrivenSnowBC{
+        A <: AbstractAtmosphericDrivers,
+        B <: AbstractRadiativeDrivers,
+        C::Tuple
+    } <: AbstractSnowBC
+
+A struct used to specify the snow fluxes, referred
+to as ``boundary conditions", at the surface and
+bottom of the snowpack, for water and energy.
+
+These fluxes include turbulent surface fluxes
+computed with Monin-Obukhov theory, and radiative fluxes.
+$(DocStringExtensions.FIELDS)
+"""
+struct AtmosDrivenSnowBC{
+    A <: AbstractAtmosphericDrivers,
+    B <: AbstractRadiativeDrivers,
+    C <: Tuple,
+} <: AbstractSnowBC
+    "The atmospheric conditions driving the model"
+    atmos::A
+    "The radiative fluxes driving the model"
+    radiation::B
+    "Prognostic land components present"
+    prognostic_land_components::C
+end
+
+function AtmosDrivenSnowBC(
+    atmos,
+    radiation;
+    prognostic_land_components = (:snow,),
+)
+    args = (atmos, radiation, prognostic_land_components)
+    return AtmosDrivenSnowBC(args...)
+end
+
+
+"""
+    snow_boundary_fluxes!(bc::AtmosDrivenSnowBC, model::SnowModel, Y, p, t)
+
+Updates in place various volumetric water flux (m/s) and energy
+flux (W/m^2) terms for the snow model:
+
+- p.snow.turbulent fluxes (latent, sensible, and evaporative fluxes)
+- p.snow.R_n (radiative fluxes)
+- p.snow.total_water_flux
+- p.snow.total_energy_flux
+
+The two latter fluxes also include contributions from fluxes 
+due to melt and precipitation, but note that precipitation and melt flux are not computed or updated in `snow_boundary_fluxes` currently. Instead, they 
+are updated in `update_aux!`, which happens prior to the `snow_boundary_fluxes!` call, and used in the `snow_boundary_fluxes!` call.
+
+
+This function calls the `turbulent_fluxes` and `net_radiation`
+functions, which use the snow surface conditions as well as
+the atmos and radiation conditions in order to
+compute the surface fluxes using Monin Obukhov Surface Theory.
+It also accounts for the presence of other components, if run as
+part of an integrated land model, and their effect on boundary conditions.
+"""
+function snow_boundary_fluxes!(bc::AtmosDrivenSnowBC, model::SnowModel, Y, p, t)
+    snow_boundary_fluxes!(
+        bc,
+        Val(bc.prognostic_land_components),
+        model,
+        Y,
+        p,
+        t,
+    )
+end
+
+"""
+    snow_boundary_fluxes!(
+        bc::AtmosDrivenSnowBC,
+        prognostic_land_components::Val{(:snow,)},
+        model::SnowModel{FT},
+        Y,
+        p,
+        t,
+    ) where {FT}
+
+Computes the boundary fluxes for the snow model in standalone mode.
+
+The ground heat flux is assumed to be zero, and the snow surface is 
+assumed to be bare (no vegetation).
+"""
+function snow_boundary_fluxes!(
+    bc::AtmosDrivenSnowBC,
+    prognostic_land_components::Val{(:snow,)},
+    model::SnowModel{FT},
+    Y,
+    p,
+    t,
+) where {FT}
+    bc = model.boundary_conditions
+    p.snow.turbulent_fluxes .= turbulent_fluxes(bc.atmos, model, Y, p, t)
+    p.snow.R_n .= net_radiation(bc.radiation, model, Y, p, t)
+    # How does rain affect the below?
+    P_snow = p.drivers.P_snow
+
+    @. p.snow.total_water_flux =
+        P_snow +
+        (p.snow.turbulent_fluxes.vapor_flux - p.snow.water_runoff) *
+        p.snow.snow_cover_fraction
+
+    # I think we want dU/dt to include energy of falling snow.
+    # otherwise snow can fall but energy wont change
+    # We are assuming that the sensible heat portion of snow is negligible.
+    _LH_f0 = FT(LP.LH_f0(model.parameters.earth_param_set))
+    _ρ_liq = FT(LP.ρ_cloud_liq(model.parameters.earth_param_set))
+    ρe_falling_snow = -_LH_f0 * _ρ_liq # per unit vol of liquid water
+
+    # positive fluxes are TOWARDS atmos
+    @. p.snow.total_energy_flux =
+        P_snow * ρe_falling_snow +
+        (
+            p.snow.turbulent_fluxes.lhf +
+            p.snow.turbulent_fluxes.shf +
+            p.snow.R_n - p.snow.energy_runoff
+        ) * p.snow.snow_cover_fraction
+end

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -8,7 +8,20 @@ export snow_surface_temperature,
     runoff_timescale,
     compute_water_runoff,
     energy_from_q_l_and_swe,
-    energy_from_T_and_swe
+    energy_from_T_and_swe,
+    snow_cover_fraction
+
+"""
+    snow_cover_fraction(x::FT; α = FT(1e-3))::FT where {FT}
+
+Returns the snow cover fraction, assuming it is a heaviside
+function at 1e-3 meters.
+
+In the future we can play around with other forms.
+"""
+function snow_cover_fraction(x::FT; α = FT(1e-3))::FT where {FT}
+    return heaviside(x - α)
+end
 
 """
     ClimaLand.surface_height(

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -741,7 +741,7 @@ functions, which use the soil surface conditions as well as
 the atmos and radiation conditions in order to
 compute the surface fluxes using Monin Obukhov Surface Theory.
 It also accounts for the presence of other components, if run as
-part of an integrated land model, and their affect on boundary conditions.
+part of an integrated land model, and their effect on boundary conditions.
 """
 function soil_boundary_fluxes!(
     bc::AtmosDrivenFluxBC,

--- a/test/standalone/Snow/snow.jl
+++ b/test/standalone/Snow/snow.jl
@@ -46,8 +46,7 @@ import ClimaLand.Parameters as LP
     model = ClimaLand.Snow.SnowModel(
         parameters = parameters,
         domain = domain,
-        atmos = atmos,
-        radiation = rad,
+        boundary_conditions = ClimaLand.Snow.AtmosDrivenSnowBC(atmos, rad),
     )
     drivers = ClimaLand.get_drivers(model)
     @test drivers == (atmos, rad)
@@ -55,8 +54,10 @@ import ClimaLand.Parameters as LP
     @test (Y.snow |> propertynames) == (:S, :U)
     @test (p.snow |> propertynames) == (
         :q_l,
+        :κ,
         :T,
         :T_sfc,
+        :z,
         :turbulent_fluxes,
         :R_n,
         :energy_runoff,
@@ -84,8 +85,13 @@ import ClimaLand.Parameters as LP
     # Check if aux update occurred correctly
     @test p.snow.R_n ==
           @. (-(1 - α_snow) * 20.0f0 - ϵ_snow * (20.0f0 - _σ * p.snow.T_sfc^4))
-    @test p.snow.R_n ==
-          ClimaLand.net_radiation(model.radiation, model, Y, p, t0)
+    @test p.snow.R_n == ClimaLand.net_radiation(
+        model.boundary_conditions.radiation,
+        model,
+        Y,
+        p,
+        t0,
+    )
     @test p.snow.q_l ==
           snow_liquid_mass_fraction.(Y.snow.U, Y.snow.S, Ref(model.parameters))
     @test p.snow.T_sfc ==
@@ -99,7 +105,7 @@ import ClimaLand.Parameters as LP
     )
 
     ρ_sfc = ClimaLand.surface_air_density(
-        model.atmos,
+        model.boundary_conditions.atmos,
         model,
         Y,
         p,
@@ -115,7 +121,13 @@ import ClimaLand.Parameters as LP
             ρ_sfc,
             Ref(Thermodynamics.Ice()),
         )
-    turb_fluxes = ClimaLand.turbulent_fluxes(model.atmos, model, Y, p, t0)
+    turb_fluxes = ClimaLand.turbulent_fluxes(
+        model.boundary_conditions.atmos,
+        model,
+        Y,
+        p,
+        t0,
+    )
     @test turb_fluxes.shf == p.snow.turbulent_fluxes.shf
     @test turb_fluxes.lhf == p.snow.turbulent_fluxes.lhf
     @test turb_fluxes.vapor_flux == p.snow.turbulent_fluxes.vapor_flux


### PR DESCRIPTION
## Purpose 
Introduce a ground heat flux between the soil and snow. This is important as it is the major heat flux the soil feels when it is covered by snow.

Introduce the same type of handing of boundary conditions for snow as for soil when multiple components are present

## To-do
maybe @AlexisRenchon could review the ground heat flux term, and @juliasloan25 could review the prognostic_land_components and dispatch side of things (similar to the PR you reviewed where we implemented it for soil)?


## Content
- Introduce Snow.AtmosDrivenSnowBC, which is a direct analog of Soil.AtmosDrivenFluxBC for snow. (Future PR is to change the name of AtmosDrivenFluxBC to AtmosDrivenSoilBC)
- Introduce `snow_boundary_fluxes!` function, a direct analog of `soil_boundary_fluxes!`. What these functions do depends on the values of the `prognostic_land_components` field of the bc.
- When snow is run by itself `prognostic_land_components = (;snow,)`, and the `snow_boundary_fluxes!` function treats the ground heat flux as zero [future PR could be to add in a prescribed soil component, but this can definitely wait until we have a use case]
- When the snow is run with a soil model, `prognostic_land_components = (;snow, :soil)`, and the `snow_boundary_fluxes!` function compute a ground heat flux. I had to add some extra aux fields to the cache for this computation in order to avoid allocations.
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
