### PR TITLE
Use fluxnet data from ClimaArtifacts

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -44,3 +44,10 @@ git-tree-sha1 = "043f9354b961fd3ef6ac4cf71d0c99930e177a92"
     [[bonan_richards_eqn.download]]
     sha256 = "50f1739dfd8193742488f249bd1ba8a157dfc7c1d8a27392ba7edbe9b4c0db03"
     url = "https://caltech.box.com/shared/static/4jcz9c1lp6rt750q28kx3qvihi8393tv.gz"
+
+[fluxnet_sites]
+git-tree-sha1 = "2fc70601badf6f83dee2b84ba9c386ad041de8e2"
+
+    [[fluxnet_sites.download]]
+    sha256 = "f05b4c01b57afe9c0f59095b39cea1c0cf46b20deecd5c7afb44f474d9cd9966"
+    url = "https://caltech.box.com/shared/static/otrr2y0rgjct7hqhmq214nb8qjsvqj5p.gz"

--- a/experiments/integrated/fluxnet/met_drivers_FLUXNET.jl
+++ b/experiments/integrated/fluxnet/met_drivers_FLUXNET.jl
@@ -17,7 +17,7 @@ include(
     joinpath(pkgdir(ClimaLand), "experiments/integrated/fluxnet/pull_MODIS.jl"),
 )
 
-data_path = ClimaLand.Artifacts.experiment_fluxnet_data_path(site_ID, data_link)
+data_path = ClimaLand.Artifacts.experiment_fluxnet_data_path(site_ID)
 driver_data = readdlm(data_path, ',')
 
 LOCAL_DATETIME = DateTime.(format.(driver_data[2:end, 1]), "yyyymmddHHMM")

--- a/lib/ClimaLandSimulations/src/Artifacts.toml
+++ b/lib/ClimaLandSimulations/src/Artifacts.toml
@@ -1,0 +1,6 @@
+[fluxnet_sites]
+git-tree-sha1 = "2fc70601badf6f83dee2b84ba9c386ad041de8e2"
+
+    [[fluxnet_sites.download]]
+    sha256 = "f05b4c01b57afe9c0f59095b39cea1c0cf46b20deecd5c7afb44f474d9cd9966"
+    url = "https://caltech.box.com/shared/static/otrr2y0rgjct7hqhmq214nb8qjsvqj5p.gz"

--- a/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_utilities/make_drivers.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/fluxnet_utilities/make_drivers.jl
@@ -1,19 +1,12 @@
 export make_drivers
 
+import ClimaUtilities.ClimaArtifacts: @clima_artifact
+
 function make_drivers(site_ID, setup, config, params, context)
     #earth_param_set = create_lsm_parameters(FT)
 
-    af = ArtifactFile(
-        url = config.data_link,
-        filename = "AMF_$(site_ID)_FLUXNET_FULLSET.csv",
-    )
-    dataset = ArtifactWrapper(
-        "$climalandsimulations_dir/src/Fluxnet/fluxnet_sites/$site_ID",
-        "ameriflux_data",
-        ArtifactFile[af],
-    )
-    dataset_path = get_data_folder(dataset)
-    data = joinpath(dataset_path, "AMF_$(site_ID)_FLUXNET_FULLSET.csv")
+    dataset_path = @clima_artifact("fluxnet_sites", context)
+    data = joinpath(dataset_path, "$(site_ID).csv")
     driver_data = readdlm(data, ',')
 
     LOCAL_DATETIME = DateTime.(format.(driver_data[2:end, 1]), "yyyymmddHHMM")

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -43,8 +43,7 @@ end
 
 """
     experiment_fluxnet_data_path(
-        site_ID,
-        data_link;
+        site_ID;
         context = nothing,
     )
 
@@ -86,17 +85,11 @@ Citation: Siyan Ma, Liukang Xu, Joseph Verfaillie, Dennis Baldocchi (2023), Amer
 
 AmeriFlux CC-BY-4.0 License
 """
-function experiment_fluxnet_data_path(site_ID, data_link; context = nothing)
+function experiment_fluxnet_data_path(site_ID; context = nothing)
     @assert site_ID ∈ ("US-MOz", "US-Var", "US-NR1", "US-Ha1")
-    dir = joinpath(@__DIR__, "../")
-    af = ArtifactFile(
-        url = data_link,
-        filename = "AMF_$(site_ID)_FLUXNET_FULLSET.csv",
-    )
-    dataset =
-        ArtifactWrapper(dir, "ameriflux_data_$(site_ID)", ArtifactFile[af])
-    folder_path = get_data_folder(dataset)
-    data_path = joinpath(folder_path, "AMF_$(site_ID)_FLUXNET_FULLSET.csv")
+
+    folder_path = @clima_artifact("fluxnet_sites", context)
+    data_path = joinpath(folder_path, "$(site_ID).csv")
     return data_path
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

This PR edits site-level experiments to use the FLUXNET datasets added to ClimaArtifacts [here](https://github.com/CliMA/ClimaArtifacts/pull/65). This is a step towards #580.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->

- [x] Successfully run all experiments using climaArtifacts

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->

Adds fluxtower data to Artifacts.toml and a method to fetch the data to Artifacts.jl. Switches site-level experiments to retrieve their data from the new sources.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
