### PR TITLE
Remove root_distribution as param

### DIFF
--- a/deprecated_features.md
+++ b/deprecated_features.md
@@ -2,8 +2,3 @@
 
 This file lists deprecated features and the recommended alternative practice
 
-- ## `root_distribution`
-
-    The `root_distribution` in `PlantHydraulicsParameters` is replaced by `rooting_depth`.
-    If using a `root_distribution` function of the form P(x) = 1/d e^(z/d), then `rooting_depth`
-    is equivalent to d.

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -261,11 +261,6 @@ function make_update_boundary_fluxes(
         # Note that in `PrescribedSoil` mode, we compute the flux using K_soil = K_plant(ψ_soil)
         # and K_canopy = K_plant(ψ_canopy). In `PrognosticSoil` mode here, we compute the flux using
         # K_soil = K_soil(ψ_soil) and K_canopy = K_plant(ψ_canopy).
-        # if rooting_depth param is not nothing, use root_distribution from source
-        # otherwise use root_distribution from params
-        root_likelihood(z::FT, rd::Union{FT, Nothing}) =
-            !isnothing(rd) ? root_distribution(z, rd) :
-            model.parameters.root_distribution(z)
         @. p.root_extraction =
             above_ground_area_index *
             PlantHydraulics.water_flux(
@@ -279,7 +274,7 @@ function make_update_boundary_fluxes(
                     p.canopy.hydraulics.ψ.:1,
                 ),
             ) *
-            (root_likelihood(
+            (root_distribution(
                 z,
                 land.canopy.hydraulics.parameters.rooting_depth,
             ))

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -137,8 +137,7 @@ struct PlantHydraulicsParameters{
     PSAI <: PrescribedSiteAreaIndex{FT},
     CP,
     RP,
-    RDTH <: Union{FT, ClimaCore.Fields.Field, Nothing},
-    RDST <: Union{Function, Nothing},
+    RDTH <: Union{FT, ClimaCore.Fields.Field},
 }
     "The area index model for LAI, SAI, RAI"
     ai_parameterization::PSAI
@@ -152,8 +151,6 @@ struct PlantHydraulicsParameters{
     retention_model::RP
     "Rooting depth parameter (m) - a characteristic depth below which 1/e of the root mass lies"
     rooting_depth::RDTH
-    "DEPRECATED: Root distribution function P(z)"
-    root_distribution::RDST
 end
 
 """
@@ -163,12 +160,10 @@ end
         S_s::FT,
         conductivity_model,
         retention_model,
-        rooting_depth::Union{Nothing, FT, ClimaCore.Fields.Field} = nothing,
-        root_distribution::Union{Nothing, Function} = nothing, # DEPRECATED
+        rooting_depth::Union{FT, ClimaCore.Fields.Field},
     )
 
-Constructor for PlantHydraulicsParameters. The root_distribution parameter is deprecated.
-If root_distribution and rooting_depth are both provided, root_distribution is ignored.
+Constructor for PlantHydraulicsParameters.
 """
 function PlantHydraulicsParameters(;
     ai_parameterization::PrescribedSiteAreaIndex{FT},
@@ -176,31 +171,14 @@ function PlantHydraulicsParameters(;
     S_s::FT,
     conductivity_model,
     retention_model,
-    rooting_depth::Union{Nothing, FT, ClimaCore.Fields.Field} = nothing,
-    root_distribution::Union{Nothing, Function} = nothing, # DEPRECATED
+    rooting_depth::Union{Nothing, FT, ClimaCore.Fields.Field},
 ) where {FT}
-    if !isnothing(root_distribution)
-        if !isnothing(rooting_depth)
-            Base.depwarn(
-                "root_distribution is deprecated and will be ignored when rooting_depth is provided",
-                :PlantHydraulicsParameters,
-            )
-        else
-            Base.depwarn(
-                "root_distribution keyword argument is deprecated. Use rooting_depth instead.",
-                :PlantHydraulicsParameters,
-            )
-        end
-    elseif isnothing(rooting_depth)
-        error("rooting_depth must be provided")
-    end
     return PlantHydraulicsParameters{
         FT,
         typeof(ai_parameterization),
         typeof(conductivity_model),
         typeof(retention_model),
         typeof(rooting_depth),
-        typeof(root_distribution),
     }(
         ai_parameterization,
         ν,
@@ -208,7 +186,6 @@ function PlantHydraulicsParameters(;
         conductivity_model,
         retention_model,
         rooting_depth,
-        root_distribution,
     )
 end
 
@@ -683,11 +660,6 @@ function root_water_flux_per_ground_area!(
     n_root_layers = length(root_depths)
     ψ_soil::FT = s.ψ(t)
     fa .= FT(0.0)
-    # if rooting_depth param is not nothing, use root_distribution from source
-    # otherwise use root_distribution from params
-    root_likelihood(z::FT, rd::Union{FT, Nothing}) =
-        !isnothing(rd) ? root_distribution(z, rd) :
-        model.parameters.root_distribution(z)
     @inbounds for i in 1:n_root_layers
         above_ground_area_index =
             getproperty(area_index, model.compartment_labels[1])
@@ -702,7 +674,7 @@ function root_water_flux_per_ground_area!(
                     hydraulic_conductivity(conductivity_model, ψ_soil),
                     hydraulic_conductivity(conductivity_model, ψ_base),
                 ) *
-                root_likelihood(root_depths[i], rooting_depth) *
+                root_distribution(root_depths[i], rooting_depth) *
                 (root_depths[i + 1] - root_depths[i]) *
                 above_ground_area_index
         else
@@ -715,7 +687,7 @@ function root_water_flux_per_ground_area!(
                     hydraulic_conductivity(conductivity_model, ψ_soil),
                     hydraulic_conductivity(conductivity_model, ψ_base),
                 ) *
-                root_likelihood(root_depths[i], rooting_depth) *
+                root_distribution(root_depths[i], rooting_depth) *
                 (model.compartment_surfaces[1] - root_depths[n_root_layers]) *
                 above_ground_area_index
         end

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -36,8 +36,9 @@ import ClimaParams
         g1_cases = (FT(790), fill(FT(790), domain.space.surface))
         Vcmax25_cases = (FT(9e-5), fill(FT(9e-5), domain.space.surface))
         mechanism_cases = (FT(1), mechanism_field)
-        zipped = zip(g1_cases, Vcmax25_cases, mechanism_cases)
-        for (g1, Vcmax25, is_c3) in zipped
+        rooting_cases = (FT(0.5), fill(FT(0.5), domain.space.surface))
+        zipped = zip(g1_cases, Vcmax25_cases, mechanism_cases, rooting_cases)
+        for (g1, Vcmax25, is_c3, rooting_depth) in zipped
             AR_params = AutotrophicRespirationParameters(FT)
             RTparams = BeerLambertParameters(FT)
             photosynthesis_params = FarquharParameters(FT, is_c3; Vcmax25)
@@ -149,14 +150,11 @@ import ClimaParams
             retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
             root_depths =
                 SVector{10, FT}(-(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0) # 1st element is the deepest root depth
-            function root_distribution(z::T) where {T}
-                return T(1.0 / 0.5) * exp(z / T(0.5)) # (1/m)
-            end
             param_set = PlantHydraulics.PlantHydraulicsParameters(;
                 ai_parameterization = ai_parameterization,
                 ν = plant_ν,
                 S_s = plant_S_s,
-                root_distribution = root_distribution,
+                rooting_depth = rooting_depth,
                 conductivity_model = conductivity_model,
                 retention_model = retention_model,
             )


### PR DESCRIPTION
Previously, rooting_depth was added as a PlayHydraulics param to replace rootdistribution. Support for root_distribution continued, but this caused an isbits error with broadcasting. This commit removes support for the deprecated root_distribution param

One of the tests I changed in the previous PR fails when run with CUDA. Is this something that I should fix, and if so, should it be in a separate pr?

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
