### PR TITLE
Allocation removal with Wvector scratch space

### DIFF
--- a/src/shared_utilities/boundary_conditions.jl
+++ b/src/shared_utilities/boundary_conditions.jl
@@ -93,9 +93,12 @@ update_boundary_fluxes functions are coded to access the field
 this is the default.  If this is not your (PDE) model's 
 desired behavior, you can extend this function with a new method.
 
+The field `top_bc_wvec` is created to prevent allocations only; it is used
+in the tendency function only.
+
 Use this function in the exact same way you would use `auxiliary_vars`.
 """
-boundary_vars(::AbstractBC, ::ClimaLand.TopBoundary) = (:top_bc,)
+boundary_vars(::AbstractBC, ::ClimaLand.TopBoundary) = (:top_bc, :top_bc_wvec)
 
 """
     boundary_vars(::AbstractBC, ::ClimaLand.BottomBoundary)
@@ -113,9 +116,13 @@ update_boundary_fluxes functions are coded to access the field
 this is the default.  If this is not your (PDE) model's 
 desired behavior, you can extend this function with a new method.
 
+The field `bottom_bc_wvec` is created to prevent allocations only; it is used
+in the tendency function only.
+
 Use this function in the exact same way you would use `auxiliary_vars`.
 """
-boundary_vars(::AbstractBC, ::ClimaLand.BottomBoundary) = (:bottom_bc,)
+boundary_vars(::AbstractBC, ::ClimaLand.BottomBoundary) =
+    (:bottom_bc, :bottom_bc_wvec)
 
 """
     boundary_var_domain_names(::AbstractBC, ::ClimaLand.AbstractBoundary)
@@ -131,7 +138,7 @@ Use in conjunction with `boundary_vars`, in the same way you would use
 `auxiliary_var_domain_names`. 
 """
 boundary_var_domain_names(::AbstractBC, ::ClimaLand.AbstractBoundary) =
-    (:surface,)
+    (:surface, :surface)
 
 """
     boundary_var_types(model::AbstractModel{FT}, ::AbstractBC, ::ClimaLand.AbstractBoundary) where {FT}
@@ -153,5 +160,5 @@ function boundary_var_types(
     ::AbstractBC,
     ::ClimaLand.AbstractBoundary,
 ) where {FT}
-    (FT,)
+    (FT, ClimaCore.Geometry.WVector{FT})
 end

--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -315,6 +315,7 @@ auxiliary_types(::BucketModel{FT}) where {FT} = (
     FT,
     FT,
     FT,
+    ClimaCore.Geometry.WVector{FT},
 )
 auxiliary_vars(::BucketModel) = (
     :q_sfc,
@@ -329,8 +330,10 @@ auxiliary_vars(::BucketModel) = (
     :G,
     :snow_melt,
     :infiltration,
+    :top_bc_wvec,
 )
 auxiliary_domain_names(::BucketModel) = (
+    :surface,
     :surface,
     :surface,
     :surface,
@@ -357,16 +360,15 @@ function make_compute_exp_tendency(model::BucketModel{FT}) where {FT}
 
         # Temperature profile of soil.
         gradc2f = ClimaCore.Operators.GradientC2F()
+        @. p.bucket.top_bc_wvec = ClimaCore.Geometry.WVector(p.bucket.G)
         divf2c = ClimaCore.Operators.DivergenceF2C(
-            top = ClimaCore.Operators.SetValue(
-                ClimaCore.Geometry.WVector.(p.bucket.G),
-            ),
+            top = ClimaCore.Operators.SetValue(p.bucket.top_bc_wvec),
             bottom = ClimaCore.Operators.SetValue(
-                ClimaCore.Geometry.WVector.(FT(0.0)),
+                ClimaCore.Geometry.WVector(zero(FT)),
             ),
         )
 
-        @. dY.bucket.T = -1 / ρc_soil * (divf2c(-κ_soil * gradc2f(Y.bucket.T))) # Simple heat equation, Eq 10
+        @. dY.bucket.T = -1 / ρc_soil * divf2c(-κ_soil * gradc2f(Y.bucket.T)) # Simple heat equation, Eq 10
 
         # Positive infiltration -> net (negative) flux into soil
         @. dY.bucket.W = -p.bucket.infiltration # Equation (2) of the text.

--- a/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
+++ b/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
@@ -203,16 +203,13 @@ function ClimaLand.make_compute_exp_tendency(model::SoilCO2Model)
     function compute_exp_tendency!(dY, Y, p, t)
         top_flux_bc = p.soilco2.top_bc
         bottom_flux_bc = p.soilco2.bottom_bc
-
+        @. p.soilco2.top_bc_wvec = Geometry.WVector(top_flux_bc)
+        @. p.soilco2.bottom_bc_wvec = Geometry.WVector(bottom_flux_bc)
         interpc2f = ClimaCore.Operators.InterpolateC2F()
         gradc2f_C = ClimaCore.Operators.GradientC2F()
         divf2c_C = ClimaCore.Operators.DivergenceF2C(
-            top = ClimaCore.Operators.SetValue(
-                ClimaCore.Geometry.WVector.(top_flux_bc),
-            ),
-            bottom = ClimaCore.Operators.SetValue(
-                ClimaCore.Geometry.WVector.(bottom_flux_bc),
-            ),
+            top = ClimaCore.Operators.SetValue(p.soilco2.top_bc_wvec),
+            bottom = ClimaCore.Operators.SetValue(p.soilco2.bottom_bc_wvec),
         ) # -∇ ⋅ (-D∇C), where -D∇C is a flux of CO2. ∇C point in direction of increasing C, so the flux is - this.
         @. dY.soilco2.C =
             -divf2c_C(-interpc2f(p.soilco2.D) * gradc2f_C(Y.soilco2.C))

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -112,7 +112,7 @@ boundary_vars(
         <:Runoff.AbstractRunoffModel,
     },
     ::ClimaLand.TopBoundary,
-) = (:top_bc, Runoff.runoff_vars(bc.runoff)...)
+) = (:top_bc, :top_bc_wvec, Runoff.runoff_vars(bc.runoff)...)
 
 """
     boundary_var_domain_names(::RichardsAtmosDrivenFluxBC{<:PrescribedPrecipitation,
@@ -129,7 +129,7 @@ boundary_var_domain_names(
         <:Runoff.AbstractRunoffModel,
     },
     ::ClimaLand.TopBoundary,
-) = (:surface, Runoff.runoff_var_domain_names(bc.runoff)...)
+) = (:surface, :surface, Runoff.runoff_var_domain_names(bc.runoff)...)
 """
     boundary_var_types(::RichardsModel{FT},
                         ::RichardsAtmosDrivenFluxBC{<:PrescribedPrecipitation,
@@ -148,7 +148,11 @@ boundary_var_types(
         <:Runoff.AbstractRunoffModel,
     },
     ::ClimaLand.TopBoundary,
-) where {FT} = (FT, Runoff.runoff_var_types(bc.runoff, FT)...)
+) where {FT} = (
+    FT,
+    ClimaCore.Geometry.WVector{FT},
+    Runoff.runoff_var_types(bc.runoff, FT)...,
+)
 
 
 """
@@ -642,7 +646,7 @@ function boundary_var_types(
     ::AbstractEnergyHydrologyBC,
     ::ClimaLand.AbstractBoundary,
 ) where {FT}
-    (NamedTuple{(:water, :heat), Tuple{FT, FT}},)
+    (NamedTuple{(:water, :heat), Tuple{FT, FT}}, ClimaCore.Geometry.WVector{FT})
 end
 
 """
@@ -683,6 +687,7 @@ boundary_vars(bc::AtmosDrivenFluxBC, ::ClimaLand.TopBoundary) = (
     :turbulent_fluxes,
     :R_n,
     :top_bc,
+    :top_bc_wvec,
     :sfc_scratch,
     Runoff.runoff_vars(bc.runoff)...,
 )
@@ -696,6 +701,7 @@ specifies the part of the domain on which the additional variables should be
 defined.
 """
 boundary_var_domain_names(bc::AtmosDrivenFluxBC, ::ClimaLand.TopBoundary) = (
+    :surface,
     :surface,
     :surface,
     :surface,
@@ -723,6 +729,7 @@ boundary_var_types(
     },
     FT,
     NamedTuple{(:water, :heat), Tuple{FT, FT}},
+    ClimaCore.Geometry.WVector{FT},
     FT,
     Runoff.runoff_var_types(bc.runoff, FT)...,
 )
@@ -812,7 +819,7 @@ top boundary.
 These variables are updated in place in `boundary_flux`.
 """
 boundary_vars(bc::MoistureStateBC, ::ClimaLand.TopBoundary) =
-    (:top_bc, :dfluxBCdY)
+    (:top_bc, :top_bc_wvec, :dfluxBCdY)
 
 """
     boundary_var_domain_names(::MoistureStateBC, ::ClimaLand.TopBoundary)
@@ -821,7 +828,7 @@ An extension of the `boundary_var_domain_names` method for MoistureStateBC at th
 top boundary.
 """
 boundary_var_domain_names(bc::MoistureStateBC, ::ClimaLand.TopBoundary) =
-    (:surface, :surface)
+    (:surface, :surface, :surface)
 """
     boundary_var_types(::RichardsModel{FT},
                         ::MoistureStateBC,
@@ -835,7 +842,11 @@ boundary_var_types(
     model::RichardsModel{FT},
     bc::MoistureStateBC,
     ::ClimaLand.TopBoundary,
-) where {FT} = (FT, ClimaCore.Geometry.Covariant3Vector{FT})
+) where {FT} = (
+    FT,
+    ClimaCore.Geometry.WVector{FT},
+    ClimaCore.Geometry.Covariant3Vector{FT},
+)
 
 
 function sublimation_source(::Val{(:soil,)}, FT)

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -247,18 +247,23 @@ function ClimaLand.make_compute_imp_tendency(
         # Passing WVector to gradient BC is passing a normal flux.
 
         # Richards-Richardson RHS
+        @. p.soil.top_bc_wvec = Geometry.WVector(rre_top_flux_bc)
+        @. p.soil.bottom_bc_wvec = Geometry.WVector(rre_bottom_flux_bc)
         divf2c_rre = Operators.DivergenceF2C(
-            top = Operators.SetValue(Geometry.WVector.(rre_top_flux_bc)),
-            bottom = Operators.SetValue(Geometry.WVector.(rre_bottom_flux_bc)),
+            top = Operators.SetValue(p.soil.top_bc_wvec),
+            bottom = Operators.SetValue(p.soil.bottom_bc_wvec),
         )
         # GradC2F returns a Covariant3Vector, so no need to convert.
         @. dY.soil.ϑ_l =
             -(divf2c_rre(-interpc2f(p.soil.K) * gradc2f(p.soil.ψ + z)))
 
         # Heat equation RHS
+        # Reuse the same scratch space:
+        @. p.soil.top_bc_wvec = Geometry.WVector(heat_top_flux_bc)
+        @. p.soil.bottom_bc_wvec = Geometry.WVector(heat_bottom_flux_bc)
         divf2c_heat = Operators.DivergenceF2C(
-            top = Operators.SetValue(Geometry.WVector.(heat_top_flux_bc)),
-            bottom = Operators.SetValue(Geometry.WVector.(heat_bottom_flux_bc)),
+            top = Operators.SetValue(p.soil.top_bc_wvec),
+            bottom = Operators.SetValue(p.soil.bottom_bc_wvec),
         )
 
         # GradC2F returns a Covariant3Vector, so no need to convert.

--- a/src/standalone/Soil/rre.jl
+++ b/src/standalone/Soil/rre.jl
@@ -150,7 +150,8 @@ function ClimaLand.make_compute_imp_tendency(model::RichardsModel)
         z = model.domain.fields.z
         top_flux_bc = p.soil.top_bc
         bottom_flux_bc = p.soil.bottom_bc
-
+        @. p.soil.top_bc_wvec = Geometry.WVector(top_flux_bc)
+        @. p.soil.bottom_bc_wvec = Geometry.WVector(bottom_flux_bc)
         interpc2f = Operators.InterpolateC2F()
         gradc2f_water = Operators.GradientC2F()
 
@@ -167,8 +168,8 @@ function ClimaLand.make_compute_imp_tendency(model::RichardsModel)
         # the bc is WVector(F) or Covariant3Vector(F*Δr) or Contravariant3Vector(F/Δr)
 
         divf2c_water = Operators.DivergenceF2C(
-            top = Operators.SetValue(Geometry.WVector.(top_flux_bc)),
-            bottom = Operators.SetValue(Geometry.WVector.(bottom_flux_bc)),
+            top = Operators.SetValue(p.soil.top_bc_wvec),
+            bottom = Operators.SetValue(p.soil.bottom_bc_wvec),
         )
 
         # GradC2F returns a Covariant3Vector, so no need to convert.

--- a/test/shared_utilities/variable_types.jl
+++ b/test/shared_utilities/variable_types.jl
@@ -149,13 +149,17 @@ end
         bc = BC()
 
         # Test that bc variables added if invoked
-        @test boundary_vars(bc, ClimaLand.TopBoundary()) == (:top_bc,)
-        @test boundary_vars(bc, ClimaLand.BottomBoundary()) == (:bottom_bc,)
+        @test boundary_vars(bc, ClimaLand.TopBoundary()) ==
+              (:top_bc, :top_bc_wvec)
+        @test boundary_vars(bc, ClimaLand.BottomBoundary()) ==
+              (:bottom_bc, :bottom_bc_wvec)
         @test boundary_var_domain_names(bc, ClimaLand.TopBoundary()) ==
-              (:surface,)
+              (:surface, :surface)
         @test boundary_var_domain_names(bc, ClimaLand.BottomBoundary()) ==
-              (:surface,)
-        @test boundary_var_types(m, bc, ClimaLand.TopBoundary()) == (FT,)
-        @test boundary_var_types(m, bc, ClimaLand.BottomBoundary()) == (FT,)
+              (:surface, :surface)
+        @test boundary_var_types(m, bc, ClimaLand.TopBoundary()) ==
+              (FT, ClimaCore.Geometry.WVector{FT})
+        @test boundary_var_types(m, bc, ClimaLand.BottomBoundary()) ==
+              (FT, ClimaCore.Geometry.WVector{FT})
     end
 end

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -157,6 +157,8 @@ for FT in (Float32, Float64)
             @test mean(Array(parent(dY.bucket.W))) < eps(FT)
             @test mean(Array(parent(dY.bucket.Ws))) < eps(FT)
             @test mean(Array(parent(dY.bucket.σS))) < eps(FT)
+            @test p.bucket.top_bc_wvec ==
+                  ClimaCore.Geometry.WVector.(p.bucket.G)
         end
 
 

--- a/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
+++ b/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
@@ -81,6 +81,10 @@ for FT in (Float32, Float64)
         set_initial_cache!(p, Y, t)
         exp_tendency!(dY, Y, p, t)
         @test dY.soilco2.C ≈ p.soilco2.Sm
+        @test p.soilco2.top_bc_wvec ==
+              ClimaCore.Geometry.WVector.(p.soilco2.top_bc)
+        @test p.soilco2.bottom_bc_wvec ==
+              ClimaCore.Geometry.WVector.(p.soilco2.bottom_bc)
     end
 
 
@@ -157,5 +161,9 @@ for FT in (Float32, Float64)
         set_initial_cache!(p, Y, t)
         exp_tendency!(dY, Y, p, t)
         @test sum(dY.soilco2.C) ≈ FT(0.0)
+        @test p.soilco2.top_bc_wvec ==
+              ClimaCore.Geometry.WVector.(p.soilco2.top_bc)
+        @test p.soilco2.bottom_bc_wvec ==
+              ClimaCore.Geometry.WVector.(p.soilco2.bottom_bc)
     end
 end

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -139,9 +139,11 @@ for FT in (Float32, Float64)
                 :turbulent_fluxes,
                 :R_n,
                 :top_bc,
+                :top_bc_wvec,
                 :sfc_scratch,
                 :infiltration,
                 :bottom_bc,
+                :bottom_bc_wvec,
             )
             function init_soil!(Y, z, params)
                 ν = params.ν

--- a/test/standalone/Soil/soil_bc.jl
+++ b/test/standalone/Soil/soil_bc.jl
@@ -263,30 +263,36 @@ end
     )
 
     @test Soil.boundary_vars(boundary_fluxes.top, ClimaLand.TopBoundary()) ==
-          (:top_bc,)
+          (:top_bc, :top_bc_wvec)
     @test Soil.boundary_var_domain_names(
         boundary_fluxes.top,
         ClimaLand.TopBoundary(),
-    ) == (:surface,)
+    ) == (:surface, :surface)
     @test Soil.boundary_var_types(
         energy_hydrology,
         boundary_fluxes.top,
         ClimaLand.TopBoundary(),
-    ) == (NamedTuple{(:water, :heat), Tuple{Float32, Float32}},)
+    ) == (
+        NamedTuple{(:water, :heat), Tuple{Float32, Float32}},
+        ClimaCore.Geometry.WVector{Float32},
+    )
 
     @test Soil.boundary_vars(
         boundary_fluxes.bottom,
         ClimaLand.BottomBoundary(),
-    ) == (:bottom_bc,)
+    ) == (:bottom_bc, :bottom_bc_wvec)
     @test Soil.boundary_var_domain_names(
         boundary_fluxes.bottom,
         ClimaLand.BottomBoundary(),
-    ) == (:surface,)
+    ) == (:surface, :surface)
     @test Soil.boundary_var_types(
         energy_hydrology,
         boundary_fluxes.bottom,
         ClimaLand.BottomBoundary(),
-    ) == (NamedTuple{(:water, :heat), Tuple{Float32, Float32}},)
+    ) == (
+        NamedTuple{(:water, :heat), Tuple{Float32, Float32}},
+        ClimaCore.Geometry.WVector{Float32},
+    )
     Y, p, cds = initialize(energy_hydrology)
     Y.soil.ϑ_l .= ν
     Y.soil.θ_i .= 0
@@ -321,28 +327,28 @@ end
     )
 
     @test Soil.boundary_vars(boundary_fluxes.top, ClimaLand.TopBoundary()) ==
-          (:top_bc,)
+          (:top_bc, :top_bc_wvec)
     @test Soil.boundary_var_domain_names(
         boundary_fluxes.top,
         ClimaLand.TopBoundary(),
-    ) == (:surface,)
+    ) == (:surface, :surface)
     @test Soil.boundary_var_types(
         rre,
         boundary_fluxes.top,
         ClimaLand.TopBoundary(),
-    ) == (FT,)
+    ) == (FT, ClimaCore.Geometry.WVector{Float32})
 
     @test Soil.boundary_vars(boundary_fluxes.top, ClimaLand.BottomBoundary()) ==
-          (:bottom_bc,)
+          (:bottom_bc, :bottom_bc_wvec)
     @test Soil.boundary_var_domain_names(
         boundary_fluxes.top,
         ClimaLand.BottomBoundary(),
-    ) == (:surface,)
+    ) == (:surface, :surface)
     @test Soil.boundary_var_types(
         rre,
         boundary_fluxes.bottom,
         ClimaLand.BottomBoundary(),
-    ) == (FT,)
+    ) == (FT, ClimaCore.Geometry.WVector{FT})
 
     Y, p, cds = initialize(rre)
     Y.soil.ϑ_l .= ν

--- a/test/standalone/Soil/soiltest.jl
+++ b/test/standalone/Soil/soiltest.jl
@@ -84,6 +84,9 @@ for FT in (Float32, Float64)
         @test mean(
             Array(parent(p.soil.ψ .+ coords.subsurface.z))[:] .+ FT(10),
         ) < 2eps(FT)
+        @test p.soil.top_bc_wvec == ClimaCore.Geometry.WVector.(p.soil.top_bc)
+        @test p.soil.bottom_bc_wvec ==
+              ClimaCore.Geometry.WVector.(p.soil.bottom_bc)
     end
 
     # This next test suite tests the full soil model right-hand-side functions
@@ -628,6 +631,13 @@ for FT in (Float32, Float64)
         expected = -(flux[2:end] - flux[1:(end - 1)]) ./ Δz
         @test mean(abs.(expected .- Array(parent(dY.soil.ϑ_l)))) / ν <
               10^2 * eps(FT)
+        # We reuse the same wvec scratch space for heat and water boundary fluxes
+        # and heat is updated last. so here we check that the Wvec cache matches the Wvec
+        # of the heat flux cache
+        @test p.soil.top_bc_wvec ==
+              ClimaCore.Geometry.WVector.(p.soil.top_bc.heat)
+        @test p.soil.bottom_bc_wvec ==
+              ClimaCore.Geometry.WVector.(p.soil.bottom_bc.heat)
 
     end
 


### PR DESCRIPTION
## Purpose 
Currently, 6x per step - in the tendency function of soil and soil CO2 -  we allocate a 2d surface field of type WVector{FT}. This PR adds space to the cache so we don't do this allocation. Not a big deal, but an easy fix.

Canopy and Snow do not use ClimaCore operators so they are not affected by this PR.

We also added the same var to the bucket model cache, but note that the bucket does not the same `boundary_vars...` functionality to add variables to the cache. so we add it directly to `auxiliary_vars()`
## To-do
Benchmark after merging/rebasing off of #823 


## Content
Adds :top_bc_wvec and :bottom_bc_wvec to the cache. Note that for soil Energy Hydrology, we use the same cache spot for both heat and water BC (no need to store both at the same time). 




<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
