### PR TITLE
nan fix

### DIFF
--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -204,8 +204,24 @@ function compute_total_respiration!(
 end
 
 # variables stored in Y (prognostic or state variables)
+nan_if_no_canopy(T::FT, AI::FT) where {FT <: Real} = AI > 0 ? T : FT(NaN)
+function compute_canopy_temperature!(
+    out,
+    Y,
+    p,
+    t,
+    land_model::SoilCanopyModel{FT},
+) where {FT}
+    AI =
+        p.canopy.hydraulics.area_index.leaf .+
+        p.canopy.hydraulics.area_index.stem
+    if isnothing(out)
+        return nan_if_no_canopy.(Y.canopy.energy.T, AI)
+    else
+        out .= nan_if_no_canopy.(Y.canopy.energy.T, AI)
+    end
+end
 
-@diagnostic_compute "canopy_temperature" SoilCanopyModel Y.canopy.energy.T
 @diagnostic_compute "soilco2" SoilCanopyModel Y.soilco2.C
 @diagnostic_compute "soil_water_content" SoilCanopyModel Y.soil.ϑ_l
 # @diagnostic_compute "plant_water_content" SoilCanopyModel Y.canopy.hydraulics.ϑ_l # return a Tuple

--- a/src/standalone/Vegetation/canopy_parameterizations.jl
+++ b/src/standalone/Vegetation/canopy_parameterizations.jl
@@ -281,7 +281,8 @@ function plant_absorbed_pfd_two_stream(
     # Compute μ̄, the average inverse diffuse optical length per LAI
     μ̄ = 1 / (2G)
 
-    ω = α_leaf + τ_leaf
+    # Clip this to eps(FT) to prevent dividing by zero
+    ω = max(α_leaf + τ_leaf, eps(FT))
 
     # Compute aₛ, the single scattering albedo
     aₛ = 0.5 * ω * (1 - cos(θs) * log((abs(cos(θs)) + 1) / abs(cos(θs))))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
In areas where there is no canopy, albedo = transmissivity = 0. Add a fix so that we dont divide by zero in this case.


## To-do
[X] Test long run - should have NaNs in canopy temperature where this is no canopy, but the other variables should have no NaNs (compared with previous last long run, 2 days ago: https://buildkite.com/clima/climaland-long-runs/builds/1461)


## Content
Clip something to eps(FT) instead of zero


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
