### PR TITLE
use dt=600s, tf=4years in longruns

### DIFF
--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -380,8 +380,8 @@ end
 function setup_and_solve_problem(; greet = false)
 
     t0 = 0.0
-    tf = 60 * 60.0 * 24 * 365 * 2
-    Δt = 450.0
+    tf = 60 * 60.0 * 24 * 365 * 4
+    Δt = Float64(600)
     nelements = (101, 15)
     if greet
         @info "Run: Global Soil-Canopy Model"

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -396,7 +396,7 @@ function setup_and_solve_problem(; greet = false)
 
     t0 = 0.0
     tf = 60 * 60.0 * 24 * 365
-    Δt = 450.0
+    Δt = Float64(600)
     nelements = (10, 10, 15)
     if greet
         @info "Run: Regional Soil-Canopy-Snow Model"

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -402,8 +402,8 @@ end
 function setup_and_solve_problem(; greet = false)
 
     t0 = 0.0
-    tf = 60 * 60.0 * 24 * 365 * 2
-    Δt = 450.0
+    tf = 60 * 60.0 * 24 * 365 * 4
+    Δt = Float64(600)
     nelements = (101, 15)
     if greet
         @info "Run: Global Soil-Canopy-Snow Model"

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -221,8 +221,8 @@ end
 function setup_and_solve_problem(; greet = false)
 
     t0 = 0.0
-    tf = 60 * 60.0 * 24 * 365 * 2
-    Δt = 450.0
+    tf = 60 * 60.0 * 24 * 365 * 4
+    Δt = Float64(600)
     nelements = (101, 15)
     if greet
         @info "Run: Global Soil Model"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
After the most recent jacobian update, the longruns are stable after 4 years using dt=400s, but unstable using dt=900s. This PR tests out an intermediate dt value and also extends the length of longruns to use 4 years.
