### PR TITLE
use updated Bonan comparison artifact

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -38,3 +38,9 @@ git-tree-sha1 = "b849eb95c09190095e7bf021494ddeda8858af01"
     [[modis_clumping_index.download]]
     sha256 = "e4c766a93a673e5dc22540687ef5616416d65bb13a0f4a67789b95d49ccbb158"
     url = "https://caltech.box.com/shared/static/ec2y3k5kqpl9wjvtsx3584wgkp5q8dyw.gz"
+
+[bonan_richards_eqn]
+git-tree-sha1 = "043f9354b961fd3ef6ac4cf71d0c99930e177a92"
+    [[bonan_richards_eqn.download]]
+    sha256 = "50f1739dfd8193742488f249bd1ba8a157dfc7c1d8a27392ba7edbe9b4c0db03"
+    url = "https://caltech.box.com/shared/static/4jcz9c1lp6rt750q28kx3qvihi8393tv.gz"

--- a/experiments/standalone/Soil/richards_comparison.jl
+++ b/experiments/standalone/Soil/richards_comparison.jl
@@ -138,7 +138,9 @@ end
         S_s = FT(1e-3) #inverse meters
         vg_n = FT(3.96)
         vg_α = FT(2.7) # inverse meters
-        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
+        vg_m = FT(1)
+        S_c = ν + 1
+        hcm = vanGenuchten(vg_α, vg_n, vg_m, S_c)
         θ_r = FT(0.075)
         zmax = FT(0)
         zmin = FT(-1.5)

--- a/experiments/standalone/Soil/richards_comparison.jl
+++ b/experiments/standalone/Soil/richards_comparison.jl
@@ -16,8 +16,9 @@ import ClimaUtilities.OutputPathGenerator: generate_output_path
 import ClimaLand
 import ClimaLand.Parameters as LP
 
-clay_datapath, sand_datapath =
-    ClimaLand.Artifacts.richards_eqn_bonan_data_path()
+bonan_data_folder = ClimaLand.Artifacts.richards_eqn_bonan_data_path()
+clay_datapath = joinpath(bonan_data_folder, "bonan_data_clay.txt")
+sand_datapath = joinpath(bonan_data_folder, "bonan_data_sand.txt")
 
 context = ClimaComms.context()
 device_suffix =
@@ -207,7 +208,7 @@ end
         if FT == Float64 && context.device isa ClimaComms.CPUSingleThreaded
             N = length(sol.t)
             ϑ_l = parent(sol.u[N].soil.ϑ_l)
-            ds_bonan = readdlm(sand_datapath, ',')
+            ds_bonan = readdlm(sand_datapath)
             bonan_moisture = reverse(ds_bonan[:, 1])
             bonan_z = reverse(ds_bonan[:, 2]) ./ 100.0
             @test sqrt.(mean((bonan_moisture .- ϑ_l) .^ 2.0)) < FT(1e-3)

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -153,6 +153,8 @@ end
 Returns the file path for data created solving Richards equation
 with G. Bonan's matlab code, found here:
 https://github.com/gbonan/bonanmodeling/tree/master/sp_08_01
+This folder contains two data files: bonan_data_clay.txt and
+bonan_data_sand.txt.
 
 The data files correspond to the clay and sand data set described in
 that code and in G. Bonan's book,
@@ -162,31 +164,7 @@ Publisher: Cambridge University Press
 Print publication year: 2019
 """
 function richards_eqn_bonan_data_path(; context = nothing)
-    dir = joinpath(@__DIR__, "../")
-    bonan_clay_dataset = ArtifactWrapper(
-        dir,
-        "richards_clay_bonan_ref_soln",
-        ArtifactFile[ArtifactFile(
-            url = "https://caltech.box.com/shared/static/nk89znth59gcsdb65lnywnzjnuno3h6k.txt",
-            filename = "clay_bonan_sp801_22323.txt",
-        ),],
-    )
-    clay_datapath = joinpath(
-        get_data_folder(bonan_clay_dataset),
-        "clay_bonan_sp801_22323.txt",
-    )
-
-    bonan_sand_dataset = ArtifactWrapper(
-        dir,
-        "richards_sand_bonan_ref_soln",
-        ArtifactFile[ArtifactFile(
-            url = "https://caltech.box.com/shared/static/2vk7bvyjah8xd5b7wxcqy72yfd2myjss.csv",
-            filename = "sand_bonan_sp801.csv",
-        ),],
-    )
-    sand_datapath =
-        joinpath(get_data_folder(bonan_sand_dataset), "sand_bonan_sp801.csv")
-    return clay_datapath, sand_datapath
+    return @clima_artifact("bonan_richards_eqn", context)
 end
 
 """

--- a/src/standalone/Soil/retention_models.jl
+++ b/src/standalone/Soil/retention_models.jl
@@ -1,10 +1,10 @@
 export AbstractSoilHydrologyClosure, vanGenuchten, BrooksCorey
 
 """
-    AbstractSoilHydrologyClosure{FT <: AbstractFloat} 
+    AbstractSoilHydrologyClosure{FT <: AbstractFloat}
 
 The abstract type of soil hydrology closure, of which
-vanGenuchten{FT} and BrooksCorey{FT} are the two supported 
+vanGenuchten{FT} and BrooksCorey{FT} are the two supported
 concrete types.
 
 To add a new parameterization, methods are required for:
@@ -20,7 +20,7 @@ Base.broadcastable(x::AbstractSoilHydrologyClosure) = tuple(x)
 """
     vanGenuchten{FT} <: AbstractSoilHydrologyClosure{FT}
 
-The van Genuchten soil hydrology closure, chosen when the 
+The van Genuchten soil hydrology closure, chosen when the
 hydraulic conductivity and matric potential are modeled
 using the van Genuchten parameterization (van Genuchten 1980;
 see also Table 8.2 of G. Bonan 2019).
@@ -36,18 +36,17 @@ struct vanGenuchten{FT} <: AbstractSoilHydrologyClosure{FT}
     m::FT
     "A derived parameter: the critical saturation at which capillary flow no longer replenishes the surface"
     S_c::FT
-    function vanGenuchten{FT}(; α::FT, n::FT) where {FT}
-        m = 1 - 1 / n
-        S_c = (1 + ((n - 1) / n)^(1 - 2 * n))^(-m)
-        return new{FT}(α, n, m, S_c)
-    end
-
+end
+function vanGenuchten{FT}(; α::FT, n::FT) where {FT}
+    m = 1 - 1 / n
+    S_c = (1 + ((n - 1) / n)^(1 - 2 * n))^(-m)
+    return vanGenuchten{FT}(α, n, m, S_c)
 end
 
 """
    BrooksCorey{FT} <: AbstractSoilHydrologyClosure{FT}
 
-The Brooks and Corey soil hydrology closure, chosen when the 
+The Brooks and Corey soil hydrology closure, chosen when the
 hydraulic conductivity and matric potential are modeled
 using the Brooks and Corey parameterization (Brooks and Corey,
 1964, 1966; see also Table 8.2 of G. Bonan 2019).


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Use updated Bonan comparison dataset uploaded to ClimaArtifacts in https://github.com/CliMA/ClimaArtifacts/pull/58.

Also moves the `vanGenuchten` inner constructor out of the struct definition so we have access to the default constructor. We use this to use the same value `vg_m = 1` as Bonan for the sand case.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
