### PR TITLE
Update soil water bc and snow conductivity to match paper

### DIFF
--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -481,19 +481,22 @@ function soil_boundary_fluxes!(
 ) where {FT}
     bc = soil.boundary_conditions.top
     p.soil.turbulent_fluxes .= turbulent_fluxes(bc.atmos, soil, Y, p, t)
-    Soil.Runoff.update_runoff!(
-        p,
-        bc.runoff,
-        p.drivers.P_liq .+ p.snow.water_runoff .* p.snow.snow_cover_fraction .+
-        p.excess_water_flux,
-        Y,
-        t,
-        soil,
-    )
-    @. p.soil.top_bc.water =
-        p.soil.infiltration +
+    # influx = maximum possible rate of infiltration given precip, snowmelt, evaporation/condensation
+    # but if this exceeds infiltration capacity of the soil, runoff will
+    # be generated.
+    # Use top_bc.water as temporary storage to avoid allocation
+    influx = p.soil.top_bc.water
+    @. influx =
+        p.drivers.P_liq +
+        p.snow.water_runoff * p.snow.snow_cover_fraction +
+        p.excess_water_flux +
         (1 - p.snow.snow_cover_fraction) *
         p.soil.turbulent_fluxes.vapor_flux_liq
+    # The update_runoff! function computes how much actually infiltrates
+    # given influx and our runoff model bc.runoff, and updates
+    # p.soil.infiltration in place
+    Soil.Runoff.update_runoff!(p, bc.runoff, influx, Y, t, soil)
+    @. p.soil.top_bc.water = p.soil.infiltration
     @. p.soil.top_bc.heat =
         (1 - p.snow.snow_cover_fraction) * (
             p.soil.R_n +

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -370,9 +370,17 @@ function soil_boundary_fluxes!(
 ) where {FT}
     bc = soil.boundary_conditions.top
     p.soil.turbulent_fluxes .= turbulent_fluxes(bc.atmos, soil, Y, p, t)
-    Soil.Runoff.update_runoff!(p, bc.runoff, p.drivers.P_liq, Y, t, soil)
-    @. p.soil.top_bc.water =
-        p.soil.infiltration + p.soil.turbulent_fluxes.vapor_flux_liq
+    # influx = maximum possible rate of infiltration given precip, snowmelt, evaporation/condensation
+    # but if this exceeds infiltration capacity of the soil, runoff will
+    # be generated.
+    # Use top_bc.water as temporary storage to avoid allocation
+    influx = p.soil.top_bc.water
+    @. influx = p.drivers.P_liq + p.soil.turbulent_fluxes.vapor_flux_liq
+    # The update_runoff! function computes how much actually infiltrates
+    # given influx and our runoff model bc.runoff, and updates
+    # p.soil.infiltration in place
+    Soil.Runoff.update_runoff!(p, bc.runoff, influx, Y, t, soil)
+    @. p.soil.top_bc.water = p.soil.infiltration
     @. p.soil.top_bc.heat =
         -p.soil.R_n + p.soil.turbulent_fluxes.lhf + p.soil.turbulent_fluxes.shf
 end

--- a/src/integrated/soil_snow_model.jl
+++ b/src/integrated/soil_snow_model.jl
@@ -387,19 +387,22 @@ function soil_boundary_fluxes!(
     bc = soil.boundary_conditions.top
     p.soil.turbulent_fluxes .= turbulent_fluxes(bc.atmos, soil, Y, p, t)
     p.soil.R_n .= net_radiation(bc.radiation, soil, Y, p, t)
-    Soil.Runoff.update_runoff!(
-        p,
-        bc.runoff,
-        p.drivers.P_liq .+ p.snow.water_runoff .* p.snow.snow_cover_fraction .+
-        p.excess_water_flux,
-        Y,
-        t,
-        soil,
-    )
-    @. p.soil.top_bc.water =
-        p.soil.infiltration +
+    # influx = maximum possible rate of infiltration given precip, snowmelt, evaporation/condensation
+    # but if this exceeds infiltration capacity of the soil, runoff will
+    # be generated.
+    # Use top_bc.water as temporary storage to avoid allocation
+    influx = p.soil.top_bc.water
+    @. influx =
+        p.drivers.P_liq +
+        p.snow.water_runoff * p.snow.snow_cover_fraction +
+        p.excess_water_flux +
         (1 - p.snow.snow_cover_fraction) *
         p.soil.turbulent_fluxes.vapor_flux_liq
+    # The update_runoff! function computes how much actually infiltrates
+    # given influx and our runoff model bc.runoff, and updates
+    # p.soil.infiltration in place
+    Soil.Runoff.update_runoff!(p, bc.runoff, influx, Y, t, soil)
+    @. p.soil.top_bc.water = p.soil.infiltration
 
     @. p.soil.top_bc.heat =
         (1 - p.snow.snow_cover_fraction) * (

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -165,15 +165,23 @@ Computes the thermal conductivity, given the density
 of the snow, according to Equation
 5.33 from Bonan's textbook, which in turn is taken from
 Jordan (1991).
+
+We have adjusted the original equation to make the coefficients
+non-dimensional by multiplying by the first by x = ρ_ice/ρ_ice
+and the second by x², with ρ_ice in kg/m³.
+
+When ρ_snow = ρ_ice, we recover κ_snow = κ_ice.
 """
 function snow_thermal_conductivity(
     ρ_snow::FT,
     parameters::SnowParameters{FT},
 ) where {FT}
     _κ_air = FT(LP.K_therm(parameters.earth_param_set))
+    _ρ_ice = FT(LP.ρ_cloud_ice(parameters.earth_param_set))
     κ_ice = parameters.κ_ice
     return _κ_air +
-           (FT(7.75e-5) * ρ_snow + FT(1.105e-6) * ρ_snow^2) * (κ_ice - _κ_air)
+           (FT(0.07) * (ρ_snow / _ρ_ice) + FT(0.93) * (ρ_snow / _ρ_ice)^2) *
+           (κ_ice - _κ_air)
 end
 
 """

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -825,10 +825,18 @@ function soil_boundary_fluxes!(
 )
     p.soil.turbulent_fluxes .= turbulent_fluxes(bc.atmos, model, Y, p, t)
     p.soil.R_n .= net_radiation(bc.radiation, model, Y, p, t)
-    update_runoff!(p, bc.runoff, p.drivers.P_liq, Y, t, model)
+    # influx = maximum possible rate of infiltration given precip, snowmelt, evaporation/condensation
+    # but if this exceeds infiltration capacity of the soil, runoff will
+    # be generated.
+    # Use top_bc.water as temporary storage to avoid allocation
+    influx = p.soil.top_bc.water
+    @. influx = p.drivers.P_liq + p.soil.turbulent_fluxes.vapor_flux_liq
+    # The update_runoff! function computes how much actually infiltrates
+    # given influx and our runoff model bc.runoff, and updates
+    # p.soil.infiltration in place
+    update_runoff!(p, bc.runoff, influx, Y, t, model)
     # We do not model the energy flux from infiltration.
-    @. p.soil.top_bc.water =
-        p.soil.infiltration + p.soil.turbulent_fluxes.vapor_flux_liq
+    @. p.soil.top_bc.water = p.soil.infiltration
     @. p.soil.top_bc.heat =
         p.soil.R_n + p.soil.turbulent_fluxes.lhf + p.soil.turbulent_fluxes.shf
 end

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -987,8 +987,6 @@ function soil_turbulent_fluxes_at_a_point(
         )
         x::FT = 4 * K_sfc * (1 + Ẽ0 / (4 * K_c))
         Ẽ *= x / (Ẽ0 + x)
-    else
-        Ẽ *= 0 # condensation, set to zero
     end
 
     # sensible heat flux
@@ -1011,8 +1009,6 @@ function soil_turbulent_fluxes_at_a_point(
     β_i::FT = FT(1)
     if q_air < q_sat_ice # sublimation, adjust β
         β_i *= (θ_i_sfc / ν_sfc)^4
-    else
-        β_i *= 0 # frost, set to zero
     end
 
     state_sfc = SurfaceFluxes.StateValues(

--- a/test/standalone/Snow/parameterizations.jl
+++ b/test/standalone/Snow/parameterizations.jl
@@ -73,7 +73,8 @@ for FT in (Float32, Float64)
         @test specific_heat_capacity(FT(0.0), parameters) == _cp_i
         @test snow_thermal_conductivity(ρ_snow, parameters) ==
               κ_air +
-              (FT(7.75e-5) * ρ_snow + FT(1.105e-6) * ρ_snow^2) * (κ_ice - κ_air)
+              (FT(0.07) * (ρ_snow / _ρ_i) + FT(0.93) * (ρ_snow / _ρ_i)^2) *
+              (κ_ice - κ_air)
         @test runoff_timescale.(z, Ksat, FT(Δt)) ≈ max.(Δt, z ./ Ksat)
 
 


### PR DESCRIPTION
## Purpose 
This PR makes two changes which bring the soil and snow model in line with the equations we have in the paper.
1. Evaporation/condensation is include in the "influx" term from which we then compute runoff and infiltration. Previously, we computed infiltration/runoff from Precip+snowmelt (if applicable), and then set the BC as infiltration+evap. Now we compute infiltration/runoff from Precip+snowmelt+evap, and set the BC = infiltration. This allows us to handle heavy condensation events also, which I think caused NaN before, and so I also stopped setting Evap and subl to 0 if condensation was occuring.
2. Non-dimensionalize the coefficients for thermal conductivity in snow. If the snow density = ice density, we get kappa_snow = kappa_ice exactly
