### PR TITLE
Remove rho_c_D_g parameter

### DIFF
--- a/src/standalone/Snow/Snow.jl
+++ b/src/standalone/Snow/Snow.jl
@@ -108,8 +108,8 @@ Base.@kwdef struct SnowParameters{
     κ_ice::FT
     "Timestep of the model (s)"
     Δt::FT
-    "Areal specific heat of ground interacting with snow (J/m^2/K)"
-    ρcD_g::FT
+    "Parameter to prevent dividing by zero when computing snow temperature (m)"
+    ΔS::FT
     "Clima-wide parameters"
     earth_param_set::PSE
 end
@@ -124,7 +124,7 @@ end
                       θ_r = FT(0.08),
                       Ksat = FT(1e-3),
                       κ_ice = FT(2.21),
-                      ρcD_g = FT(3.553e5),
+                      ΔS = FT(0.1),
                       earth_param_set::PSE) where {FT, PSE}
 
 An outer constructor for `SnowParameters` which supplies defaults for
@@ -140,7 +140,7 @@ function SnowParameters{FT}(
     θ_r = FT(0.08),
     Ksat = FT(1e-3),
     κ_ice = FT(2.21),
-    ρcD_g = FT(3.553e5),
+    ΔS = FT(0.1),
     earth_param_set::PSE,
 ) where {FT <: AbstractFloat, DM <: AbstractDensityModel, PSE}
     return SnowParameters{FT, DM, PSE}(
@@ -153,7 +153,7 @@ function SnowParameters{FT}(
         Ksat,
         κ_ice,
         Δt,
-        ρcD_g,
+        ΔS,
         earth_param_set,
     )
 end

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -216,11 +216,11 @@ function snow_bulk_temperature(
     _T_ref = FT(LP.T_0(parameters.earth_param_set))
     _LH_f0 = FT(LP.LH_f0(parameters.earth_param_set))
     cp_s = specific_heat_capacity(q_l, parameters)
-    _ρcD_g = parameters.ρcD_g
+    _ΔS = parameters.ΔS
     _T_freeze = FT(LP.T_freeze(parameters.earth_param_set))
     return _T_ref +
-           (U + _LH_f0 * _ρ_l * S_safe * (1 - q_l)) /
-           (_ρ_l * S_safe * cp_s + _ρcD_g)
+           (U + _ρ_l * _LH_f0 * S_safe * (1 - q_l)) /
+           (_ρ_l * cp_s * (S_safe + _ΔS))
 end
 
 """
@@ -238,7 +238,6 @@ function snow_bulk_density(
     #also handle instabilities when z, SWE both near machine precision
     return max(SWE, ε) / max(z, SWE, ε) * _ρ_l
 end
-
 
 """
     maximum_liquid_mass_fraction(ρ_snow::FT, T::FT, parameters::SnowParameters{FT}) where {FT}
@@ -357,11 +356,11 @@ function energy_from_q_l_and_swe(S::FT, q_l::FT, parameters) where {FT}
     _ρ_l = FT(LP.ρ_cloud_liq(parameters.earth_param_set))
     _T_ref = FT(LP.T_0(parameters.earth_param_set))
     _LH_f0 = FT(LP.LH_f0(parameters.earth_param_set))
+    _ΔS = parameters.ΔS
 
     c_snow = specific_heat_capacity(q_l, parameters)
-    _ρcD_g = parameters.ρcD_g
-    return _ρ_l * S * (c_snow * (_T_freeze - _T_ref) - (1 - q_l) * _LH_f0) +
-           _ρcD_g * (_T_freeze - _T_ref)
+    return _ρ_l * (S + _ΔS) * c_snow * (_T_freeze - _T_ref) -
+           _ρ_l * S * (1 - q_l) * _LH_f0
 end
 
 """
@@ -379,11 +378,12 @@ function energy_from_T_and_swe(S::FT, T::FT, parameters) where {FT}
     _LH_f0 = FT(LP.LH_f0(parameters.earth_param_set))
     _cp_i = FT(LP.cp_i(parameters.earth_param_set))
     _cp_l = FT(LP.cp_l(parameters.earth_param_set))
-    _ρcD_g = parameters.ρcD_g
+    _ΔS = parameters.ΔS
+
     if T <= _T_freeze
-        return (_ρ_l * S * _cp_i + _ρcD_g) * (T - _T_ref) - _ρ_l * S * _LH_f0
+        return _ρ_l * _cp_i * (S + _ΔS) * (T - _T_ref) - _ρ_l * S * _LH_f0
     else
-        return (_ρ_l * S * _cp_l + _ρcD_g) * (T - _T_ref)
+        return _ρ_l * (S + _ΔS) * _cp_l * (T - _T_ref)
     end
 
 end

--- a/test/standalone/Snow/parameterizations.jl
+++ b/test/standalone/Snow/parameterizations.jl
@@ -36,7 +36,7 @@ for FT in (Float32, Float64)
         θ_r = FT(0.08)
         Ksat = FT(1e-3)
         κ_ice = FT(2.21)
-        ρcD_g = FT(1700 * 2.09e3 * 0.1)
+        ΔS = FT(0.1)
         Δt = Float64(180.0)
         parameters = SnowParameters{FT}(
             Δt,
@@ -45,8 +45,8 @@ for FT in (Float32, Float64)
         )
         @test parameters.density.ρ_min == ρ_min
         @test typeof(parameters.density.ρ_min) == FT
-        @test parameters.ρcD_g == ρcD_g
-        @test typeof(parameters.ρcD_g) == FT
+        @test parameters.ΔS == ΔS
+        @test typeof(parameters.ΔS) == FT
         @test parameters.z_0m == z_0m
         @test typeof(parameters.z_0m) == FT
         @test parameters.z_0b == z_0b
@@ -84,5 +84,13 @@ for FT in (Float32, Float64)
         @test all(ρ_calc[1:(end - 1)] .≈ ρ_snow)
         @test ρ_calc[end] == _ρ_l
         @test snow_bulk_density(eps(FT(0)), 2 * eps(FT(0)), parameters) == _ρ_l
+
+        U = energy_from_q_l_and_swe(FT(1), FT(0.5), parameters)
+        T = snow_bulk_temperature(U, FT(1), FT(0.5), parameters)
+        @test T ≈ _T_freeze
+
+        U = energy_from_T_and_swe.(FT(1), FT.([272, 274]), parameters)
+        T = snow_bulk_temperature.(U, FT(1), FT.([0.0, 1.0]), parameters)
+        @test all(T .≈ FT.([272, 274]))
     end
 end


### PR DESCRIPTION
## Purpose 
To prevent division by zero in snow bulk temperature, we had previously followed the UEB model with the parameter "rho *c * D" for the ground, i.e. the amount of mass of ground interacting thermally with the snow (assumed to be at the same temp as the snow).

In the ground heat flux between snow and soil, we used this parameter to solve for the thickness of the layer of soil interacting thermally with the snow.

After reading the draft, Tapio preferred that we change this to a small "delta S" parameter - i.e. to keep the interpretation numerical, not physical, and limited only to the snow model.

This makes that change.


## To-do


## Content



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
