### PR TITLE
update coupler downstream test

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -40,4 +40,4 @@ jobs:
       - run: |
           julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ -e 'using Pkg; Pkg.instantiate()'
           julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ -e 'using Pkg; Pkg.develop(; path = ".")'
-          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ ClimaCoupler.jl/experiments/ClimaEarth/run_amip.jl --config_file ClimaCoupler.jl/config/ci_configs/target_amip_albedo_function.yml --job_id target_amip_albedo_function
+          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ ClimaCoupler.jl/experiments/ClimaEarth/test/runtests.jl


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
https://github.com/CliMA/ClimaCoupler.jl/pull/1033 added a `test/runtests.jl` file inside of the ClimaCoupler.jl `experiments/ClimaEarth/` directory. This sets up a coarse AMIP simulation and runs it for 2 timesteps. This is meant to be used in upstream packages as a way to ensure downstream compatibility. Note that it doesn't test long-term simulation stability.

This PR adds a downstream test for that environment in this package.

Note that this package already had a ClimaCoupler downstream test before; it is changed here to run a similar setup, but with the configuration setting moved into ClimaCoupler.jl to isolate future changes to that repo.
