### PR TITLE
Replace cesm2_albedo artifact with sw_albedo

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -7,12 +7,12 @@ git-tree-sha1 = "6ce1717bb8b7aa767380f1053b9d8d3a4e4edaa6"
     sha256 = "27d49fce7f4a5e2b81bbd29e8a7caf08f568a2df53e3af817126363decfd5a7c"
     url = "https://caltech.box.com/shared/static/99aw2gce2k65bdu0h8jkfxq4vin08gi2.gz"
 
-[cesm2_albedo]
-git-tree-sha1 = "316096635acaa8102477820f480ca02fe66eb828"
+[sw_albedo]
+git-tree-sha1 = "136f1db3ed969614fb589c5250545a3ed1e8aaab"
 
-    [[cesm2_albedo.download]]
-    sha256 = "5ac358d4485f6ba7bae129d4570cabc712b793d4a3e22caa8808de147b2c8f9b"
-    url = "https://caltech.box.com/shared/static/awz2lku3ngoto6t78muktzfk3kjloxsw.gz"
+    [[sw_albedo.download]]
+    sha256 = "777371543cc3285c0779e7ecd925fe782b5b45e0ed27f82260827ac8ebe6a700"
+    url = "https://caltech.box.com/shared/static/of1admpndmikoumtgk5j3yvt92v71awk.gz"
 
 [clm_data]
 git-tree-sha1 = "3f6873a3e67722bda1fd23f7d5a05f5e2df1fe8c"

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -290,21 +290,20 @@ function mizoguchi1990_soil_freezing_data(; context = nothing)
 end
 
 """
-    cesm2_albedo_dataset_folder()
+    sw_albedo_dataset_folder(; context = nothing)
 
-Triggers the download of the CESM2 albedo folder, if not
+Triggers the download of the sw_albedo folder, if not
 already downloaded, using Julia Artifacts, and returns the path to
 this file.
 
-This dataset contains monthly albedo data from 15/01/1850
-to 15/12/2014.
+This dataset contains surface shortwave albedo calculated from CESM2 and CERES data.
 """
-function cesm2_albedo_dataset_folder(; context = nothing)
-    return artifact_path = @clima_artifact("cesm2_albedo", context)
+function sw_albedo_dataset_folder(; context = nothing)
+    return artifact_path = @clima_artifact("sw_albedo", context)
 end
 
 """
-    cesm2_albedo_dataset_path()
+    cesm2_albedo_dataset_path(; context = nothing)
 
 Triggers the download of the CESM2 land albedo dataset, if not
 already downloaded, using Julia Artifacts, and returns the path to
@@ -315,13 +314,13 @@ to 15/12/2014.
 """
 function cesm2_albedo_dataset_path(; context = nothing)
     return joinpath(
-        cesm2_albedo_dataset_folder(; context),
+        sw_albedo_dataset_folder(; context),
         "sw_albedo_Amon_CESM2_historical_r1i1p1f1_gn_185001-201412_v2_no-nans.nc",
     )
 end
 
 """
-    bareground_albedo_dataset_path()
+    bareground_albedo_dataset_path(; context = nothing)
 
 Triggers the download of the average bareground land albedo dataset, if not
 already downloaded, using Julia Artifacts, and returns the path to
@@ -330,9 +329,24 @@ this file.
 This dataset does not contain a time component.
 """
 function bareground_albedo_dataset_path(; context = nothing)
+    return joinpath(sw_albedo_dataset_folder(; context), "bareground_albedo.nc")
+end
+
+"""
+    ceres_albedo_dataset_path(; context = nothing)
+
+Triggers the download of the CERES land albedo dataset, if not
+already downloaded, using Julia Artifacts, and returns the path to
+this file.
+
+This dataset contains the monthly average shortwave albedo in the
+`sw_alb` variable, and the monthly average clear-sky shortwave albedo in the
+`sw_alb_clr` variable. Both variables cover from 15/03/2000 to 15/10/2019.
+"""
+function ceres_albedo_dataset_path(; context = nothing)
     return joinpath(
-        cesm2_albedo_dataset_folder(; context),
-        "bareground_albedo.nc",
+        sw_albedo_dataset_folder(; context),
+        "sw_albedo_Amon_CERES_EBAF_Ed4.2_Subset_200003-201910.nc",
     )
 end
 

--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -155,15 +155,14 @@ end
     PrescribedSurfaceAlbedo{FT}(
         start_date::Union{DateTime, DateTimeNoLeap},
         Space::ClimaCore.Spaces.AbstractSpace;
-        get_infile = ClimaLand.Artifacts.cesm2_albedo_dataset_path,
-        varname = "sw_alb"
+        albedo_file_path = ClimaLand.Artifacts.cesm2_albedo_dataset_path(),
+        varname = "sw_alb",
+        regridder_type = :InterpolationsRegridder,
     ) where {FT}
 
 Constructor for the PrescribedSurfaceAlbedo struct.
 The `varname` must correspond to the name of the variable in the NetCDF
 file retrieved by the `get_infile` function.
-`get_infile` uses ArtifactWrappers.jl to return a path to the data file
-and download the data if it doesn't already exist on the machine.
 The input data file must have a time component.
 """
 function PrescribedSurfaceAlbedo{FT}(


### PR DESCRIPTION


<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The cesm2_albedo artifact was renamed to sw_albedo in ClimaArtifacts PR #97. This PR also added
a new dataset with two new albedo variables. This commit updates the Artifacts accessor functions for albedo and adds tests for the new dataset.

An example use of the new dataset is

```
albedo = PrescribedSurfaceAlbedo{FT}(
            start_date,
            space;
            albedo_file_path = ClimaLand.Artifacts.ceres_albedo_dataset_path(),
            varname ="św_alb_clr",
        )
``` 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
- added the `ceres_albedo_dataset_path` function
- changed `cesm2_albedo_dataset_folder()` to `sw_albedo_dataset_folder()`
- changed cesm2 to sw_albedo in Artifact.toml
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
