### PR TITLE
Higher resolution output

### DIFF
--- a/experiments/long_runs/bucket.jl
+++ b/experiments/long_runs/bucket.jl
@@ -124,11 +124,14 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 7))
     updatefunc = ClimaLand.make_update_drivers(drivers)
 
     # ClimaDiagnostics
-
+    # num_points is the resolution of the output diagnostics
+    # These are currently chosen to get a 1:1 ration with the number of
+    # simulation points, ~101x101x4x4
     nc_writer = ClimaDiagnostics.Writers.NetCDFWriter(
         subsurface_space,
         outdir;
         start_date,
+        num_points = (570, 285, 50),
     )
 
     diags = ClimaLand.default_diagnostics(

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -355,11 +355,14 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     updatefunc = ClimaLand.make_update_drivers(drivers)
 
     # ClimaDiagnostics
-
+    # num_points is the resolution of the output diagnostics
+    # These are currently chosen to get a 1:1 ration with the number of
+    # simulation points, ~101x101x4x4
     nc_writer = ClimaDiagnostics.Writers.NetCDFWriter(
         subsurface_space,
         outdir;
         start_date,
+        num_points = (570, 285, 50), # use default in `z`.
     )
 
     diags = ClimaLand.default_diagnostics(

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -376,6 +376,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
         subsurface_space,
         outdir;
         start_date,
+        num_points = n_elements,
     )
 
     diags = ClimaLand.default_diagnostics(

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -370,11 +370,14 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     updatefunc = ClimaLand.make_update_drivers(drivers)
 
     # ClimaDiagnostics
-
+    # num_points is the resolution of the output diagnostics
+    # These are currently chosen to get a 1:1 ration with the number of
+    # simulation points, ~101x101x4x4
     nc_writer = ClimaDiagnostics.Writers.NetCDFWriter(
         subsurface_space,
         outdir;
         start_date,
+        num_points = (570, 285, 50), # use default in `z`.
     )
 
     diags = ClimaLand.default_diagnostics(

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -197,11 +197,14 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     updatefunc = ClimaLand.make_update_drivers(drivers)
 
     # ClimaDiagnostics
-
+    # num_points is the resolution of the output diagnostics
+    # These are currently chosen to get a 1:1 ration with the number of
+    # simulation points, ~101x101x4x4
     nc_writer = ClimaDiagnostics.Writers.NetCDFWriter(
         subsurface_space,
         outdir;
         start_date,
+        num_points = (570, 285, 50), # use default in `z`.
     )
 
     diags = ClimaLand.default_diagnostics(


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
We currently store 180x90 points in lat/lon, but this causes poor quality figures along coastlines in particular, and doesnt make use of the higher resolution of our simulation (~0.2 degrees). This increases the resolution of the stored output. For monthly output the extra size is OK.


## To-do


## Content
We have ~101x101x4x4 points in our simulation. The output now has 570x285 points. This is a ratio of ~1 output point to simulation point


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
