### PR TITLE
set NaNs to 1

### DIFF
--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -261,7 +261,7 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     Ω = SpaceVaryingInput(
         joinpath(modis_ci_artifact_path, "He_et_al_2012_1x1.nc"),
         "ci",
-        surface_space,
+        surface_space;
         regridder_type,
         regridder_kwargs = (; extrapolation_bc,),
         file_reader_kwargs = (; preprocess_func = nans_to_one,),

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -257,12 +257,14 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
         ClimaLand.Artifacts.modis_ci_data_folder_path(; context)
 
     # TwoStreamModel parameters
+    nans_to_one(x) = isnan(x) ? eltype(x)(1) : x
     Ω = SpaceVaryingInput(
         joinpath(modis_ci_artifact_path, "He_et_al_2012_1x1.nc"),
         "ci",
         surface_space,
         regridder_type,
         regridder_kwargs = (; extrapolation_bc,),
+        file_reader_kwargs = (; preprocess_func = nans_to_one,),
     )
     χl = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -594,7 +594,8 @@ setup_and_solve_problem(; greet = true);
 # read in diagnostics and make some plots!
 #### ClimaAnalysis ####
 simdir = ClimaAnalysis.SimDir(outdir)
-short_names = ["gpp", "ct", "lai", "swc", "si", "swa", "lwu", "et", "er", "sr"]
+short_names =
+    ["gpp", "ct", "lai", "swc", "si", "swa", "lwu", "et", "er", "sr", "sif"]
 for short_name in short_names
     var = get(simdir; short_name)
     times = ClimaAnalysis.times(var)

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -255,12 +255,14 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
         ClimaLand.Artifacts.modis_ci_data_folder_path(; context)
 
     # TwoStreamModel parameters
+    nans_to_one(x) = isnan(x) ? eltype(x)(1) : x
     Ω = SpaceVaryingInput(
         joinpath(modis_ci_artifact_path, "He_et_al_2012_1x1.nc"),
         "ci",
         surface_space,
         regridder_type,
         regridder_kwargs = (; extrapolation_bc,),
+        file_reader_kwargs = (; preprocess_func = nans_to_one,),
     )
     χl = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -259,7 +259,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     Ω = SpaceVaryingInput(
         joinpath(modis_ci_artifact_path, "He_et_al_2012_1x1.nc"),
         "ci",
-        surface_space,
+        surface_space;
         regridder_type,
         regridder_kwargs = (; extrapolation_bc,),
         file_reader_kwargs = (; preprocess_func = nans_to_one,),

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -261,7 +261,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
     Ω = SpaceVaryingInput(
         joinpath(modis_ci_artifact_path, "He_et_al_2012_1x1.nc"),
         "ci",
-        surface_space,
+        surface_space;
         regridder_type,
         regridder_kwargs = (; extrapolation_bc,),
         file_reader_kwargs = (; preprocess_func = nans_to_one,),

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -257,12 +257,14 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
         ClimaLand.Artifacts.modis_ci_data_folder_path(; context)
 
     # TwoStreamModel parameters
+    nans_to_one(x) = isnan(x) ? eltype(x)(1) : x
     Ω = SpaceVaryingInput(
         joinpath(modis_ci_artifact_path, "He_et_al_2012_1x1.nc"),
         "ci",
         surface_space,
         regridder_type,
         regridder_kwargs = (; extrapolation_bc,),
+        file_reader_kwargs = (; preprocess_func = nans_to_one,),
     )
 
     χl = SpaceVaryingInput(

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -179,8 +179,19 @@ function default_diagnostics(
             "ghf",
         ]
     elseif output_vars == :short
-        soilcanopy_diagnostics =
-            ["gpp", "ct", "lai", "swc", "si", "swa", "lwu", "et", "er", "sr"]
+        soilcanopy_diagnostics = [
+            "gpp",
+            "ct",
+            "lai",
+            "swc",
+            "si",
+            "swa",
+            "lwu",
+            "et",
+            "er",
+            "sr",
+            "sif",
+        ]
     end
 
     if average_period == :hourly

--- a/src/standalone/Vegetation/solar_induced_fluorescence.jl
+++ b/src/standalone/Vegetation/solar_induced_fluorescence.jl
@@ -110,14 +110,14 @@ function compute_SIF_at_a_point(
     (; kf, kd_p1, kd_p2, min_kd, kn_p1, kn_p2, kp, kappa_p1, kappa_p2) =
         sif_parameters
     kd = max(kd_p1 * (Tc - T_freeze) + kd_p2, min_kd)
-    x = 1 - J / Jmax
+    x = 1 - J / max(Jmax, eps(FT))
     kn = (kn_p1 * x - kn_p2) * x
-    ϕp0 = kp / (kf + kp + kn)
-    ϕp = J / Jmax * ϕp0
-    ϕf = kf / (kf + kd + kn) * (1 - ϕp)
+    ϕp0 = kp / max(kf + kp + kn, eps(FT))
+    ϕp = J / max(Jmax, eps(FT)) * ϕp0
+    ϕf = kf / max(kf + kp + kn, eps(FT)) * (1 - ϕp)
     κ = kappa_p1 * Vcmax25 * FT(1e6) + kappa_p2 # formula expects Vcmax25 in μmol/m^2/s
     F = APAR * ϕf
-    SIF_755 = F / κ
+    SIF_755 = F / max(κ, eps(FT))
 
     return SIF_755
 end


### PR DESCRIPTION
## Purpose 
Sets clumping index to 1 if Nan in preprocessing of data.
Removes divide by zero in SIF measurement where canopy is not present.

Verified that Nans are not present in SIF and other output (besides canopy temp, which has NaNs where canopy is not present).


## To-do

## Content
Adds a nans_to_one function and uses in SpaceVaryingInput call.
Removes divide by zero in SIF measurement where canopy is not present by using max(VCmax25, eps(FT)), etc.
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
