### PR TITLE
Override AbstractSoilHydrologyClosure broadcast behavior

### DIFF
--- a/src/standalone/Soil/retention_models.jl
+++ b/src/standalone/Soil/retention_models.jl
@@ -1,10 +1,10 @@
 export AbstractSoilHydrologyClosure, vanGenuchten, BrooksCorey
 
 """
-    AbstractSoilHydrologyClosure{FT <: AbstractFloat} 
+    AbstractSoilHydrologyClosure{FT <: AbstractFloat}
 
 The abstract type of soil hydrology closure, of which
-vanGenuchten{FT} and BrooksCorey{FT} are the two supported 
+vanGenuchten{FT} and BrooksCorey{FT} are the two supported
 concrete types.
 
 To add a new parameterization, methods are required for:
@@ -20,7 +20,7 @@ Base.broadcastable(x::AbstractSoilHydrologyClosure) = tuple(x)
 """
     vanGenuchten{FT} <: AbstractSoilHydrologyClosure{FT}
 
-The van Genuchten soil hydrology closure, chosen when the 
+The van Genuchten soil hydrology closure, chosen when the
 hydraulic conductivity and matric potential are modeled
 using the van Genuchten parameterization (van Genuchten 1980;
 see also Table 8.2 of G. Bonan 2019).
@@ -43,11 +43,12 @@ struct vanGenuchten{FT} <: AbstractSoilHydrologyClosure{FT}
     end
 
 end
+Base.broadcastable(VG::vanGenuchten) = Ref(VG)
 
 """
    BrooksCorey{FT} <: AbstractSoilHydrologyClosure{FT}
 
-The Brooks and Corey soil hydrology closure, chosen when the 
+The Brooks and Corey soil hydrology closure, chosen when the
 hydraulic conductivity and matric potential are modeled
 using the Brooks and Corey parameterization (Brooks and Corey,
 1964, 1966; see also Table 8.2 of G. Bonan 2019).
@@ -66,3 +67,4 @@ struct BrooksCorey{FT} <: AbstractSoilHydrologyClosure{FT}
         return new{FT}(c, ψb, S_c)
     end
 end
+Base.broadcastable(BC::vanGenuchten) = Ref(BC)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Previously, the "Phase change source term" failed when run on a GPU. 
Closes #860  

The fix is adding 
`Base.broadcastable(BC::vanGenuchten) = Ref(BC)`

I tried adding `Base.broadcastable(BC::vanGenuchten) = tuple(BC)` as suggested [here](https://github.com/CliMA/ClimaLand.jl/pull/739#issuecomment-2379610674), but that does not fix the error. 
## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
- isolated the problem to broadcasting over vanGenuchten struct
- fixed by overriding the broadcast behavior for vanGenuchten struct
- also applied the fix to BrooksCorey struct, even though it is not causing any failures


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
