### PR TITLE
Compute SHF using SF, do not re-compute offline

### DIFF
--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -859,6 +859,17 @@ Computes turbulent surface fluxes for soil at a point on a surface given
 
 This returns an energy flux and a liquid water volume flux, stored in
 a tuple with self explanatory keys.
+
+Notes:
+In this function, we call SF twice - once for ice, and once for water. 
+We then combine the fluxes from them to get the total SH, LH. 
+The vapor fluxes are applied to ice and water differently - as either a source term
+or a boundary condition-  so they are kept separate.
+
+For ice, we supply a beta factor and do not need an additional surface resistance, 
+and so we use the output of surface_conditions directly. 
+For water, we do, and it's a little complicated how we handle it. 
+But once we correct E, we compute SH and LH the same as SurfaceFluxes.jl does.
 """
 function soil_turbulent_fluxes_at_a_point(
     T_sfc::FT,
@@ -881,24 +892,31 @@ function soil_turbulent_fluxes_at_a_point(
     γT_ref::FT,
     earth_param_set::P,
 ) where {FT <: AbstractFloat, P}
+    # Parameters
+    surface_flux_params = LP.surface_fluxes_parameters(earth_param_set)
     thermo_params = LP.thermodynamic_parameters(earth_param_set)
+    _LH_v0::FT = LP.LH_v0(earth_param_set)
+    _ρ_liq::FT = LP.ρ_cloud_liq(earth_param_set)
+
+    # Atmos air state
+    state_air = SurfaceFluxes.StateValues(
+        h_air - d_sfc - h_sfc,
+        SVector{2, FT}(u_air, 0),
+        thermal_state_air,
+    )
+    q_air::FT =
+        Thermodynamics.total_specific_humidity(thermo_params, thermal_state_air)
+
     # Estimate surface air density
     ρ_sfc::FT = ClimaLand.compute_ρ_sfc(thermo_params, thermal_state_air, T_sfc)
-    # Compute saturated specific humidities at surface over ice and liquid water
-    q_sat_ice::FT = Thermodynamics.q_vap_saturation_generic(
-        thermo_params,
-        T_sfc,
-        ρ_sfc,
-        Thermodynamics.Ice(),
-    )
+
+    # Now compute surface fluxes from liquid water component:
     q_sat_liq::FT = Thermodynamics.q_vap_saturation_generic(
         thermo_params,
         T_sfc,
         ρ_sfc,
         Thermodynamics.Liquid(),
     )
-
-    # Evaporation:
     thermal_state_sfc::Thermodynamics.PhaseEquil{FT} =
         Thermodynamics.PhaseEquil_ρTq(thermo_params, ρ_sfc, T_sfc, q_sat_liq)# use to get potential evaporation E0, r_ae (weak dependence on q).
 
@@ -916,12 +934,6 @@ function soil_turbulent_fluxes_at_a_point(
         SVector{2, FT}(0, 0),
         thermal_state_sfc,
     )
-    state_air = SurfaceFluxes.StateValues(
-        h_air - d_sfc - h_sfc,
-        SVector{2, FT}(u_air, 0),
-        thermal_state_air,
-    )
-
     # State containers
     states = SurfaceFluxes.ValuesOnly(
         state_air,
@@ -930,21 +942,9 @@ function soil_turbulent_fluxes_at_a_point(
         z_0b,
         gustiness = gustiness,
     )
-    surface_flux_params = LP.surface_fluxes_parameters(earth_param_set)
-    conditions = SurfaceFluxes.surface_conditions(
-        surface_flux_params,
-        states;
-        tol_neutral = SFP.cp_d(surface_flux_params) / 100000,
-    )
-    _LH_v0::FT = LP.LH_v0(earth_param_set)
-    _ρ_liq::FT = LP.ρ_cloud_liq(earth_param_set)
-    cp_m::FT = Thermodynamics.cp_m(thermo_params, thermal_state_air)
-    T_air::FT = Thermodynamics.air_temperature(thermo_params, thermal_state_air)
-    ρ_air::FT = Thermodynamics.air_density(thermo_params, thermal_state_air)
-    q_air::FT =
-        Thermodynamics.total_specific_humidity(thermo_params, thermal_state_air)
-
-    ΔT::FT = T_air - T_sfc
+    scheme = SurfaceFluxes.PointValueScheme()
+    conditions =
+        SurfaceFluxes.surface_conditions(surface_flux_params, states, scheme)
     r_ae_liq::FT = 1 / (conditions.Ch * SurfaceFluxes.windspeed(states))
 
     E0::FT =
@@ -970,9 +970,22 @@ function soil_turbulent_fluxes_at_a_point(
     else
         Ẽ *= 0 # condensation, set to zero
     end
-    H_liq::FT = -ρ_air * cp_m * ΔT / r_ae_liq
 
-    # Sublimation:
+    # sensible heat flux
+    SH_liq = SurfaceFluxes.sensible_heat_flux(
+        surface_flux_params,
+        conditions.Ch,
+        states,
+        scheme,
+    )
+
+    # Repeat for ice component:
+    q_sat_ice::FT = Thermodynamics.q_vap_saturation_generic(
+        thermo_params,
+        T_sfc,
+        ρ_sfc,
+        Thermodynamics.Ice(),
+    )
     thermal_state_sfc =
         Thermodynamics.PhaseEquil_ρTq(thermo_params, ρ_sfc, T_sfc, q_sat_ice)
     β_i::FT = FT(1)
@@ -996,25 +1009,28 @@ function soil_turbulent_fluxes_at_a_point(
         beta = β_i,
         gustiness = gustiness,
     )
-    conditions = SurfaceFluxes.surface_conditions(
-        surface_flux_params,
-        states;
-        tol_neutral = SFP.cp_d(surface_flux_params) / 100000,
-    )
+    conditions =
+        SurfaceFluxes.surface_conditions(surface_flux_params, states, scheme)
     S::FT =
         SurfaceFluxes.evaporation(surface_flux_params, states, conditions.Ch)# sublimation rate, mass flux
     S̃::FT = S / _ρ_liq
 
     r_ae_ice::FT = 1 / (conditions.Ch * SurfaceFluxes.windspeed(states))
-    H_ice::FT = -ρ_air * cp_m * ΔT / r_ae_ice
+    # sensible heat flux from ice
+    SH_ice = SurfaceFluxes.sensible_heat_flux(
+        surface_flux_params,
+        conditions.Ch,
+        states,
+        scheme,
+    )
 
-    # Heat fluxes
+    # Heat fluxes for soil
     LH::FT = _LH_v0 * (Ẽ + S̃) * _ρ_liq
-    H::FT = (H_ice + H_liq) / 2
+    SH::FT = (SH_ice + SH_liq) / 2
     r_ae::FT = 2 * r_ae_liq * r_ae_ice / (r_ae_liq + r_ae_ice) # implied by definition of H
     return (
         lhf = LH,
-        shf = H,
+        shf = SH,
         vapor_flux_liq = Ẽ,
         r_ae = r_ae,
         vapor_flux_ice = S̃,

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -1070,12 +1070,12 @@ end
         finitediff_SHF = (p_2.canopy.energy.shf .- p.canopy.energy.shf) ./ ΔT
         estimated_SHF = p.canopy.energy.∂SHF∂Tc
         @test parent(abs.(finitediff_SHF .- estimated_SHF) ./ finitediff_SHF)[1] <
-              0.05
+              0.15
 
         finitediff_LHF = (p_2.canopy.energy.lhf .- p.canopy.energy.lhf) ./ ΔT
         estimated_LHF = p.canopy.energy.∂LHF∂qc .* p.canopy.energy.∂qc∂Tc
         @test parent(abs.(finitediff_LHF .- estimated_LHF) ./ finitediff_LHF)[1] <
-              0.5
+              0.3
 
         # Error in `q` derivative is large
         finitediff_q = (q_sfc2 .- q_sfc) ./ ΔT


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Since evaporation is no longer included in the SH computation in [SF.jl](https://github.com/CliMA/SurfaceFluxes.jl/pull/176/files#diff-6059b3ed786f8df9a4697af825ca0c680479fec22c617e328302dc4e2aaece66R687-R688), we now use the output of `sensible_heat_flux` provided directly by SF.jl's call to `surface_conditions`. This will make fluxes calculated in atmos and in land more similar, which is a good to prepare for coupled runs.

Our fluxes differ from those calculated in SurfaceFluxes still in these ways:
- land components usually require `r_sfc`, an additional resistance term, in the evaporation calculation.
- for the bucket and snow models, this is the only change
- for the soil model, we do not allow for condensation or frost. Again we modify the evaporation using a surface resistance. We also compute SF twice, once for liquid water, and once for ice. This requires us to combine the SH_ice and SH_water into a single number also.
- for the canopy, the surface resistance affects SH and E



## To-do

## Content
Note that this change required an increase in the threshold for passing in one of our tests (for the canopy temperature jacobian contribution from SHF). Previously, we used only cp_m of the atmos in the SH flux, which is indep of T_canopy. now, the coefficient in the Jacobian depends on cp_m_sfc. This does depend on T_canopy, because it depends on q_canopy, which we approximate as q_sat(T_canopy).  We hypothesize that this is why the error in the SH approximation grew with this PR. @trontrytel 

Previous: SHF = -rho_sfc cp_m_atmos (T_atmos - T_canopy)/resistances
Now: SHF = -rho_sfc/resistances *  [stuff indep of T_canopy ..... - cp_m_sfc(T_canopy)*T_canopy ....]

Since we already have an issue open to improve the jacobian approximation, we are accepting this for now. @juliasloan25 

For good measure, though, I added the derivative of rho_sfc with respect to T_sfc

## Comparisons
This PR followed by implicit canopy PR long run:
Long Runs at 1/2 year:
Canopy Temp: 
![image](https://github.com/user-attachments/assets/bac34e86-e7c9-4861-8ee3-61dfff5f46ed)
![image](https://github.com/user-attachments/assets/04f62614-8a19-413a-a2d6-5039a74f87fb)
ET:
![image](https://github.com/user-attachments/assets/5bd779ad-6a31-4fec-bb6f-aa445d02254f)
![image](https://github.com/user-attachments/assets/0197941c-64ac-4186-b638-b2651cc9cf6e)
SWC:
![image](https://github.com/user-attachments/assets/85bc78fc-ee04-491b-95d0-30a8ceee72d8)
![image](https://github.com/user-attachments/assets/d555d2c8-af33-4592-952b-998e6e044d61)

Canopy Alone Convergence:
this PR vs current main
![image](https://github.com/user-attachments/assets/e0f8fc38-e90f-4e74-bf2d-30c7a080b5d0)
![image](https://github.com/user-attachments/assets/0ccc9f98-0a8e-4521-8946-36dbdf0728f8)
Errors:
![image](https://github.com/user-attachments/assets/47e118de-207c-43ef-8c47-7cc380421bdd)
![image](https://github.com/user-attachments/assets/c8179d2b-3ae5-4e67-afc5-266e6e12c43f)

SoilCanopy Convergence:
this PR vs current main
![image](https://github.com/user-attachments/assets/7dd6835f-83b4-425a-8635-421fd188f683)
![image](https://github.com/user-attachments/assets/aebfb0b9-a24b-40c6-bb8f-fa57e2e1bbfa)
Errors:
![image](https://github.com/user-attachments/assets/375810bc-9bbf-47e4-9e71-39e7f4b31c82)
![image](https://github.com/user-attachments/assets/fe4cffa6-4c2f-430f-9333-aa674ddb9285)


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
