### PR TITLE
new version of formatter plus formatting changes

### DIFF
--- a/.dev/Project.toml
+++ b/.dev/Project.toml
@@ -1,2 +1,5 @@
 [deps]
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
+
+[compat]
+JuliaFormatter = "2"

--- a/docs/tutorials/integrated/soil_canopy_tutorial.jl
+++ b/docs/tutorials/integrated/soil_canopy_tutorial.jl
@@ -327,13 +327,12 @@ jac_kwargs =
 Y.soil.ϑ_l = FT(0.4)
 Y.soil.θ_i = FT(0.0)
 T_0 = FT(288.7)
-ρc_s =
-    volumetric_heat_capacity.(
-        Y.soil.ϑ_l,
-        Y.soil.θ_i,
-        land.soil.parameters.ρc_ds,
-        earth_param_set,
-    )
+ρc_s = volumetric_heat_capacity.(
+    Y.soil.ϑ_l,
+    Y.soil.θ_i,
+    land.soil.parameters.ρc_ds,
+    earth_param_set,
+)
 Y.soil.ρe_int =
     volumetric_internal_energy.(Y.soil.θ_i, ρc_s, T_0, earth_param_set)
 
@@ -342,13 +341,12 @@ Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
 ψ_stem_0 = FT(-1e5 / 9800)
 ψ_leaf_0 = FT(-2e5 / 9800)
 
-S_l_ini =
-    inverse_water_retention_curve.(
-        retention_model,
-        [ψ_stem_0, ψ_leaf_0],
-        plant_ν,
-        plant_S_s,
-    )
+S_l_ini = inverse_water_retention_curve.(
+    retention_model,
+    [ψ_stem_0, ψ_leaf_0],
+    plant_ν,
+    plant_S_s,
+)
 
 for i in 1:2
     Y.canopy.hydraulics.ϑ_l.:($i) .=
@@ -363,7 +361,7 @@ N_days = 100
 tf = t0 + Float64(3600 * 24 * N_days)
 dt = Float64(30)
 n = 120
-saveat = Array(t0:(n * dt):tf)
+saveat = Array(t0:(n*dt):tf)
 
 timestepper = CTS.ARS343()
 ode_algo = CTS.IMEXAlgorithm(

--- a/docs/tutorials/shared_utilities/driver_tutorial.jl
+++ b/docs/tutorials/shared_utilities/driver_tutorial.jl
@@ -58,7 +58,7 @@ long = -92.2000; # degree
 # vector into a vector of seconds since the start date
 start_date = local_datetime[1] + Dates.Hour(time_offset);
 data_dt = 3600.0;
-seconds = 0:data_dt:((length(local_datetime) - 1) * data_dt);
+seconds = 0:data_dt:((length(local_datetime)-1)*data_dt);
 
 # Assume the downwelling long and shortwave radiation are read in from the file
 # and are measured at the times in local_datetime. Here, we'll just make them up
@@ -134,7 +134,7 @@ update_radiation!(p, t0);
 # In general, then, we don't update drivers every timestep, but less frequently.
 # For example, the simulation timestep may be 10 minutes, but we may only update
 # the drivers every three hours:
-updateat = collect(seconds[1]:(3600 * 3):seconds[end]);
+updateat = collect(seconds[1]:(3600*3):seconds[end]);
 updatefunc = update_radiation!;
 cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc);
 

--- a/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -269,13 +269,12 @@ exp_tendency! = make_exp_tendency(canopy);
 ψ_stem_0 = FT(-1e5 / 9800)
 ψ_leaf_0 = FT(-2e5 / 9800)
 
-S_l_ini =
-    inverse_water_retention_curve.(
-        retention_model,
-        [ψ_stem_0, ψ_leaf_0],
-        ν,
-        S_s,
-    )
+S_l_ini = inverse_water_retention_curve.(
+    retention_model,
+    [ψ_stem_0, ψ_leaf_0],
+    ν,
+    S_s,
+)
 
 for i in 1:2
     Y.canopy.hydraulics.ϑ_l.:($i) .= augmented_liquid_fraction.(ν, S_l_ini[i])
@@ -301,7 +300,7 @@ set_initial_cache!(p, Y, t0);
 # and create the callback which saves it at each element in saveat.
 
 n = 16
-saveat = Array(t0:(n * dt):tf)
+saveat = Array(t0:(n*dt):tf)
 sv = (;
     t = Array{Float64}(undef, length(saveat)),
     saveval = Array{NamedTuple}(undef, length(saveat)),

--- a/docs/tutorials/standalone/Soil/evaporation_gilat_loess.jl
+++ b/docs/tutorials/standalone/Soil/evaporation_gilat_loess.jl
@@ -152,13 +152,12 @@ function init_soil!(Y, z, params)
         params.ρc_ds,
         params.earth_param_set,
     )
-    Y.soil.ρe_int =
-        Soil.volumetric_internal_energy.(
-            Y.soil.θ_i,
-            ρc_s,
-            T,
-            params.earth_param_set,
-        )
+    Y.soil.ρe_int = Soil.volumetric_internal_energy.(
+        Y.soil.θ_i,
+        ρc_s,
+        T,
+        params.earth_param_set,
+    )
 end
 
 init_soil!(Y, z, soil.parameters)

--- a/docs/tutorials/standalone/Soil/freezing_front.jl
+++ b/docs/tutorials/standalone/Soil/freezing_front.jl
@@ -189,13 +189,12 @@ function init_soil!(Ysoil, z, params)
         params.ρc_ds,
         params.earth_param_set,
     )
-    Ysoil.soil.ρe_int .=
-        Soil.volumetric_internal_energy.(
-            FT(0.0),
-            ρc_s,
-            T,
-            params.earth_param_set,
-        )
+    Ysoil.soil.ρe_int .= Soil.volumetric_internal_energy.(
+        FT(0.0),
+        ρc_s,
+        T,
+        params.earth_param_set,
+    )
 end
 
 init_soil!(Y, coords.subsurface.z, soil.parameters);

--- a/docs/tutorials/standalone/Soil/soil_energy_hydrology.jl
+++ b/docs/tutorials/standalone/Soil/soil_energy_hydrology.jl
@@ -221,20 +221,18 @@ function init_soil!(Y, z, params)
     T = @.(T_min + (T_max - T_min) * exp(-(z - zmax) / (zmin - zmax) * c))
 
     θ_l = Soil.volumetric_liquid_fraction.(Y.soil.ϑ_l, ν, θ_r)
-    ρc_s =
-        Soil.volumetric_heat_capacity.(
-            θ_l,
-            Y.soil.θ_i,
-            params.ρc_ds,
-            params.earth_param_set,
-        )
-    Y.soil.ρe_int .=
-        Soil.volumetric_internal_energy.(
-            Y.soil.θ_i,
-            ρc_s,
-            T,
-            params.earth_param_set,
-        )
+    ρc_s = Soil.volumetric_heat_capacity.(
+        θ_l,
+        Y.soil.θ_i,
+        params.ρc_ds,
+        params.earth_param_set,
+    )
+    Y.soil.ρe_int .= Soil.volumetric_internal_energy.(
+        Y.soil.θ_i,
+        ρc_s,
+        T,
+        params.earth_param_set,
+    )
 end
 
 init_soil!(Y, coords.subsurface.z, soil.parameters);

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -182,30 +182,26 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     θ_r .= oceans_to_value.(θ_r, soil_params_mask, 0)
 
 
-    S_s =
-        oceans_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(1e-3),
-            soil_params_mask,
-            1,
-        )
-    ν_ss_om =
-        oceans_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
-            soil_params_mask,
-            0,
-        )
-    ν_ss_quartz =
-        oceans_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
-            soil_params_mask,
-            0,
-        )
-    ν_ss_gravel =
-        oceans_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
-            soil_params_mask,
-            0,
-        )
+    S_s = oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(1e-3),
+        soil_params_mask,
+        1,
+    )
+    ν_ss_om = oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+        soil_params_mask,
+        0,
+    )
+    ν_ss_quartz = oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+        soil_params_mask,
+        0,
+    )
+    ν_ss_gravel = oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+        soil_params_mask,
+        0,
+    )
     PAR_albedo = ClimaCore.Fields.zeros(surface_space) .+ FT(0.2)
     NIR_albedo = ClimaCore.Fields.zeros(surface_space) .+ FT(0.2)
     soil_params = Soil.EnergyHydrologyParameters(
@@ -489,20 +485,18 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     Y.soil.ϑ_l .= init_soil.(ν, θ_r)
     Y.soil.θ_i .= FT(0.0)
     T = FT(276.85)
-    ρc_s =
-        Soil.volumetric_heat_capacity.(
-            Y.soil.ϑ_l,
-            Y.soil.θ_i,
-            soil_params.ρc_ds,
-            soil_params.earth_param_set,
-        )
-    Y.soil.ρe_int .=
-        Soil.volumetric_internal_energy.(
-            Y.soil.θ_i,
-            ρc_s,
-            T,
-            soil_params.earth_param_set,
-        )
+    ρc_s = Soil.volumetric_heat_capacity.(
+        Y.soil.ϑ_l,
+        Y.soil.θ_i,
+        soil_params.ρc_ds,
+        soil_params.earth_param_set,
+    )
+    Y.soil.ρe_int .= Soil.volumetric_internal_energy.(
+        Y.soil.θ_i,
+        ρc_s,
+        T,
+        soil_params.earth_param_set,
+    )
     Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
     Y.canopy.hydraulics.ϑ_l.:1 .= plant_ν
     evaluate!(Y.canopy.energy.T, atmos.T, t0)
@@ -528,7 +522,7 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
         p,
     )
 
-    updateat = Array(t0:(3600 * 3):tf)
+    updateat = Array(t0:(3600*3):tf)
     drivers = ClimaLand.get_drivers(land)
     updatefunc = ClimaLand.make_update_drivers(drivers)
     cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)

--- a/experiments/integrated/fluxnet/data_tools.jl
+++ b/experiments/integrated/fluxnet/data_tools.jl
@@ -25,7 +25,7 @@ data with QC flag = 2,3.
 function replace_poor_quality_with_mean!(field, flag)
     good_indices = (flag .== 0) .|| (flag .== 1)
     fill_value = mean(field[good_indices])
-    field[.~good_indices] .= fill_value
+    field[.~ good_indices] .= fill_value
     return field
 end
 
@@ -39,9 +39,9 @@ This uses the Fluxnet convention of a value of -9999 indicating
 missing data.
 """
 function replace_missing_with_mean_by_value!(field)
-    good_indices = .~(field .== -9999)
+    good_indices = .~ (field .== -9999)
     fill_value = mean(field[good_indices])
-    field[.~good_indices] .= fill_value
+    field[.~ good_indices] .= fill_value
     return field
 end
 

--- a/experiments/integrated/fluxnet/met_drivers_FLUXNET.jl
+++ b/experiments/integrated/fluxnet/met_drivers_FLUXNET.jl
@@ -101,12 +101,11 @@ if length(missing_drivers) != 0
 end
 
 thermo_params = LP.thermodynamic_parameters(earth_param_set)
-esat =
-    Thermodynamics.saturation_vapor_pressure.(
-        Ref(thermo_params),
-        FT.(drivers.TA.values),
-        Ref(Thermodynamics.Liquid()),
-    )
+esat = Thermodynamics.saturation_vapor_pressure.(
+    Ref(thermo_params),
+    FT.(drivers.TA.values),
+    Ref(Thermodynamics.Liquid()),
+)
 e = @. esat - drivers.VPD.values
 q = @. 0.622 * e ./ (drivers.PA.values - 0.378 * e)
 RH = @. e / esat
@@ -134,7 +133,7 @@ end
 snow_frac = snow_precip_fraction.(drivers.TA.values[:], RH[:])
 # Create interpolators for each atmospheric driver needed for PrescribedAtmosphere and for
 # PrescribedRadiation
-seconds = FT.(0:DATA_DT:((length(UTC_DATETIME) - 1) * DATA_DT));
+seconds = FT.(0:DATA_DT:((length(UTC_DATETIME)-1)*DATA_DT));
 
 P_liq = -FT.(drivers.P.values[:] .* (1 .- snow_frac))
 precip = TimeVaryingInput(seconds, P_liq; context) # m/s
@@ -174,14 +173,13 @@ function zenith_angle(
     current_datetime = start_date + Dates.Second(round(t))
 
     # Orbital Data uses Float64, so we need to convert to our sim FT
-    d, δ, η_UTC =
-        FT.(
-            Insolation.helper_instantaneous_zenith_angle(
-                current_datetime,
-                start_date,
-                insol_params,
-            )
-        )
+    d, δ, η_UTC = FT.(
+        Insolation.helper_instantaneous_zenith_angle(
+            current_datetime,
+            start_date,
+            insol_params,
+        ),
+    )
 
     FT(
         Insolation.instantaneous_zenith_angle(
@@ -221,7 +219,7 @@ MODIS_LAI = single_col_data_matrix(
 )
 
 LAI_dt = Second(MODIS_LAI[2, 1] - MODIS_LAI[1, 1]).value
-LAI_seconds = FT.(0:LAI_dt:((length(MODIS_LAI[:, 1]) - 1) * LAI_dt))
+LAI_seconds = FT.(0:LAI_dt:((length(MODIS_LAI[:, 1])-1)*LAI_dt))
 
 # LAI function for radiative transfer
 LAIfunction = TimeVaryingInput(LAI_seconds, FT.(MODIS_LAI[:, 2]); context)

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -262,13 +262,12 @@ T_0 =
     drivers.TS.status != absent ?
     drivers.TS.values[1 + Int(round(t0 / DATA_DT))] :
     drivers.TA.values[1 + Int(round(t0 / DATA_DT))] + 40# Get soil temperature at t0
-ρc_s =
-    volumetric_heat_capacity.(
-        Y.soil.ϑ_l,
-        Y.soil.θ_i,
-        land.soil.parameters.ρc_ds,
-        earth_param_set,
-    )
+ρc_s = volumetric_heat_capacity.(
+    Y.soil.ϑ_l,
+    Y.soil.θ_i,
+    land.soil.parameters.ρc_ds,
+    earth_param_set,
+)
 Y.soil.ρe_int =
     volumetric_internal_energy.(Y.soil.θ_i, ρc_s, T_0, earth_param_set)
 
@@ -280,7 +279,7 @@ Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
 S_l_ini =
     inverse_water_retention_curve.(retention_model, ψ_comps, plant_ν, plant_S_s)
 
-for i in 1:(n_stem + n_leaf)
+for i in 1:(n_stem+n_leaf)
     Y.canopy.hydraulics.ϑ_l.:($i) .=
         augmented_liquid_fraction.(plant_ν, S_l_ini[i])
 end
@@ -343,8 +342,8 @@ end
 num_days = N_days - N_spinup_days
 
 # Time series of model and data outputs
-data_times = [0:DATA_DT:(num_days * S_PER_DAY);]
-model_times = [0:dt_save:(num_days * S_PER_DAY);]
+data_times = [0:DATA_DT:(num_days*S_PER_DAY);]
+model_times = [0:dt_save:(num_days*S_PER_DAY);]
 
 # Plot model diurnal cycles without data comparisons
 # Autotrophic Respiration
@@ -409,9 +408,9 @@ if drivers.SW_OUT.status == absent
         "model",
     )
 else
-    SW_u_data = FT.(drivers.SW_OUT.values)[Int64(t_spinup ÷ DATA_DT):Int64(
-        tf ÷ DATA_DT,
-    )]
+    SW_u_data = FT.(drivers.SW_OUT.values)[Int64(
+        t_spinup ÷ DATA_DT,
+    ):Int64(tf ÷ DATA_DT)]
     plot_avg_comp(
         "SW up",
         SW_u_model,
@@ -437,9 +436,9 @@ if drivers.LW_OUT.status == absent
         "model",
     )
 else
-    LW_u_data = FT.(drivers.LW_OUT.values)[Int64(t_spinup ÷ DATA_DT):Int64(
-        tf ÷ DATA_DT,
-    )]
+    LW_u_data = FT.(drivers.LW_OUT.values)[Int64(
+        t_spinup ÷ DATA_DT,
+    ):Int64(tf ÷ DATA_DT)]
     plot_avg_comp(
         "LW up",
         LW_u_model,
@@ -589,9 +588,9 @@ if drivers.G.status != absent
             num_days,
         )
         RminusG_avg = compute_diurnal_avg(
-            FT.(Rn .- drivers.G.values)[Int64(t_spinup ÷ DATA_DT):Int64(
-                tf ÷ DATA_DT,
-            )],
+            FT.(Rn .- drivers.G.values)[Int64(
+                t_spinup ÷ DATA_DT,
+            ):Int64(tf ÷ DATA_DT)],
             data_times,
             num_days,
         )

--- a/experiments/integrated/fluxnet/plot_utils.jl
+++ b/experiments/integrated/fluxnet/plot_utils.jl
@@ -14,7 +14,7 @@ hourly intervals."""
 function interp_to_hh(data::Vector, timeseries::Vector, num_days::Int64)
     # Rescale the data to a half hourly interval by linear interpolation
     interp = LinearInterpolation(timeseries, data)
-    half_hourly = (0.5 * 3600):(0.5 * 3600):(24 * num_days * 3600)
+    half_hourly = (0.5*3600):(0.5*3600):(24*num_days*3600)
     hh_data = [interp[i] for i in half_hourly]
     return hh_data
 end
@@ -58,7 +58,7 @@ function plot_daily_avg(
 )
     # Rescale the data and take the average diurnal cycle
     data_hh_avg =
-        compute_diurnal_avg(data, [0:data_dt:(num_days * S_PER_DAY);], num_days)
+        compute_diurnal_avg(data, [0:data_dt:(num_days*S_PER_DAY);], num_days)
 
     # Plot the data diurnal cycle
     plt = Plots.plot(size = (800, 400))
@@ -88,13 +88,10 @@ function plot_avg_comp(
     savedir::String,
 )
     # Rescale teh data and take the average diurnal cycle
-    model_hh_avg = compute_diurnal_avg(
-        model,
-        [0:model_dt:(num_days * S_PER_DAY);],
-        num_days,
-    )
+    model_hh_avg =
+        compute_diurnal_avg(model, [0:model_dt:(num_days*S_PER_DAY);], num_days)
     data_hh_avg =
-        compute_diurnal_avg(data, [0:data_dt:(num_days * S_PER_DAY);], num_days)
+        compute_diurnal_avg(data, [0:data_dt:(num_days*S_PER_DAY);], num_days)
 
     # Compute the GOF stats
     RMSD = StatsBase.rmsd(model_hh_avg, data_hh_avg)

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -214,13 +214,12 @@ T_0 =
     drivers.TS.status != absent ?
     drivers.TS.values[1 + Int(round(t0 / DATA_DT))] :
     drivers.TA.values[1 + Int(round(t0 / DATA_DT))] + 40# Get soil temperature at t0
-ρc_s =
-    volumetric_heat_capacity.(
-        Y.soil.ϑ_l,
-        Y.soil.θ_i,
-        land.soil.parameters.ρc_ds,
-        earth_param_set,
-    )
+ρc_s = volumetric_heat_capacity.(
+    Y.soil.ϑ_l,
+    Y.soil.θ_i,
+    land.soil.parameters.ρc_ds,
+    earth_param_set,
+)
 Y.soil.ρe_int =
     volumetric_internal_energy.(Y.soil.θ_i, ρc_s, T_0, earth_param_set)
 Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
@@ -231,7 +230,7 @@ Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
 S_l_ini =
     inverse_water_retention_curve.(retention_model, ψ_comps, plant_ν, plant_S_s)
 
-for i in 1:(n_stem + n_leaf)
+for i in 1:(n_stem+n_leaf)
     Y.canopy.hydraulics.ϑ_l.:($i) .=
         augmented_liquid_fraction.(plant_ν, S_l_ini[i])
 end
@@ -287,8 +286,8 @@ end
 num_days = N_days - N_spinup_days
 
 # Time series of model and data outputs
-data_times = [0:DATA_DT:(num_days * S_PER_DAY);]
-model_times = [0:dt_save:(num_days * S_PER_DAY);]
+data_times = [0:DATA_DT:(num_days*S_PER_DAY);]
+model_times = [0:dt_save:(num_days*S_PER_DAY);]
 
 # Plot model diurnal cycles without data comparisons
 # Autotrophic Respiration
@@ -353,9 +352,9 @@ if drivers.SW_OUT.status == absent
         "model",
     )
 else
-    SW_u_data = FT.(drivers.SW_OUT.values)[Int64(t_spinup ÷ DATA_DT):Int64(
-        tf ÷ DATA_DT,
-    )]
+    SW_u_data = FT.(drivers.SW_OUT.values)[Int64(
+        t_spinup ÷ DATA_DT,
+    ):Int64(tf ÷ DATA_DT)]
     plot_avg_comp(
         "SW up",
         SW_u_model,
@@ -381,9 +380,9 @@ if drivers.LW_OUT.status == absent
         "model",
     )
 else
-    LW_u_data = FT.(drivers.LW_OUT.values)[Int64(t_spinup ÷ DATA_DT):Int64(
-        tf ÷ DATA_DT,
-    )]
+    LW_u_data = FT.(drivers.LW_OUT.values)[Int64(
+        t_spinup ÷ DATA_DT,
+    ):Int64(tf ÷ DATA_DT)]
     plot_avg_comp(
         "LW up",
         LW_u_model,
@@ -533,9 +532,9 @@ if drivers.G.status != absent
             num_days,
         )
         RminusG_avg = compute_diurnal_avg(
-            FT.(Rn .- drivers.G.values)[Int64(t_spinup ÷ DATA_DT):Int64(
-                tf ÷ DATA_DT,
-            )],
+            FT.(Rn .- drivers.G.values)[Int64(
+                t_spinup ÷ DATA_DT,
+            ):Int64(tf ÷ DATA_DT)],
             data_times,
             num_days,
         )

--- a/experiments/integrated/fluxnet/snow_soil/simulation.jl
+++ b/experiments/integrated/fluxnet/snow_soil/simulation.jl
@@ -123,13 +123,12 @@ Y.soil.θ_i = 0
 T_0 =
     drivers.TS.status != absent ? drivers.TS.values[t0_idx] :
     drivers.TA.values[t0_idx]
-ρc_s =
-    volumetric_heat_capacity.(
-        Y.soil.ϑ_l,
-        Y.soil.θ_i,
-        soil_ps.ρc_ds,
-        earth_param_set,
-    )
+ρc_s = volumetric_heat_capacity.(
+    Y.soil.ϑ_l,
+    Y.soil.θ_i,
+    soil_ps.ρc_ds,
+    earth_param_set,
+)
 Y.soil.ρe_int =
     volumetric_internal_energy.(Y.soil.θ_i, ρc_s, T_0, earth_param_set)
 
@@ -251,7 +250,7 @@ ax1 = Axis(fig[2, 1], ylabel = "ΔEnergy (J/A)", xlabel = "Days")
             parent(
                 sv.saveval[k].atmos_energy_flux .-
                 sv.saveval[k].soil.bottom_bc.heat,
-            )[end] for k in 1:1:(length(sv.t) - 1)
+            )[end] for k in 1:1:(length(sv.t)-1)
         ],
     ) * (sv.t[2] - sv.t[1])
 E_measured = [
@@ -264,7 +263,7 @@ E_measured = [
             parent(
                 sv.saveval[k].atmos_water_flux .-
                 sv.saveval[k].soil.bottom_bc.water .+ sv.saveval[k].soil.R_s,
-            )[end] for k in 1:1:(length(sv.t) - 1)
+            )[end] for k in 1:1:(length(sv.t)-1)
         ],
     ) * (sv.t[2] - sv.t[1])
 W_measured = [

--- a/experiments/integrated/global/global_parameters.jl
+++ b/experiments/integrated/global/global_parameters.jl
@@ -82,30 +82,26 @@ K_sat .= oceans_to_value.(K_sat, soil_params_mask, 10.0^μ)
 θ_r .= oceans_to_value.(θ_r, soil_params_mask, 0)
 
 
-S_s =
-    oceans_to_value.(
-        ClimaCore.Fields.zeros(subsurface_space) .+ FT(1e-3),
-        soil_params_mask,
-        1,
-    )
-ν_ss_om =
-    oceans_to_value.(
-        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
-        soil_params_mask,
-        0,
-    )
-ν_ss_quartz =
-    oceans_to_value.(
-        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
-        soil_params_mask,
-        0,
-    )
-ν_ss_gravel =
-    oceans_to_value.(
-        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
-        soil_params_mask,
-        0,
-    )
+S_s = oceans_to_value.(
+    ClimaCore.Fields.zeros(subsurface_space) .+ FT(1e-3),
+    soil_params_mask,
+    1,
+)
+ν_ss_om = oceans_to_value.(
+    ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+    soil_params_mask,
+    0,
+)
+ν_ss_quartz = oceans_to_value.(
+    ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+    soil_params_mask,
+    0,
+)
+ν_ss_gravel = oceans_to_value.(
+    ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+    soil_params_mask,
+    0,
+)
 PAR_albedo = ClimaCore.Fields.zeros(surface_space) .+ FT(0.2)
 NIR_albedo = ClimaCore.Fields.zeros(surface_space) .+ FT(0.2)
 soil_params = Soil.EnergyHydrologyParameters(

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -209,20 +209,18 @@ init_soil(ν, θ_r) = θ_r + (ν - θ_r) / 2
 Y.soil.ϑ_l .= init_soil.(ν, θ_r)
 Y.soil.θ_i .= FT(0.0)
 T = FT(276.85)
-ρc_s =
-    Soil.volumetric_heat_capacity.(
-        Y.soil.ϑ_l,
-        Y.soil.θ_i,
-        soil_params.ρc_ds,
-        soil_params.earth_param_set,
-    )
-Y.soil.ρe_int .=
-    Soil.volumetric_internal_energy.(
-        Y.soil.θ_i,
-        ρc_s,
-        T,
-        soil_params.earth_param_set,
-    )
+ρc_s = Soil.volumetric_heat_capacity.(
+    Y.soil.ϑ_l,
+    Y.soil.θ_i,
+    soil_params.ρc_ds,
+    soil_params.earth_param_set,
+)
+Y.soil.ρe_int .= Soil.volumetric_internal_energy.(
+    Y.soil.θ_i,
+    ρc_s,
+    T,
+    soil_params.earth_param_set,
+)
 Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
 Y.canopy.hydraulics.ϑ_l.:1 .= plant_ν
 evaluate!(Y.canopy.energy.T, atmos.T, t0)
@@ -272,7 +270,7 @@ diagnostic_handler =
 
 diag_cb = ClimaDiagnostics.DiagnosticsCallback(diagnostic_handler)
 
-updateat = Array(t0:(3600 * 3):tf)
+updateat = Array(t0:(3600*3):tf)
 drivers = ClimaLand.get_drivers(land)
 updatefunc = ClimaLand.make_update_drivers(drivers)
 driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)

--- a/experiments/integrated/performance/conservation/ozark_conservation.jl
+++ b/experiments/integrated/performance/conservation/ozark_conservation.jl
@@ -119,7 +119,7 @@ for float_type in (Float32, Float64)
         p_mutable = Vector{FT}(undef, 1)
 
         precip =
-            map(sol.t[k] for k in 1:(length(sol.t) - 1)) do time
+            map(sol.t[k] for k in 1:(length(sol.t)-1)) do time
                 ClimaLand.evaluate!(p_mutable, atmos.liquid_precip, time)
                 return p_mutable[]
             end |> collect
@@ -188,20 +188,18 @@ for float_type in (Float32, Float64)
         Plots.plot!(
             plt2,
             daily,
-            eps(FT) .+
-            abs.(
+            eps(FT) .+ abs.(
                 (soil_mass_change_actual - soil_mass_change_exp) ./
-                soil_mass_change_exp
+                soil_mass_change_exp,
             ),
             label = "Soil Water Balance",
         )
         Plots.plot!(
             plt2,
             daily,
-            eps(FT) .+
-            abs.(
+            eps(FT) .+ abs.(
                 (canopy_mass_change_actual - canopy_mass_change_exp) ./
-                canopy_mass_change_exp
+                canopy_mass_change_exp,
             ),
             label = "Canopy Water Balance",
         )
@@ -257,10 +255,9 @@ for float_type in (Float32, Float64)
         Plots.plot!(
             plt2,
             daily,
-            eps(FT) .+
-            abs.(
+            eps(FT) .+ abs.(
                 (soil_energy_change_actual - soil_energy_change_exp) ./
-                soil_energy_change_exp
+                soil_energy_change_exp,
             ),
             label = "Soil Energy Balance",
         )

--- a/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
+++ b/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
@@ -196,13 +196,12 @@ Y.soil.ϑ_l = drivers.SWC.values[1 + Int(round(t0 / 1800))] # Get soil water con
 # or 2005-01-01-06 (UTC)
 Y.soil.θ_i = FT(0.0)
 T_0 = FT(drivers.TS.values[1 + Int(round(t0 / 1800))]) # Get soil temperature at t0
-ρc_s =
-    volumetric_heat_capacity.(
-        Y.soil.ϑ_l,
-        Y.soil.θ_i,
-        land.soil.parameters.ρc_ds,
-        earth_param_set,
-    )
+ρc_s = volumetric_heat_capacity.(
+    Y.soil.ϑ_l,
+    Y.soil.θ_i,
+    land.soil.parameters.ρc_ds,
+    earth_param_set,
+)
 Y.soil.ρe_int =
     volumetric_internal_energy.(Y.soil.θ_i, ρc_s, T_0, earth_param_set)
 
@@ -211,13 +210,12 @@ Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
 ψ_stem_0 = FT(-1e5 / 9800)
 ψ_leaf_0 = FT(-2e5 / 9800)
 
-S_l_ini =
-    inverse_water_retention_curve.(
-        retention_model,
-        [ψ_stem_0, ψ_leaf_0],
-        plant_ν,
-        plant_S_s,
-    )
+S_l_ini = inverse_water_retention_curve.(
+    retention_model,
+    [ψ_stem_0, ψ_leaf_0],
+    plant_ν,
+    plant_S_s,
+)
 
 for i in 1:2
     Y.canopy.hydraulics.ϑ_l.:($i) .=

--- a/experiments/integrated/performance/integrated_timestep_test.jl
+++ b/experiments/integrated/performance/integrated_timestep_test.jl
@@ -74,33 +74,30 @@ function set_initial_conditions(land, t0)
     Y.soil.ϑ_l = FT(0.3)
     Y.soil.θ_i = FT(0.0)
     T_0 = FT(297.5)
-    ρc_s =
-        volumetric_heat_capacity.(
-            Y.soil.ϑ_l,
-            Y.soil.θ_i,
-            land.soil.parameters.ρc_ds,
-            land.soil.parameters.earth_param_set,
-        )
-    Y.soil.ρe_int =
-        volumetric_internal_energy.(
-            Y.soil.θ_i,
-            ρc_s,
-            T_0,
-            land.soil.parameters.earth_param_set,
-        )
+    ρc_s = volumetric_heat_capacity.(
+        Y.soil.ϑ_l,
+        Y.soil.θ_i,
+        land.soil.parameters.ρc_ds,
+        land.soil.parameters.earth_param_set,
+    )
+    Y.soil.ρe_int = volumetric_internal_energy.(
+        Y.soil.θ_i,
+        ρc_s,
+        T_0,
+        land.soil.parameters.earth_param_set,
+    )
 
     Y.soilco2.C = FT(0.000412) # set to atmospheric co2, mol co2 per mol air
 
     ψ_stem_0 = FT(-1e5 / 9800)
     ψ_leaf_0 = FT(-2e5 / 9800)
     canopy_params = land.canopy.hydraulics.parameters
-    S_l_ini =
-        inverse_water_retention_curve.(
-            canopy_params.retention_model,
-            [ψ_stem_0, ψ_leaf_0],
-            canopy_params.ν,
-            canopy_params.S_s,
-        )
+    S_l_ini = inverse_water_retention_curve.(
+        canopy_params.retention_model,
+        [ψ_stem_0, ψ_leaf_0],
+        canopy_params.ν,
+        canopy_params.S_s,
+    )
 
     for i in 1:2
         Y.canopy.hydraulics.ϑ_l.:($i) .=
@@ -181,14 +178,13 @@ function zenith_angle(
     current_datetime = start_date + Dates.Second(round(t))
 
     # Orbital Data uses Float64, so we need to convert to our sim FT
-    d, δ, η_UTC =
-        FT.(
-            Insolation.helper_instantaneous_zenith_angle(
-                current_datetime,
-                start_date,
-                insol_params,
-            )
-        )
+    d, δ, η_UTC = FT.(
+        Insolation.helper_instantaneous_zenith_angle(
+            current_datetime,
+            start_date,
+            insol_params,
+        ),
+    )
 
     Insolation.instantaneous_zenith_angle.(
         d,
@@ -406,8 +402,8 @@ for dt in dts
     )
 
     # Create callback for driver updates
-    saveat = vcat(Array(t0:(3 * 3600):tf), tf)
-    updateat = vcat(Array(t0:(3 * 3600):tf), tf)
+    saveat = vcat(Array(t0:(3*3600):tf), tf)
+    updateat = vcat(Array(t0:(3*3600):tf), tf)
     driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
 
     # Solve simulation

--- a/experiments/long_runs/bucket.jl
+++ b/experiments/long_runs/bucket.jl
@@ -115,7 +115,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 7))
         p,
     )
 
-    updateat = Array(t0:(3600 * 3):tf)
+    updateat = Array(t0:(3600*3):tf)
     drivers = ClimaLand.get_drivers(bucket)
     updatefunc = ClimaLand.make_update_drivers(drivers)
 

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -181,30 +181,26 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     θ_r .= oceans_to_value.(θ_r, soil_params_mask, 0)
 
 
-    S_s =
-        oceans_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(1e-3),
-            soil_params_mask,
-            1,
-        )
-    ν_ss_om =
-        oceans_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
-            soil_params_mask,
-            0,
-        )
-    ν_ss_quartz =
-        oceans_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
-            soil_params_mask,
-            0,
-        )
-    ν_ss_gravel =
-        oceans_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
-            soil_params_mask,
-            0,
-        )
+    S_s = oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(1e-3),
+        soil_params_mask,
+        1,
+    )
+    ν_ss_om = oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+        soil_params_mask,
+        0,
+    )
+    ν_ss_quartz = oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+        soil_params_mask,
+        0,
+    )
+    ν_ss_gravel = oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+        soil_params_mask,
+        0,
+    )
     PAR_albedo = ClimaCore.Fields.zeros(surface_space) .+ FT(0.2)
     NIR_albedo = ClimaCore.Fields.zeros(surface_space) .+ FT(0.2)
     soil_params = Soil.EnergyHydrologyParameters(
@@ -487,20 +483,18 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     Y.soil.ϑ_l .= init_soil.(ν, θ_r)
     Y.soil.θ_i .= FT(0.0)
     T = FT(276.85)
-    ρc_s =
-        Soil.volumetric_heat_capacity.(
-            Y.soil.ϑ_l,
-            Y.soil.θ_i,
-            soil_params.ρc_ds,
-            soil_params.earth_param_set,
-        )
-    Y.soil.ρe_int .=
-        Soil.volumetric_internal_energy.(
-            Y.soil.θ_i,
-            ρc_s,
-            T,
-            soil_params.earth_param_set,
-        )
+    ρc_s = Soil.volumetric_heat_capacity.(
+        Y.soil.ϑ_l,
+        Y.soil.θ_i,
+        soil_params.ρc_ds,
+        soil_params.earth_param_set,
+    )
+    Y.soil.ρe_int .= Soil.volumetric_internal_energy.(
+        Y.soil.θ_i,
+        ρc_s,
+        T,
+        soil_params.earth_param_set,
+    )
     Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
     Y.canopy.hydraulics.ϑ_l.:1 .= plant_ν
     evaluate!(Y.canopy.energy.T, atmos.T, t0)
@@ -526,7 +520,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
         p,
     )
 
-    updateat = Array(t0:(3600 * 3):tf)
+    updateat = Array(t0:(3600*3):tf)
     drivers = ClimaLand.get_drivers(land)
     updatefunc = ClimaLand.make_update_drivers(drivers)
 

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -183,30 +183,26 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
     θ_r .= oceans_to_value.(θ_r, soil_params_mask, 0)
 
 
-    S_s =
-        oceans_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(1e-3),
-            soil_params_mask,
-            1,
-        )
-    ν_ss_om =
-        oceans_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
-            soil_params_mask,
-            0,
-        )
-    ν_ss_quartz =
-        oceans_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
-            soil_params_mask,
-            0,
-        )
-    ν_ss_gravel =
-        oceans_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
-            soil_params_mask,
-            0,
-        )
+    S_s = oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(1e-3),
+        soil_params_mask,
+        1,
+    )
+    ν_ss_om = oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+        soil_params_mask,
+        0,
+    )
+    ν_ss_quartz = oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+        soil_params_mask,
+        0,
+    )
+    ν_ss_gravel = oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+        soil_params_mask,
+        0,
+    )
     PAR_albedo = ClimaCore.Fields.zeros(surface_space) .+ FT(0.2)
     NIR_albedo = ClimaCore.Fields.zeros(surface_space) .+ FT(0.2)
     soil_params = Soil.EnergyHydrologyParameters(
@@ -489,20 +485,18 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
     Y.soil.ϑ_l .= init_soil.(ν, θ_r)
     Y.soil.θ_i .= FT(0.0)
     T = FT(276.85)
-    ρc_s =
-        Soil.volumetric_heat_capacity.(
-            Y.soil.ϑ_l,
-            Y.soil.θ_i,
-            soil_params.ρc_ds,
-            soil_params.earth_param_set,
-        )
-    Y.soil.ρe_int .=
-        Soil.volumetric_internal_energy.(
-            Y.soil.θ_i,
-            ρc_s,
-            T,
-            soil_params.earth_param_set,
-        )
+    ρc_s = Soil.volumetric_heat_capacity.(
+        Y.soil.ϑ_l,
+        Y.soil.θ_i,
+        soil_params.ρc_ds,
+        soil_params.earth_param_set,
+    )
+    Y.soil.ρe_int .= Soil.volumetric_internal_energy.(
+        Y.soil.θ_i,
+        ρc_s,
+        T,
+        soil_params.earth_param_set,
+    )
     Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
     Y.canopy.hydraulics.ϑ_l.:1 .= plant_ν
     evaluate!(Y.canopy.energy.T, atmos.T, t0)
@@ -528,7 +522,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
         p,
     )
 
-    updateat = Array(t0:(3600 * 3):tf)
+    updateat = Array(t0:(3600*3):tf)
     drivers = ClimaLand.get_drivers(land)
     updatefunc = ClimaLand.make_update_drivers(drivers)
 

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -178,30 +178,26 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     θ_r .= oceans_to_value.(θ_r, soil_params_mask, 0)
 
 
-    S_s =
-        oceans_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(1e-3),
-            soil_params_mask,
-            1,
-        )
-    ν_ss_om =
-        oceans_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
-            soil_params_mask,
-            0,
-        )
-    ν_ss_quartz =
-        oceans_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
-            soil_params_mask,
-            0,
-        )
-    ν_ss_gravel =
-        oceans_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
-            soil_params_mask,
-            0,
-        )
+    S_s = oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(1e-3),
+        soil_params_mask,
+        1,
+    )
+    ν_ss_om = oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+        soil_params_mask,
+        0,
+    )
+    ν_ss_quartz = oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+        soil_params_mask,
+        0,
+    )
+    ν_ss_gravel = oceans_to_value.(
+        ClimaCore.Fields.zeros(subsurface_space) .+ FT(0.1),
+        soil_params_mask,
+        0,
+    )
     PAR_albedo = ClimaCore.Fields.zeros(surface_space) .+ FT(0.2)
     NIR_albedo = ClimaCore.Fields.zeros(surface_space) .+ FT(0.2)
     soil_params = Soil.EnergyHydrologyParameters(
@@ -272,20 +268,18 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     Y.soil.ϑ_l .= init_soil.(ν, θ_r)
     Y.soil.θ_i .= FT(0.0)
     T = FT(276.85)
-    ρc_s =
-        Soil.volumetric_heat_capacity.(
-            Y.soil.ϑ_l,
-            Y.soil.θ_i,
-            soil_params.ρc_ds,
-            soil_params.earth_param_set,
-        )
-    Y.soil.ρe_int .=
-        Soil.volumetric_internal_energy.(
-            Y.soil.θ_i,
-            ρc_s,
-            T,
-            soil_params.earth_param_set,
-        )
+    ρc_s = Soil.volumetric_heat_capacity.(
+        Y.soil.ϑ_l,
+        Y.soil.θ_i,
+        soil_params.ρc_ds,
+        soil_params.earth_param_set,
+    )
+    Y.soil.ρe_int .= Soil.volumetric_internal_energy.(
+        Y.soil.θ_i,
+        ρc_s,
+        T,
+        soil_params.earth_param_set,
+    )
 
     set_initial_cache! = make_set_initial_cache(soil)
     exp_tendency! = make_exp_tendency(soil)
@@ -308,7 +302,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
         p,
     )
 
-    updateat = Array(t0:(3600 * 3):tf)
+    updateat = Array(t0:(3600*3):tf)
     drivers = ClimaLand.get_drivers(soil)
     updatefunc = ClimaLand.make_update_drivers(drivers)
 

--- a/experiments/standalone/Biogeochemistry/experiment.jl
+++ b/experiments/standalone/Biogeochemistry/experiment.jl
@@ -132,13 +132,12 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
             params.ρc_ds,
             params.earth_param_set,
         )
-        Y.soil.ρe_int .=
-            Soil.volumetric_internal_energy.(
-                FT(0.0),
-                ρc_s,
-                T,
-                params.earth_param_set,
-            )
+        Y.soil.ρe_int .= Soil.volumetric_internal_energy.(
+            FT(0.0),
+            ρc_s,
+            T,
+            params.earth_param_set,
+        )
     end
 
     function init_co2!(Y, z)
@@ -158,7 +157,7 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
     timestepper = CTS.RK4()
     ode_algo = CTS.ExplicitAlgorithm(timestepper)
 
-    saveat = collect(t0:FT(10 * dt):tf)
+    saveat = collect(t0:FT(10*dt):tf)
     sv = (;
         t = Array{Float64}(undef, length(saveat)),
         saveval = Array{NamedTuple}(undef, length(saveat)),

--- a/experiments/standalone/Bucket/bucket_era5.jl
+++ b/experiments/standalone/Bucket/bucket_era5.jl
@@ -169,7 +169,7 @@ prob = SciMLBase.ODEProblem(
     p,
 );
 
-saveat = collect(t0:(Δt * 3):tf);
+saveat = collect(t0:(Δt*3):tf);
 saved_values = (;
     t = Array{Float64}(undef, length(saveat)),
     saveval = Array{NamedTuple}(undef, length(saveat)),
@@ -295,12 +295,7 @@ for (i, (field_ts, field_name)) in enumerate(
             outdir,
             string("anim_$(device_suffix)_", field_name, ".mp4"),
         )
-        record(
-            fig,
-            outfile,
-            (nframes - 7 * 24):2:nframes;
-            framerate = 3,
-        ) do frame
+        record(fig, outfile, (nframes-7*24):2:nframes; framerate = 3) do frame
             CairoMakie.heatmap!(
                 longpts,
                 latpts,

--- a/experiments/standalone/Bucket/global_bucket_function.jl
+++ b/experiments/standalone/Bucket/global_bucket_function.jl
@@ -176,7 +176,7 @@ diagnostic_handler =
 
 diag_cb = ClimaDiagnostics.DiagnosticsCallback(diagnostic_handler)
 
-updateat = collect(t0:(Δt * 3):tf);
+updateat = collect(t0:(Δt*3):tf);
 drivers = ClimaLand.get_drivers(model)
 updatefunc = ClimaLand.make_update_drivers(drivers)
 driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)

--- a/experiments/standalone/Bucket/global_bucket_temporalmap.jl
+++ b/experiments/standalone/Bucket/global_bucket_temporalmap.jl
@@ -174,7 +174,7 @@ function setup_prob(t0, tf, Δt)
         (t0, tf),
         p,
     )
-    saveat = collect(t0:(Δt * 3):tf)
+    saveat = collect(t0:(Δt*3):tf)
     saved_values = (;
         t = Array{Float64}(undef, length(saveat)),
         saveval = Array{NamedTuple}(undef, length(saveat)),

--- a/experiments/standalone/Snow/process_snowmip.jl
+++ b/experiments/standalone/Snow/process_snowmip.jl
@@ -63,14 +63,13 @@ function zenith_angle(
     current_datetime = start_date + Dates.Second(round(t))
 
     # Orbital Data uses Float64, so we need to convert to our sim FT
-    d, δ, η_UTC =
-        FT.(
-            Insolation.helper_instantaneous_zenith_angle(
-                current_datetime,
-                start_date,
-                insol_params,
-            )
-        )
+    d, δ, η_UTC = FT.(
+        Insolation.helper_instantaneous_zenith_angle(
+            current_datetime,
+            start_date,
+            insol_params,
+        ),
+    )
 
     FT(
         Insolation.instantaneous_zenith_angle(
@@ -120,11 +119,11 @@ albedo = snow_data["albs"][:][mask]
 z = snow_data["snd_man"][:][mask]
 mass = snow_data["snw_man"][:][mask]
 
-snow_data_avail = .!(typeof.(mass) .<: Missing)
+snow_data_avail = .! (typeof.(mass) .<: Missing)
 T_snow = snow_data["ts"][:][mask][snow_data_avail]
 ρ_snow = mass[snow_data_avail] ./ z[snow_data_avail]
 SWE = z[snow_data_avail] .* ρ_snow ./ 1000.0
 α = median(
-    albedo[snow_data_avail][.!(typeof.(albedo[snow_data_avail]) .<: Missing)],
+    albedo[snow_data_avail][.! (typeof.(albedo[snow_data_avail]) .<: Missing)],
 )
-ρ = median(ρ_snow[.~isnan.(ρ_snow)])
+ρ = median(ρ_snow[.~ isnan.(ρ_snow)])

--- a/experiments/standalone/Soil/richards_runoff.jl
+++ b/experiments/standalone/Soil/richards_runoff.jl
@@ -240,7 +240,7 @@ prob = SciMLBase.ODEProblem(
     p,
 )
 save_every = 100
-saveat = Array(t0:(save_every * dt):tf)
+saveat = Array(t0:(save_every*dt):tf)
 sv = (;
     t = Array{Float64}(undef, length(saveat)),
     saveval = Array{NamedTuple}(undef, length(saveat)),
@@ -258,8 +258,8 @@ if context.device isa ClimaComms.CPUSingleThreaded
     longpts = range(-180.0, 180.0, 101)
     latpts = range(-90.0, 90.0, 101)
     hcoords = [
-        ClimaCore.Geometry.LatLongPoint(lat, long) for long in longpts,
-        lat in latpts
+        ClimaCore.Geometry.LatLongPoint(lat, long) for
+        long in longpts, lat in latpts
     ]
     remapper = ClimaCore.Remapping.Remapper(surface_space, hcoords)
 

--- a/experiments/standalone/Soil/water_energy_conservation.jl
+++ b/experiments/standalone/Soil/water_energy_conservation.jl
@@ -85,20 +85,18 @@ function init_soil!(Y, z, Trange, params)
     T = @.(T_min + (T_max - T_min) * exp(-(z - zmax) / (zmin - zmax) * c))
 
     θ_l = Soil.volumetric_liquid_fraction.(Y.soil.ϑ_l, ν, θ_r)
-    ρc_s =
-        Soil.volumetric_heat_capacity.(
-            θ_l,
-            Y.soil.θ_i,
-            params.ρc_ds,
-            params.earth_param_set,
-        )
-    Y.soil.ρe_int .=
-        Soil.volumetric_internal_energy.(
-            Y.soil.θ_i,
-            ρc_s,
-            T,
-            params.earth_param_set,
-        )
+    ρc_s = Soil.volumetric_heat_capacity.(
+        θ_l,
+        Y.soil.θ_i,
+        params.ρc_ds,
+        params.earth_param_set,
+    )
+    Y.soil.ρe_int .= Soil.volumetric_internal_energy.(
+        Y.soil.θ_i,
+        ρc_s,
+        T,
+        params.earth_param_set,
+    )
 end
 set_initial_cache! = make_set_initial_cache(soil);
 

--- a/experiments/standalone/Vegetation/no_vegetation.jl
+++ b/experiments/standalone/Vegetation/no_vegetation.jl
@@ -182,7 +182,7 @@ set_initial_cache!(p, Y, t0);
 
 
 n = 16
-saveat = Array(t0:(n * dt):tf)
+saveat = Array(t0:(n*dt):tf)
 sv = (;
     t = Array{Float64}(undef, length(saveat)),
     saveval = Array{NamedTuple}(undef, length(saveat)),

--- a/experiments/standalone/Vegetation/timestep_test.jl
+++ b/experiments/standalone/Vegetation/timestep_test.jl
@@ -190,13 +190,12 @@ updatefunc = ClimaLand.make_update_drivers(drivers)
 
 ψ_leaf_0 = FT(-2e5 / 9800)
 ψ_stem_0 = FT(-1e5 / 9800)
-S_l_ini =
-    inverse_water_retention_curve.(
-        retention_model,
-        [ψ_stem_0, ψ_leaf_0],
-        ν,
-        S_s,
-    )
+S_l_ini = inverse_water_retention_curve.(
+    retention_model,
+    [ψ_stem_0, ψ_leaf_0],
+    ν,
+    S_s,
+)
 
 seconds_per_day = 3600 * 24.0
 t0 = 150seconds_per_day
@@ -242,8 +241,8 @@ for dt in dts
     set_initial_cache!(p, Y, t0)
 
     # Create callback for driver updates
-    saveat = vcat(Array(t0:(3 * 3600):tf), tf)
-    updateat = vcat(Array(t0:(3 * 3600):tf), tf)
+    saveat = vcat(Array(t0:(3*3600):tf), tf)
+    updateat = vcat(Array(t0:(3*3600):tf), tf)
     cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
 
     # Solve simulation

--- a/experiments/standalone/Vegetation/varying_lai.jl
+++ b/experiments/standalone/Vegetation/varying_lai.jl
@@ -182,7 +182,7 @@ set_initial_cache!(p, Y, t0);
 
 
 n = 16
-saveat = Array(t0:(n * dt):tf)
+saveat = Array(t0:(n*dt):tf)
 sv = (;
     t = Array{Float64}(undef, length(saveat)),
     saveval = Array{NamedTuple}(undef, length(saveat)),

--- a/experiments/standalone/Vegetation/varying_lai_with_stem.jl
+++ b/experiments/standalone/Vegetation/varying_lai_with_stem.jl
@@ -166,13 +166,12 @@ exp_tendency! = make_exp_tendency(canopy);
 ψ_leaf_0 = FT(-2e5 / 9800)
 ψ_stem_0 = FT(-1e5 / 9800)
 
-S_l_ini =
-    inverse_water_retention_curve.(
-        retention_model,
-        [ψ_stem_0, ψ_leaf_0],
-        ν,
-        S_s,
-    )
+S_l_ini = inverse_water_retention_curve.(
+    retention_model,
+    [ψ_stem_0, ψ_leaf_0],
+    ν,
+    S_s,
+)
 
 Y.canopy.hydraulics.ϑ_l.:1 .= augmented_liquid_fraction.(ν, S_l_ini[1])
 Y.canopy.hydraulics.ϑ_l.:2 .= augmented_liquid_fraction.(ν, S_l_ini[2])
@@ -189,7 +188,7 @@ set_initial_cache!(p, Y, t0);
 
 
 n = 16
-saveat = Array(t0:(n * dt):tf)
+saveat = Array(t0:(n*dt):tf)
 sv = (;
     t = Array{Float64}(undef, length(saveat)),
     saveval = Array{NamedTuple}(undef, length(saveat)),

--- a/ext/neural_snow/DataTools.jl
+++ b/ext/neural_snow/DataTools.jl
@@ -386,17 +386,15 @@ function rectify_daily_hourly(
         elseif Symbol(var) in hourly_only
             combined[!, Symbol(var)] .= combined[!, Symbol(var * "_1")]
         elseif Symbol(var) in prioritize_hour
-            combined[!, Symbol(var)] .=
-                coalesce.(
-                    combined[!, Symbol(var * "_1")],
-                    combined[!, Symbol(var)],
-                )
+            combined[!, Symbol(var)] .= coalesce.(
+                combined[!, Symbol(var * "_1")],
+                combined[!, Symbol(var)],
+            )
         else
-            combined[!, Symbol(var)] .=
-                coalesce.(
-                    combined[!, Symbol(var)],
-                    combined[!, Symbol(var * "_1")],
-                )
+            combined[!, Symbol(var)] .= coalesce.(
+                combined[!, Symbol(var)],
+                combined[!, Symbol(var * "_1")],
+            )
         end
     end
     return sort(select(combined, vars), :date)
@@ -548,8 +546,7 @@ and remove days when z != 0 but SWE = 0. Defauly eps is 0.005 m (5 cm, since z i
 """
 function train_filter(data::DataFrame; eps::Real = 0.005)
     zero_condition1 =
-        (data[!, :SWE] .< eps) .&
-        (data[!, :z] .< eps) .&
+        (data[!, :SWE] .< eps) .& (data[!, :z] .< eps) .&
         (data[!, :dprecipdt] .< eps / 86400.0)
     data = data[Not(zero_condition1), :]
     zero_condition2 = (data[!, :z] .!= 0.0f0) .& (data[!, :SWE] .== 0.0f0)
@@ -739,7 +736,7 @@ function serreze_qc(input::DataFrame, id::Int, state::AbstractString)
             continue
         end
         precips = data[allyear, :precip]
-        for i in 2:(length(precips) - 1)
+        for i in 2:(length(precips)-1)
             if sum(ismissing.(precips[(i - 1):(i + 1)])) == 0
                 if 0 <= precips[i + 1] - precips[i - 1] <= 0.5
                     if (precips[i] < precips[i - 1]) |
@@ -759,10 +756,9 @@ function serreze_qc(input::DataFrame, id::Int, state::AbstractString)
     data = data[in.(data[!, :date], [overlap]), :]
     data[!, :tmin] = maxmin[!, :tmin]
     data[!, :tmax] = maxmin[!, :tmax]
-    flags =
-        ismissing.(
-            data[1:(end - 1), [:SWE, :precip, :air_temp_avg, :tmin, :tmax]]
-        )
+    flags = ismissing.(
+        data[1:(end - 1), [:SWE, :precip, :air_temp_avg, :tmin, :tmax]],
+    )
     flags[!, :date] = data[1:(end - 1), :date]
 
     dswes = data[2:end, :SWE] - data[1:(end - 1), :SWE]
@@ -1072,7 +1068,7 @@ function z_filter(
     wait_for_zero = false
     n_rut = 0
     spring_thaw = (Dates.month(ts[1]) in 4:8)
-    for i in 2:(size(zs)[1] - 1)
+    for i in 2:(size(zs)[1]-1)
         z = zs[i]
         dzp = zs[i + 1] - zs[i]
         dzm = zs[i] - zs[i - 1]
@@ -1489,7 +1485,7 @@ function impute_data(
             )
             newvar[(idx_miss - 1):idx_next] .= interp
         elseif Δt <= t2
-            for k in idx_miss:(idx_next - 1)
+            for k in idx_miss:(idx_next-1)
                 a = bwk[k]
                 if dt == Hour(1)
                     b = Dates.hour(data[k, :date]) + 1

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_utilities/data_tools.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_utilities/data_tools.jl
@@ -22,7 +22,7 @@ data with QC flag = 2,3.
 function replace_poor_quality_with_mean!(field, flag)
     good_indices = (flag .== 0) .|| (flag .== 1)
     fill_value = mean(field[good_indices])
-    field[.~good_indices] .= fill_value
+    field[.~ good_indices] .= fill_value
     return field
 end
 
@@ -36,9 +36,9 @@ This uses the Fluxnet convention of a value of -9999 indicating
 missing data.
 """
 function replace_missing_with_mean_by_value!(field)
-    good_indices = .~(field .== -9999)
+    good_indices = .~ (field .== -9999)
     fill_value = mean(field[good_indices])
-    field[.~good_indices] .= fill_value
+    field[.~ good_indices] .= fill_value
     return field
 end
 

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_utilities/make_drivers.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_utilities/make_drivers.jl
@@ -101,18 +101,17 @@ function make_drivers(site_ID, setup, config, params, context)
     end
 
     thermo_params = LP.thermodynamic_parameters(earth_param_set)
-    esat =
-        Thermodynamics.saturation_vapor_pressure.(
-            Ref(thermo_params),
-            FT.(drivers.TA.values),
-            Ref(Thermodynamics.Liquid()),
-        )
+    esat = Thermodynamics.saturation_vapor_pressure.(
+        Ref(thermo_params),
+        FT.(drivers.TA.values),
+        Ref(Thermodynamics.Liquid()),
+    )
     e = @. esat - drivers.VPD.values
     q = @. 0.622 * e ./ (drivers.PA.values - 0.378 * e)
 
     # Create interpolators for each atmospheric driver needed for PrescribedAtmosphere and
     # for PrescribedRadiation
-    seconds = FT.(0:DATA_DT:((length(UTC_DATETIME) - 1) * DATA_DT))
+    seconds = FT.(0:DATA_DT:((length(UTC_DATETIME)-1)*DATA_DT))
     precip = TimeVaryingInput(seconds, -FT.(drivers.P.values[:]); context) # m/s
     atmos_q = TimeVaryingInput(seconds, FT.(q[:]); context)
     atmos_T = TimeVaryingInput(seconds, FT.(drivers.TA.values[:]); context)
@@ -149,14 +148,13 @@ function make_drivers(site_ID, setup, config, params, context)
         current_datetime = start_date + Dates.Second(round(t))
 
         # Orbital Data uses Float64, so we need to convert to our sim FT
-        d, δ, η_UTC =
-            FT.(
-                Insolation.helper_instantaneous_zenith_angle(
-                    current_datetime,
-                    start_date,
-                    insol_params,
-                )
-            )
+        d, δ, η_UTC = FT.(
+            Insolation.helper_instantaneous_zenith_angle(
+                current_datetime,
+                start_date,
+                insol_params,
+            ),
+        )
 
         FT(
             Insolation.instantaneous_zenith_angle(
@@ -196,7 +194,7 @@ function make_drivers(site_ID, setup, config, params, context)
     )
 
     LAI_dt = Second(MODIS_LAI[2, 1] - MODIS_LAI[1, 1]).value
-    LAI_seconds = FT.(0:LAI_dt:((length(MODIS_LAI[:, 1]) - 1) * LAI_dt))
+    LAI_seconds = FT.(0:LAI_dt:((length(MODIS_LAI[:, 1])-1)*LAI_dt))
 
     # LAI for radiative transfer
     LAIfunction = TimeVaryingInput(LAI_seconds, FT.(MODIS_LAI[:, 2]); context)

--- a/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
@@ -67,7 +67,7 @@ function run_fluxnet(
     soilco2_sources = (MicrobeProduction{FT}(),)
 
     soilco2_boundary_conditions =
-        (; top = soilco2_top_bc, bottom = CO2 = soilco2_bot_bc)
+        (; top = soilco2_top_bc, bottom =  CO2 = soilco2_bot_bc )
 
     soilco2_args = (;
         boundary_conditions = soilco2_boundary_conditions,
@@ -232,32 +232,29 @@ function run_fluxnet(
         drivers.drivers.TS.values[1 + Int(round(setup.t0 / drivers.DATA_DT))] :
         drivers.drivers.TA.values[1 + Int(round(setup.t0 / drivers.DATA_DT))] +
         40# Get soil temperature at t0
-    ρc_s =
-        volumetric_heat_capacity.(
-            Y.soil.ϑ_l,
-            Y.soil.θ_i,
-            land.soil.parameters.ρc_ds,
-            land.soil.parameters.earth_param_set,
-        )
-    Y.soil.ρe_int =
-        volumetric_internal_energy.(
-            Y.soil.θ_i,
-            ρc_s,
-            T_0,
-            land.soil.parameters.earth_param_set,
-        )
+    ρc_s = volumetric_heat_capacity.(
+        Y.soil.ϑ_l,
+        Y.soil.θ_i,
+        land.soil.parameters.ρc_ds,
+        land.soil.parameters.earth_param_set,
+    )
+    Y.soil.ρe_int = volumetric_internal_energy.(
+        Y.soil.θ_i,
+        ρc_s,
+        T_0,
+        land.soil.parameters.earth_param_set,
+    )
     Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
     ψ_stem_0 = FT(-1e5 / 9800) # pressure in the leaf divided by rho_liquid*gravitational acceleration [m]
     ψ_leaf_0 = FT(-2e5 / 9800)
     ψ_comps = setup.n_stem > 0 ? [ψ_stem_0, ψ_leaf_0] : ψ_leaf_0
 
-    S_l_ini =
-        inverse_water_retention_curve.(
-            params.plant_hydraulics.retention_model,
-            ψ_comps,
-            drivers.plant_ν,
-            params.plant_hydraulics.S_s,
-        )
+    S_l_ini = inverse_water_retention_curve.(
+        params.plant_hydraulics.retention_model,
+        ψ_comps,
+        drivers.plant_ν,
+        params.plant_hydraulics.S_s,
+    )
 
     for i in 1:(setup.n_stem + setup.n_leaf)
         Y.canopy.hydraulics.ϑ_l.:($i) .=

--- a/lib/ClimaLandSimulations/src/utilities/makie_plots.jl
+++ b/lib/ClimaLandSimulations/src/utilities/makie_plots.jl
@@ -547,9 +547,9 @@ function cumulative_H2O_fig(
         (LP.LH_v0(earth_param_set) * 1000) .* (1e3 * 24 * 3600)
     P_obs = inputs.P[index_t_start:index_t_end] .* 1e3 .* 24 .* 3600
 
-    p_P = lines!(ax, (1 / 48):(1 / 48):(length(P_obs) / 48), cumsum(P_obs)) # Precip
-    p_ET_m = lines!(ax, (1 / 48):(1 / 48):(length(ET_m) / 48), cumsum(ET_m)) # ET model
-    p_ET_d = lines!(ax, (1 / 48):(1 / 48):(length(ET_obs) / 48), cumsum(ET_obs)) # ET observations
+    p_P = lines!(ax, (1/48):(1/48):(length(P_obs)/48), cumsum(P_obs)) # Precip
+    p_ET_m = lines!(ax, (1/48):(1/48):(length(ET_m)/48), cumsum(ET_m)) # ET model
+    p_ET_d = lines!(ax, (1/48):(1/48):(length(ET_obs)/48), cumsum(ET_obs)) # ET observations
 
     axislegend(
         ax,

--- a/src/shared_utilities/Domains.jl
+++ b/src/shared_utilities/Domains.jl
@@ -949,16 +949,14 @@ will need to be modified upon the introduction of
 Since the depth will be a field in this case, it should be allocated and
 stored in domain.fields, which is why we store it there now even though it is not a field.
 """
-depth(space::ClimaCore.Spaces.CenterExtrudedFiniteDifferenceSpace) =
-    (
-        space.grid.vertical_grid.topology.mesh.domain.coord_max -
-        space.grid.vertical_grid.topology.mesh.domain.coord_min
-    ).z
-depth(space::ClimaCore.Spaces.CenterFiniteDifferenceSpace) =
-    (
-        space.grid.topology.mesh.domain.coord_max -
-        space.grid.topology.mesh.domain.coord_min
-    ).z
+depth(space::ClimaCore.Spaces.CenterExtrudedFiniteDifferenceSpace) = (
+    space.grid.vertical_grid.topology.mesh.domain.coord_max -
+    space.grid.vertical_grid.topology.mesh.domain.coord_min
+).z
+depth(space::ClimaCore.Spaces.CenterFiniteDifferenceSpace) = (
+    space.grid.topology.mesh.domain.coord_max -
+    space.grid.topology.mesh.domain.coord_min
+).z
 
 export AbstractDomain
 export Column, Plane, HybridBox, Point, SphericalShell, SphericalSurface

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -1130,22 +1130,15 @@ function prescribed_forcing_era5(
         current_datetime = start_date + Dates.Second(round(t))
 
         # Orbital Data uses Float64, so we need to convert to our sim FT
-        d, δ, η_UTC =
-            FT.(
-                Insolation.helper_instantaneous_zenith_angle(
-                    current_datetime,
-                    start_date,
-                    insol_params,
-                )
-            )
+        d, δ, η_UTC = FT.(
+            Insolation.helper_instantaneous_zenith_angle(
+                current_datetime,
+                start_date,
+                insol_params,
+            ),
+        )
 
-        Insolation.instantaneous_zenith_angle.(
-            d,
-            δ,
-            η_UTC,
-            longitude,
-            latitude,
-        ).:1
+        Insolation.instantaneous_zenith_angle.(d, δ, η_UTC, longitude, latitude).:1
     end
     radiation =
         PrescribedRadiativeFluxes(FT, SW_d, LW_d, start_date; θs = zenith_angle)

--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -407,16 +407,11 @@ function make_update_aux(model::BucketModel{FT}) where {FT}
         # This relies on the surface specific humidity being computed
         # entirely over snow or over soil. i.e. the snow cover fraction must be a heaviside
         # here, otherwise we would need two values of q_sfc!
-        p.bucket.q_sfc .=
-            saturation_specific_humidity.(
-                p.bucket.T_sfc,
-                p.bucket.ρ_sfc,
-                Ref(
-                    LP.thermodynamic_parameters(
-                        model.parameters.earth_param_set,
-                    ),
-                ),
-            )
+        p.bucket.q_sfc .= saturation_specific_humidity.(
+            p.bucket.T_sfc,
+            p.bucket.ρ_sfc,
+            Ref(LP.thermodynamic_parameters(model.parameters.earth_param_set)),
+        )
         # Compute turbulent surface fluxes
         p.bucket.turbulent_fluxes .=
             turbulent_fluxes(model.atmos, model, Y, p, t)
@@ -456,17 +451,16 @@ function make_update_aux(model::BucketModel{FT}) where {FT}
         _ρ_liq = LP.ρ_cloud_liq(model.parameters.earth_param_set)
         _ρLH_f0 = _ρ_liq * _LH_f0 # Latent heat per unit volume.
         # partition energy fluxes for snow covered area
-        p.bucket.partitioned_fluxes .=
-            partition_snow_surface_fluxes.(
-                Y.bucket.σS,
-                p.bucket.T_sfc,
-                model.parameters.τc,
-                p.bucket.snow_cover_fraction,
-                p.bucket.turbulent_fluxes.vapor_flux,
-                p.bucket.F_sfc,
-                _ρLH_f0,
-                _T_freeze,
-            )
+        p.bucket.partitioned_fluxes .= partition_snow_surface_fluxes.(
+            Y.bucket.σS,
+            p.bucket.T_sfc,
+            model.parameters.τc,
+            p.bucket.snow_cover_fraction,
+            p.bucket.turbulent_fluxes.vapor_flux,
+            p.bucket.F_sfc,
+            _ρLH_f0,
+            _T_freeze,
+        )
         @. p.bucket.G =
             p.bucket.F_sfc * (1 - p.bucket.snow_cover_fraction) +
             p.bucket.partitioned_fluxes.G_under_snow *

--- a/src/standalone/Bucket/bucket_parameterizations.jl
+++ b/src/standalone/Bucket/bucket_parameterizations.jl
@@ -55,14 +55,13 @@ a helper function which computes and returns the surface evaporative scaling
  factor for the bucket model.
 """
 function ClimaLand.surface_evaporative_scaling(model::BucketModel, Y, p)
-    beta =
-        beta_factor.(
-            Y.bucket.W,
-            Y.bucket.σS,
-            model.parameters.f_bucket * model.parameters.W_f,
-            model.parameters.f_snow * model.parameters.σS_c,
-            model.parameters.p,
-        )
+    beta = beta_factor.(
+        Y.bucket.W,
+        Y.bucket.σS,
+        model.parameters.f_bucket * model.parameters.W_f,
+        model.parameters.f_snow * model.parameters.σS_c,
+        model.parameters.p,
+    )
     return beta
 end
 

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -83,20 +83,18 @@ function ClimaLand.surface_specific_humidity(
 )
     thermo_params =
         LP.thermodynamic_parameters(model.parameters.earth_param_set)
-    qsat_over_ice =
-        Thermodynamics.q_vap_saturation_generic.(
-            Ref(thermo_params),
-            T_sfc,
-            ρ_sfc,
-            Ref(Thermodynamics.Ice()),
-        )
-    qsat_over_liq =
-        Thermodynamics.q_vap_saturation_generic.(
-            Ref(thermo_params),
-            T_sfc,
-            ρ_sfc,
-            Ref(Thermodynamics.Liquid()),
-        )
+    qsat_over_ice = Thermodynamics.q_vap_saturation_generic.(
+        Ref(thermo_params),
+        T_sfc,
+        ρ_sfc,
+        Ref(Thermodynamics.Ice()),
+    )
+    qsat_over_liq = Thermodynamics.q_vap_saturation_generic.(
+        Ref(thermo_params),
+        T_sfc,
+        ρ_sfc,
+        Ref(Thermodynamics.Liquid()),
+    )
     q_l = p.snow.q_l
     return @. qsat_over_ice * (1 - q_l) + q_l * (qsat_over_liq)
 end

--- a/src/standalone/Soil/Runoff/preprocess_topographic_index_simple.jl
+++ b/src/standalone/Soil/Runoff/preprocess_topographic_index_simple.jl
@@ -24,9 +24,9 @@ function main(; resolution)
             lon_indices =
                 Array(1:1:length(lon))[(lon .>= lon_min + resolution * (lon_id - 1)) .& (lon .< lon_min + resolution * lon_id)]
             ϕ = data["Band1"][lon_indices, lat_indices][:]
-            present = .~(typeof.(ϕ) .<: Missing)
+            present = .~ (typeof.(ϕ) .<: Missing)
             present_count = sum(present)
-            zero_count = sum(.~(typeof.(ϕ) .<: Missing) .& (ϕ .== 0))
+            zero_count = sum(.~ (typeof.(ϕ) .<: Missing) .& (ϕ .== 0))
             #present_nonzero = .~(typeof.(ϕ) .<: Missing) .& (ϕ .> 0)
             if present_count / prod(size(ϕ)) > 0.5
                 # Land
@@ -48,11 +48,11 @@ function main(; resolution)
 
     la = defVar(ds, "lat", Float32, ("lat",))
     la[:] =
-        (0.5:1:(lat_count - 0.5)) ./ lat_count .* (lat_max - lat_min) .+ lat_min
+        (0.5:1:(lat_count-0.5)) ./ lat_count .* (lat_max - lat_min) .+ lat_min
 
     lo = defVar(ds, "lon", Float32, ("lon",))
     lo[:] =
-        (0.5:1:(lon_count - 0.5)) ./ lon_count .* (lon_max - lon_min) .+ lon_min
+        (0.5:1:(lon_count-0.5)) ./ lon_count .* (lon_max - lon_min) .+ lon_min
 
     mean_ϕ = defVar(ds, "ϕ_mean", Float32, ("lon", "lat"))
     mean_ϕ[:, :] = parameters[:, :, 2]

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -517,7 +517,7 @@ function ClimaLand.make_update_aux(
         # for broadcasted expressions using the macro @.
         # field.:($index) .= value # works
         # @ field.:($$index) = value # works
-        @inbounds for i in 1:(n_stem + n_leaf - 1)
+        @inbounds for i in 1:(n_stem+n_leaf-1)
             ip1 = i + 1
             @. ψ.:($$ip1) = PlantHydraulics.water_retention_curve(
                 retention_model,

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -251,7 +251,7 @@ function PlantHydraulicsModel{FT}(;
                 compartment_surfaces[i]
     end
     compartment_labels = Vector{Symbol}(undef, n_stem + n_leaf)
-    for i in 1:(n_stem + n_leaf)
+    for i in 1:(n_stem+n_leaf)
         if i <= n_stem
             compartment_labels[i] = :stem
         else
@@ -592,19 +592,18 @@ function make_compute_exp_tendency(
         # for broadcasted expressions using the macro @.
         # field.:($index) .= value # works
         # @ field.:($$index) = value # works
-        @inbounds for i in 1:(n_stem + n_leaf)
+        @inbounds for i in 1:(n_stem+n_leaf)
             im1 = i - 1
             ip1 = i + 1
             # To prevent dividing by zero, change AI/(AI x dz)" to
             # "AI/max(AI x dz, eps(FT))"
-            AIdz =
-                max.(
-                    getproperty(area_index, model.compartment_labels[i]) .* (
-                        model.compartment_surfaces[ip1] -
-                        model.compartment_surfaces[i]
-                    ),
-                    eps(FT),
-                )
+            AIdz = max.(
+                getproperty(area_index, model.compartment_labels[i]) .* (
+                    model.compartment_surfaces[ip1] -
+                    model.compartment_surfaces[i]
+                ),
+                eps(FT),
+            )
             if i == 1
                 @inbounds @. dY.canopy.hydraulics.ϑ_l.:($$i) =
                     1 / AIdz * (fa_roots - fa.:($$i))

--- a/src/standalone/Vegetation/optimality_farquhar.jl
+++ b/src/standalone/Vegetation/optimality_farquhar.jl
@@ -134,18 +134,17 @@ function update_photosynthesis!(
     ci = intercellular_co2.(c_co2, Γstar, medlyn_factor)# may change?
     Kc = MM_Kc.(Kc25, ΔHkc, T, To, R)
     Ko = MM_Ko.(Ko25, ΔHko, T, To, R)
-    rates =
-        optimality_max_photosynthetic_rates.(
-            APAR,
-            θj,
-            ϕ,
-            oi,
-            ci,
-            Γstar,
-            Kc,
-            Ko,
-            c,
-        )
+    rates = optimality_max_photosynthetic_rates.(
+        APAR,
+        θj,
+        ϕ,
+        oi,
+        ci,
+        Γstar,
+        Kc,
+        Ko,
+        c,
+    )
     Jmax = rates.:1
     Vcmax = rates.:2
     J = electron_transport.(APAR, Jmax, θj, ϕ)

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -127,22 +127,20 @@ for FT in (Float32, Float64)
             Y.soil.ϑ_l .= FT(0.33)
             Y.soil.θ_i .= FT(0.0)
             T = FT(279.85)
-            ρc_s =
-                FT.(
-                    Soil.volumetric_heat_capacity(
-                        FT(0.33),
-                        FT(0.0),
-                        params.ρc_ds,
-                        params.earth_param_set,
-                    )
-                )
-            Y.soil.ρe_int .=
-                Soil.volumetric_internal_energy.(
+            ρc_s = FT.(
+                Soil.volumetric_heat_capacity(
+                    FT(0.33),
                     FT(0.0),
-                    ρc_s,
-                    T,
+                    params.ρc_ds,
                     params.earth_param_set,
-                )
+                ),
+            )
+            Y.soil.ρe_int .= Soil.volumetric_internal_energy.(
+                FT(0.0),
+                ρc_s,
+                T,
+                params.earth_param_set,
+            )
         end
 
         function init_co2!(Y, C_0)

--- a/test/integrated/soil_snow.jl
+++ b/test/integrated/soil_snow.jl
@@ -121,13 +121,12 @@ function init_soil!(Y, z, params)
         params.ρc_ds,
         params.earth_param_set,
     )
-    Y.soil.ρe_int =
-        ClimaLand.Soil.volumetric_internal_energy.(
-            FT(0),
-            ρc_s,
-            T,
-            params.earth_param_set,
-        )
+    Y.soil.ρe_int = ClimaLand.Soil.volumetric_internal_energy.(
+        FT(0),
+        ρc_s,
+        T,
+        params.earth_param_set,
+    )
 end
 function init_snow!(Y, S)
     Y.snow.S .= S

--- a/test/shared_utilities/drivers.jl
+++ b/test/shared_utilities/drivers.jl
@@ -66,7 +66,7 @@ end
     t_range = collect(t0:dt:tf)
     nsteps = Int((tf - t0) / dt)
     # specify when to update in the callback
-    updateat = collect((t0 + dt * 0.5):(5.5 * dt):tf)
+    updateat = collect((t0+dt*0.5):(5.5*dt):tf)
 
     # set up components of callback
     cond = ClimaLand.update_condition(updateat)

--- a/test/shared_utilities/implicit_timestepping/richards_model.jl
+++ b/test/shared_utilities/implicit_timestepping/richards_model.jl
@@ -121,13 +121,8 @@ for FT in (Float32, Float64)
                     dtγ * (-K_ic / dz^2 * dψdϑ_ic) - I,
                 )
                 @test all(
-                    Array(parent(jac_ϑ_l.entries.:2))[
-                        2:(end - 1),
-                        :,
-                        1,
-                        1,
-                        1,
-                    ] .≈ dtγ * (-2 * K_ic / dz^2 * dψdϑ_ic) - I,
+                    Array(parent(jac_ϑ_l.entries.:2))[2:(end - 1), :, 1, 1, 1] .≈
+                    dtγ * (-2 * K_ic / dz^2 * dψdϑ_ic) - I,
                 )
                 @test all(
                     Array(parent(jac_ϑ_l.entries.:2))[end, :, 1, 1, 1] .≈
@@ -210,13 +205,8 @@ for FT in (Float32, Float64)
                     dtγ * (-K_ic / dz^2 * dψdϑ_ic) - I,
                 )
                 @test all(
-                    Array(parent(jac_ϑ_l.entries.:2))[
-                        2:(end - 1),
-                        :,
-                        1,
-                        1,
-                        1,
-                    ] .≈ dtγ * (-2 * K_ic / dz^2 * dψdϑ_ic) - I,
+                    Array(parent(jac_ϑ_l.entries.:2))[2:(end - 1), :, 1, 1, 1] .≈
+                    dtγ * (-2 * K_ic / dz^2 * dψdϑ_ic) - I,
                 )
                 @test all(
                     Array(parent(jac_ϑ_l.entries.:2))[end, :, 1, 1, 1] .≈

--- a/test/shared_utilities/utilities.jl
+++ b/test/shared_utilities/utilities.jl
@@ -27,9 +27,9 @@ FT = Float32
     # specify when to save in the callback (test different dts)
     saveats = (
         collect(t0:dt:tf),
-        collect(t0:(2 * dt):tf),
-        collect(t0:(tf - t0):tf),
-        collect(t0:(0.5 * dt):tf),
+        collect(t0:(2*dt):tf),
+        collect(t0:(tf-t0):tf),
+        collect(t0:(0.5*dt):tf),
     )
     for saveat in saveats
         # note: delete non-multiples of dt in saveat before calling callback

--- a/test/standalone/Bucket/snow_bucket_tests.jl
+++ b/test/standalone/Bucket/snow_bucket_tests.jl
@@ -123,17 +123,15 @@ for FT in (Float32, Float64)
         set_initial_cache! = make_set_initial_cache(model)
         set_initial_cache!(p, Y, t0)
         # Test that the albedo is the bareground albedo (negative snow treated as zero snow)
-        @test p.bucket.α_sfc ==
-              FT.(
+        @test p.bucket.α_sfc == FT.(
             α_bareground_func.(
-                ClimaCore.Fields.coordinate_field(surface_space)
-            )
+                ClimaCore.Fields.coordinate_field(surface_space),
+            ),
         )
         # Test that evaporation is zero
         @test all(parent(p.bucket.turbulent_fluxes.vapor_flux) .== FT(0.0))
         # Test that q_sfc is computed as if there was zero snow
-        @test p.bucket.q_sfc ==
-              ClimaLand.Bucket.saturation_specific_humidity.(
+        @test p.bucket.q_sfc == ClimaLand.Bucket.saturation_specific_humidity.(
             p.bucket.T_sfc,
             p.bucket.ρ_sfc,
             earth_param_set.thermo_params,
@@ -244,26 +242,23 @@ for FT in (Float32, Float64)
                 return σS > eps(typeof(σS)) ? typeof(σS)(1.0) : typeof(σS)(0.0)
             end
 
-            partitioned_fluxes =
-                partition_snow_surface_fluxes.(
-                    Y.bucket.σS,
-                    p.bucket.T_sfc,
-                    model.parameters.τc,
-                    snow_cover_fraction.(Y.bucket.σS),
-                    p.bucket.turbulent_fluxes.vapor_flux,
-                    p.bucket.turbulent_fluxes.lhf .+
-                    p.bucket.turbulent_fluxes.shf .+ p.bucket.R_n,
-                    _ρLH_f0,
-                    _T_freeze,
-                )
+            partitioned_fluxes = partition_snow_surface_fluxes.(
+                Y.bucket.σS,
+                p.bucket.T_sfc,
+                model.parameters.τc,
+                snow_cover_fraction.(Y.bucket.σS),
+                p.bucket.turbulent_fluxes.vapor_flux,
+                p.bucket.turbulent_fluxes.lhf .+ p.bucket.turbulent_fluxes.shf .+ p.bucket.R_n,
+                _ρLH_f0,
+                _T_freeze,
+            )
             F_melt = partitioned_fluxes.F_melt
             F_into_snow =
                 partitioned_fluxes.F_into_snow .- _ρLH_f0 .* FT(snow_precip(t0))
             G = partitioned_fluxes.G_under_snow
             F_sfc =
-                p.bucket.turbulent_fluxes.lhf .+
-                p.bucket.turbulent_fluxes.shf .+ p.bucket.R_n .-
-                _ρLH_f0 .* FT(snow_precip(t0))
+                p.bucket.turbulent_fluxes.lhf .+ p.bucket.turbulent_fluxes.shf .+
+                p.bucket.R_n .- _ρLH_f0 .* FT(snow_precip(t0))
             F_water_sfc =
                 FT(liquid_precip(t0)) + FT(snow_precip(t0)) .+
                 p.bucket.turbulent_fluxes.vapor_flux
@@ -358,26 +353,23 @@ for FT in (Float32, Float64)
                 return σS > eps(typeof(σS)) ? typeof(σS)(1.0) : typeof(σS)(0.0)
             end
 
-            partitioned_fluxes =
-                partition_snow_surface_fluxes.(
-                    Y.bucket.σS,
-                    p.bucket.T_sfc,
-                    model.parameters.τc,
-                    snow_cover_fraction.(Y.bucket.σS),
-                    p.bucket.turbulent_fluxes.vapor_flux,
-                    p.bucket.turbulent_fluxes.lhf .+
-                    p.bucket.turbulent_fluxes.shf .+ p.bucket.R_n,
-                    _ρLH_f0,
-                    _T_freeze,
-                )
+            partitioned_fluxes = partition_snow_surface_fluxes.(
+                Y.bucket.σS,
+                p.bucket.T_sfc,
+                model.parameters.τc,
+                snow_cover_fraction.(Y.bucket.σS),
+                p.bucket.turbulent_fluxes.vapor_flux,
+                p.bucket.turbulent_fluxes.lhf .+ p.bucket.turbulent_fluxes.shf .+ p.bucket.R_n,
+                _ρLH_f0,
+                _T_freeze,
+            )
             F_melt = partitioned_fluxes.F_melt
             F_into_snow =
                 partitioned_fluxes.F_into_snow .- _ρLH_f0 .* FT(snow_precip(t0))
             G = partitioned_fluxes.G_under_snow
             F_sfc =
-                p.bucket.turbulent_fluxes.lhf .+
-                p.bucket.turbulent_fluxes.shf .+ p.bucket.R_n .-
-                _ρLH_f0 .* FT(snow_precip(t0))
+                p.bucket.turbulent_fluxes.lhf .+ p.bucket.turbulent_fluxes.shf .+
+                p.bucket.R_n .- _ρLH_f0 .* FT(snow_precip(t0))
             F_water_sfc =
                 FT(liquid_precip(t0)) + FT(snow_precip(t0)) .+
                 p.bucket.turbulent_fluxes.vapor_flux
@@ -478,17 +470,16 @@ for FT in (Float32, Float64)
         F_sfc = @. p.bucket.turbulent_fluxes.lhf +
            p.bucket.turbulent_fluxes.shf +
            p.bucket.R_n
-        partitioned_fluxes =
-            partition_snow_surface_fluxes.(
-                Y.bucket.σS,
-                p.bucket.T_sfc,
-                model.parameters.τc,
-                σ_snow,
-                p.bucket.turbulent_fluxes.vapor_flux,
-                F_sfc,
-                _ρLH_f0,
-                _T_freeze,
-            )
+        partitioned_fluxes = partition_snow_surface_fluxes.(
+            Y.bucket.σS,
+            p.bucket.T_sfc,
+            model.parameters.τc,
+            σ_snow,
+            p.bucket.turbulent_fluxes.vapor_flux,
+            F_sfc,
+            _ρLH_f0,
+            _T_freeze,
+        )
         F_melt = partitioned_fluxes.F_melt
         F_into_snow = @. partitioned_fluxes.F_into_snow * σ_snow -
            _ρLH_f0 * FT(snow_precip(t0))

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -216,8 +216,8 @@ for FT in (Float32, Float64)
             exp_tendency!(dY, Y, p, t0)
             F_water_sfc = FT(precip(t0)) .+ p.bucket.turbulent_fluxes.vapor_flux
             F_sfc =
-                p.bucket.turbulent_fluxes.lhf .+
-                p.bucket.turbulent_fluxes.shf .+ p.bucket.R_n
+                p.bucket.turbulent_fluxes.lhf .+ p.bucket.turbulent_fluxes.shf .+
+                p.bucket.R_n
             surface_space = model.domain.space.surface
             A_sfc = sum(ones(surface_space))
 

--- a/test/standalone/Snow/parameterizations.jl
+++ b/test/standalone/Snow/parameterizations.jl
@@ -83,10 +83,8 @@ for FT in (Float32, Float64)
         @test all(q_l[T_bulk .== _T_freeze] .> FT(0.0)) &&
               all(q_l[T_bulk .== _T_freeze] .< FT(1.1))
         Upred =
-            (
-                _ρ_l .* SWE .* specific_heat_capacity.(q_l, parameters) .+
-                ρcD_g
-            ) .* (T_bulk .- _T_ref) .- _ρ_l .* SWE .* (1.0f0 .- q_l) .* _LH_f0
+            (_ρ_l .* SWE .* specific_heat_capacity.(q_l, parameters) .+ ρcD_g) .*
+            (T_bulk .- _T_ref) .- _ρ_l .* SWE .* (1.0f0 .- q_l) .* _LH_f0
 
         q_lpred = snow_liquid_mass_fraction.(Upred, SWE, parameters)
         T_pred = snow_bulk_temperature.(Upred, SWE, q_lpred, parameters)

--- a/test/standalone/Snow/snow.jl
+++ b/test/standalone/Snow/snow.jl
@@ -70,12 +70,11 @@ import ClimaLand.Parameters as LP
     )
 
     Y.snow.S .= FT(0.1)
-    Y.snow.U .=
-        ClimaLand.Snow.energy_from_T_and_swe.(
-            Y.snow.S,
-            FT(273.0),
-            Ref(model.parameters),
-        )
+    Y.snow.U .= ClimaLand.Snow.energy_from_T_and_swe.(
+        Y.snow.S,
+        FT(273.0),
+        Ref(model.parameters),
+    )
     set_initial_cache! = ClimaLand.make_set_initial_cache(model)
     t0 = FT(0.0)
     set_initial_cache!(p, Y, t0)
@@ -94,14 +93,13 @@ import ClimaLand.Parameters as LP
     )
     @test p.snow.q_l ==
           snow_liquid_mass_fraction.(Y.snow.U, Y.snow.S, Ref(model.parameters))
-    @test p.snow.T_sfc ==
-          snow_surface_temperature.(
+    @test p.snow.T_sfc == snow_surface_temperature.(
         snow_bulk_temperature.(
             Y.snow.U,
             Y.snow.S,
             p.snow.q_l,
             Ref(model.parameters),
-        )
+        ),
     )
 
     ρ_sfc = ClimaLand.surface_air_density(
@@ -114,13 +112,12 @@ import ClimaLand.Parameters as LP
     )
     thermo_params =
         LP.thermodynamic_parameters(model.parameters.earth_param_set)
-    q_sfc =
-        Thermodynamics.q_vap_saturation_generic.(
-            Ref(thermo_params),
-            p.snow.T_sfc,
-            ρ_sfc,
-            Ref(Thermodynamics.Ice()),
-        )
+    q_sfc = Thermodynamics.q_vap_saturation_generic.(
+        Ref(thermo_params),
+        p.snow.T_sfc,
+        ρ_sfc,
+        Ref(Thermodynamics.Ice()),
+    )
     turb_fluxes = ClimaLand.turbulent_fluxes(
         model.boundary_conditions.atmos,
         model,

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -157,13 +157,12 @@ for FT in (Float32, Float64)
                     params.ρc_ds,
                     params.earth_param_set,
                 )
-                Y.soil.ρe_int =
-                    Soil.volumetric_internal_energy.(
-                        FT(0),
-                        ρc_s,
-                        T,
-                        params.earth_param_set,
-                    )
+                Y.soil.ρe_int = Soil.volumetric_internal_energy.(
+                    FT(0),
+                    ρc_s,
+                    T,
+                    params.earth_param_set,
+                )
             end
 
             t = Float64(0)

--- a/test/standalone/Soil/runoff.jl
+++ b/test/standalone/Soil/runoff.jl
@@ -165,8 +165,7 @@ end
         ClimaLand.heaviside.(Y.soil.ϑ_l .- model.parameters.ν),
     )
     @test scratch == p.soil.h∇
-    @test p.soil.R_ss ==
-          ClimaLand.Soil.Runoff.topmodel_ss_flux.(
+    @test p.soil.R_ss == ClimaLand.Soil.Runoff.topmodel_ss_flux.(
         runoff_model.subsurface_source.R_sb,
         runoff_model.f_over,
         model.domain.depth .- p.soil.h∇,
@@ -257,8 +256,7 @@ end
     set_initial_cache!(p, Y, FT(0))
     ic = ClimaLand.Soil.Runoff.soil_infiltration_capacity(model, Y, p)
     @test ic == ClimaCore.Fields.zeros(surface_space) .- FT(1e-6) #Ksat
-    @test p.soil.infiltration ==
-          ClimaLand.Soil.Runoff.surface_infiltration.(
+    @test p.soil.infiltration == ClimaLand.Soil.Runoff.surface_infiltration.(
         ic,
         precip_field,
         ClimaLand.Domains.top_center_to_surface(p.soil.is_saturated),

--- a/test/standalone/Soil/soil_bc.jl
+++ b/test/standalone/Soil/soil_bc.jl
@@ -168,25 +168,24 @@ for FT in (Float32, Float64)
         T_bc = FT(298)
         T_c = FT(290)
 
-        κ_c =
-            thermal_conductivity.(
-                parameters.κ_dry,
-                kersten_number.(
-                    θ_i,
-                    relative_saturation.(ϑ_c, θ_i, ν),
-                    parameters.α,
-                    parameters.β,
-                    ν_ss_om,
-                    ν_ss_quartz,
-                    ν_ss_gravel,
-                ),
-                κ_sat.(
-                    ϑ_c,
-                    θ_i,
-                    parameters.κ_sat_unfrozen,
-                    parameters.κ_sat_frozen,
-                ),
-            )
+        κ_c = thermal_conductivity.(
+            parameters.κ_dry,
+            kersten_number.(
+                θ_i,
+                relative_saturation.(ϑ_c, θ_i, ν),
+                parameters.α,
+                parameters.β,
+                ν_ss_om,
+                ν_ss_quartz,
+                ν_ss_gravel,
+            ),
+            κ_sat.(
+                ϑ_c,
+                θ_i,
+                parameters.κ_sat_unfrozen,
+                parameters.κ_sat_frozen,
+            ),
+        )
 
         flux_int = diffusive_flux(κ_c, T_bc, T_c, Δz)
         flux_expected = -κ_c * (T_bc - T_c) / Δz

--- a/test/standalone/Soil/soil_parameterizations.jl
+++ b/test/standalone/Soil/soil_parameterizations.jl
@@ -271,12 +271,11 @@ for FT in (Float32, Float64)
         @test eltype(k) == FT
 
         # Volumetric Liquid Fraction
-        vlf =
-            volumetric_liquid_fraction.(
-                FT.([0.25, 0.5, 0.75]),
-                FT(0.5),
-                FT(0.0),
-            )
+        vlf = volumetric_liquid_fraction.(
+            FT.([0.25, 0.5, 0.75]),
+            FT(0.5),
+            FT(0.0),
+        )
         @test vlf ≈ FT.([0.25, 0.5, 0.5])
     end
 

--- a/test/standalone/SurfaceWater/pond_test.jl
+++ b/test/standalone/SurfaceWater/pond_test.jl
@@ -52,7 +52,7 @@ for FT in (Float32, Float64)
             if t % 40 == 0
                 @test abs.(
                     FT(expected_pond_height(t)) .-
-                    Array(parent(Y.surface_water.η))[1]
+                    Array(parent(Y.surface_water.η))[1],
                 ) < eps(FT)
             end
         end

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -52,6 +52,7 @@ import ClimaParams
         )
         for (g1, Vcmax25, is_c3, rooting_depth, α_PAR_leaf, α_NIR_leaf, ld) in
             zipped_params
+
             AR_params = AutotrophicRespirationParameters(FT)
             G_Function = ConstantGFunction(ld)
             RTparams =
@@ -84,14 +85,13 @@ import ClimaParams
                 insol_params = earth_param_set.insol_params,
             )
                 current_datetime = start_date + Dates.Second(round(t))
-                d, δ, η_UTC =
-                    FT.(
-                        Insolation.helper_instantaneous_zenith_angle(
-                            current_datetime,
-                            start_date,
-                            insol_params,
-                        )
-                    )
+                d, δ, η_UTC = FT.(
+                    Insolation.helper_instantaneous_zenith_angle(
+                        current_datetime,
+                        start_date,
+                        insol_params,
+                    ),
+                )
                 return Insolation.instantaneous_zenith_angle(
                     d,
                     δ,
@@ -175,26 +175,24 @@ import ClimaParams
             Δz = FT(1.0) # height of compartments
             n_stem = Int64(0) # number of stem elements
             n_leaf = Int64(1) # number of leaf elements
-            compartment_centers =
-                FT.(
-                    Vector(
-                        range(
-                            start = Δz / 2,
-                            step = Δz,
-                            stop = Δz * (n_stem + n_leaf) - (Δz / 2),
-                        ),
+            compartment_centers = FT.(
+                Vector(
+                    range(
+                        start = Δz / 2,
+                        step = Δz,
+                        stop = Δz * (n_stem + n_leaf) - (Δz / 2),
                     ),
-                )
-            compartment_faces =
-                FT.(
-                    Vector(
-                        range(
-                            start = 0.0,
-                            step = Δz,
-                            stop = Δz * (n_stem + n_leaf),
-                        ),
-                    )
-                )
+                ),
+            )
+            compartment_faces = FT.(
+                Vector(
+                    range(
+                        start = 0.0,
+                        step = Δz,
+                        stop = Δz * (n_stem + n_leaf),
+                    ),
+                ),
+            )
 
             ψ_soil0 = FT(0.0)
             soil_driver = PrescribedGroundConditions(FT)
@@ -314,13 +312,12 @@ import ClimaParams
             Rn = FT(shortwave_radiation(t0))
             G = FT(0.0)
             thermo_params = canopy.parameters.earth_param_set.thermo_params
-            ts_in =
-                Thermodynamics.PhaseEquil_pTq.(
-                    thermo_params,
-                    p.drivers.P,
-                    p.drivers.T,
-                    p.drivers.q,
-                )
+            ts_in = Thermodynamics.PhaseEquil_pTq.(
+                thermo_params,
+                p.drivers.P,
+                p.drivers.T,
+                p.drivers.q,
+            )
             ρa = Thermodynamics.air_density.(thermo_params, ts_in)
             cp = FT(
                 cp_m(
@@ -329,18 +326,16 @@ import ClimaParams
                 ),
             )
 
-            es =
-                Thermodynamics.saturation_vapor_pressure.(
-                    Ref(thermo_params),
-                    FT.(T_atmos(t0)),
-                    Ref(Thermodynamics.Liquid()),
-                )
-            ea =
-                Thermodynamics.partial_pressure_vapor.(
-                    thermo_params,
-                    FT(P_atmos(t0)),
-                    Thermodynamics.PhasePartition.(FT.(q_atmos(t0))),
-                )
+            es = Thermodynamics.saturation_vapor_pressure.(
+                Ref(thermo_params),
+                FT.(T_atmos(t0)),
+                Ref(Thermodynamics.Liquid()),
+            )
+            ea = Thermodynamics.partial_pressure_vapor.(
+                thermo_params,
+                FT(P_atmos(t0)),
+                Thermodynamics.PhasePartition.(FT.(q_atmos(t0))),
+            )
 
             VPD = es .- ea
 
@@ -384,9 +379,8 @@ import ClimaParams
             @test ClimaLand.surface_height(canopy, Y, p) == compartment_faces[1]
             T_sfc = FT.(T_atmos(t0))
             @test all(
-                Array(
-                    parent(ClimaLand.surface_temperature(canopy, Y, p, t0)),
-                ) .== [T_sfc],
+                Array(parent(ClimaLand.surface_temperature(canopy, Y, p, t0))) .==
+                [T_sfc],
             )
             @test ClimaLand.surface_temperature(canopy, Y, p, t0) isa
                   ClimaCore.Fields.Field
@@ -449,26 +443,20 @@ end
         Δz = FT(1.0) # height of compartments
         n_stem = Int64(0) # number of stem elements
         n_leaf = Int64(1) # number of leaf elements
-        compartment_centers =
-            FT.(
-                Vector(
-                    range(
-                        start = Δz / 2,
-                        step = Δz,
-                        stop = Δz * (n_stem + n_leaf) - (Δz / 2),
-                    ),
+        compartment_centers = FT.(
+            Vector(
+                range(
+                    start = Δz / 2,
+                    step = Δz,
+                    stop = Δz * (n_stem + n_leaf) - (Δz / 2),
                 ),
-            )
-        compartment_faces =
-            FT.(
-                Vector(
-                    range(
-                        start = 0.0,
-                        step = Δz,
-                        stop = Δz * (n_stem + n_leaf),
-                    ),
-                )
-            )
+            ),
+        )
+        compartment_faces = FT.(
+            Vector(
+                range(start = 0.0, step = Δz, stop = Δz * (n_stem + n_leaf)),
+            ),
+        )
 
         plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
             parameters = param_set,
@@ -593,6 +581,7 @@ end
         )
         for (g1, Vcmax25, is_c3, rooting_depth, α_PAR_leaf, α_NIR_leaf, ld) in
             zipped_params
+
             G_Function = ConstantGFunction(ld)
             RTparams =
                 BeerLambertParameters(FT; α_PAR_leaf, α_NIR_leaf, G_Function)
@@ -624,14 +613,13 @@ end
                 insol_params = earth_param_set.insol_params,
             )
                 current_datetime = start_date + Dates.Second(round(t))
-                d, δ, η_UTC =
-                    FT.(
-                        Insolation.helper_instantaneous_zenith_angle(
-                            current_datetime,
-                            start_date,
-                            insol_params,
-                        )
-                    )
+                d, δ, η_UTC = FT.(
+                    Insolation.helper_instantaneous_zenith_angle(
+                        current_datetime,
+                        start_date,
+                        insol_params,
+                    ),
+                )
                 return Insolation.instantaneous_zenith_angle(
                     d,
                     δ,
@@ -716,26 +704,24 @@ end
             Δz = FT(1.0) # height of compartments
             n_stem = Int64(0) # number of stem elements
             n_leaf = Int64(1) # number of leaf elements
-            compartment_centers =
-                FT.(
-                    Vector(
-                        range(
-                            start = Δz / 2,
-                            step = Δz,
-                            stop = Δz * (n_stem + n_leaf) - (Δz / 2),
-                        ),
+            compartment_centers = FT.(
+                Vector(
+                    range(
+                        start = Δz / 2,
+                        step = Δz,
+                        stop = Δz * (n_stem + n_leaf) - (Δz / 2),
                     ),
-                )
-            compartment_faces =
-                FT.(
-                    Vector(
-                        range(
-                            start = 0.0,
-                            step = Δz,
-                            stop = Δz * (n_stem + n_leaf),
-                        ),
-                    )
-                )
+                ),
+            )
+            compartment_faces = FT.(
+                Vector(
+                    range(
+                        start = 0.0,
+                        step = Δz,
+                        stop = Δz * (n_stem + n_leaf),
+                    ),
+                ),
+            )
 
             ψ_soil0 = FT(0.0)
             T_soil0 = FT(290)
@@ -827,9 +813,8 @@ end
             @test all(Array(parent(p.canopy.energy.fa_energy_roots)) .== FT(0))
 
             @test all(
-                Array(
-                    parent(ClimaLand.surface_temperature(canopy, Y, p, t0)),
-                ) .== FT(289),
+                Array(parent(ClimaLand.surface_temperature(canopy, Y, p, t0))) .==
+                FT(289),
             )
             @test all(
                 Array(
@@ -884,14 +869,13 @@ end
             insol_params = earth_param_set.insol_params,
         )
             current_datetime = start_date + Dates.Second(round(t))
-            d, δ, η_UTC =
-                FT.(
-                    Insolation.helper_instantaneous_zenith_angle(
-                        current_datetime,
-                        start_date,
-                        insol_params,
-                    )
-                )
+            d, δ, η_UTC = FT.(
+                Insolation.helper_instantaneous_zenith_angle(
+                    current_datetime,
+                    start_date,
+                    insol_params,
+                ),
+            )
             return Insolation.instantaneous_zenith_angle(
                 d,
                 δ,
@@ -975,26 +959,20 @@ end
         Δz = FT(1.0) # height of compartments
         n_stem = Int64(0) # number of stem elements
         n_leaf = Int64(1) # number of leaf elements
-        compartment_centers =
-            FT.(
-                Vector(
-                    range(
-                        start = Δz / 2,
-                        step = Δz,
-                        stop = Δz * (n_stem + n_leaf) - (Δz / 2),
-                    ),
+        compartment_centers = FT.(
+            Vector(
+                range(
+                    start = Δz / 2,
+                    step = Δz,
+                    stop = Δz * (n_stem + n_leaf) - (Δz / 2),
                 ),
-            )
-        compartment_faces =
-            FT.(
-                Vector(
-                    range(
-                        start = 0.0,
-                        step = Δz,
-                        stop = Δz * (n_stem + n_leaf),
-                    ),
-                )
-            )
+            ),
+        )
+        compartment_faces = FT.(
+            Vector(
+                range(start = 0.0, step = Δz, stop = Δz * (n_stem + n_leaf)),
+            ),
+        )
 
         ψ_soil0 = FT(0.0)
         T_soil0 = FT(290)
@@ -1055,13 +1033,12 @@ end
             T_sfc,
         )
         thermo_params = canopy.parameters.earth_param_set.thermo_params
-        q_sfc =
-            Thermodynamics.q_vap_saturation_generic.(
-                thermo_params,
-                T_sfc,
-                ρ_sfc,
-                Thermodynamics.Liquid(),
-            )
+        q_sfc = Thermodynamics.q_vap_saturation_generic.(
+            thermo_params,
+            T_sfc,
+            ρ_sfc,
+            Thermodynamics.Liquid(),
+        )
         dY = similar(Y)
         imp_tendency!(dY, Y, p, t0)
         jac = ImplicitEquationJacobian(Y)
@@ -1083,13 +1060,12 @@ end
             t0,
             T_sfc2,
         )
-        q_sfc2 =
-            Thermodynamics.q_vap_saturation_generic.(
-                thermo_params,
-                T_sfc2,
-                ρ_sfc2,
-                Thermodynamics.Liquid(),
-            )
+        q_sfc2 = Thermodynamics.q_vap_saturation_generic.(
+            thermo_params,
+            T_sfc2,
+            ρ_sfc2,
+            Thermodynamics.Liquid(),
+        )
         dY_2 = similar(Y_2)
         imp_tendency!(dY_2, Y_2, p_2, t0)
 
@@ -1138,7 +1114,7 @@ end
         # Recall jac = ∂Ṫ∂T - 1 [dtγ = 1]
         ∂Ṫ∂T = jac_value .+ 1
         @test (abs.(
-            parent((dY_2.canopy.energy.T .- dY.canopy.energy.T) ./ ΔT) - ∂Ṫ∂T
+            parent((dY_2.canopy.energy.T .- dY.canopy.energy.T) ./ ΔT) - ∂Ṫ∂T,
         ) / ∂Ṫ∂T)[1] < 0.25 # Error propagates here from ∂LHF∂T
     end
 end
@@ -1189,6 +1165,7 @@ end
             τ_NIR_leaf,
             χl,
         ) in zipped_params
+
             BeerLambertparams = BeerLambertParameters(FT)
             # TwoStreamModel parameters
             Ω = FT(0.69)
@@ -1243,14 +1220,13 @@ end
                 insol_params = earth_param_set.insol_params,
             )
                 current_datetime = start_date + Dates.Second(round(t))
-                d, δ, η_UTC =
-                    FT.(
-                        Insolation.helper_instantaneous_zenith_angle(
-                            current_datetime,
-                            start_date,
-                            insol_params,
-                        )
-                    )
+                d, δ, η_UTC = FT.(
+                    Insolation.helper_instantaneous_zenith_angle(
+                        current_datetime,
+                        start_date,
+                        insol_params,
+                    ),
+                )
                 return Insolation.instantaneous_zenith_angle(
                     d,
                     δ,
@@ -1334,26 +1310,24 @@ end
             Δz = FT(1.0) # height of compartments
             n_stem = Int64(0) # number of stem elements
             n_leaf = Int64(1) # number of leaf elements
-            compartment_centers =
-                FT.(
-                    Vector(
-                        range(
-                            start = Δz / 2,
-                            step = Δz,
-                            stop = Δz * (n_stem + n_leaf) - (Δz / 2),
-                        ),
+            compartment_centers = FT.(
+                Vector(
+                    range(
+                        start = Δz / 2,
+                        step = Δz,
+                        stop = Δz * (n_stem + n_leaf) - (Δz / 2),
                     ),
-                )
-            compartment_faces =
-                FT.(
-                    Vector(
-                        range(
-                            start = 0.0,
-                            step = Δz,
-                            stop = Δz * (n_stem + n_leaf),
-                        ),
-                    )
-                )
+                ),
+            )
+            compartment_faces = FT.(
+                Vector(
+                    range(
+                        start = 0.0,
+                        step = Δz,
+                        stop = Δz * (n_stem + n_leaf),
+                    ),
+                ),
+            )
 
             ψ_soil0 = FT(0.0)
             T_soil0 = FT(290)

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -147,14 +147,13 @@ for FT in (Float32, Float64)
             insol_params = earth_param_set.insol_params,
         )
             current_datetime = start_date + Dates.Second(round(t))
-            d, δ, η_UTC =
-                FT.(
-                    Insolation.helper_instantaneous_zenith_angle(
-                        current_datetime,
-                        start_date,
-                        insol_params,
-                    )
-                )
+            d, δ, η_UTC = FT.(
+                Insolation.helper_instantaneous_zenith_angle(
+                    current_datetime,
+                    start_date,
+                    insol_params,
+                ),
+            )
             return Insolation.instantaneous_zenith_angle(
                 d,
                 δ,
@@ -290,7 +289,7 @@ for FT in (Float32, Float64)
                 function initial_compute_exp_tendency!(F, Y)
                     AI = (; leaf = LAI(1.0), root = RAI, stem = SAI)
                     T0A = FT(1e-8) * AI[:leaf]
-                    for i in 1:(n_leaf + n_stem)
+                    for i in 1:(n_leaf+n_stem)
                         if i == 1
                             fa =
                                 sum(
@@ -351,13 +350,12 @@ for FT in (Float32, Float64)
                     iterations = 20,
                 )
 
-                S_l =
-                    inverse_water_retention_curve.(
-                        retention_model,
-                        soln.zero,
-                        plant_ν,
-                        plant_S_s,
-                    )
+                S_l = inverse_water_retention_curve.(
+                    retention_model,
+                    soln.zero,
+                    plant_ν,
+                    plant_S_s,
+                )
 
                 ϑ_l_0 = augmented_liquid_fraction.(plant_ν, S_l)
 
@@ -375,7 +373,7 @@ for FT in (Float32, Float64)
                 end
 
                 dY = similar(Y)
-                for i in 1:(n_stem + n_leaf)
+                for i in 1:(n_stem+n_leaf)
                     Y.canopy.hydraulics.ϑ_l.:($i) .= ϑ_l_0[i]
                     p.canopy.hydraulics.ψ.:($i) .= NaN
                     p.canopy.hydraulics.fa.:($i) .= NaN
@@ -394,7 +392,7 @@ for FT in (Float32, Float64)
                 # make sure it agrees with what we get when use the canopy model ODE
                 Y, p, coords = initialize(model)
                 standalone_dY = similar(Y)
-                for i in 1:(n_stem + n_leaf)
+                for i in 1:(n_stem+n_leaf)
                     Y.canopy.hydraulics.ϑ_l.:($i) .= ϑ_l_0[i]
                     p.canopy.hydraulics.ψ.:($i) .= NaN
                     p.canopy.hydraulics.fa.:($i) .= NaN
@@ -451,14 +449,13 @@ for FT in (Float32, Float64)
             insol_params = earth_param_set.insol_params,
         )
             current_datetime = start_date + Dates.Second(round(t))
-            d, δ, η_UTC =
-                FT.(
-                    Insolation.helper_instantaneous_zenith_angle(
-                        current_datetime,
-                        start_date,
-                        insol_params,
-                    )
-                )
+            d, δ, η_UTC = FT.(
+                Insolation.helper_instantaneous_zenith_angle(
+                    current_datetime,
+                    start_date,
+                    insol_params,
+                ),
+            )
             return Insolation.instantaneous_zenith_angle(
                 d,
                 δ,
@@ -575,7 +572,7 @@ for FT in (Float32, Float64)
 
         Y, p, coords = initialize(model)
         dY = similar(Y)
-        for i in 1:(n_stem + n_leaf)
+        for i in 1:(n_stem+n_leaf)
             Y.canopy.hydraulics.ϑ_l.:($i) .= FT(0.1)
             p.canopy.hydraulics.ψ.:($i) .= NaN
             p.canopy.hydraulics.fa.:($i) .= NaN

--- a/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
+++ b/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
@@ -98,21 +98,20 @@ for FT in (Float32, Float64)
         p_l = FT(-2e6) # Pa
         ca = FT(4.11e-4) # mol/mol
         R = FT(LP.gas_constant(earth_param_set))
-        θs = FT.(Array(0:0.1:(π / 2)))
+        θs = FT.(Array(0:0.1:(π/2)))
         SW(θs) = cos.(θs) * FT.(500) # W/m^2
         PAR = SW(θs) ./ (energy_per_photon * N_a) # convert 500 W/m^2 to mol of photons per m^2/s
         G = compute_G(RTparams.G_Function, θs)
         K_c = extinction_coeff.(G, θs)
         α_soil_PAR = FT(0.2)
-        output =
-            plant_absorbed_pfd_beer_lambert.(
-                RTparams.Ω,
-                PAR,
-                RTparams.α_PAR_leaf,
-                LAI,
-                K_c,
-                α_soil_PAR,
-            )
+        output = plant_absorbed_pfd_beer_lambert.(
+            RTparams.Ω,
+            PAR,
+            RTparams.α_PAR_leaf,
+            LAI,
+            K_c,
+            α_soil_PAR,
+        )
         APAR = getproperty.(output, :abs)
         TPAR = getproperty.(output, :trans)
         RPAR = getproperty.(output, :refl)
@@ -189,13 +188,12 @@ for FT in (Float32, Float64)
               photosynthesisparams.Vcmax25 *
               FT(exp(1)) *
               arrhenius_function(T, To, R, photosynthesisparams.ΔHJmax)
-        J =
-            electron_transport.(
-                APAR,
-                Jmax,
-                photosynthesisparams.θj,
-                photosynthesisparams.ϕ,
-            ) # mol m-2 s-1
+        J = electron_transport.(
+            APAR,
+            Jmax,
+            photosynthesisparams.θj,
+            photosynthesisparams.ϕ,
+        ) # mol m-2 s-1
         @test all(
             @.(
                 photosynthesisparams.θj * J^2 -
@@ -243,14 +241,13 @@ for FT in (Float32, Float64)
               photosynthesisparams.f *
               arrhenius_function(T, To, R, photosynthesisparams.ΔHRd)
         An = net_photosynthesis.(Ac, Aj, Rd, β)
-        stomatal_conductance =
-            medlyn_conductance.(
-                stomatal_g_params.g0,
-                stomatal_g_params.Drel,
-                m_t,
-                An,
-                ca,
-            )
+        stomatal_conductance = medlyn_conductance.(
+            stomatal_g_params.g0,
+            stomatal_g_params.Drel,
+            m_t,
+            An,
+            ca,
+        )
         @test all(
             @.(
                 stomatal_conductance ≈ (

--- a/test/standalone/Vegetation/test_two_stream.jl
+++ b/test/standalone/Vegetation/test_two_stream.jl
@@ -67,7 +67,7 @@ for FT in (Float32, Float64)
 
             # Python code does not use clumping index, and λ_γ does not impact FAPAR
             # Test over all rows in the stored output from the Python module
-            for i in 2:(size(test_set, 1) - 1)
+            for i in 2:(size(test_set, 1)-1)
 
                 # Set the parameters based on the setup read from the file
                 RT_params = TwoStreamParameters(
@@ -87,20 +87,19 @@ for FT in (Float32, Float64)
                 # Compute the predicted FAPAR using the ClimaLand TwoStream implementation
                 G = compute_G(RT_params.G_Function, θs)
                 K = extinction_coeff.(G, θs[i])
-                output =
-                    plant_absorbed_pfd_two_stream.(
-                        G,
-                        RT_params.Ω,
-                        RT_params.n_layers,
-                        FT(1),
-                        RT_params.α_PAR_leaf,
-                        RT_params.τ_PAR_leaf,
-                        LAI[i],
-                        K,
-                        θs[i],
-                        a_soil[i],
-                        PropDif[i],
-                    )
+                output = plant_absorbed_pfd_two_stream.(
+                    G,
+                    RT_params.Ω,
+                    RT_params.n_layers,
+                    FT(1),
+                    RT_params.α_PAR_leaf,
+                    RT_params.τ_PAR_leaf,
+                    LAI[i],
+                    K,
+                    θs[i],
+                    a_soil[i],
+                    PropDif[i],
+                )
                 FAPAR = output.abs
                 # Check that the predictions are app. equivalent to the Python model
                 # Create a field of the expect value because isapprox cannot be broadcast


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
JuliaFormatter made a major release to v2, and so in CI we also use v2 by default (since, prior to this PR, the .dev Project.toml is instantiated without any compat requirement). Hence anyone who is working locally needs to also use v2 (e.g., previously @AlexisRenchon  and I were on v1). If not, your local formatting changes wont match the CI formatting changes, and CI will fail.

This PR 
- formats all files with JuliaFormatter 2.0.0
- adds a compat entry to our .dev Project.toml to prevent the issue happening again.
