### PR TITLE
remove HydrologyEarthParameters struct

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ ClimaLand.jl Release Notes
 main
 -------
 
+- Change `Soil.phase_change_source` interface to take model parameters
+  as the final argument; remove `HydrologyEarthParameters` struct.
+  PR[#982](https://github.com/CliMA/ClimaLand.jl/pull/982)
 
 v0.15.7
 -------

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -640,7 +640,7 @@ function ClimaLand.source!(
     model,
 ) where {FT}
     params = model.parameters
-    (; ν, ρc_ds, θ_r, earth_param_set) = params
+    (; ν, ρc_ds, θ_r, hydrology_cm, earth_param_set) = params
     _ρ_l = FT(LP.ρ_cloud_liq(earth_param_set))
     _ρ_i = FT(LP.ρ_cloud_ice(earth_param_set))
     Δz = model.domain.fields.Δz # center face distance
@@ -662,6 +662,7 @@ function ClimaLand.source!(
             ),
             ν,
             θ_r,
+            hydrology_cm,
             params,
         )
     @. dY.soil.θ_i +=
@@ -681,6 +682,7 @@ function ClimaLand.source!(
             ),
             ν,
             θ_r,
+            hydrology_cm,
             params,
         )
 end

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -640,14 +640,10 @@ function ClimaLand.source!(
     model,
 ) where {FT}
     params = model.parameters
-    (; ν, ρc_ds, θ_r, hydrology_cm, earth_param_set) = params
+    (; ν, ρc_ds, θ_r, earth_param_set) = params
     _ρ_l = FT(LP.ρ_cloud_liq(earth_param_set))
     _ρ_i = FT(LP.ρ_cloud_ice(earth_param_set))
     Δz = model.domain.fields.Δz # center face distance
-
-    # Wrap hydrology and earth parameters in one struct to avoid type inference failure. This is allocating! We should remove it.
-    hydrology_earth_params =
-        ClimaLand.Soil.HydrologyEarthParameters.(hydrology_cm, earth_param_set)
 
     @. dY.soil.ϑ_l +=
         -phase_change_source(
@@ -666,7 +662,7 @@ function ClimaLand.source!(
             ),
             ν,
             θ_r,
-            hydrology_earth_params,
+            params,
         )
     @. dY.soil.θ_i +=
         (_ρ_l / _ρ_i) * phase_change_source(
@@ -685,7 +681,7 @@ function ClimaLand.source!(
             ),
             ν,
             θ_r,
-            hydrology_earth_params,
+            params,
         )
 end
 

--- a/src/standalone/Soil/soil_heat_parameterizations.jl
+++ b/src/standalone/Soil/soil_heat_parameterizations.jl
@@ -31,8 +31,8 @@ end
         τ::FT,
         ν::FT,
         θ_r::FT,
-        hydrology_earth_params::HEP
-    ) where {FT, HEP}
+        params::P
+    ) where {FT, P}
 Returns the source term (1/s) used for converting liquid water
 and ice into each other during phase changes. Note that
 there are unitless prefactors multiplying this term in the
@@ -49,11 +49,10 @@ function phase_change_source(
     τ::FT,
     ν::FT,
     θ_r::FT,
-    hydrology_earth_params::HEP,
-) where {FT, HEP}
+    params::P,
+) where {FT, P}
     # Extract parameter sets from their container
-    hydrology_cm = hydrology_earth_params.hydrology_cm
-    earth_param_set = hydrology_earth_params.earth_param_set
+    (; hydrology_cm, earth_param_set) = params
 
     _ρ_i = FT(LP.ρ_cloud_ice(earth_param_set))
     _ρ_l = FT(LP.ρ_cloud_liq(earth_param_set))
@@ -73,29 +72,6 @@ function phase_change_source(
 
     return (θ_l - θstar) / τ
 end
-
-"""
-    struct HydrologyEarthParameters{
-        HCM <: AbstractSoilHydrologyClosure,
-        EP <: ClimaLand.Parameters.AbstractLandParameters,
-    }
-
-A wrapper type around the hydrology closure model and land parameter
-structs. This is needed because of a type inference failure coming from
-ClimaCore when multiple structs and fields are broadcasted over.
-This struct circumvents that issue by wrapping the structs in a single
-type, that can be unpacked within the broadcasted function.
-
-See github.com/CliMA/ClimaCore.jl/issues/2065 for more information
-"""
-struct HydrologyEarthParameters{
-    HCM <: AbstractSoilHydrologyClosure,
-    EP <: ClimaLand.Parameters.AbstractLandParameters,
-}
-    hydrology_cm::HCM
-    earth_param_set::EP
-end
-Base.broadcastable(x::HydrologyEarthParameters) = tuple(x)
 
 """
     volumetric_heat_capacity(

--- a/src/standalone/Soil/soil_heat_parameterizations.jl
+++ b/src/standalone/Soil/soil_heat_parameterizations.jl
@@ -31,8 +31,9 @@ end
         τ::FT,
         ν::FT,
         θ_r::FT,
+        hydrology_cm::HCM,
         params::P
-    ) where {FT, P}
+    ) where {FT, HCM, P}
 Returns the source term (1/s) used for converting liquid water
 and ice into each other during phase changes. Note that
 there are unitless prefactors multiplying this term in the
@@ -49,10 +50,10 @@ function phase_change_source(
     τ::FT,
     ν::FT,
     θ_r::FT,
+    hydrology_cm::HCM,
     params::P,
-) where {FT, P}
-    # Extract parameter sets from their container
-    (; hydrology_cm, earth_param_set) = params
+) where {FT, HCM, P}
+    (; earth_param_set) = params
 
     _ρ_i = FT(LP.ρ_cloud_ice(earth_param_set))
     _ρ_l = FT(LP.ρ_cloud_liq(earth_param_set))

--- a/test/standalone/Soil/soil_parameterizations.jl
+++ b/test/standalone/Soil/soil_parameterizations.jl
@@ -307,10 +307,6 @@ for FT in (Float32, Float64)
         vg_n = FT(1.4)
         hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
 
-        # Wrap hydrology and earth parameters in one struct to avoid type inference failure
-        hydrology_earth_params =
-            ClimaLand.Soil.HydrologyEarthParameters(hcm, param_set)
-
         K_sat = FT(1e-5)
         ν_ss_om = FT(0.1)
         ν_ss_gravel = FT(0.1)
@@ -343,26 +339,11 @@ for FT in (Float32, Float64)
         ρc_s = volumetric_heat_capacity.(θ_l, θ_i, parameters.ρc_ds, param_set)
         τ = thermal_time.(ρc_s, Δz, parameters.κ_dry)
         @test (
-            phase_change_source.(
-                θ_l,
-                θ_i,
-                T,
-                τ,
-                ν,
-                θ_r,
-                hydrology_earth_params,
-            ) ≈ (θ_l .- θ_star) ./ τ
+            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, parameters) ≈
+            (θ_l .- θ_star) ./ τ
         )
         @test sum(
-            phase_change_source.(
-                θ_l,
-                θ_i,
-                T,
-                τ,
-                ν,
-                θ_r,
-                hydrology_earth_params,
-            ) .> 0.0,
+            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, parameters) .> 0.0,
         ) == 3
 
         θ_l = FT.([0.11, 0.15, ν])
@@ -378,15 +359,8 @@ for FT in (Float32, Float64)
         ρc_s = volumetric_heat_capacity.(θ_l, θ_i, parameters.ρc_ds, param_set)
         τ = thermal_time.(ρc_s, Δz, parameters.κ_dry)
         @test (
-            phase_change_source.(
-                θ_l,
-                θ_i,
-                T,
-                τ,
-                ν,
-                θ_r,
-                hydrology_earth_params,
-            ) ≈ zeros(FT, 3)
+            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, parameters) ≈
+            zeros(FT, 3)
         )
         @test (θ_star ≈ θ_l)
 
@@ -404,26 +378,11 @@ for FT in (Float32, Float64)
         ρc_s = volumetric_heat_capacity.(θ_l, θ_i, parameters.ρc_ds, param_set)
         τ = thermal_time.(ρc_s, Δz, parameters.κ_dry)
         @test (
-            phase_change_source.(
-                θ_l,
-                θ_i,
-                T,
-                τ,
-                ν,
-                θ_r,
-                hydrology_earth_params,
-            ) ≈ (θ_l .- θ_star) ./ τ
+            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, parameters) ≈
+            (θ_l .- θ_star) ./ τ
         )
         @test sum(
-            phase_change_source.(
-                θ_l,
-                θ_i,
-                T,
-                τ,
-                ν,
-                θ_r,
-                hydrology_earth_params,
-            ) .< 0.0,
+            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, parameters) .< 0.0,
         ) == 2
 
 
@@ -440,26 +399,11 @@ for FT in (Float32, Float64)
         ρc_s = volumetric_heat_capacity.(θ_l, θ_i, parameters.ρc_ds, param_set)
         τ = thermal_time.(ρc_s, Δz, parameters.κ_dry)
         @test (
-            phase_change_source.(
-                θ_l,
-                θ_i,
-                T,
-                τ,
-                ν,
-                θ_r,
-                hydrology_earth_params,
-            ) ≈ (θ_l .- θ_star) ./ τ
+            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, parameters) ≈
+            (θ_l .- θ_star) ./ τ
         )
         @test sum(
-            phase_change_source.(
-                θ_l,
-                θ_i,
-                T,
-                τ,
-                ν,
-                θ_r,
-                hydrology_earth_params,
-            ) .> 0.0,
+            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, parameters) .> 0.0,
         ) == 2
     end
 end

--- a/test/standalone/Soil/soil_parameterizations.jl
+++ b/test/standalone/Soil/soil_parameterizations.jl
@@ -339,11 +339,12 @@ for FT in (Float32, Float64)
         ρc_s = volumetric_heat_capacity.(θ_l, θ_i, parameters.ρc_ds, param_set)
         τ = thermal_time.(ρc_s, Δz, parameters.κ_dry)
         @test (
-            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, parameters) ≈
+            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, hcm, parameters) ≈
             (θ_l .- θ_star) ./ τ
         )
         @test sum(
-            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, parameters) .> 0.0,
+            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, hcm, parameters) .>
+            0.0,
         ) == 3
 
         θ_l = FT.([0.11, 0.15, ν])
@@ -359,7 +360,7 @@ for FT in (Float32, Float64)
         ρc_s = volumetric_heat_capacity.(θ_l, θ_i, parameters.ρc_ds, param_set)
         τ = thermal_time.(ρc_s, Δz, parameters.κ_dry)
         @test (
-            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, parameters) ≈
+            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, hcm, parameters) ≈
             zeros(FT, 3)
         )
         @test (θ_star ≈ θ_l)
@@ -378,11 +379,12 @@ for FT in (Float32, Float64)
         ρc_s = volumetric_heat_capacity.(θ_l, θ_i, parameters.ρc_ds, param_set)
         τ = thermal_time.(ρc_s, Δz, parameters.κ_dry)
         @test (
-            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, parameters) ≈
+            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, hcm, parameters) ≈
             (θ_l .- θ_star) ./ τ
         )
         @test sum(
-            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, parameters) .< 0.0,
+            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, hcm, parameters) .<
+            0.0,
         ) == 2
 
 
@@ -399,11 +401,12 @@ for FT in (Float32, Float64)
         ρc_s = volumetric_heat_capacity.(θ_l, θ_i, parameters.ρc_ds, param_set)
         τ = thermal_time.(ρc_s, Δz, parameters.κ_dry)
         @test (
-            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, parameters) ≈
+            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, hcm, parameters) ≈
             (θ_l .- θ_star) ./ τ
         )
         @test sum(
-            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, parameters) .> 0.0,
+            phase_change_source.(θ_l, θ_i, T, τ, ν, θ_r, hcm, parameters) .>
+            0.0,
         ) == 2
     end
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR removes the `HydrologyEarthParameters` struct, which was introduced in https://github.com/CliMA/ClimaLand.jl/pull/739 to fix a GPU inference issue. Here, we instead update the interface of `phase_change_source` to take in the full model parameters as its final argument. This both fixes the inference issue we saw before, and removes the allocating use of `HydrologyEarthParameters`.

closes #975
