### PR TITLE
Reduce allocations I

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,8 @@ main
 
 v0.15.2
 --------
-
+- Boundary fluxes are non-allocating
+PR[#819](https://github.com/CliMA/ClimaLand.jl/pull/819)
 - Artifacts for the bucket model are now automatically downloaded. PR [#820](https://github.com/CliMA/ClimaLand.jl/pull/820)
 
 v0.15.1

--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -55,7 +55,7 @@ ClimaLand.source!
 ClimaLand.AbstractBoundary
 ClimaLand.TopBoundary
 ClimaLand.BottomBoundary
-ClimaLand.boundary_flux
+ClimaLand.boundary_flux!
 ClimaLand.diffusive_flux
 ClimaLand.boundary_vars
 ClimaLand.boundary_var_domain_names

--- a/experiments/benchmarks/bucket.jl
+++ b/experiments/benchmarks/bucket.jl
@@ -187,7 +187,7 @@ average_timing_s = round(sum(timings_s) / num_samples, sigdigits = 3)
 max_timing_s = round(maximum(timings_s), sigdigits = 3)
 min_timing_s = round(minimum(timings_s), sigdigits = 3)
 std_timing_s = round(
-    sum(((timings_s .- average_timing_s) .^ 2) / num_samples),
+    sqrt(sum(((timings_s .- average_timing_s) .^ 2) / num_samples)),
     sigdigits = 3,
 )
 @info "Num samples: $num_samples"
@@ -220,19 +220,37 @@ ProfileCanvas.html_file(alloc_flame_file, profile)
 if ClimaComms.device() isa ClimaComms.CUDADevice
     import CUDA
     lprob, lode_algo, lΔt, lcb = setup_simulation()
-    CUDA.@profile SciMLBase.solve(lprob, lode_algo; dt = lΔt, callback = lcb)
+    p = CUDA.@profile SciMLBase.solve(
+        lprob,
+        lode_algo;
+        dt = lΔt,
+        callback = lcb,
+    )
+    # use "COLUMNS" to set how many horizontal characters to crop:
+    # See https://github.com/ronisbr/PrettyTables.jl/issues/11#issuecomment-2145550354
+    envs = ("COLUMNS" => 120,)
+    withenv(envs...) do
+        io = IOContext(
+            stdout,
+            :crop => :horizontal,
+            :limit => true,
+            :displaysize => displaysize(),
+        )
+        show(io, p)
+    end
+    println()
 end
 
 if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaland-benchmark"
-    PREVIOUS_BEST_TIME = 1.5
+    PREVIOUS_BEST_TIME = 1.2
     if average_timing_s > PREVIOUS_BEST_TIME + std_timing_s
         @info "Possible performance regression, previous average time was $(PREVIOUS_BEST_TIME)"
     elseif average_timing_s < PREVIOUS_BEST_TIME - std_timing_s
         @info "Possible significant performance improvement, please update PREVIOUS_BEST_TIME in $(@__DIR__)"
     end
     @testset "Performance" begin
-        @test PREVIOUS_BEST_TIME - std_timing_s <=
-              average_timing_s ≤
-              PREVIOUS_BEST_TIME + std_timing_s
+        @test PREVIOUS_BEST_TIME - 2std_timing_s <=
+              average_timing_s <=
+              PREVIOUS_BEST_TIME + 2std_timing_s
     end
 end

--- a/experiments/benchmarks/richards.jl
+++ b/experiments/benchmarks/richards.jl
@@ -337,7 +337,7 @@ average_timing_s = round(sum(timings_s) / num_samples, sigdigits = 3)
 max_timing_s = round(maximum(timings_s), sigdigits = 3)
 min_timing_s = round(minimum(timings_s), sigdigits = 3)
 std_timing_s = round(
-    sum(((timings_s .- average_timing_s) .^ 2) / num_samples),
+    sqrt(sum(((timings_s .- average_timing_s) .^ 2) / num_samples)),
     sigdigits = 3,
 )
 @info "Num samples: $num_samples"
@@ -370,19 +370,37 @@ ProfileCanvas.html_file(alloc_flame_file, profile)
 if ClimaComms.device() isa ClimaComms.CUDADevice
     import CUDA
     lprob, lode_algo, lΔt, lcb = setup_simulation()
-    CUDA.@profile SciMLBase.solve(lprob, lode_algo; dt = lΔt, callback = lcb)
+    p = CUDA.@profile SciMLBase.solve(
+        lprob,
+        lode_algo;
+        dt = lΔt,
+        callback = lcb,
+    )
+    # use "COLUMNS" to set how many horizontal characters to crop:
+    # See https://github.com/ronisbr/PrettyTables.jl/issues/11#issuecomment-2145550354
+    envs = ("COLUMNS" => 120,)
+    withenv(envs...) do
+        io = IOContext(
+            stdout,
+            :crop => :horizontal,
+            :limit => true,
+            :displaysize => displaysize(),
+        )
+        show(io, p)
+    end
+    println()
 end
 
 if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaland-benchmark"
-    PREVIOUS_BEST_TIME = 6.0
+    PREVIOUS_BEST_TIME = 5.1
     if average_timing_s > PREVIOUS_BEST_TIME + std_timing_s
         @info "Possible performance regression, previous average time was $(PREVIOUS_BEST_TIME)"
     elseif average_timing_s < PREVIOUS_BEST_TIME - std_timing_s
         @info "Possible significant performance improvement, please update PREVIOUS_BEST_TIME in $(@__DIR__)"
     end
     @testset "Performance" begin
-        @test PREVIOUS_BEST_TIME - std_timing_s <=
-              average_timing_s ≤
-              PREVIOUS_BEST_TIME + std_timing_s
+        @test PREVIOUS_BEST_TIME - 2std_timing_s <=
+              average_timing_s <=
+              PREVIOUS_BEST_TIME + 2std_timing_s
     end
 end

--- a/src/integrated/pond_soil_model.jl
+++ b/src/integrated/pond_soil_model.jl
@@ -245,7 +245,7 @@ is also used to compute the runoff for the surface water.
 struct RunoffBC <: Soil.AbstractWaterBC end
 
 """
-    function ClimaLand.boundary_flux(
+    function ClimaLand.boundary_flux!(bc_field,
         bc::RunoffBC,
         ::TopBoundary,
         model::Soil.RichardsModel,
@@ -254,14 +254,15 @@ struct RunoffBC <: Soil.AbstractWaterBC end
         p::NamedTuple,
         t,
         params,
-    )::ClimaCore.Fields.Field
+    )
 
 Extension of the `ClimaLand.boundary_flux` function, which returns the water volume
 boundary flux for the soil.
 At the top boundary, return the soil infiltration (computed each step and
 stored in `p.soil_infiltration`).
 """
-function ClimaLand.boundary_flux(
+function ClimaLand.boundary_flux!(
+    bc_field,
     bc::RunoffBC,
     ::TopBoundary,
     model::Soil.RichardsModel,
@@ -269,6 +270,6 @@ function ClimaLand.boundary_flux(
     Y::ClimaCore.Fields.FieldVector,
     p::NamedTuple,
     t,
-)::ClimaCore.Fields.Field
-    return p.soil_infiltration
+)
+    bc_field .= p.soil_infiltration
 end

--- a/src/shared_utilities/boundary_conditions.jl
+++ b/src/shared_utilities/boundary_conditions.jl
@@ -1,4 +1,4 @@
-export boundary_flux,
+export boundary_flux!,
     AbstractBC,
     AbstractBoundary,
     TopBoundary,
@@ -61,20 +61,21 @@ Calculates the diffusive flux of a quantity x (water content, temp, etc).
 Here, x_2 = x(z + Δz) and x_1 = x(z), so x_2 is at a larger z by convention.
 """
 function diffusive_flux(K, x_2, x_1, Δz)
-    return @. -K * (x_2 - x_1) / Δz
+    return -K * (x_2 - x_1) / Δz
 end
 
 """
-    boundary_flux(bc::AbstractBC, bound_type::AbstractBoundary, Δz, _...)::ClimaCore.Fields.Field
-A function which returns the correct boundary flux  given
-    any boundary condition (BC). 
+    boundary_flux!(bc_field, bc::AbstractBC, bound_type::AbstractBoundary, Δz, _...)
+A function which updates bc_field with the correct boundary flux  given
+any boundary condition (BC). 
 """
-function boundary_flux(
+function boundary_flux!(
+    bc_field,
     bc::AbstractBC,
     bound_type::AbstractBoundary,
     Δz,
     _...,
-)::ClimaCore.Fields.Field end
+) end
 
 
 """

--- a/src/standalone/Soil/rre.jl
+++ b/src/standalone/Soil/rre.jl
@@ -102,7 +102,8 @@ function make_update_boundary_fluxes(model::RichardsModel)
         z = model.domain.fields.z
         Δz_top = model.domain.fields.Δz_top
         Δz_bottom = model.domain.fields.Δz_bottom
-        p.soil.top_bc .= boundary_flux(
+        boundary_flux!(
+            p.soil.top_bc,
             model.boundary_conditions.top,
             TopBoundary(),
             model,
@@ -111,7 +112,8 @@ function make_update_boundary_fluxes(model::RichardsModel)
             p,
             t,
         )
-        p.soil.bottom_bc .= boundary_flux(
+        boundary_flux!(
+            p.soil.bottom_bc,
             model.boundary_conditions.bottom,
             BottomBoundary(),
             model,

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -404,7 +404,8 @@ function ClimaLand.make_update_aux(
         Ra = p.canopy.autotrophic_respiration.Ra
         β = p.canopy.hydraulics.β
         medlyn_factor = p.canopy.conductance.medlyn_term
-        gs = p.canopy.conductance.gs
+        gs = p.canopy.conductance.gs # leaf level
+        rs_canopy = p.canopy.conductance.r_stomata_canopy
         An = p.canopy.photosynthesis.An
         GPP = p.canopy.photosynthesis.GPP
         Rd = p.canopy.photosynthesis.Rd
@@ -587,6 +588,7 @@ function ClimaLand.make_update_aux(
         )
         @. GPP = compute_GPP(An, K, LAI, Ω)
         @. gs = medlyn_conductance(g0, Drel, medlyn_factor, An, c_co2_air)
+        @. rs_canopy = 1 / upscale_leaf_conductance(gs, LAI, T_air, R, P_air)
         # update autotrophic respiration
         h_canopy = hydraulics.compartment_surfaces[end]
         @. Ra = compute_autrophic_respiration(

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -5,7 +5,6 @@ import SurfaceFluxes.Parameters as SFP
 
 import ClimaLand:
     surface_temperature,
-    surface_specific_humidity,
     surface_evaporative_scaling,
     surface_height,
     surface_resistance,
@@ -112,22 +111,7 @@ function ClimaLand.surface_resistance(
     p,
     t,
 ) where {FT}
-    earth_param_set = model.parameters.earth_param_set
-    R = FT(LP.gas_constant(earth_param_set))
-    ρ_liq = FT(LP.ρ_cloud_liq(earth_param_set))
-    P_air = p.drivers.P
-    T_air = p.drivers.T
-    leaf_conductance = p.canopy.conductance.gs
-    canopy_conductance =
-        upscale_leaf_conductance.(
-            leaf_conductance,
-            p.canopy.hydraulics.area_index.leaf,
-            T_air,
-            R,
-            P_air,
-        )
-
-    return 1 ./ canopy_conductance # [s/m]
+    return p.canopy.conductance.r_stomata_canopy
 end
 
 """
@@ -148,29 +132,6 @@ model, which is stored in the parameter struct.
 """
 function ClimaLand.surface_height(model::CanopyModel, _...)
     return model.hydraulics.compartment_surfaces[1]
-end
-
-"""
-    ClimaLand.surface_specific_humidity(model::CanopyModel, Y, p)
-
-A helper function which returns the surface specific humidity for the canopy
-model, which is stored in the aux state.
-"""
-function ClimaLand.surface_specific_humidity(
-    model::CanopyModel,
-    Y,
-    p,
-    T_canopy,
-    ρ_canopy,
-)
-    thermo_params =
-        LP.thermodynamic_parameters(model.parameters.earth_param_set)
-    return Thermodynamics.q_vap_saturation_generic.(
-        Ref(thermo_params),
-        T_canopy,
-        ρ_canopy,
-        Ref(Thermodynamics.Liquid()),
-    )
 end
 
 function make_update_boundary_fluxes(canopy::CanopyModel)
@@ -311,19 +272,15 @@ function ClimaLand.turbulent_fluxes(
     t,
 )
     T_sfc = ClimaLand.surface_temperature(model, Y, p, t)
-    ρ_sfc = ClimaLand.surface_air_density(atmos, model, Y, p, t, T_sfc)
-    q_sfc = ClimaLand.surface_specific_humidity(model, Y, p, T_sfc, ρ_sfc)
     h_sfc = ClimaLand.surface_height(model, Y, p)
-    leaf_r_stomata = ClimaLand.surface_resistance(model, Y, p, t)
+    r_stomata_canopy = ClimaLand.surface_resistance(model, Y, p, t)
     d_sfc = ClimaLand.displacement_height(model, Y, p)
     u_air = p.drivers.u
     h_air = atmos.h
     return canopy_turbulent_fluxes_at_a_point.(
         T_sfc,
-        q_sfc,
-        ρ_sfc,
         h_sfc,
-        leaf_r_stomata,
+        r_stomata_canopy,
         d_sfc,
         p.drivers.thermal_state,
         u_air,
@@ -340,8 +297,6 @@ end
 """
     function canopy_turbulent_fluxes_at_a_point(
         T_sfc::FT,
-        q_sfc::FT,
-        ρ_sfc::FT,
         h_sfc::FT,
         leaf_r_stomata::FT,
         d_sfc::FT,
@@ -365,8 +320,6 @@ of `SurfaceFluxes.surface_conditions`.
 """
 function canopy_turbulent_fluxes_at_a_point(
     T_sfc::FT,
-    q_sfc::FT,
-    ρ_sfc::FT,
     h_sfc::FT,
     leaf_r_stomata::FT,
     d_sfc::FT,
@@ -381,14 +334,22 @@ function canopy_turbulent_fluxes_at_a_point(
     earth_param_set::EP,
 ) where {FT <: AbstractFloat, EP}
     thermo_params = LP.thermodynamic_parameters(earth_param_set)
-    ts_sfc = Thermodynamics.PhaseEquil_ρTq(thermo_params, ρ_sfc, T_sfc, q_sfc)
-
-    state_sfc = SurfaceFluxes.StateValues(FT(0), SVector{2, FT}(0, 0), ts_sfc)
     state_in = SurfaceFluxes.StateValues(
         h - d_sfc - h_sfc,
         SVector{2, FT}(u, 0),
         ts_in,
     )
+
+    ρ_sfc = compute_ρ_sfc(thermo_params, ts_in, T_sfc)
+    q_sfc = Thermodynamics.q_vap_saturation_generic(
+        thermo_params,
+        T_sfc,
+        ρ_sfc,
+        Thermodynamics.Liquid(),
+    )
+    ts_sfc = Thermodynamics.PhaseEquil_ρTq(thermo_params, ρ_sfc, T_sfc, q_sfc)
+
+    state_sfc = SurfaceFluxes.StateValues(FT(0), SVector{2, FT}(0, 0), ts_sfc)
 
     # State containers
     states = SurfaceFluxes.ValuesOnly(

--- a/src/standalone/Vegetation/stomatalconductance.jl
+++ b/src/standalone/Vegetation/stomatalconductance.jl
@@ -38,8 +38,8 @@ end
 
 ClimaLand.name(model::AbstractStomatalConductanceModel) = :conductance
 ClimaLand.auxiliary_vars(model::MedlynConductanceModel) =
-    (:medlyn_term, :gs, :transpiration)
+    (:medlyn_term, :gs, :r_stomata_canopy, :transpiration)
 ClimaLand.auxiliary_types(model::MedlynConductanceModel{FT}) where {FT} =
-    (FT, FT, FT)
+    (FT, FT, FT, FT)
 ClimaLand.auxiliary_domain_names(::MedlynConductanceModel) =
-    (:surface, :surface, :surface)
+    (:surface, :surface, :surface, :surface)

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -409,23 +409,6 @@ import ClimaParams
                 p,
                 t0,
             ) isa ClimaCore.Fields.Field
-
-            ρ_sfc =
-                ClimaLand.surface_air_density(atmos, canopy, Y, p, t0, T_sfc)
-            @test ClimaLand.surface_specific_humidity(
-                canopy,
-                Y,
-                p,
-                T_sfc,
-                ρ_sfc,
-            ) ==
-                  Thermodynamics.q_vap_saturation_generic.(
-                Ref(thermo_params),
-                T_sfc,
-                ρ_sfc,
-                Ref(Thermodynamics.Liquid()),
-            )
-            @test ρ_sfc == compute_ρ_sfc.(thermo_params, ts_in, T_sfc)
         end
     end
 end
@@ -1070,7 +1053,14 @@ end
             t0,
             T_sfc,
         )
-        q_sfc = ClimaLand.surface_specific_humidity(canopy, Y, p, T_sfc, ρ_sfc)
+        thermo_params = canopy.parameters.earth_param_set.thermo_params
+        q_sfc =
+            Thermodynamics.q_vap_saturation_generic.(
+                thermo_params,
+                T_sfc,
+                ρ_sfc,
+                Thermodynamics.Liquid(),
+            )
         dY = similar(Y)
         imp_tendency!(dY, Y, p, t0)
         jac = ImplicitEquationJacobian(Y)
@@ -1092,13 +1082,13 @@ end
             t0,
             T_sfc2,
         )
-        q_sfc2 = ClimaLand.surface_specific_humidity(
-            canopy,
-            Y_2,
-            p_2,
-            T_sfc2,
-            ρ_sfc2,
-        )
+        q_sfc2 =
+            Thermodynamics.q_vap_saturation_generic.(
+                thermo_params,
+                T_sfc2,
+                ρ_sfc2,
+                Thermodynamics.Liquid(),
+            )
         dY_2 = similar(Y_2)
         imp_tendency!(dY_2, Y_2, p_2, t0)
 


### PR DESCRIPTION
## Purpose 
Reduce allocations by 
(1) making boundary_flux! update in place rather than boundary_flux() creating and returning a field
(2) Allocate space in cache for canopy stomatal resistance instead of allocating each step
(3) compute rho_sfc and q_sfc in canopy_turbulent_fluxes_at_a_point instead of allocating the fields each step and passing to this function

## To-do

## Content
As above


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
