### PR TITLE
unset memory pool for gpu

### DIFF
--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -23,6 +23,7 @@ steps:
     env:
       JULIA_NUM_PRECOMPILE_TASKS: 8
       JULIA_MAX_NUM_PRECOMPILE_FILES: 50
+      JULIA_CUDA_MEMORY_POOL: none
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,6 +8,7 @@ env:
   OPENBLAS_NUM_THREADS: 1
   SLURM_KILL_BAD_EXIT: 1
   JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/default"
+  JULIA_CUDA_MEMORY_POOL: none
 
 steps:
   - label: "init environment :computer:"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,6 +8,7 @@ env:
   OPENBLAS_NUM_THREADS: 1
   SLURM_KILL_BAD_EXIT: 1
   JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/default"
+  # In the future, if we add MPI jobs, add this to each GPU job that needs it
   JULIA_CUDA_MEMORY_POOL: none
 
 steps:

--- a/.buildkite/target/pipeline.yml
+++ b/.buildkite/target/pipeline.yml
@@ -7,6 +7,7 @@ env:
   JULIA_NVTX_CALLBACKS: gc
   OPENBLAS_NUM_THREADS: 1
   SLURM_KILL_BAD_EXIT: 1
+  JULIA_CUDA_MEMORY_POOL: none
 
 steps:
   - label: "init environment :computer:"


### PR DESCRIPTION
## Purpose 
From Gabriele: I flipped a switch and unset JULIA_CUDA_MEMORY_POOL=none. This is setting we have to run with MPI, but this is a setting we would want to not use because it disables a useful feature in CUDA to reuse allocated memory. Once I disabled that, the smaller jobs got more than twice as fast, because I removed one of the sources of inefficiency.

This PR unsets JULIA_CUDA_MEMORY_POOL.

## To-do
test


## Content
Updates our three pipelines to unset JULIA_CUDA_MEMORY_POOL. If we add tests with MPI in the future, we would need to unset this for specific experiments only. Right now this PR unsets for all experiments in each buildkite run.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
