### PR TITLE
Misc fixes to canopy model, diagnostics, and simulations

### DIFF
--- a/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -262,6 +262,10 @@ canopy = ClimaLand.Canopy.CanopyModel{FT}(;
 
 Y, p, coords = ClimaLand.initialize(canopy)
 exp_tendency! = make_exp_tendency(canopy);
+imp_tendency! = make_imp_tendency(canopy)
+jacobian! = make_jacobian(canopy);
+jac_kwargs =
+    (; jac_prototype = ClimaLand.ImplicitEquationJacobian(Y), Wfact = jacobian!);
 
 # Provide initial conditions for the canopy hydraulics model
 
@@ -317,12 +321,21 @@ cb = SciMLBase.CallbackSet(driver_cb, saving_cb);
 
 
 # Select a timestepping algorithm and setup the ODE problem.
-
-timestepper = CTS.RK4();
-ode_algo = CTS.ExplicitAlgorithm(timestepper)
+timestepper = CTS.ARS111();
+ode_algo = CTS.IMEXAlgorithm(
+    timestepper,
+    CTS.NewtonsMethod(
+        max_iters = 6,
+        update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
+    ),
+);
 
 prob = SciMLBase.ODEProblem(
-    CTS.ClimaODEFunction(T_exp! = exp_tendency!, dss! = ClimaLand.dss!),
+    CTS.ClimaODEFunction(
+        T_exp! = exp_tendency!,
+        T_imp! = SciMLBase.ODEFunction(imp_tendency!; jac_kwargs...),
+        dss! = ClimaLand.dss!,
+    ),
     Y,
     (t0, tf),
     p,

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -30,11 +30,11 @@ include(joinpath(climaland_dir, "experiments/integrated/fluxnet/data_tools.jl"))
 include(joinpath(climaland_dir, "experiments/integrated/fluxnet/plot_utils.jl"))
 
 # Read in the site to be run from the command line
-if length(ARGS) < 1
-    error("Must provide site ID on command line")
-end
+#if length(ARGS) < 1
+#    error("Must provide site ID on command line")
+#end
 
-site_ID = ARGS[1]
+site_ID = "US-MOz"#ARGS[1]
 
 # Read all site-specific domain parameters from the simulation file for the site
 include(

--- a/experiments/standalone/Vegetation/no_vegetation.jl
+++ b/experiments/standalone/Vegetation/no_vegetation.jl
@@ -162,7 +162,10 @@ canopy = ClimaLand.Canopy.CanopyModel{FT}(;
 
 Y, p, coords = ClimaLand.initialize(canopy)
 exp_tendency! = make_exp_tendency(canopy);
-
+imp_tendency! = make_imp_tendency(canopy)
+jacobian! = make_jacobian(canopy);
+jac_kwargs =
+    (; jac_prototype = ClimaLand.ImplicitEquationJacobian(Y), Wfact = jacobian!);
 
 ψ_leaf_0 = FT(-2e5 / 9800)
 
@@ -195,11 +198,22 @@ updatefunc = ClimaLand.make_update_drivers(drivers)
 driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
 cb = SciMLBase.CallbackSet(driver_cb, saving_cb);
 
-timestepper = CTS.RK4();
-ode_algo = CTS.ExplicitAlgorithm(timestepper)
+# Set up timestepper
+timestepper = CTS.ARS111();
+ode_algo = CTS.IMEXAlgorithm(
+    timestepper,
+    CTS.NewtonsMethod(
+        max_iters = 6,
+        update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
+    ),
+);
 
 prob = SciMLBase.ODEProblem(
-    CTS.ClimaODEFunction(T_exp! = exp_tendency!, dss! = ClimaLand.dss!),
+    CTS.ClimaODEFunction(
+        T_exp! = exp_tendency!,
+        T_imp! = SciMLBase.ODEFunction(imp_tendency!; jac_kwargs...),
+        dss! = ClimaLand.dss!,
+    ),
     Y,
     (t0, tf),
     p,

--- a/experiments/standalone/Vegetation/varying_lai.jl
+++ b/experiments/standalone/Vegetation/varying_lai.jl
@@ -162,6 +162,10 @@ canopy = ClimaLand.Canopy.CanopyModel{FT}(;
 
 Y, p, coords = ClimaLand.initialize(canopy)
 exp_tendency! = make_exp_tendency(canopy);
+imp_tendency! = make_imp_tendency(canopy)
+jacobian! = make_jacobian(canopy);
+jac_kwargs =
+    (; jac_prototype = ClimaLand.ImplicitEquationJacobian(Y), Wfact = jacobian!);
 
 
 ψ_leaf_0 = FT(-2e5 / 9800)
@@ -195,11 +199,22 @@ updatefunc = ClimaLand.make_update_drivers(drivers)
 driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
 cb = SciMLBase.CallbackSet(driver_cb, saving_cb);
 
-timestepper = CTS.RK4();
-ode_algo = CTS.ExplicitAlgorithm(timestepper)
+# Set up timestepper
+timestepper = CTS.ARS111();
+ode_algo = CTS.IMEXAlgorithm(
+    timestepper,
+    CTS.NewtonsMethod(
+        max_iters = 6,
+        update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
+    ),
+);
 
 prob = SciMLBase.ODEProblem(
-    CTS.ClimaODEFunction(T_exp! = exp_tendency!, dss! = ClimaLand.dss!),
+    CTS.ClimaODEFunction(
+        T_exp! = exp_tendency!,
+        T_imp! = SciMLBase.ODEFunction(imp_tendency!; jac_kwargs...),
+        dss! = ClimaLand.dss!,
+    ),
     Y,
     (t0, tf),
     p,

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -117,7 +117,7 @@ function default_diagnostics(
             "trans",
             "clhf",
             "cshf",
-            # "lwp", # last(p.canopy.hydraulics.ψ) errors
+            "lwp",
             # "fa", # return a Tuple
             "far",
             "lai",
@@ -264,7 +264,7 @@ function default_diagnostics(
             "trans",
             "clhf",
             "cshf",
-            # "lwp", # last(p.canopy.hydraulics.ψ) errors
+            "lwp",
             # "fa", # return a Tuple
             "far",
             "lai",

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -224,7 +224,7 @@ function define_diagnostics!(land_model)
     ### Canopy - Hydraulics
     # Leaf water potential
 
-    #=
+
     add_diagnostic_variable!(
         short_name = "lwp",
         long_name = "Leaf Water Potential",
@@ -234,18 +234,18 @@ function define_diagnostics!(land_model)
         compute! = (out, Y, p, t) ->
             compute_leaf_water_potential!(out, Y, p, t, land_model),
     )
-
-    # Flux per ground area
-    add_diagnostic_variable!(
-        short_name = "fa",
-        long_name = "Flux Per Ground Area",
-        standard_name = "flux_per_ground_area",
-        units = "m s^-1",
-        comments = "Flux of water volume per m^2 of plant per second, multiplied by the area index (plant area/ground area).",
-        compute! = (out, Y, p, t) ->
-            compute_flux_per_ground_area!(out, Y, p, t, land_model),
-    )
-    =#
+    #=
+        # Flux per ground area
+        add_diagnostic_variable!(
+            short_name = "fa",
+            long_name = "Flux Per Ground Area",
+            standard_name = "flux_per_ground_area",
+            units = "m s^-1",
+            comments = "Flux of water volume per m^2 of plant per second, multiplied by the area index (plant area/ground area).",
+            compute! = (out, Y, p, t) ->
+                compute_flux_per_ground_area!(out, Y, p, t, land_model),
+        )
+        =#
 
     # Root flux per ground area
     add_diagnostic_variable!(

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -88,9 +88,24 @@ end
 } p.canopy.energy.turbulent_fluxes.shf
 
 # Canopy - Hydraulics
-#@diagnostic_compute "leaf_water_potential" Union{SoilCanopyModel, LandModel} last(
-#    p.canopy.hydraulics.ψ,
-#)
+function compute_leaf_water_potential!(
+    out,
+    Y,
+    p,
+    t,
+    land_model::Union{SoilCanopyModel, LandModel},
+)
+    hydraulics = land_model.canopy.hydraulics
+    n_stem = hydraulics.n_stem
+    n_leaf = hydraulics.n_leaf
+    n = n_stem + n_leaf
+    if isnothing(out)
+        return p.canopy.hydraulics.ψ.:($n)
+    else
+        out .= p.canopy.hydraulics.ψ.:($n)
+    end
+end
+
 # @diagnostic_compute "flux_per_ground_area" Union{SoilCanopyModel, LandModel} p.canopy.hydraulics.fa # return a Tuple
 @diagnostic_compute "root_flux_per_ground_area" Union{
     SoilCanopyModel,

--- a/src/integrated/soil_canopy_root_interactions.jl
+++ b/src/integrated/soil_canopy_root_interactions.jl
@@ -9,9 +9,15 @@ function update_root_extraction!(p, Y, t, land)
     z = land.soil.domain.fields.z
     (; conductivity_model) = land.canopy.hydraulics.parameters
     area_index = p.canopy.hydraulics.area_index
-
+    # allocates
     above_ground_area_index =
-        getproperty(area_index, land.canopy.hydraulics.compartment_labels[1])
+        PlantHydraulics.harmonic_mean.(
+            getproperty(
+                area_index,
+                land.canopy.hydraulics.compartment_labels[1],
+            ),
+            getproperty(area_index, :root),
+        )
     # Note that we model the flux between each soil layer and the canopy as:
     # Flux = -K_eff x [(ψ_canopy - ψ_soil)/(z_canopy - z_soil) + 1], where
     # K_eff = K_soil K_canopy /(K_canopy + K_soil)

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -539,7 +539,7 @@ function ClimaLand.make_update_aux(
                         conductivity_model,
                         ψ.:($$ip1),
                     ),
-                ) * areaip1
+                ) * PlantHydraulics.harmonic_mean(areaip1, areai)
         end
         # We update the fa[n_stem+n_leaf] element once we have computed transpiration, below
         # update photosynthesis and conductance terms


### PR DESCRIPTION
## Purpose 
Improve the canopy model, implement a diagnostic, and fix a bug in the timestepper of a few canopy alone simulations

## Content 
1. Change to canopy model: use the harmonic mean of K and areas at the interface/face between two centers (how we interpolate center to face). This ensures that if either layer has zero K or zero area, that the flux between them is zero. Previously, we were using the harmonic mean of K and the area of the top layer instead of a mean. Using the arithmetic mean does not give the correct behavior if K or area is zero. [this is in line with the paper, now]
2. Use the implicit tendency in canopy alone runs (that this was not happening is a bug)
3. Output the leaf water potential as a diagnostic.




<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
