### PR TITLE
typo in previous PR

### DIFF
--- a/src/standalone/Vegetation/solar_induced_fluorescence.jl
+++ b/src/standalone/Vegetation/solar_induced_fluorescence.jl
@@ -114,7 +114,7 @@ function compute_SIF_at_a_point(
     kn = (kn_p1 * x - kn_p2) * x
     ϕp0 = kp / max(kf + kp + kn, eps(FT))
     ϕp = J / max(Jmax, eps(FT)) * ϕp0
-    ϕf = kf / max(kf + kp + kn, eps(FT)) * (1 - ϕp)
+    ϕf = kf / max(kf + kd + kn, eps(FT)) * (1 - ϕp)
     κ = kappa_p1 * Vcmax25 * FT(1e6) + kappa_p2 # formula expects Vcmax25 in μmol/m^2/s
     F = APAR * ϕf
     SIF_755 = F / max(κ, eps(FT))


### PR DESCRIPTION
## Purpose 
PR #880 introduced a bug in SIF, using kp instead of kd. See Equation 7 of https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2018JG004883


## To-do



## Content
Changes kp to kd


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
