### PR TITLE
Add context and device for Model/Domain

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@ ClimaLand.jl Release Notes
 main
 --------
 
+- It is now possible to call `ClimaComms.context` and `ClimaComms.device` Models
+  and Domains. This provides a unambiguous way to determine the context and
+  device for general simulations.
+  PR[#852](https://github.com/CliMA/ClimaLand.jl/pull/852)
+
+
 v0.15.2
 --------
 - Boundary fluxes are non-allocating

--- a/src/shared_utilities/Domains.jl
+++ b/src/shared_utilities/Domains.jl
@@ -24,6 +24,11 @@ element), and the top face space where surface fluxes are computed.
 abstract type AbstractDomain{FT <: AbstractFloat} end
 Base.eltype(::AbstractDomain{FT}) where {FT} = FT
 
+ClimaComms.context(domain::AbstractDomain) =
+    ClimaComms.context(first(domain.space))
+ClimaComms.device(domain::AbstractDomain) =
+    ClimaComms.device(first(domain.space))
+
 """
     coordinates(domain::AbstractDomain)
 

--- a/src/shared_utilities/models.jl
+++ b/src/shared_utilities/models.jl
@@ -23,6 +23,7 @@ export AbstractModel,
     get_drivers,
     name
 
+import ClimaComms
 import .Domains: coordinates
 ## Default methods for all models - to be in a seperate module at some point.
 """
@@ -444,4 +445,24 @@ function initialize(model::AbstractModel{FT}) where {FT}
     p = initialize_auxiliary(model, coords)
     p = add_drivers_to_cache(p, model, coords)
     return Y, p, coords
+end
+
+function ClimaComms.context(model::AbstractModel)
+    if :domain ∈ propertynames(model)
+        return ClimaComms.context(model.domain)
+    else
+        error(
+            "Your model does not contain a domain. If this is intended, you will need a new method of ClimaComms.context.",
+        )
+    end
+end
+
+function ClimaComms.device(model::AbstractModel)
+    if :domain ∈ propertynames(model)
+        return ClimaComms.device(model.domain)
+    else
+        error(
+            "Your model does not contain a domain. If this is intended, you will need a new method of ClimaComms.device.",
+        )
+    end
 end

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -111,6 +111,9 @@ for FT in (Float32, Float64)
             soil_args = soil_args,
             soilco2_args = soilco2_args,
         )
+        @test_throws ErrorException ClimaComms.context(model)
+        @test_throws ErrorException ClimaComms.device(model)
+
         @test model.soilco2.drivers.met.ν == model.soil.parameters.ν
         @test model.soilco2.drivers.met isa ClimaLand.PrognosticMet
         drivers = ClimaLand.get_drivers(model)

--- a/test/shared_utilities/domains.jl
+++ b/test/shared_utilities/domains.jl
@@ -94,6 +94,8 @@ FT = Float32
     @test typeof(shell_surface.space.surface) <:
           ClimaCore.Spaces.SpectralElementSpace2D
 
+    @test ClimaComms.context(shell_surface) == ClimaComms.context()
+    @test ClimaComms.device(shell_surface) == ClimaComms.device()
 
     # HybridBox
     box = HybridBox(;

--- a/test/standalone/Bucket/albedo_types.jl
+++ b/test/standalone/Bucket/albedo_types.jl
@@ -242,6 +242,9 @@ end
                 atmosphere = bucket_atmos,
                 radiation = bucket_rad,
             )
+            @test ClimaComms.context(model) == ClimaComms.context()
+            @test ClimaComms.device(model) == ClimaComms.device()
+
             # Initial conditions with no moisture
             Y, p, coords = initialize(model)
             Y.bucket.T .= init_temp.(coords.subsurface.z, FT(280.0))


### PR DESCRIPTION
This provides a function to determine the context for generic models without any knowledge of the variables in the model
