### PR TITLE
use ARS222; run longruns for 4 years

### DIFF
--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -37,7 +37,7 @@ steps:
           - "snowy_land_longrun_gpu/*pdf"
         agents:
           slurm_gpus: 1
-          slurm_time: 15:00:00
+          slurm_time: 20:00:00
         env:
           CLIMACOMMS_DEVICE: "CUDA"
 
@@ -47,7 +47,7 @@ steps:
         artifact_paths: "land_longrun_gpu/*pdf"
         agents:
           slurm_gpus: 1
-          slurm_time: 15:00:00
+          slurm_time: 18:00:00
         env:
           CLIMACOMMS_DEVICE: "CUDA"
 
@@ -57,7 +57,7 @@ steps:
         artifact_paths: "california_longrun_gpu/*pdf"
         agents:
           slurm_gpus: 1
-          slurm_time: 00:30:00
+          slurm_time: 01:00:00
         env:
           CLIMACOMMS_DEVICE: "CUDA"
 
@@ -77,6 +77,6 @@ steps:
         artifact_paths: "bucket_longrun_gpu/*pdf"
         agents:
           slurm_gpus: 1
-          slurm_time: 00:30:00
+          slurm_time: 01:00:00
         env:
           CLIMACOMMS_DEVICE: "CUDA"

--- a/docs/tutorials/integrated/soil_canopy_tutorial.jl
+++ b/docs/tutorials/integrated/soil_canopy_tutorial.jl
@@ -365,7 +365,7 @@ dt = Float64(30)
 n = 120
 saveat = Array(t0:(n * dt):tf)
 
-timestepper = CTS.ARS343()
+timestepper = CTS.ARS222()
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
     CTS.NewtonsMethod(

--- a/docs/tutorials/standalone/Soil/evaporation.jl
+++ b/docs/tutorials/standalone/Soil/evaporation.jl
@@ -184,7 +184,7 @@ imp_tendency! = make_imp_tendency(soil);
 jacobian! = ClimaLand.make_jacobian(soil);
 jac_kwargs = (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!);
 
-timestepper = CTS.ARS111();
+timestepper = CTS.ARS222();
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
     CTS.NewtonsMethod(

--- a/docs/tutorials/standalone/Soil/evaporation_gilat_loess.jl
+++ b/docs/tutorials/standalone/Soil/evaporation_gilat_loess.jl
@@ -171,7 +171,7 @@ imp_tendency! = make_imp_tendency(soil);
 jacobian! = ClimaLand.make_jacobian(soil);
 jac_kwargs = (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!);
 
-timestepper = CTS.ARS111();
+timestepper = CTS.ARS222();
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
     CTS.NewtonsMethod(
@@ -224,7 +224,7 @@ soil_exp_tendency! = make_exp_tendency(soil)
 exp_tendency! = make_exp_tendency(soil)
 imp_tendency! = make_imp_tendency(soil);
 jacobian! = ClimaLand.make_jacobian(soil);
-timestepper = CTS.ARS111();
+timestepper = CTS.ARS222();
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
     CTS.NewtonsMethod(
@@ -288,7 +288,7 @@ set_initial_cache!(p, Y, t0)
 exp_tendency! = make_exp_tendency(soil)
 imp_tendency! = make_imp_tendency(soil);
 jacobian! = ClimaLand.make_jacobian(soil);
-timestepper = CTS.ARS111();
+timestepper = CTS.ARS222();
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
     CTS.NewtonsMethod(

--- a/docs/tutorials/standalone/Soil/freezing_front.jl
+++ b/docs/tutorials/standalone/Soil/freezing_front.jl
@@ -216,7 +216,7 @@ jac_kwargs = (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!);
 
 dt = Float64(100)
 
-timestepper = CTS.ARS111();
+timestepper = CTS.ARS222();
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
     CTS.NewtonsMethod(

--- a/docs/tutorials/standalone/Soil/layered_soil.jl
+++ b/docs/tutorials/standalone/Soil/layered_soil.jl
@@ -108,7 +108,7 @@ set_initial_cache! = make_set_initial_cache(soil)
 set_initial_cache!(p, Y, t0);
 
 # Timestepping:
-stepper = CTS.ARS111()
+stepper = CTS.ARS222()
 @assert FT in (Float32, Float64)
 err = (FT == Float64) ? 1e-8 : 1e-4
 convergence_cond = CTS.MaximumError(err)

--- a/docs/tutorials/standalone/Soil/richards_equation.jl
+++ b/docs/tutorials/standalone/Soil/richards_equation.jl
@@ -172,10 +172,10 @@ set_initial_cache!(p, Y, t0);
 dt = Float64(1e3);
 
 # Now, we choose the timestepping algorithm we want to use.
-# We'll use the ARS111 algorithm with 1 Newton iteration per timestep;
+# We'll use the ARS222 algorithm with 1 Newton iteration per timestep;
 # you can also specify a convergence criterion and a maximum number
 # of Newton iterations.
-stepper = CTS.ARS111();
+stepper = CTS.ARS222();
 ode_algo = CTS.IMEXAlgorithm(
     stepper,
     CTS.NewtonsMethod(

--- a/docs/tutorials/standalone/Soil/soil_energy_hydrology.jl
+++ b/docs/tutorials/standalone/Soil/soil_energy_hydrology.jl
@@ -252,7 +252,7 @@ set_initial_cache!(p, Y, t0);
 
 # Choose a timestepper and set up the ODE problem:
 dt = Float64(1000.0);
-timestepper = CTS.ARS111();
+timestepper = CTS.ARS222();
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
     CTS.NewtonsMethod(

--- a/docs/tutorials/standalone/Soil/sublimation.jl
+++ b/docs/tutorials/standalone/Soil/sublimation.jl
@@ -170,7 +170,7 @@ imp_tendency! = make_imp_tendency(soil)
 jacobian! = ClimaLand.make_jacobian(soil)
 jac_kwargs = (; jac_prototype = ImplicitEquationJacobian(Y), Wfact = jacobian!)
 
-timestepper = CTS.ARS111()
+timestepper = CTS.ARS222()
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
     CTS.NewtonsMethod(

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -16,7 +16,7 @@
 # Soil depth: 50 m
 # Simulation duration: 6 hours
 # Timestep: 450 s
-# Timestepper: ARS111
+# Timestepper: ARS222
 # Fixed number of iterations: 3
 # Jacobian update: Every Newton iteration
 # Atmos forcing update: every 3 hours
@@ -368,7 +368,7 @@ function setup_simulation(; greet = false)
     prob, cb = setup_prob(t0, tf, Δt; nelements)
 
     # Define timestepper and ODE algorithm
-    stepper = CTS.ARS111()
+    stepper = CTS.ARS222()
     ode_algo = CTS.IMEXAlgorithm(
         stepper,
         CTS.NewtonsMethod(

--- a/experiments/benchmarks/richards.jl
+++ b/experiments/benchmarks/richards.jl
@@ -17,7 +17,7 @@
 # Soil depth: 50 m
 # Simulation duration: 7 days
 # Timestep: 1800 s (30 min)
-# Timestepper: ARS111
+# Timestepper: ARS222
 # Fixed number of iterations: 2
 # Jacobian update: Every Newton iteration
 # Precipitation data update: every timestep
@@ -199,7 +199,7 @@ function setup_simulation(; greet = false)
     prob, cb = setup_prob(t0, tf, Δt; nelements)
 
     # Define timestepper and ODE algorithm
-    stepper = CTS.ARS111()
+    stepper = CTS.ARS222()
     ode_algo = CTS.IMEXAlgorithm(
         stepper,
         CTS.NewtonsMethod(

--- a/experiments/benchmarks/snowy_land.jl
+++ b/experiments/benchmarks/snowy_land.jl
@@ -11,7 +11,7 @@
 # Soil depth: 50 m
 # Simulation duration: 6 hours
 # Timestep: 450 s
-# Timestepper: ARS111
+# Timestepper: ARS222
 # Fixed number of iterations: 3
 # Jacobian update: every Newton iteration
 # Atmos forcing update: every 3 hours
@@ -374,7 +374,7 @@ function setup_simulation(; greet = false)
     prob, cb = setup_prob(t0, tf, Δt; nelements)
 
     # Define timestepper and ODE algorithm
-    stepper = CTS.ARS111()
+    stepper = CTS.ARS222()
     ode_algo = CTS.IMEXAlgorithm(
         stepper,
         CTS.NewtonsMethod(

--- a/experiments/integrated/fluxnet/fluxnet_simulation.jl
+++ b/experiments/integrated/fluxnet/fluxnet_simulation.jl
@@ -9,7 +9,7 @@ tf = Float64(t0 + 3600 * 24 * N_days)
 t_spinup = Float64(t0 + N_spinup_days * 3600 * 24)
 
 # Set up timestepper
-timestepper = CTS.ARS111();
+timestepper = CTS.ARS222();
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
     CTS.NewtonsMethod(

--- a/experiments/integrated/fluxnet/snow_soil/simulation.jl
+++ b/experiments/integrated/fluxnet/snow_soil/simulation.jl
@@ -150,7 +150,7 @@ updatefunc = ClimaLand.make_update_drivers(model_drivers)
 driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
 cb = SciMLBase.CallbackSet(driver_cb, saving_cb)
 # TIME STEPPING
-timestepper = CTS.ARS111();
+timestepper = CTS.ARS222();
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
     CTS.NewtonsMethod(

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -227,7 +227,7 @@ exp_tendency! = make_exp_tendency(land);
 imp_tendency! = ClimaLand.make_imp_tendency(land);
 jacobian! = ClimaLand.make_jacobian(land);
 set_initial_cache!(p, Y, t0)
-stepper = CTS.ARS343()
+stepper = CTS.ARS222()
 ode_algo = CTS.IMEXAlgorithm(
     stepper,
     CTS.NewtonsMethod(

--- a/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
+++ b/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
@@ -15,7 +15,7 @@ h_leaf = FT(9.5) # m
 t0 = Float64(120 * 3600 * 24)# start mid year
 dt = Float64(150)
 
-timestepper = CTS.ARS111()
+timestepper = CTS.ARS222()
 # Select conv. condition based on float type due to different precision
 err = (FT == Float64) ? 1e-8 : 1e-4
 norm_condition = CTS.MaximumError(err)

--- a/experiments/integrated/performance/integrated_timestep_test.jl
+++ b/experiments/integrated/performance/integrated_timestep_test.jl
@@ -30,7 +30,7 @@
 # Soil depth: 5 m
 # Simulation duration: 12.5 hours
 # Timestep: variable, ranging from 0.6s to 3600s
-# Timestepper: ARS111
+# Timestepper: ARS222
 # Fixed number of iterations: 6
 # Jacobian update: Every Newton iteration
 # Atmospheric and radiation driver updates: Every 3 hours
@@ -372,7 +372,7 @@ N_hours = 8
 tf = Float64(t0 + N_hours * 3600.0)
 sim_time = round((tf - t0) / 3600, digits = 2) # simulation length in hours
 
-timestepper = CTS.ARS111()
+timestepper = CTS.ARS222()
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
     CTS.NewtonsMethod(

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -379,7 +379,7 @@ end
 function setup_and_solve_problem(; greet = false)
 
     t0 = 0.0
-    tf = 60 * 60.0 * 24 * 365
+    tf = 60 * 60.0 * 24 * 365 * 4
     Δt = 450.0
     nelements = (101, 15)
     if greet

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -10,7 +10,7 @@
 # Soil depth: 50 m
 # Simulation duration: 365 d
 # Timestep: 450 s
-# Timestepper: ARS111
+# Timestepper: ARS222
 # Fixed number of iterations: 3
 # Jacobian update: every new Newton iteration
 # Atmos forcing update: every 3 hours
@@ -392,7 +392,7 @@ function setup_and_solve_problem(; greet = false)
     prob, cb = setup_prob(t0, tf, Δt; nelements)
 
     # Define timestepper and ODE algorithm
-    stepper = CTS.ARS111()
+    stepper = CTS.ARS222()
     ode_algo = CTS.IMEXAlgorithm(
         stepper,
         CTS.NewtonsMethod(

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -11,7 +11,7 @@
 # Soil depth: 50 m
 # Simulation duration: 4 years
 # Timestep: 450 s
-# Timestepper: ARS111
+# Timestepper: ARS222
 # Fixed number of iterations: 3
 # Jacobian update: every new timestep
 # Atmos forcing update: every 3 hours
@@ -407,7 +407,7 @@ function setup_and_solve_problem(; greet = false)
     prob, cb = setup_prob(t0, tf, Δt; nelements)
 
     # Define timestepper and ODE algorithm
-    stepper = CTS.ARS111()
+    stepper = CTS.ARS222()
     ode_algo = CTS.IMEXAlgorithm(
         stepper,
         CTS.NewtonsMethod(

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -389,7 +389,7 @@ end
 function setup_and_solve_problem(; greet = false)
 
     t0 = 0.0
-    tf = 60 * 60.0 * 24 * 365 * 1
+    tf = 60 * 60.0 * 24 * 365 * 4
     Δt = 450.0
     nelements = (101, 15)
     if greet

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -11,7 +11,7 @@
 # Soil depth: 50 m
 # Simulation duration: 365 d
 # Timestep: 450 s
-# Timestepper: ARS111
+# Timestepper: ARS222
 # Fixed number of iterations: 3
 # Jacobian update: every new Newton iteration
 # Atmos forcing update: every 3 hours
@@ -402,7 +402,7 @@ function setup_and_solve_problem(; greet = false)
     prob, cb = setup_prob(t0, tf, Δt; nelements)
 
     # Define timestepper and ODE algorithm
-    stepper = CTS.ARS111()
+    stepper = CTS.ARS222()
     ode_algo = CTS.IMEXAlgorithm(
         stepper,
         CTS.NewtonsMethod(

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -220,7 +220,7 @@ end
 function setup_and_solve_problem(; greet = false)
 
     t0 = 0.0
-    tf = 60 * 60.0 * 24 * 365
+    tf = 60 * 60.0 * 24 * 365 * 4
     Δt = 450.0
     nelements = (101, 15)
     if greet

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -10,7 +10,7 @@
 # Soil depth: 50 m
 # Simulation duration: 365 d
 # Timestep: 450 s
-# Timestepper: ARS111
+# Timestepper: ARS222
 # Fixed number of iterations: 1
 # Jacobian update: every new timestep
 # Atmos forcing update: every 3 hours
@@ -233,7 +233,7 @@ function setup_and_solve_problem(; greet = false)
     prob, cb = setup_prob(t0, tf, Δt; nelements)
 
     # Define timestepper and ODE algorithm
-    stepper = CTS.ARS111()
+    stepper = CTS.ARS222()
     ode_algo = CTS.IMEXAlgorithm(
         stepper,
         CTS.NewtonsMethod(

--- a/experiments/standalone/Snow/snowmip_simulation.jl
+++ b/experiments/standalone/Snow/snowmip_simulation.jl
@@ -63,8 +63,8 @@ Y.snow.U .=
 set_initial_cache! = ClimaLand.make_set_initial_cache(model)
 set_initial_cache!(p, Y, t0)
 exp_tendency! = ClimaLand.make_exp_tendency(model)
-# We use ARS111 (equivalent to explicit Euler) here for ease of assessing conservation
-timestepper = CTS.ARS111()
+# We use ARS222 (equivalent to explicit Euler) here for ease of assessing conservation
+timestepper = CTS.ARS222()
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
     CTS.NewtonsMethod(

--- a/experiments/standalone/Soil/richards_comparison.jl
+++ b/experiments/standalone/Soil/richards_comparison.jl
@@ -78,7 +78,7 @@ outdir = generate_output_path(
         jacobian! = ClimaLand.make_jacobian(soil)
         set_initial_cache!(p, Y, t0)
 
-        stepper = CTS.ARS111()
+        stepper = CTS.ARS222()
         norm_condition = CTS.MaximumError(FT(1e-8))
         conv_checker = CTS.ConvergenceChecker(; norm_condition = norm_condition)
         ode_algo = CTS.IMEXAlgorithm(
@@ -174,7 +174,7 @@ end
         jacobian! = ClimaLand.make_jacobian(soil)
         set_initial_cache!(p, Y, t0)
 
-        stepper = CTS.ARS111()
+        stepper = CTS.ARS222()
         norm_condition = CTS.MaximumError(FT(1e-8))
         conv_checker = CTS.ConvergenceChecker(; norm_condition = norm_condition)
         ode_algo = CTS.IMEXAlgorithm(

--- a/experiments/standalone/Soil/richards_runoff.jl
+++ b/experiments/standalone/Soil/richards_runoff.jl
@@ -133,7 +133,7 @@ imp_tendency! = ClimaLand.make_imp_tendency(model);
 jacobian! = ClimaLand.make_jacobian(model);
 
 set_initial_cache!(p, Y, t0)
-stepper = CTS.ARS111()
+stepper = CTS.ARS222()
 ode_algo = CTS.IMEXAlgorithm(
     stepper,
     CTS.NewtonsMethod(

--- a/experiments/standalone/Soil/water_conservation.jl
+++ b/experiments/standalone/Soil/water_conservation.jl
@@ -27,7 +27,7 @@ dt_min = Float64(10)
 t_end = Float64(1e6)
 
 for FT in (Float32, Float64)
-    stepper = CTS.ARS111()
+    stepper = CTS.ARS222()
     # Select conv. condition based on float type due to different precision
     err = (FT == Float64) ? 1e-8 : 1e-4
     convergence_cond = CTS.MaximumError(err)

--- a/experiments/standalone/Soil/water_energy_conservation.jl
+++ b/experiments/standalone/Soil/water_energy_conservation.jl
@@ -103,7 +103,7 @@ function init_soil!(Y, z, Trange, params)
 end
 set_initial_cache! = make_set_initial_cache(soil);
 
-stepper = CTS.ARS111()
+stepper = CTS.ARS222()
 err = (FT == Float64) ? 1e-8 : 1e-4
 convergence_cond = CTS.MaximumError(err)
 conv_checker = CTS.ConvergenceChecker(norm_condition = convergence_cond)

--- a/experiments/standalone/Vegetation/timestep_test.jl
+++ b/experiments/standalone/Vegetation/timestep_test.jl
@@ -29,7 +29,7 @@
 # Space: single point
 # Simulation duration: 20 days + 80 seconds (= 480.02 hours)
 # Timestep: variable, ranging from 0.6s to 3600s
-# Timestepper: ARS111
+# Timestepper: ARS222
 # Fixed number of iterations: 6
 # Jacobian update: Every Newton iteration
 # Atmospheric and radiation driver updates: Every 3 hours
@@ -205,7 +205,7 @@ tf = t0 + N_days * seconds_per_day + 80
 sim_time = round((tf - t0) / 3600, digits = 2) # simulation length in hours
 set_initial_cache! = make_set_initial_cache(canopy)
 
-timestepper = CTS.ARS111();
+timestepper = CTS.ARS222();
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
     CTS.NewtonsMethod(

--- a/lib/ClimaLandSimulations/src/utilities/make_timestepper.jl
+++ b/lib/ClimaLandSimulations/src/utilities/make_timestepper.jl
@@ -4,7 +4,7 @@ export make_timestepper
     make_timestepper(site_setup_out;
         N_spinup_days = 30,
         N_days_sim = 30,
-        timestepper = CTS.ARS111(),
+        timestepper = CTS.ARS222(),
         ode_algo = CTS.IMEXAlgorithm(
             timestepper,
             CTS.NewtonsMethod(
@@ -15,15 +15,15 @@ export make_timestepper
     )
 
 Define the setup for the simulation timestepper.
-The default timestepper (ARS111) is an IMEX ARK algorithm with
-1 implicit stage, 1 explicit stages, and 1st order accuracy.
+The default timestepper (ARS222) is an IMEX ARK algorithm with
+2 implicit stages, 2 explicit stages, and 2nd order accuracy.
 Other IMEX timesteppers from ClimaTimeSteppers.jl can be used.
 """
 function make_timestepper(
     site_setup_out;
     N_spinup_days = 30,
     N_days_sim = 30,
-    timestepper = CTS.ARS111(),
+    timestepper = CTS.ARS222(),
     ode_algo = CTS.IMEXAlgorithm(
         timestepper,
         CTS.NewtonsMethod(


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR switches all of our experiments and tutorials to use ARS222. They were previously using ARS111, but this fails to converge in some cases, which we first discovered in multi-year global runs. For example, see the following plot where the solver fails to converge and instead oscillates unphysically before breaking.

Note that two runs (soil_canopy_tutorial.jl and global_soil_canopy.jl) were previously using ARS343 and are unified here with the other runs to use ARS222.

This PR also extends the longruns to run for 4 years, so we can see the behavior in the time range where we've been seeing NaNs.