### PR TITLE
run integrated timestep test for 8hr

### DIFF
--- a/experiments/integrated/performance/integrated_timestep_test.jl
+++ b/experiments/integrated/performance/integrated_timestep_test.jl
@@ -367,7 +367,7 @@ imp_tendency! = make_imp_tendency(land);
 jacobian! = make_jacobian(land);
 
 # Timestepping information
-N_hours = 12.5
+N_hours = 8
 tf = Float64(t0 + N_hours * 3600.0)
 sim_time = round((tf - t0) / 3600, digits = 2) # simulation length in hours
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The integrated_timestep_test.jl experiment takes the longest of everything in our CI. Specifically, it takes about 5 minutes longer than the GPU tests. Ideally it would take roughly the same amount of time as the GPU tests

This PR decreases the length of the experiment to decrease its runtime and speed up the overall CI

In the [buildkite run for this PR](https://buildkite.com/clima/climaland-ci/builds/5495#_), `integrated_timestep_test.jl` takes 13 mins and GPU tests take 15 mins