### PR TITLE
integrate neural network into Snow.jl architecture

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.1"
 manifest_format = "2.0"
-project_hash = "bf1216ed2bc76713a01437d07332219f6bcd0c54"
+project_hash = "14f223707cbd1a2cb15b66a90e7be9a546a0f205"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "eea5d80188827b35333801ef97a40c2ed653b081"
@@ -289,6 +289,12 @@ git-tree-sha1 = "e329286945d0cfc04456972ea732551869af1cfc"
 uuid = "4e9b3aee-d8a1-5a3d-ad8b-7d824db253f0"
 version = "1.0.1+0"
 
+[[deps.CSV]]
+deps = ["CodecZlib", "Dates", "FilePathsBase", "InlineStrings", "Mmap", "Parsers", "PooledArrays", "PrecompileTools", "SentinelArrays", "Tables", "Unicode", "WeakRefStrings", "WorkerUtilities"]
+git-tree-sha1 = "deddd8725e5e1cc49ee205a1964256043720a6c3"
+uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+version = "0.10.15"
+
 [[deps.CUDA]]
 deps = ["AbstractFFTs", "Adapt", "BFloat16s", "CEnum", "CUDA_Driver_jll", "CUDA_Runtime_Discovery", "CUDA_Runtime_jll", "Crayons", "DataFrames", "ExprTools", "GPUArrays", "GPUCompiler", "KernelAbstractions", "LLVM", "LLVMLoopInfo", "LazyArtifacts", "Libdl", "LinearAlgebra", "Logging", "NVTX", "Preferences", "PrettyTables", "Printf", "Random", "Random123", "RandomNumbers", "Reexport", "Requires", "SparseArrays", "StaticArrays", "Statistics"]
 git-tree-sha1 = "cdbdca28f19c2c7fcf34ffb48bfdaca404dcd18a"
@@ -408,20 +414,11 @@ deps = ["ArtifactWrappers", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "Clim
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
 version = "0.15.4"
+weakdeps = ["BSON", "CSV", "CUDA", "ClimaParams", "DataFrames", "Flux", "HTTP", "StatsBase", "cuDNN"]
 
     [deps.ClimaLand.extensions]
     CreateParametersExt = "ClimaParams"
-    NeuralSnowExt = ["CSV", "DataFrames", "HTTP", "Flux", "StatsBase", "cuDNN"]
-
-    [deps.ClimaLand.weakdeps]
-    CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
-    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-    ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"
-    DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-    Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-    HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-    StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-    cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
+    NeuralSnowExt = ["CSV", "DataFrames", "HTTP", "Flux", "StatsBase", "cuDNN", "BSON"]
 
 [[deps.ClimaParams]]
 deps = ["TOML"]
@@ -3019,11 +3016,22 @@ git-tree-sha1 = "93f43ab61b16ddfb2fd3bb13b3ce241cafb0e6c9"
 uuid = "2381bf8a-dfd0-557d-9999-79630e7b1b91"
 version = "1.31.0+0"
 
+[[deps.WeakRefStrings]]
+deps = ["DataAPI", "InlineStrings", "Parsers"]
+git-tree-sha1 = "b1be2855ed9ed8eac54e5caff2afcdb442d52c23"
+uuid = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
+version = "1.4.2"
+
 [[deps.WoodburyMatrices]]
 deps = ["LinearAlgebra", "SparseArrays"]
 git-tree-sha1 = "c1a7aa6219628fcd757dede0ca95e245c5cd9511"
 uuid = "efce3f68-66dc-5838-9240-27a6d6f5f9b6"
 version = "1.0.0"
+
+[[deps.WorkerUtilities]]
+git-tree-sha1 = "cd1659ba0d57b71a464a29e64dbc67cfe83d54e7"
+uuid = "76eceee3-57b5-4d4a-8e66-0e911cebbf60"
+version = "1.6.1"
 
 [[deps.XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Zlib_jll"]

--- a/.buildkite/Project.toml
+++ b/.buildkite/Project.toml
@@ -2,6 +2,7 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ArtifactWrappers = "a14bc488-3040-4b00-9dc1-f6467924858a"
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 ClimaAnalysis = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"

--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ SurfaceFluxes = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [weakdeps]
+BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"
@@ -33,10 +34,11 @@ cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [extensions]
 CreateParametersExt = "ClimaParams"
-NeuralSnowExt = ["CSV", "DataFrames", "HTTP", "Flux", "StatsBase", "cuDNN"]
+NeuralSnowExt = ["CSV", "DataFrames", "HTTP", "Flux", "StatsBase", "cuDNN", "BSON"]
 
 [compat]
 ArtifactWrappers = "0.2"
+BSON = "0.3.9"
 CSV = "0.10.14"
 CUDA = "5.5"
 ClimaComms = "0.6"

--- a/docs/tutorials/standalone/Snow/base_tutorial.jl
+++ b/docs/tutorials/standalone/Snow/base_tutorial.jl
@@ -43,10 +43,10 @@
 # We begin by importing the developed code to create and run the neural network,
 # as well as some preliminary packages:
 using ClimaLand
-using DataFrames, CSV, HTTP, Dates, Flux, StatsBase, cuDNN
+using DataFrames, CSV, HTTP, Dates, Flux, StatsBase, cuDNN, BSON
 
 # The code lives in an extenson that we have to manually load. The extension can
-# be loaded only if "CSV", "HTTP", "Flux", "StatsBase", "cuDNN" and "ClimaLand"
+# be loaded only if "CSV", "HTTP", "Flux", "StatsBase", "cuDNN", "BSON", and "ClimaLand"
 # are loaded.
 DataTools = Base.get_extension(ClimaLand, :NeuralSnowExt).DataTools
 ModelTools = Base.get_extension(ClimaLand, :NeuralSnowExt).ModelTools;

--- a/docs/tutorials/standalone/Snow/data_tutorial.jl
+++ b/docs/tutorials/standalone/Snow/data_tutorial.jl
@@ -11,10 +11,10 @@
 
 # We begin by importing all required packages:
 using ClimaLand
-using DataFrames, CSV, HTTP, Dates, Flux, StatsBase, cuDNN
+using DataFrames, CSV, HTTP, Dates, Flux, StatsBase, cuDNN, BSON
 
 # The code lives in an extenson that we have to manually load. The extension can
-# be loaded only if "CSV", "HTTP", "Flux", "StatsBase", "cuDNN" and "ClimaLand"
+# be loaded only if "DataFrames", "CSV", "HTTP", "Flux", "StatsBase", "cuDNN", "BSON", and "ClimaLand"
 # are loaded.
 DataTools = Base.get_extension(ClimaLand, :NeuralSnowExt).DataTools;
 

--- a/ext/NeuralSnowExt.jl
+++ b/ext/NeuralSnowExt.jl
@@ -4,5 +4,7 @@ include("neural_snow/DataTools.jl")
 using .DataTools
 include("neural_snow/ModelTools.jl")
 using .ModelTools
+include("neural_snow/NeuralSnow.jl")
+using .NeuralSnow
 
 end

--- a/ext/neural_snow/NeuralSnow.jl
+++ b/ext/neural_snow/NeuralSnow.jl
@@ -1,0 +1,240 @@
+module NeuralSnow
+
+using Flux
+using ClimaLand
+using ClimaLand.Snow: AbstractDensityModel, SnowModel, SnowParameters
+import ClimaLand.Snow:
+    density_prog_vars,
+    density_prog_types,
+    density_prog_names,
+    density_aux_vars,
+    density_aux_types,
+    density_aux_names,
+    update_density!,
+    update_density_prog!
+import ClimaLand.Parameters as LP
+using Thermodynamics
+
+using DataFrames, Dates, CSV, HTTP, Flux, cuDNN, StatsBase, BSON
+ModelTools = Base.get_extension(ClimaLand, :NeuralSnowExt).ModelTools
+#^^is this correct format since this is within the extension itself, or do i just use include(./ModelTools); using ModelTools; here?
+#the only reason I am using this is for the make_model() (once) and settimescale!() (twice) functions.
+
+export NeuralDepthModel, update_density!, update_density_prog!
+
+"""
+    NeuralDepthModel{FT <: AbstractFloat} <: AbstractDensityModel{FT}
+Establishes the density parameterization where snow density
+is calculated from a neural network determining the rate of change of snow depth, dzdt.
+"""
+struct NeuralDepthModel{FT} <: AbstractDensityModel{FT}
+    z_model::Flux.Chain
+    α::FT
+end
+
+"""
+    get_znetwork(; download_link = "https://caltech.box.com/shared/static/ay7cv0rhuiytrqbongpeq2y7m3cimhm4.bson")
+A default function for returning the snow-depth neural network from the paper.
+"""
+#This is the only place that creates the necessity of BSON for the neural extension and the make_model() from ModelTools. Keep or get rid of?
+#Can I change this to something CliMA already includes? is BSON vs JLD2 or anything else better? An artifact (can they store BSON/.jld2 files for direct usage without those packages?)?
+function get_znetwork(;
+    download_link = "https://caltech.box.com/shared/static/ay7cv0rhuiytrqbongpeq2y7m3cimhm4.bson",
+)
+    z_idx = 1
+    p_idx = 7
+    nfeatures = 7
+    zmodel = ModelTools.make_model(nfeatures, 4, z_idx, p_idx)
+    zmodel_state = BSON.load(IOBuffer(HTTP.get(download_link).body))[:zstate]
+    Flux.loadmodel!(zmodel, zmodel_state)
+    ModelTools.settimescale!(zmodel, 86400.0)
+    return zmodel
+
+    #should I write this function to give the ability to also load from local file too?
+    #BSON.@load "../SnowResearch/cleancode/testhrmodel.bson" zstate
+    #Flux.loadmodel!(zmodel, zstate)
+end
+
+"""
+    converted_model_type!(model::Flux.Chain, FT::Type)
+A wrapper function to aid conversion of the utilized Flux network weights to the type determined by the simulation.
+Currently supports `Float32` and `Float64` types.
+"""
+function converted_model_type(model::Flux.Chain, FT::DataType)
+    if FT == Float32
+        return Flux.f32(model)
+    elseif FT == Float64
+        return Flux.f64(model)
+    else
+        error(
+            "Conversion of Flux Chain weights to the desired float-type is not supported. Please implement the desired conversion
+      in NeuralSnow.convert_model_type!() or a custom constructor for the NeuralDepthModel with the desired type.",
+        )
+    end
+end
+
+"""
+    NeuralDepthModel(FT::DataType; Δt::Union{Nothing, FT}=nothing; model::Flux.Chain, α::Union{FT, Nothing})
+An outer constructor for the `NeuralDepthModel` density parameterization for usage in a snow model.
+Can choose to use custom models via the `model` argument, or a custom exponential moving average weight for the network inputs.
+The Δt argument can be used to set the lower boundary value on the network (when not using a custom model) in accordance with the paper upon initialization,
+equivalent to ModelTools.settimescale!(model, Δt, dtype = FT).
+"""
+function NeuralDepthModel(
+    FT::DataType;
+    Δt = nothing,
+    model::Flux.Chain = get_znetwork(),
+    α = nothing,
+)
+    usemodel = converted_model_type(model, FT)
+    weight =
+        !isnothing(α) ? FT(α) :
+        (isnothing(Δt) ? FT(1 / 12) : FT(maximum([2 * Δt / 86400, 1])))
+    # should we set the timescale of the model to Δt? getting rid of get_znetwork() and below line mitigates the need to import ModelTools entirely.
+    if !isnothing(Δt)
+        ModelTools.settimescale!(usemodel, Δt, dtype = FT) #assumes Δt is provided in seconds
+    end
+    return NeuralDepthModel{FT}(usemodel, weight)
+end
+
+#Define the additional prognostic variables needed for using this parameterization:
+#do I need to export these for them to be utilized in the simulation?
+ClimaLand.Snow.density_prog_vars(m::NeuralDepthModel) =
+    (:Z, :P_avg, :T_avg, :R_avg, :Qrel_avg, :u_avg)
+ClimaLand.Snow.density_prog_types(m::NeuralDepthModel{FT}) where {FT} =
+    (FT, FT, FT, FT, FT, FT)
+ClimaLand.Snow.density_prog_names(m::NeuralDepthModel) =
+    (:surface, :surface, :surface, :surface, :surface, :surface)
+
+#so far, every type is just blank here - is it even worth providing this feature or just get rid of this feature in Snow.jl entirely?
+ClimaLand.Snow.density_aux_vars(m::NeuralDepthModel) = ()
+ClimaLand.Snow.density_aux_types(m::NeuralDepthModel{FT}) where {FT} = ()
+ClimaLand.Snow.density_aux_names(m::NeuralDepthModel) = ()
+
+"""
+    snow_density(density::NeuralDepthModel, SWE::FT, z::FT, parameters::SnowParameters{FT}) where {FT}
+Returns the snow density given the current model state and the `NeuralDepthModel`
+density paramterization.
+"""
+function snow_density(
+    density::NeuralDepthModel{FT},
+    SWE::FT,
+    z::FT,
+    parameters::SnowParameters{FT},
+)::FT where {FT}
+    ρ_l = FT(LP.ρ_cloud_liq(parameters.earth_param_set))
+    if SWE <= eps(FT) #if there is no snowpack, aka avoid NaN
+        return FT(ρ_l)
+    end
+    ρ_new = SWE / z * ρ_l
+    return ρ_new
+end
+
+"""
+    update_density!(density::NeuralDepthModel, params::SnowParameters, Y, p)
+Updates the snow density given the current model state and the `NeuralDepthModel`
+density paramterization.
+"""
+function update_density!(
+    density::NeuralDepthModel,
+    params::SnowParameters,
+    Y,
+    p,
+)
+    p.snow.ρ_snow .= snow_density.(Ref(density), Y.snow.S, Y.snow.Z, params)
+end
+
+"""
+    eval_nn(vmodel, z::FT, swe::FT, P::FT, T::FT, R::FT, qrel::FT, u::FT)::FT where {FT}
+Helper function for evaluating the neural network in a pointwise manner over a `ClimaCore.Field`
+and returning the output in a broadcastable way.
+"""
+function eval_nn(
+    model,
+    z::FT,
+    swe::FT,
+    P::FT,
+    T::FT,
+    R::FT,
+    qrel::FT,
+    u::FT,
+)::FT where {FT}
+    input = FT.([z, swe, qrel, R, u, T, P])
+    return model(input)[1]
+end
+
+"""
+    dzdt(density::NeuralDepthModel, model::SnowModel{FT}, Y, p, t) where {FT}
+Returns the change in snow depth (rate) given the current model state and the `NeuralDepthModel`
+density paramterization, passing the approximate average of the forcings over the last 24 hours instead of
+the instantaneous value.
+"""
+function dzdt(density::NeuralDepthModel, Y)
+    return eval_nn.(
+        Ref(density.z_model),
+        Y.snow.Z,
+        Y.snow.S,
+        Y.snow.P_avg,
+        Y.snow.T_avg,
+        Y.snow.R_avg,
+        Y.snow.Qrel_avg,
+        Y.snow.u_avg,
+    )
+end
+
+"""
+    clip_dZdt(S::FT, Z::FT, dSdt::FT, dZdt::FT, Δt::FT)::FT
+A helper function which clips the tendency of Z such that
+its behavior is consistent with that of S.
+"""
+function clip_dZdt(S::FT, Z::FT, dSdt::FT, dZdt::FT, Δt::FT)::FT where {FT}
+    if (S + dSdt * Δt) <= eps(FT)
+        return -Z / Δt
+    elseif (Z + dZdt * Δt) < (S + dSdt * Δt)
+        #do we need to do something about setting q_l = 1 here?
+        return (S - Z) / Δt + dSdt
+    else
+        return dZdt
+    end
+end
+
+"""
+    update_density_prog!(density::NeuralDepthModel, model::SnowModel, Y, p)
+Updates all prognostic variables associated with density/depth given the current model state and the `NeuralDepthModel`
+density paramterization.
+"""
+function update_density_prog!(
+    density::NeuralDepthModel,
+    model::SnowModel,
+    dY,
+    Y,
+    p,
+)
+    #Get Inputs:
+    #is this too many allocations?
+    z = Y.snow.Z
+    swe = Y.snow.S
+    dswedt = p.snow.applied_water_flux #do i need to multiply by -1 here for directions?
+    dprecipdt_snow = abs.(p.drivers.P_snow) #need to change downward direction to scalar
+    air_temp = p.drivers.T .- model.parameters.earth_param_set.T_freeze
+    sol_rad = abs.(p.drivers.SW_d) #need to change downward direction to scalar
+    rel_hum =
+        Thermodynamics.relative_humidity.(
+            Ref(model.boundary_conditions.atmos.thermo_params),
+            p.drivers.thermal_state,
+        )
+    wind_speed = p.drivers.u
+    dt = model.parameters.Δt
+    β = density.α
+
+    dY.snow.Z .= clip_dZdt.(swe, z, dswedt, dzdt(density, Y), dt)
+    dY.snow.P_avg = β .* (dprecipdt_snow .- Y.snow.P_avg)
+    dY.snow.T_avg = β .* (air_temp .- Y.snow.T_avg)
+    dY.snow.R_avg = β .* (sol_rad .- Y.snow.R_avg)
+    dY.snow.Qrel_avg = β .* (rel_hum .- Y.snow.Qrel_avg)
+    dY.snow.u_avg = β .* (wind_speed .- Y.snow.u_avg)
+end
+
+end
+
+#do tests need to be made for these functions? since it is an extension?


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Integrate the neural snow depth model into the Snow model architecture. This involves small changes to Snow.jl and SnowParameterizations.jl as well as expanding the NeuralSnow extension to allow the neural model as a type of AbstractDensityModel. "CSV" was also added to the buildkite dependencies to permit testing of the NeuralSnow extension, and BSON has been appropriately added to the ClimaLand weak dependencies to enable the expanded functionality of the extension.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
Questions are commented in the changed files about different possible approaches. With this PR merged, I can also add a slightly faster and more abstract/streamlined form of the neural model itself (changes to ModelTools, etc).

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
Expanded NeuralSnow extension and changed some of the syntax of the Snow model.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
