### PR TITLE
Fix plant_hydraulics_test to work on GPU

### DIFF
--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -238,14 +238,6 @@ for FT in (Float32, Float64)
             range(start = 0.0, step = Δz, stop = Δz * (n_stem + n_leaf)),
         )
 
-        param_set = PlantHydraulics.PlantHydraulicsParameters(;
-            ai_parameterization = ai_parameterization,
-            ν = plant_ν,
-            S_s = plant_S_s,
-            rooting_depth = FT(0.5),
-            conductivity_model = conductivity_model,
-            retention_model = retention_model,
-        )
 
         function leaf_transpiration(t)
             T = FT(1e-8) # m/s
@@ -255,154 +247,167 @@ for FT in (Float32, Float64)
         transpiration = PrescribedTranspiration{FT}(leaf_transpiration)
 
         soil_driver = PrescribedSoil(FT)
-
-        plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
-            parameters = param_set,
-            transpiration = transpiration,
-            n_stem = n_stem,
-            n_leaf = n_leaf,
-            compartment_surfaces = compartment_surfaces,
-            compartment_midpoints = compartment_midpoints,
-        )
         autotrophic_parameters = AutotrophicRespirationParameters(FT)
         autotrophic_respiration_model =
             AutotrophicRespirationModel{FT}(autotrophic_parameters)
+        RD = FT(0.5)
         for domain in domains
-            model = ClimaLand.Canopy.CanopyModel{FT}(;
-                parameters = shared_params,
-                domain = domain,
-                autotrophic_respiration = autotrophic_respiration_model,
-                radiative_transfer = rt_model,
-                photosynthesis = photosynthesis_model,
-                conductance = stomatal_model,
-                hydraulics = plant_hydraulics,
-                soil_driver = soil_driver,
-                atmos = atmos,
-                radiation = radiation,
-            )
-            # Set system to hydrostatic equilibrium
-            function initial_compute_exp_tendency!(F, Y)
-                AI = (; leaf = LAI(1.0), root = RAI, stem = SAI)
-                T0A = FT(1e-8) * AI[:leaf]
-                for i in 1:(n_leaf + n_stem)
-                    if i == 1
-                        fa =
-                            sum(
-                                water_flux.(
-                                    root_depths,
+            # check once with rooting_depth as float and once as field
+            for rooting_depth in (RD, fill(RD, domain.space.surface))
+                plant_hydraulics_param_set =
+                    PlantHydraulics.PlantHydraulicsParameters(;
+                        ai_parameterization = ai_parameterization,
+                        ν = plant_ν,
+                        S_s = plant_S_s,
+                        rooting_depth = rooting_depth,
+                        conductivity_model = conductivity_model,
+                        retention_model = retention_model,
+                    )
+                plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
+                    parameters = plant_hydraulics_param_set,
+                    transpiration = transpiration,
+                    n_stem = n_stem,
+                    n_leaf = n_leaf,
+                    compartment_surfaces = compartment_surfaces,
+                    compartment_midpoints = compartment_midpoints,
+                )
+                model = ClimaLand.Canopy.CanopyModel{FT}(;
+                    parameters = shared_params,
+                    domain = domain,
+                    autotrophic_respiration = autotrophic_respiration_model,
+                    radiative_transfer = rt_model,
+                    photosynthesis = photosynthesis_model,
+                    conductance = stomatal_model,
+                    hydraulics = plant_hydraulics,
+                    soil_driver = soil_driver,
+                    atmos = atmos,
+                    radiation = radiation,
+                )
+                # Set system to hydrostatic equilibrium
+                function initial_compute_exp_tendency!(F, Y)
+                    AI = (; leaf = LAI(1.0), root = RAI, stem = SAI)
+                    T0A = FT(1e-8) * AI[:leaf]
+                    for i in 1:(n_leaf + n_stem)
+                        if i == 1
+                            fa =
+                                sum(
+                                    water_flux.(
+                                        root_depths,
+                                        plant_hydraulics.compartment_midpoints[i],
+                                        ψ_soil0,
+                                        Y[i],
+                                        PlantHydraulics.hydraulic_conductivity(
+                                            conductivity_model,
+                                            ψ_soil0,
+                                        ),
+                                        PlantHydraulics.hydraulic_conductivity(
+                                            conductivity_model,
+                                            Y[i],
+                                        ),
+                                    ) .*
+                                    ClimaLand.Canopy.PlantHydraulics.root_distribution.(
+                                        root_depths,
+                                        RD,
+                                    ) .* (
+                                        vcat(root_depths, [0.0])[2:end] -
+                                        vcat(root_depths, [0.0])[1:(end - 1)]
+                                    ),
+                                ) * AI[:stem]
+                        else
+                            fa =
+                                water_flux(
+                                    plant_hydraulics.compartment_midpoints[i - 1],
                                     plant_hydraulics.compartment_midpoints[i],
-                                    ψ_soil0,
+                                    Y[i - 1],
                                     Y[i],
                                     PlantHydraulics.hydraulic_conductivity(
                                         conductivity_model,
-                                        ψ_soil0,
+                                        Y[i - 1],
                                     ),
                                     PlantHydraulics.hydraulic_conductivity(
                                         conductivity_model,
                                         Y[i],
                                     ),
-                                ) .*
-                                ClimaLand.Canopy.PlantHydraulics.root_distribution.(
-                                    root_depths,
-                                    plant_hydraulics.parameters.rooting_depth,
-                                ) .* (
-                                    vcat(root_depths, [0.0])[2:end] -
-                                    vcat(root_depths, [0.0])[1:(end - 1)]
-                                ),
-                            ) * AI[:stem]
-                    else
-                        fa =
-                            water_flux(
-                                plant_hydraulics.compartment_midpoints[i - 1],
-                                plant_hydraulics.compartment_midpoints[i],
-                                Y[i - 1],
-                                Y[i],
-                                PlantHydraulics.hydraulic_conductivity(
-                                    conductivity_model,
-                                    Y[i - 1],
-                                ),
-                                PlantHydraulics.hydraulic_conductivity(
-                                    conductivity_model,
-                                    Y[i],
-                                ),
-                            ) * AI[plant_hydraulics.compartment_labels[i]]
+                                ) * AI[plant_hydraulics.compartment_labels[i]]
+                        end
+                        F[i] = fa - T0A
                     end
-                    F[i] = fa - T0A
                 end
-            end
-            #=======================
-            Here we solve for the steady state of the hydraulics
-            system. Then, the solution is used to check that evaluating the
-            tendecy of the model also results in a steady state. This check is repeated using
-            the plant hydraulics model directly.
-            =======================#
+                #=======================
+                Here we solve for the steady state of the hydraulics
+                system. Then, the solution is used to check that evaluating the
+                tendecy of the model also results in a steady state. This check is repeated using
+                the plant hydraulics model directly.
+                =======================#
 
-            soln = nlsolve(
-                initial_compute_exp_tendency!,
-                Vector{FT}(-0.03:0.01:0.07);
-                ftol = eps(FT),
-                method = :newton,
-                iterations = 20,
-            )
-
-            S_l =
-                inverse_water_retention_curve.(
-                    retention_model,
-                    soln.zero,
-                    plant_ν,
-                    plant_S_s,
+                soln = nlsolve(
+                    initial_compute_exp_tendency!,
+                    Vector{FT}(-0.03:0.01:0.07);
+                    ftol = eps(FT),
+                    method = :newton,
+                    iterations = 20,
                 )
 
-            ϑ_l_0 = augmented_liquid_fraction.(plant_ν, S_l)
+                S_l =
+                    inverse_water_retention_curve.(
+                        retention_model,
+                        soln.zero,
+                        plant_ν,
+                        plant_S_s,
+                    )
 
-            Y, p, coords = initialize(model)
-            if typeof(domain) <: ClimaLand.Domains.Point
-                @test propertynames(p) == (:canopy, :drivers)
-            elseif typeof(domain) <: ClimaLand.Domains.Plane
-                @test propertynames(p) == (:canopy, :dss_buffer_2d, :drivers)
-                @test typeof(p.dss_buffer_2d) == typeof(
-                    ClimaCore.Spaces.create_dss_buffer(
-                        ClimaCore.Fields.zeros(domain.space.surface),
-                    ),
+                ϑ_l_0 = augmented_liquid_fraction.(plant_ν, S_l)
+
+                Y, p, coords = initialize(model)
+                if typeof(domain) <: ClimaLand.Domains.Point
+                    @test propertynames(p) == (:canopy, :drivers)
+                elseif typeof(domain) <: ClimaLand.Domains.Plane
+                    @test propertynames(p) ==
+                          (:canopy, :dss_buffer_2d, :drivers)
+                    @test typeof(p.dss_buffer_2d) == typeof(
+                        ClimaCore.Spaces.create_dss_buffer(
+                            ClimaCore.Fields.zeros(domain.space.surface),
+                        ),
+                    )
+                end
+
+                dY = similar(Y)
+                for i in 1:(n_stem + n_leaf)
+                    Y.canopy.hydraulics.ϑ_l.:($i) .= ϑ_l_0[i]
+                    p.canopy.hydraulics.ψ.:($i) .= NaN
+                    p.canopy.hydraulics.fa.:($i) .= NaN
+                    dY.canopy.hydraulics.ϑ_l.:($i) .= NaN
+                end
+                set_initial_cache! = make_set_initial_cache(model)
+                set_initial_cache!(p, Y, 0.0)
+                canopy_exp_tendency! = make_exp_tendency(model)
+                canopy_exp_tendency!(dY, Y, p, 0.0)
+
+                tolerance = sqrt(eps(FT))
+                @test all(parent(dY.canopy.hydraulics.ϑ_l) .< tolerance) # starts in equilibrium
+
+
+                # repeat using the plant hydraulics model directly
+                # make sure it agrees with what we get when use the canopy model ODE
+                Y, p, coords = initialize(model)
+                standalone_dY = similar(Y)
+                for i in 1:(n_stem + n_leaf)
+                    Y.canopy.hydraulics.ϑ_l.:($i) .= ϑ_l_0[i]
+                    p.canopy.hydraulics.ψ.:($i) .= NaN
+                    p.canopy.hydraulics.fa.:($i) .= NaN
+                    standalone_dY.canopy.hydraulics.ϑ_l.:($i) .= NaN
+                end
+                set_initial_cache!(p, Y, 0.0)
+                standalone_exp_tendency! =
+                    make_compute_exp_tendency(model.hydraulics, model)
+                standalone_exp_tendency!(standalone_dY, Y, p, 0.0)
+                @test all(
+                    parent(
+                        standalone_dY.canopy.hydraulics.ϑ_l .-
+                        dY.canopy.hydraulics.ϑ_l,
+                    ) .≈ FT(0),
                 )
             end
-
-            dY = similar(Y)
-            for i in 1:(n_stem + n_leaf)
-                Y.canopy.hydraulics.ϑ_l.:($i) .= ϑ_l_0[i]
-                p.canopy.hydraulics.ψ.:($i) .= NaN
-                p.canopy.hydraulics.fa.:($i) .= NaN
-                dY.canopy.hydraulics.ϑ_l.:($i) .= NaN
-            end
-            set_initial_cache! = make_set_initial_cache(model)
-            set_initial_cache!(p, Y, 0.0)
-            canopy_exp_tendency! = make_exp_tendency(model)
-            canopy_exp_tendency!(dY, Y, p, 0.0)
-
-            tolerance = sqrt(eps(FT))
-            @test all(parent(dY.canopy.hydraulics.ϑ_l) .< tolerance) # starts in equilibrium
-
-
-            # repeat using the plant hydraulics model directly
-            # make sure it agrees with what we get when use the canopy model ODE
-            Y, p, coords = initialize(model)
-            standalone_dY = similar(Y)
-            for i in 1:(n_stem + n_leaf)
-                Y.canopy.hydraulics.ϑ_l.:($i) .= ϑ_l_0[i]
-                p.canopy.hydraulics.ψ.:($i) .= NaN
-                p.canopy.hydraulics.fa.:($i) .= NaN
-                standalone_dY.canopy.hydraulics.ϑ_l.:($i) .= NaN
-            end
-            set_initial_cache!(p, Y, 0.0)
-            standalone_exp_tendency! =
-                make_compute_exp_tendency(model.hydraulics, model)
-            standalone_exp_tendency!(standalone_dY, Y, p, 0.0)
-            @test all(
-                parent(
-                    standalone_dY.canopy.hydraulics.ϑ_l .-
-                    dY.canopy.hydraulics.ϑ_l,
-                ) .≈ FT(0),
-            )
         end
     end
 


### PR DESCRIPTION
When root_distribution was removed, it was replaced with rooting_depth, which can be a field. The Plant hydraulics model integration tests was changed to test rooting_depth as both a scalar and a field. In order to make the broadcast work, a wrapper function was used around NLsolve. This works fine with cpu, but errors on gpu because NLSolve does not return a bitstype. 

Plant hydraulics model integration tests now tests rooting_depth
as a field and as a float. The issue with this test and fields on the GPU
was the usage of NLSolve. This test first solves for the steady state of the hydraulics
system using NLSolve. Then, the solution is used to check that evaluating the
tendecy of the model also results in a steady state. Because the rooting_depth
field is constant, this commit uses NLsolve with a scalar of that constant.
Then, when the model's tendency is evaluated, the field is used.
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Make tests pass when ran on gpu


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
- make test_plant_hydraulics.jl solve for equilibrium using scalar rooting_depth


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
