### PR TITLE
change artifact to 2008 and less freq LAI

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -15,17 +15,16 @@ git-tree-sha1 = "3f6873a3e67722bda1fd23f7d5a05f5e2df1fe8c"
 [era5_land_forcing_data2008]
 git-tree-sha1 = "93d2e93f491e77cb8fba2a1b8b3946f38bde469e"
 [era5_land_forcing_data2008_lowres]
-git-tree-sha1 = "67b6daae491c1fa55406dd6a65f6b197b9bd4728"
+git-tree-sha1 = "fd826542e6ab1758c8d5a2cc6dbf1f67b47aadee"
 
     [[era5_land_forcing_data2008_lowres.download]]
-    sha256 = "f1ec64818faad37cf681caa86832b77c68f93784bf105dc85dd57079e8673b10"
+    sha256 = "c5ea5acfcab2e69c26d6ef8ba20e9e6dc018e5baa9c48d0df69cf0a5f9bf3399"
     url = "https://caltech.box.com/shared/static/6zk5fa3ka5ib62jsrs6tx35sqwe8xv2k.gz"
-
 [era5_land_forcing_data2008_lai]
-git-tree-sha1 = "f998a8db24647caf5f1693ad4a1e46bdf356a752"
+git-tree-sha1 = "df5ec5af1ea0793c0e7d49e60db5a938098e174f"
 
     [[era5_land_forcing_data2008_lai.download]]
-    sha256 = "81b357e97daf18d998c003dc00db14a7ffdd431520f2c5c4e41a1f0254864a8d"
+    sha256 = "a83bf28a7a864db285e41289031a9761c2a426373a6efecd04b866a0b5374cef"
     url = "https://caltech.box.com/shared/static/m82r23e67x04a3hb6p79dfltlumvg9z0.gz"
 
 [land_albedo]

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -12,8 +12,21 @@ git-tree-sha1 = "3f6873a3e67722bda1fd23f7d5a05f5e2df1fe8c"
     sha256 = "830136abec15551a343b7884d657fb6a79b16a37237681a2becf65bd845aa692"
     url = "https://caltech.box.com/shared/static/6pu2f6c99g29qawvjjh3j56drkonpd3z.gz"
 
-[era5_land_forcing_data2021]
-git-tree-sha1 = "ec424296df6b60cfe273ac8f981701fbbed0bd8a"
+[era5_land_forcing_data2008]
+git-tree-sha1 = "93d2e93f491e77cb8fba2a1b8b3946f38bde469e"
+[era5_land_forcing_data2008_lowres]
+git-tree-sha1 = "67b6daae491c1fa55406dd6a65f6b197b9bd4728"
+
+    [[era5_land_forcing_data2008_lowres.download]]
+    sha256 = "f1ec64818faad37cf681caa86832b77c68f93784bf105dc85dd57079e8673b10"
+    url = "https://caltech.box.com/shared/static/6zk5fa3ka5ib62jsrs6tx35sqwe8xv2k.gz"
+
+[era5_land_forcing_data2008_lai]
+git-tree-sha1 = "f998a8db24647caf5f1693ad4a1e46bdf356a752"
+
+    [[era5_land_forcing_data2008_lai.download]]
+    sha256 = "81b357e97daf18d998c003dc00db14a7ffdd431520f2c5c4e41a1f0254864a8d"
+    url = "https://caltech.box.com/shared/static/m82r23e67x04a3hb6p79dfltlumvg9z0.gz"
 
 [land_albedo]
 git-tree-sha1 = "3f07b70ab43a05123e93753a45e094dcf7a66b5b"

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -67,12 +67,12 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface
 
-    start_date = DateTime(2021)
+    start_date = DateTime(2008)
 
     # Forcing data
     era5_artifact_path =
-        ClimaLand.Artifacts.era5_land_forcing_data2021_folder_path(; context)
-    era5_ncdata_path = joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc")
+        ClimaLand.Artifacts.era5_land_forcing_data2008_folder_path(; context)
+    era5_ncdata_path = joinpath(era5_artifact_path, "era5_2008_1.0x1.0.nc")
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
         era5_ncdata_path,
         surface_space,
@@ -230,8 +230,12 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     photosynthesis_args =
         (; parameters = Canopy.FarquharParameters(FT, is_c3; Vcmax25 = Vcmax25))
     # Set up plant hydraulics
+    era5_lai_artifact_path =
+        ClimaLand.Artifacts.era5_lai_forcing_data2008_folder_path(; context)
+    era5_lai_ncdata_path =
+        joinpath(era5_lai_artifact_path, "era5_2008_1.0x1.0_lai.nc")
     LAIfunction = ClimaLand.prescribed_lai_era5(
-        era5_ncdata_path,
+        era5_lai_ncdata_path,
         surface_space,
         start_date;
         time_interpolation_method = time_interpolation_method,

--- a/experiments/benchmarks/richards.jl
+++ b/experiments/benchmarks/richards.jl
@@ -68,7 +68,7 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface
 
-    start_date = DateTime(2021)
+    start_date = DateTime(2008)
     spatially_varying_soil_params =
         ClimaLand.default_spatially_varying_soil_parameters(
             subsurface_space,
@@ -92,20 +92,18 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     )
 
     era5_artifact_path =
-        ClimaLand.Artifacts.era5_land_forcing_data2021_folder_path(; context)
+        ClimaLand.Artifacts.era5_land_forcing_data2008_folder_path(; context)
 
     # Below, the preprocess_func argument is used to
     # 1. Convert precipitation to be negative (as it is downwards)
-    # 2. Convert accumulations over an hour to a rate per second
-    start_date = DateTime(2021)
     # Precipitation:
     precip = TimeVaryingInput(
-        joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc"),
-        "tp",
+        joinpath(era5_artifact_path, "era5_2008_1.0x1.0.nc"),
+        "mtpr",
         surface_space;
         start_date,
         regridder_type,
-        file_reader_kwargs = (; preprocess_func = (data) -> -data / 3600,),
+        file_reader_kwargs = (; preprocess_func = (data) -> -data),
     )
     atmos = ClimaLand.PrescribedPrecipitation{FT, typeof(precip)}(precip)
     bottom_bc = ClimaLand.Soil.WaterFluxBC((p, t) -> 0.0)

--- a/experiments/benchmarks/richards.jl
+++ b/experiments/benchmarks/richards.jl
@@ -96,6 +96,7 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
 
     # Below, the preprocess_func argument is used to
     # 1. Convert precipitation to be negative (as it is downwards)
+    # 2. Convert mass flux to equivalent liquid water flux
     # Precipitation:
     precip = TimeVaryingInput(
         joinpath(era5_artifact_path, "era5_2008_1.0x1.0.nc"),
@@ -103,7 +104,7 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
         surface_space;
         start_date,
         regridder_type,
-        file_reader_kwargs = (; preprocess_func = (data) -> -data),
+        file_reader_kwargs = (; preprocess_func = (data) -> -data / 1000),
     )
     atmos = ClimaLand.PrescribedPrecipitation{FT, typeof(precip)}(precip)
     bottom_bc = ClimaLand.Soil.WaterFluxBC((p, t) -> 0.0)

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -49,12 +49,12 @@ domain = ClimaLand.Domains.SphericalShell(;
 surface_space = domain.space.surface
 subsurface_space = domain.space.subsurface
 
-start_date = DateTime(2021);
+start_date = DateTime(2008);
 
 # Forcing data
 era5_artifact_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2021_folder_path(; context)
-era5_ncdata_path = joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc")
+    ClimaLand.Artifacts.era5_land_forcing_data2008_folder_path(; context)
+era5_ncdata_path = joinpath(era5_artifact_path, "era5_2008_1.0x1.0.nc")
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,
@@ -124,8 +124,12 @@ conductance_args = (; parameters = Canopy.MedlynConductanceParameters(FT; g1))
 photosynthesis_args =
     (; parameters = Canopy.FarquharParameters(FT, is_c3; Vcmax25 = Vcmax25))
 # Set up plant hydraulics
+era5_lai_artifact_path =
+    ClimaLand.Artifacts.era5_lai_forcing_data2008_folder_path(; context)
+era5_lai_ncdata_path =
+    joinpath(era5_lai_artifact_path, "era5_2008_1.0x1.0_lai.nc")
 LAIfunction = ClimaLand.prescribed_lai_era5(
-    era5_ncdata_path,
+    era5_lai_ncdata_path,
     surface_space,
     start_date;
     time_interpolation_method = time_interpolation_method,

--- a/experiments/long_runs/bucket.jl
+++ b/experiments/long_runs/bucket.jl
@@ -66,12 +66,13 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 7))
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface
 
-    start_date = DateTime(2021)
+    start_date = DateTime(2008)
     # Forcing data
     era5_artifact_path =
-        ClimaLand.Artifacts.era5_land_forcing_data2021_folder_path(; context)
+        ClimaLand.Artifacts.era5_land_forcing_data2008_folder_path(; context)
+    era5_ncdata_path = joinpath(era5_artifact_path, "era5_2008_1.0x1.0.nc")
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
-        joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc"),
+        era5_ncdata_path,
         surface_space,
         start_date,
         earth_param_set,

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -69,11 +69,11 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface
 
-    start_date = DateTime(2021)
+    start_date = DateTime(2008)
     # Forcing data
     era5_artifact_path =
-        ClimaLand.Artifacts.era5_land_forcing_data2021_folder_path(; context)
-    era5_ncdata_path = joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc")
+        ClimaLand.Artifacts.era5_land_forcing_data2008_folder_path(; context)
+    era5_ncdata_path = joinpath(era5_artifact_path, "era5_2008_1.0x1.0.nc")
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
         era5_ncdata_path,
         surface_space,
@@ -231,9 +231,12 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     photosynthesis_args =
         (; parameters = Canopy.FarquharParameters(FT, is_c3; Vcmax25 = Vcmax25))
     # Set up plant hydraulics
-
+    era5_lai_artifact_path =
+        ClimaLand.Artifacts.era5_lai_forcing_data2008_folder_path(; context)
+    era5_lai_ncdata_path =
+        joinpath(era5_lai_artifact_path, "era5_2008_1.0x1.0_lai.nc")
     LAIfunction = ClimaLand.prescribed_lai_era5(
-        era5_ncdata_path,
+        era5_lai_ncdata_path,
         surface_space,
         start_date;
         time_interpolation_method = time_interpolation_method,

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -73,11 +73,11 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface
 
-    start_date = DateTime(2021)
+    start_date = DateTime(2008)
     # Forcing data
     era5_artifact_path =
-        ClimaLand.Artifacts.era5_land_forcing_data2021_folder_path(; context)
-    era5_ncdata_path = joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc")
+        ClimaLand.Artifacts.era5_land_forcing_data2008_folder_path(; context)
+    era5_ncdata_path = joinpath(era5_artifact_path, "era5_2008_1.0x1.0.nc")
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
         era5_ncdata_path,
         surface_space,
@@ -232,8 +232,12 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
     photosynthesis_args =
         (; parameters = Canopy.FarquharParameters(FT, is_c3; Vcmax25 = Vcmax25))
     # Set up plant hydraulics
+    era5_lai_artifact_path =
+        ClimaLand.Artifacts.era5_lai_forcing_data2008_folder_path(; context)
+    era5_lai_ncdata_path =
+        joinpath(era5_lai_artifact_path, "era5_2008_1.0x1.0_lai.nc")
     LAIfunction = ClimaLand.prescribed_lai_era5(
-        era5_ncdata_path,
+        era5_lai_ncdata_path,
         surface_space,
         start_date;
         time_interpolation_method = time_interpolation_method,

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -70,11 +70,11 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface
 
-    start_date = DateTime(2021)
+    start_date = DateTime(2008)
     # Forcing data
     era5_artifact_path =
-        ClimaLand.Artifacts.era5_land_forcing_data2021_folder_path(; context)
-    era5_ncdata_path = joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc")
+        ClimaLand.Artifacts.era5_land_forcing_data2008_folder_path(; context)
+    era5_ncdata_path = joinpath(era5_artifact_path, "era5_2008_1.0x1.0.nc")
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
         era5_ncdata_path,
         surface_space,
@@ -232,9 +232,12 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     photosynthesis_args =
         (; parameters = Canopy.FarquharParameters(FT, is_c3; Vcmax25 = Vcmax25))
     # Set up plant hydraulics
-
+    era5_lai_artifact_path =
+        ClimaLand.Artifacts.era5_lai_forcing_data2008_folder_path(; context)
+    era5_lai_ncdata_path =
+        joinpath(era5_lai_artifact_path, "era5_2008_1.0x1.0_lai.nc")
     LAIfunction = ClimaLand.prescribed_lai_era5(
-        era5_ncdata_path,
+        era5_lai_ncdata_path,
         surface_space,
         start_date;
         time_interpolation_method = time_interpolation_method,

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -67,12 +67,13 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface
 
-    start_date = DateTime(2021)
+    start_date = DateTime(2008)
     # Forcing data
     era5_artifact_path =
-        ClimaLand.Artifacts.era5_land_forcing_data2021_folder_path(; context)
+        ClimaLand.Artifacts.era5_land_forcing_data2008_folder_path(; context)
+    era5_ncdata_path = joinpath(era5_artifact_path, "era5_2008_1.0x1.0.nc")
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
-        joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc"),
+        era5_ncdata_path,
         surface_space,
         start_date,
         earth_param_set,

--- a/experiments/standalone/Bucket/bucket_era5.jl
+++ b/experiments/standalone/Bucket/bucket_era5.jl
@@ -110,7 +110,7 @@ else
         dz_tuple = FT.((1.0, 0.05)),
     )
 end
-start_date = DateTime(2021);
+start_date = DateTime(2008);
 
 # Set up parameters
 σS_c = FT(0.2);
@@ -134,8 +134,8 @@ bucket_parameters = BucketModelParameters(FT; albedo, z_0m, z_0b, τc);
 
 # Forcing data
 era5_artifact_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2021_folder_path(; context)
-era5_ncdata_path = joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc")
+    ClimaLand.Artifacts.era5_land_forcing_data2008_folder_path(; context)
+era5_ncdata_path = joinpath(era5_artifact_path, "era5_2008_1.0x1.0.nc")
 bucket_atmos, bucket_rad = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,

--- a/experiments/standalone/Soil/richards_runoff.jl
+++ b/experiments/standalone/Soil/richards_runoff.jl
@@ -71,7 +71,7 @@ era5_artifact_path =
 
 # Below, the preprocess_func argument is used to
 # 1. Convert precipitation to be negative (as it is downwards)
-# 2. Convert accumulations over an hour to a rate per second
+# 2. Convert mass flux to equivalent liquid water flux
 start_date = DateTime(2008);
 # Precipitation:
 precip = TimeVaryingInput(
@@ -80,7 +80,7 @@ precip = TimeVaryingInput(
     surface_space;
     start_date,
     regridder_type,
-    file_reader_kwargs = (; preprocess_func = (data) -> -data,),
+    file_reader_kwargs = (; preprocess_func = (data) -> -data / 1000,),
 )
 atmos = ClimaLand.PrescribedPrecipitation{FT, typeof(precip)}(precip)
 bottom_bc = ClimaLand.Soil.WaterFluxBC((p, t) -> 0.0)

--- a/experiments/standalone/Soil/richards_runoff.jl
+++ b/experiments/standalone/Soil/richards_runoff.jl
@@ -67,20 +67,20 @@ soil_params = ClimaLand.Soil.RichardsParameters(;
 )
 
 era5_artifact_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2021_folder_path(; context)
+    ClimaLand.Artifacts.era5_land_forcing_data2008_folder_path(; context)
 
 # Below, the preprocess_func argument is used to
 # 1. Convert precipitation to be negative (as it is downwards)
 # 2. Convert accumulations over an hour to a rate per second
-start_date = DateTime(2021);
+start_date = DateTime(2008);
 # Precipitation:
 precip = TimeVaryingInput(
-    joinpath(era5_artifact_path, "era5_2021_0.9x1.25.nc"),
-    "tp",
+    joinpath(era5_artifact_path, "era5_2008_1.0x1.0.nc"),
+    "mtpr",
     surface_space;
     start_date,
     regridder_type,
-    file_reader_kwargs = (; preprocess_func = (data) -> -data / 3600,),
+    file_reader_kwargs = (; preprocess_func = (data) -> -data,),
 )
 atmos = ClimaLand.PrescribedPrecipitation{FT, typeof(precip)}(precip)
 bottom_bc = ClimaLand.Soil.WaterFluxBC((p, t) -> 0.0)

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -6,12 +6,30 @@ import LazyArtifacts
 
 using ArtifactWrappers
 """
-    era5_land_forcing_data2021_path(; context)
+    era5_land_forcing_data2008_path(; context, lowres=false)
 
-Return the path to the folder that contains the ERA5 data.
+Return the path to the directory that contains the ERA5 forcing data for 2008.
+
+Optionally, you can pass the lowres=true keyword to download a lower spatial resolution version of the data.
 """
-function era5_land_forcing_data2021_folder_path(; context = nothing)
-    return @clima_artifact("era5_land_forcing_data2021", context)
+function era5_land_forcing_data2008_folder_path(;
+    context = nothing,
+    lowres = false,
+)
+    if lowres
+        return @clima_artifact("era5_land_forcing_data2008_lowres", context)
+    else
+        return @clima_artifact("era5_land_forcing_data2008", context)
+    end
+end
+
+"""
+    era5_lai_forcing_data2008_path(; context)
+
+Return the path to the directory that contains the ERA5 LAI forcing data for 2008.
+"""
+function era5_lai_forcing_data2008_folder_path(; context = nothing)
+    return @clima_artifact("era5_land_forcing_data2008_lai", context)
 end
 
 """

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -1031,28 +1031,28 @@ function prescribed_forcing_era5(
 
     precip = TimeVaryingInput(
         era5_ncdata_path,
-        ["tp", "sf"],
+        ["mtpr", "msr"],
         surface_space;
         start_date,
         regridder_type,
-        file_reader_kwargs = (; preprocess_func = (data) -> -data / 3600,),
+        file_reader_kwargs = (; preprocess_func = (data) -> -data,),
         method = time_interpolation_method,
-        compose_function = (tp, sf) -> tp - sf,
+        compose_function = (mtpr, msr) -> mtpr - msr,
     )
 
     snow_precip = TimeVaryingInput(
         era5_ncdata_path,
-        "sf",
+        "msr",
         surface_space;
         start_date,
         regridder_type,
-        file_reader_kwargs = (; preprocess_func = (data) -> -data / 3600,),
+        file_reader_kwargs = (; preprocess_func = (data) -> -data,),
         method = time_interpolation_method,
     )
 
     u_atmos = TimeVaryingInput(
         era5_ncdata_path,
-        ["u10n", "v10n"],
+        ["u10", "v10"],
         surface_space;
         start_date,
         regridder_type,
@@ -1105,20 +1105,18 @@ function prescribed_forcing_era5(
 
     SW_d = TimeVaryingInput(
         era5_ncdata_path,
-        "ssrd",
+        "msdwswrf",
         surface_space;
         start_date,
         regridder_type,
-        file_reader_kwargs = (; preprocess_func = (data) -> data / 3600,),
         method = time_interpolation_method,
     )
     LW_d = TimeVaryingInput(
         era5_ncdata_path,
-        "strd",
+        "msdwlwrf",
         surface_space;
         start_date,
         regridder_type,
-        file_reader_kwargs = (; preprocess_func = (data) -> data / 3600,),
         method = time_interpolation_method,
     )
 

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -1029,24 +1029,25 @@ function prescribed_forcing_era5(
     regridder_type = :InterpolationsRegridder,
 )
 
+    # Precip is provide as a mass flux; convert to volume flux of liquid water with ρ =1000 kg/m^3
     precip = TimeVaryingInput(
         era5_ncdata_path,
         ["mtpr", "msr"],
         surface_space;
         start_date,
         regridder_type,
-        file_reader_kwargs = (; preprocess_func = (data) -> -data,),
+        file_reader_kwargs = (; preprocess_func = (data) -> -data / 1000,),
         method = time_interpolation_method,
         compose_function = (mtpr, msr) -> mtpr - msr,
     )
-
+    # Precip is provide as a mass flux; convert to volume flux of liquid water with ρ =1000 kg/m^3
     snow_precip = TimeVaryingInput(
         era5_ncdata_path,
         "msr",
         surface_space;
         start_date,
         regridder_type,
-        file_reader_kwargs = (; preprocess_func = (data) -> -data,),
+        file_reader_kwargs = (; preprocess_func = (data) -> -data / 1000,),
         method = time_interpolation_method,
     )
 


### PR DESCRIPTION
## Purpose 
Kevin recently added the 2008 year of ERA5 forcing to ClimaArtifacts. This updates our runs to use that instead of 2021

## To-do

## Content
Change artifacts toml and .jl file
Change scripts

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
