### PR TITLE
Spatially varying clumping index

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -31,3 +31,10 @@ git-tree-sha1 = "c10e8f877603bfa2c018eb2dd0c51dd078abe5df"
     [[soil_params_Gupta2020_2022.download]]
     sha256 = "6205d96ae7724c469eef5cd1cf3b99e186637427b6fb65ecc659fb808fc6cacf"
     url = "https://caltech.box.com/shared/static/7c6yx62tzjivxfmhqyy03r6e9l1glyu1.gz"
+
+[modis_clumping_index]
+git-tree-sha1 = "b849eb95c09190095e7bf021494ddeda8858af01"
+
+    [[modis_clumping_index.download]]
+    sha256 = "e4c766a93a673e5dc22540687ef5616416d65bb13a0f4a67789b95d49ccbb158"
+    url = "https://caltech.box.com/shared/static/ec2y3k5kqpl9wjvtsx3584wgkp5q8dyw.gz"

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -249,11 +249,21 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     # Energy Balance model
     ac_canopy = FT(2.5e3)
 
-    #clm_data is used for g1, vcmax, rooting, and two_stream param maps
+    # clm_data is used for g1, vcmax, rooting, and two_stream param maps
     clm_artifact_path = ClimaLand.Artifacts.clm_data_folder_path(; context)
 
+    # Foliage clumping index data derived from MODIS
+    modis_ci_artifact_path =
+        ClimaLand.Artifacts.modis_ci_data_folder_path(; context)
+
     # TwoStreamModel parameters
-    Ω = FT(0.69)
+    Ω = SpaceVaryingInput(
+        joinpath(modis_ci_artifact_path, "He_et_al_2012_1x1.nc"),
+        "ci",
+        surface_space,
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
     χl = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "xl",

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -250,9 +250,18 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
 
     #clm_data is used for g1, vcmax, rooting, and two_stream param maps
     clm_artifact_path = ClimaLand.Artifacts.clm_data_folder_path(; context)
+    # Foliage clumping index data derived from MODIS
+    modis_ci_artifact_path =
+        ClimaLand.Artifacts.modis_ci_data_folder_path(; context)
 
     # TwoStreamModel parameters
-    Ω = FT(0.69)
+    Ω = SpaceVaryingInput(
+        joinpath(modis_ci_artifact_path, "He_et_al_2012_1x1.nc"),
+        "ci",
+        surface_space,
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
     χl = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "xl",

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -252,8 +252,19 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
     #clm_data is used for g1, vcmax, rooting, and two_stream param maps
     clm_artifact_path = ClimaLand.Artifacts.clm_data_folder_path(; context)
 
+    # Foliage clumping index data derived from MODIS
+    modis_ci_artifact_path =
+        ClimaLand.Artifacts.modis_ci_data_folder_path(; context)
+
     # TwoStreamModel parameters
-    Ω = FT(0.69)
+    Ω = SpaceVaryingInput(
+        joinpath(modis_ci_artifact_path, "He_et_al_2012_1x1.nc"),
+        "ci",
+        surface_space,
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+
     χl = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "xl",

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -24,6 +24,15 @@ function clm_data_folder_path(; context = nothing)
 end
 
 """
+    modis_ci_data_folder_path(; context = nothing)
+
+Return the path to the folder that contains the MODIS clumping index data.
+"""
+function modis_ci_data_folder_path(; context = nothing)
+    return @clima_artifact("modis_clumping_index", context)
+end
+
+"""
     soil_params_artifact_path(; context)
 
 Return the path to the folder that contains the soil parameters.

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -102,7 +102,7 @@ Base.@kwdef struct TwoStreamParameters{
     "Emissivity of the canopy"
     ϵ_canopy::FT
     "Clumping index following Braghiere 2021 (unitless)"
-    Ω::FT
+    Ω::F
     "Typical wavelength per PAR photon (m)"
     λ_γ_PAR::FT
     "Typical wavelength per NIR photon (m)"

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -1158,6 +1158,7 @@ end
             mechanism_field,
         )
         # create one case where parameters are spatially varying and one where not
+        Ω_cases = (FT(0.69), fill(FT(0.69), domain.space.surface))
         g1_cases = (FT(790), fill(FT(790), domain.space.surface))
         Vcmax25_cases = (FT(9e-5), fill(FT(9e-5), domain.space.surface))
         mechanism_cases = (FT(1), mechanism_field)
@@ -1168,6 +1169,7 @@ end
         τ_NIR_leaf_cases = (FT(0.25), fill(FT(0.25), domain.space.surface))
         χl_cases = (FT(0.1), fill(FT(0.1), domain.space.surface))
         zipped_params = zip(
+            Ω_cases,
             g1_cases,
             Vcmax25_cases,
             mechanism_cases,
@@ -1179,6 +1181,7 @@ end
             χl_cases,
         )
         for (
+            Ω,
             g1,
             Vcmax25,
             is_c3,
@@ -1191,7 +1194,6 @@ end
         ) in zipped_params
             BeerLambertparams = BeerLambertParameters(FT)
             # TwoStreamModel parameters
-            Ω = FT(0.69)
             G_Function = CLMGFunction(χl)
             λ_γ_PAR = FT(5e-7)
             λ_γ_NIR = FT(1.65e-6)

--- a/test/standalone/Vegetation/test_two_stream.jl
+++ b/test/standalone/Vegetation/test_two_stream.jl
@@ -48,19 +48,21 @@ for FT in (Float32, Float64)
         τ_scalars = FT.(test_set[2:end, column_names .== "tau"])
         τ_fields = map(x -> fill(x, domain.space.surface), τ_scalars)
         # loop through once with params as floats, then with params as fields
+        Ω_cases = (FT(1), fill(FT(1), domain.space.surface))
         α_PAR_leaf_cases = (α_PAR_leaf_scalars, α_PAR_leaf_fields)
         τ_PAR_leaf_cases = (τ_scalars, τ_fields)
         α_NIR_leaf_cases = (FT(0.4), fill(FT(0.4), domain.space.surface))
         τ_NIR_leaf_cases = (FT(0.25), fill(FT(0.24), domain.space.surface))
         lds_cases = (lds, lds_field)
         zipped_params = zip(
+            Ω_cases,
             α_PAR_leaf_cases,
             τ_PAR_leaf_cases,
             α_NIR_leaf_cases,
             τ_NIR_leaf_cases,
             lds_cases,
         )
-        for (α_PAR_leaf, τ_PAR_leaf, α_NIR_leaf, τ_NIR_leaf, lds) in
+        for (Ω, α_PAR_leaf, τ_PAR_leaf, α_NIR_leaf, τ_NIR_leaf, lds) in
             zipped_params
             # Read the result for each setup from the Python output
             py_FAPAR = FT.(test_set[2:end, column_names .== "FAPAR"])
@@ -72,12 +74,12 @@ for FT in (Float32, Float64)
                 # Set the parameters based on the setup read from the file
                 RT_params = TwoStreamParameters(
                     FT;
+                    Ω = Ω,
                     G_Function = ConstantGFunction(FT.(lds[i])),
                     α_PAR_leaf = α_PAR_leaf[i],
                     τ_PAR_leaf = τ_PAR_leaf[i],
                     α_NIR_leaf = α_NIR_leaf,
                     τ_NIR_leaf = τ_NIR_leaf,
-                    Ω = FT(1),
                     n_layers = n_layers[i],
                 )
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR makes the foliage clumping index of the radiative transfer model vary spatially, and uses clumping index data derived from MODIS to drive the global run.

The related PR from ClimaArtifacts is found [here](https://github.com/CliMA/ClimaArtifacts/pull/52)


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
 - [x] Link related PR from ClimaArtifacts here
 - [ ] Pass all tests and check output plots


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Clumping index parameter of radiative transfer model can take in a field
- The various global runs load clumping index from a new ClimaArtifact containing MODIS clumping index data at the correct resolution


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
