### PR TITLE
ETOPO2022 dataset artifact

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -120,3 +120,24 @@ git-tree-sha1 = "1e77fc84a027da43f1bf6ebe0a53849595a2be22"
     [[era5_lai_covers.download]]
     sha256 = "0331e3a2fc2cb53b0f1d9c5a84f49989da0b506258edc229da161e9ca4a61457"
     url = "https://caltech.box.com/shared/static/uzuzk5wh8r9q477jbrusfg1sr0ytzem9.gz"
+
+[earth_orography_30arcseconds]
+git-tree-sha1 = "03dd08fcbf363ed055a176dd7adefb60ff1c3493"
+
+[earth_orography_60arcseconds]
+git-tree-sha1 = "fe19d8dbe7a18ff39588e1f718014b0479d9c0f7"
+lazy = true
+
+    [[earth_orography_60arcseconds.download]]
+    sha256 = "eca66c0701d1c2b9e271742314915ffbf4a0fae92709df611c323f38e019966e"
+    url = "https://caltech.box.com/shared/static/4asrxcgl6xsgenfcug9p0wkkyhtqilgk.gz"
+
+[bedrock_depth_30arcseconds]
+git-tree-sha1 = "cf5d2f9c2e04f930cd30c6ea1a063078113e2a22"
+
+[bedrock_depth_60arcseconds]
+git-tree-sha1 = "4cc329093b0dbc3443db36e7c01133267ac94d37"
+
+    [[bedrock_depth_60arcseconds.download]]
+    sha256 = "6eb359e900141de837c41c0082257f7cf082e06e1371d45b07b1078f07e96c53"
+    url = "https://caltech.box.com/shared/static/k1zq0w1psqu8dk0s9jotrfuu6hm8kxfp.gz"

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -373,4 +373,33 @@ function ilamb_dataset_path(filename; context = nothing)
     return joinpath(@clima_artifact("ilamb_data", context), filename)
 end
 
+"""
+    earth_orography_file_path(; context=nothing)
+
+Construct the file path for the 60arcsecond orography data NetCDF file.
+
+Downloads the 60arc-second dataset by default. 
+"""
+function earth_orography_file_path(; context = nothing)
+    filename = "ETOPO_2022_v1_60s_N90W180_surface.nc"
+    return joinpath(
+        @clima_artifact("earth_orography_60arcseconds", context),
+        filename,
+    )
+end
+
+"""
+    bedrock_depth_file_path(; context=nothing)
+
+Construct the file path for the 60arcsecond bedrock depth data NetCDF file.
+
+Downloads the 60arc-second dataset by default. 
+"""
+function bedrock_depth_file_path(; context = nothing)
+    filename = "ETOPO_2022_v1_60s_N90W180_bed.nc"
+    return joinpath(
+        @clima_artifact("bedrock_depth_60arcseconds", context),
+        filename,
+    )
+end
 end


### PR DESCRIPTION
## Purpose 
Adds ETOPO2022 https://www.ncei.noaa.gov/products/etopo-global-relief-model datasets to ClimaLand (ice-surface and bedrock). 60arc-second information resolution is lazily downloaded by default. 
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
