### PR TITLE
Kd/rain on snow

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -53,7 +53,7 @@ steps:
 
       - label: "Snow Col de Porte"
         command: "julia --color=yes --project=.buildkite experiments/standalone/Snow/snowmip_simulation.jl cdp"
-        artifact_paths: "experiments/standalone/Snow/output_active/*png"
+        artifact_paths: "experiments/standalone/Snow/cdp/output_active/*png"
 
       - label: "Varying LAI, no stem compartment"
         command: "julia --color=yes --project=.buildkite experiments/standalone/Vegetation/varying_lai.jl"

--- a/docs/src/APIs/Snow.md
+++ b/docs/src/APIs/Snow.md
@@ -17,7 +17,6 @@ ClimaLand.Snow.snow_surface_temperature
 ClimaLand.Snow.snow_depth
 ClimaLand.Snow.snow_thermal_conductivity
 ClimaLand.Snow.snow_bulk_temperature
-ClimaLand.Snow.snow_liquid_mass_fraction
 ClimaLand.Snow.maximum_liquid_mass_fraction
 ClimaLand.Snow.runoff_timescale
 ClimaLand.Snow.compute_water_runoff	
@@ -30,5 +29,6 @@ ClimaLand.Snow.snow_cover_fraction
 
 ```@docs
 ClimaLand.Snow.snow_boundary_fluxes!
+ClimaLand.Snow.phase_change_flux
 ClimaLand.Snow.AtmosDrivenSnowBC
 ```

--- a/experiments/benchmarks/snowy_land.jl
+++ b/experiments/benchmarks/snowy_land.jl
@@ -335,6 +335,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     evaluate!(Y.canopy.energy.T, atmos.T, t0)
 
     Y.snow.S .= 0
+    Y.snow.S_l .= 0
     Y.snow.U .= 0
 
     set_initial_cache! = make_set_initial_cache(land)

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -249,6 +249,7 @@ end
 Y.canopy.energy.T = drivers.TA.values[1 + Int(round(t0 / DATA_DT))] # Get atmos temperature at t0
 
 Y.snow.S .= 0.0
+Y.snow.S_l .= 0.0
 Y.snow.U .= 0.0
 
 set_initial_cache! = make_set_initial_cache(land)

--- a/experiments/integrated/fluxnet/snow_soil/simulation.jl
+++ b/experiments/integrated/fluxnet/snow_soil/simulation.jl
@@ -88,7 +88,7 @@ soil_model_type = Soil.EnergyHydrology
 snow_parameters = SnowParameters{FT}(
     dt;
     α_snow = α,
-    density = Snow.ConstantDensityModel(ρ),
+    density = Snow.MinimumDensityModel(ρ),
     earth_param_set = earth_param_set,
 );
 snow_args = (; parameters = snow_parameters);
@@ -134,6 +134,7 @@ Y.soil.ρe_int =
     volumetric_internal_energy.(Y.soil.θ_i, ρc_s, T_0, earth_param_set)
 
 Y.snow.S .= 0.0
+Y.snow.S_l .= 0.0
 Y.snow.U .= 0.0
 set_initial_cache!(p, Y, t0)
 

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -319,6 +319,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
     init_soil(ν, θ_r) = θ_r + (ν - θ_r) / 2
 
     Y.snow.S .= 0.0
+    Y.snow.S_l .= 0.0
     Y.snow.U .= 0.0
 
     Y.soil.ϑ_l .= init_soil.(ν, θ_r)

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -339,6 +339,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     evaluate!(Y.canopy.energy.T, atmos.T, t0)
 
     Y.snow.S .= 0.0
+    Y.snow.S_l .= 0.0
     Y.snow.U .= 0.0
 
     set_initial_cache! = make_set_initial_cache(land)

--- a/ext/neural_snow/NeuralSnow.jl
+++ b/ext/neural_snow/NeuralSnow.jl
@@ -7,9 +7,8 @@ import ClimaLand.Snow:
     density_prog_vars,
     density_prog_types,
     density_prog_names,
-    update_density!,
-    update_density_prog!,
-    snow_depth!
+    update_density_and_depth!,
+    update_density_prog!
 import ClimaLand.Parameters as LP
 using Thermodynamics
 
@@ -114,33 +113,21 @@ ClimaLand.Snow.density_prog_names(m::NeuralDepthModel) =
 #Extend/Define the appropriate functions needed for this parameterization:
 
 """
-    snow_depth!(z_snow, m::NeuralDepthModel{FT}, Y, p, params) where {FT}
+    update_density_and_depth!(ρ_snow, z_snow,density::NeuralDepthModel, Y, p, params::SnowParameters,)
 
-An extension of the `snow_depth!` function to the NeuralDepthModel density parameterization, which includes the prognostic 
-depth variable and thus does not need to derive snow depth from SWE and density.
-
-This function clips the snow depth to be between 0 and SWE.
-"""
-function snow_depth!(z_snow, m::NeuralDepthModel{FT}, Y, p, params) where {FT}
-    z_snow .= min(Y.snow.Z, Y.snow.S) # z cannot be larger than SWE
-    z_snow .= max(z_snow, eps(FT)) # z must be positive
-    return nothing
-end
-
-"""
-    update_density!(ρ_snow, density::NeuralDepthModel, Y, p, params::SnowParameters,)
-
-Updates the snow density in place given the current model state. Default for all model types,
+Updates the snow density and depth in place given the current model state. Default for all model types,
 can be extended for alternative density parameterizations.
 """
-function update_density!(
+function update_density_and_depth!(
     ρ_snow,
+    z_snow,
     density::NeuralDepthModel,
     Y,
     p,
     params::SnowParameters,
 )
-    @. ρ_snow = snow_bulk_density(Y.snow.S, p.snow.z_snow, params)
+    @. z_snow = Y.snow.Z
+    @. ρ_snow = snow_bulk_density(Y.snow.S, z_snow, params)
 end
 
 

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -509,11 +509,10 @@ function soil_boundary_fluxes!(
     # Use top_bc.water as temporary storage to avoid allocation
     influx = p.soil.top_bc.water
     @. influx =
-        p.drivers.P_liq +
         p.snow.water_runoff * p.snow.snow_cover_fraction +
         p.excess_water_flux +
         (1 - p.snow.snow_cover_fraction) *
-        p.soil.turbulent_fluxes.vapor_flux_liq
+        (p.drivers.P_liq + p.soil.turbulent_fluxes.vapor_flux_liq)
     # The update_runoff! function computes how much actually infiltrates
     # given influx and our runoff model bc.runoff, and updates
     # p.soil.infiltration in place
@@ -541,11 +540,18 @@ function snow_boundary_fluxes!(
     turbulent_fluxes!(p.snow.turbulent_fluxes, bc.atmos, model, Y, p, t)
     # How does rain affect the below?
     P_snow = p.drivers.P_snow
+    P_liq = p.drivers.P_liq
 
     @. p.snow.total_water_flux =
         P_snow +
-        (p.snow.turbulent_fluxes.vapor_flux - p.snow.water_runoff) *
+        (P_liq + p.snow.turbulent_fluxes.vapor_flux - p.snow.water_runoff) *
         p.snow.snow_cover_fraction
+
+    @. p.snow.liquid_water_flux =
+        (
+            P_liq + p.snow.turbulent_fluxes.vapor_flux * p.snow.q_l -
+            p.snow.water_runoff
+        ) * p.snow.snow_cover_fraction
 
     # I think we want dU/dt to include energy of falling snow.
     # otherwise snow can fall but energy wont change

--- a/src/shared_utilities/implicit_timestepping.jl
+++ b/src/shared_utilities/implicit_timestepping.jl
@@ -119,6 +119,7 @@ function ImplicitEquationJacobian(Y::ClimaCore.Fields.FieldVector)
         @name(soil.θ_i),
         @name(canopy.hydraulics.ϑ_l),
         @name(snow.S),
+        @name(snow.S_l),
         @name(snow.U)
     )
 

--- a/test/integrated/soil_snow.jl
+++ b/test/integrated/soil_snow.jl
@@ -135,6 +135,7 @@ function init_soil!(Y, z, params)
 end
 function init_snow!(Y, S)
     Y.snow.S .= S
+    Y.snow.S_l .= 0
     @. Y.snow.U =
         ClimaLand.Snow.energy_from_q_l_and_swe(Y.snow.S, 1.0f0, snow_params)
 end
@@ -172,7 +173,7 @@ set_initial_cache!(p, Y, t)
 # affect
 @test all(
     parent(p.soil.top_bc.water) .≈
-    parent(p.excess_water_flux .+ p.drivers.P_liq .+ p.snow.water_runoff),
+    parent(p.excess_water_flux .+ p.snow.water_runoff),
 )
 @test all(
     parent(p.soil.top_bc.heat) .≈ parent(

--- a/test/standalone/Snow/parameterizations.jl
+++ b/test/standalone/Snow/parameterizations.jl
@@ -26,8 +26,8 @@ for FT in (Float32, Float64)
         # Thermal conductivity of dry air
         κ_air = FT(LP.K_therm(param_set))
 
-        ρ_snow = FT(200)
-        densitymodel = Snow.ConstantDensityModel(ρ_snow)
+        ρ_min = FT(200)
+        densitymodel = Snow.MinimumDensityModel(ρ_min)
         z_0m = FT(0.0024)
         α_snow = FT(0.8)
         # These values should match ClimaParams
@@ -39,12 +39,12 @@ for FT in (Float32, Float64)
         ρcD_g = FT(1700 * 2.09e3 * 0.1)
         Δt = Float64(180.0)
         parameters = SnowParameters{FT}(
-            Δt;
+            Δt,
             density = densitymodel,
             earth_param_set = param_set,
         )
-        @test parameters.density.ρ_snow == ρ_snow
-        @test typeof(parameters.density.ρ_snow) == FT
+        @test parameters.density.ρ_min == ρ_min
+        @test typeof(parameters.density.ρ_min) == FT
         @test parameters.ρcD_g == ρcD_g
         @test typeof(parameters.ρcD_g) == FT
         @test parameters.z_0m == z_0m
@@ -63,58 +63,26 @@ for FT in (Float32, Float64)
         @test typeof(parameters.κ_ice) == FT
 
 
-
         T = FT.([275.0, 272, _T_freeze])
         @test snow_surface_temperature.(T) ≈ T
-        @test all(
-            maximum_liquid_mass_fraction.(T, ρ_snow, Ref(parameters)) .==
-            [FT(0), θ_r * _ρ_l / ρ_snow, θ_r * _ρ_l / ρ_snow],
-        )
-
-        SWE = cat(FT.(rand(100) .+ 0.2), FT(0), dims = 1)
-        z = SWE * _ρ_l ./ ρ_snow
         @test specific_heat_capacity(FT(1.0), parameters) == _cp_l
         @test specific_heat_capacity(FT(0.0), parameters) == _cp_i
+        ρ_snow = ρ_min
         @test snow_thermal_conductivity(ρ_snow, parameters) ==
               κ_air +
               (FT(0.07) * (ρ_snow / _ρ_i) + FT(0.93) * (ρ_snow / _ρ_i)^2) *
               (κ_ice - κ_air)
+        @test all(
+            maximum_liquid_mass_fraction.(ρ_min, T, Ref(parameters)) .-
+            [FT(0), θ_r * _ρ_l / ρ_snow, θ_r * _ρ_l / ρ_snow] .== 0,
+        )
+
+        SWE = cat(FT.(rand(10)), FT(0), dims = 1)
+        z = SWE * _ρ_l ./ ρ_snow
         @test runoff_timescale.(z, Ksat, FT(Δt)) ≈ max.(Δt, z ./ Ksat)
         ρ_calc = snow_bulk_density.(SWE, z, parameters)
-        @test prod(ρ_calc[1:(end - 1)] .≈ ρ_snow)
+        @test all(ρ_calc[1:(end - 1)] .≈ ρ_snow)
         @test ρ_calc[end] == _ρ_l
         @test snow_bulk_density(eps(FT(0)), 2 * eps(FT(0)), parameters) == _ρ_l
-
-
-        U = cat(FT.(Array(LinRange(-1e8, 1e7, 100))), FT(0), dims = 1)
-        q_l = snow_liquid_mass_fraction.(U, SWE, parameters)
-        T_bulk = snow_bulk_temperature.(U, SWE, q_l, parameters)
-
-        @test all(q_l[T_bulk .< _T_freeze] .< eps(FT))
-        @test all(q_l[T_bulk .> _T_freeze] .≈ FT(1))
-        @test all(q_l[T_bulk .== _T_freeze] .> FT(0.0)) &&
-              all(q_l[T_bulk .== _T_freeze] .< FT(1.1))
-        Upred =
-            (
-                _ρ_l .* SWE .* specific_heat_capacity.(q_l, parameters) .+
-                ρcD_g
-            ) .* (T_bulk .- _T_ref) .- _ρ_l .* SWE .* (1.0f0 .- q_l) .* _LH_f0
-
-        q_lpred = snow_liquid_mass_fraction.(Upred, SWE, parameters)
-        T_pred = snow_bulk_temperature.(Upred, SWE, q_lpred, parameters)
-        @test all(q_lpred .≈ q_l)
-        @test all(T_pred .≈ T_bulk)
-        @test ClimaLand.Snow.volumetric_internal_energy_liq(FT, parameters) ==
-              _ρ_l * _cp_l * (_T_freeze .- _T_ref)
-        temp = FT(273.0)
-        U = ClimaLand.Snow.energy_from_T_and_swe(FT(1.0), temp, parameters)
-        q_l = snow_liquid_mass_fraction(U, FT(1.0), parameters)
-        @test T_bulk =
-            snow_bulk_temperature(U, FT(1.0), q_l, parameters) == temp
-
-        q_l = FT(0.5)
-        U = ClimaLand.Snow.energy_from_q_l_and_swe(FT(1.0), q_l, parameters)
-        @test snow_liquid_mass_fraction(U, FT(1.0), parameters) == q_l
-
     end
 end


### PR DESCRIPTION
## Purpose 
Snow is made of liquid water and ice. Previously, we tracked the total water content in the snow via snow water equivalent (symbol S), which is the volume of liquid water you would get if the snow melted, per ground area. The liquid water mass fraction (symbol q_l) was obtained diagnostically and could only be nonzero if the snow was at the freezing temperature. 

This approach handled melting of snow indirectly (conversion of ice to liquid water occured when we computed q_l diagnostically, based only on the total energy per mass of the snow), and then the loss of liquid water from the snowpack ("runoff" ) was included via a term in the ODE for S which corresponded to damping q_l to zero.

This worked fine, but it made it hard to address how rain falling on snow affects the liquid water content of the snow. We ignored this, and all liquid precip went straight to the soil (equivalent to saying it percolated through the snow instantaneously).

The equation for S was:
`dS/dt = P_snow + snow_cover_fraction(Vapor Flux - Runoff)`

This PR adds a prognostic variable for snow liquid water (symbol S_l = q_l S). This allows us to better account for rain falling on snow. The equations we have are now:
```
dS/dt = P_snow + snow_cover_fraction(P_liq + Vapor Flux - Runoff)
dS_l/dt = (P_liq + Vapor Flux * q_l - Runoff + Snow Melt) * snow cover fraction
```
Where we assume that q_l * Vapor flux = evaporation of liquid water and the snow melt term has to be parameterized.

Note that now q_l can be nonzero even if T < T_freeze, but that it will decrease in time due to refreezing.



I ran the long runs - 88-> 92 NaNs in SWE @juliasloan25 

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
