### PR TITLE
qsat depends on T not snow presence

### DIFF
--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -16,8 +16,8 @@ using ClimaCore.Geometry: WVector
 using ClimaComms
 
 using ClimaLand
-
 import ..Parameters as LP
+import Thermodynamics.Parameters as TP
 import ClimaLand.Domains: coordinates, SphericalShell
 using ClimaLand:
     AbstractAtmosphericDrivers,
@@ -411,7 +411,6 @@ function make_update_aux(model::BucketModel{FT}) where {FT}
         p.bucket.q_sfc .=
             saturation_specific_humidity.(
                 p.bucket.T_sfc,
-                Y.bucket.σS,
                 p.bucket.ρ_sfc,
                 Ref(
                     LP.thermodynamic_parameters(

--- a/src/standalone/Bucket/bucket_parameterizations.jl
+++ b/src/standalone/Bucket/bucket_parameterizations.jl
@@ -185,27 +185,29 @@ function β(x::FT, x_c::FT, p::FT) where {FT}
 end
 
 """
-    saturation_specific_humidity(T::FT, σS::FT, ρ_sfc::FT, thermo_parameters::TPE)::FT where {FT, TPE}
+    saturation_specific_humidity(T::FT, ρ_sfc::FT, thermo_parameters::TPE)::FT where {FT, TPE}
 
 Computes the saturation specific humidity for the land surface, over ice
-if snow is present (σS>0), and over water for a snow-free surface.
+if the temperature is below freezing, and over water otherwise.
 """
 function saturation_specific_humidity(
     T::FT,
-    σS::FT,
     ρ_sfc::FT,
     thermo_params::TPE,
 )::FT where {FT, TPE}
-    return (1 - heaviside(σS)) * Thermodynamics.q_vap_saturation_generic(
-        thermo_params,
-        T,
-        ρ_sfc,
-        Thermodynamics.Liquid(),
-    ) +
-           heaviside(σS) * Thermodynamics.q_vap_saturation_generic(
-        thermo_params,
-        T,
-        ρ_sfc,
-        Thermodynamics.Ice(),
-    )
+    if T > TP.T_freeze(thermo_params)
+        Thermodynamics.q_vap_saturation_generic(
+            thermo_params,
+            T,
+            ρ_sfc,
+            Thermodynamics.Liquid(),
+        )
+    else
+        Thermodynamics.q_vap_saturation_generic(
+            thermo_params,
+            T,
+            ρ_sfc,
+            Thermodynamics.Ice(),
+        )
+    end
 end


### PR DESCRIPTION
## Purpose 
We had set q_sfc = q_sat(T, ice) if snow was on the ground, and q_sfc = q_sat(T, liq) if not. If the snow variable is incorrect (due to incorrect forcing or otherwise), this could mean very cold land would have a higher q_sfc (over liq). 


## To-do
Run in AMIP, Coupler PR https://github.com/CliMA/ClimaCoupler.jl/pull/976
Update unit tests to reflect change as needed


## Content
change q_sfc function

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
