### PR TITLE
Add high resolution clm data artifact

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -14,13 +14,18 @@ git-tree-sha1 = "136f1db3ed969614fb589c5250545a3ed1e8aaab"
     sha256 = "777371543cc3285c0779e7ecd925fe782b5b45e0ed27f82260827ac8ebe6a700"
     url = "https://caltech.box.com/shared/static/of1admpndmikoumtgk5j3yvt92v71awk.gz"
 
-[clm_data]
-git-tree-sha1 = "3f6873a3e67722bda1fd23f7d5a05f5e2df1fe8c"
+["clm_data_0.9x1.25"]
+git-tree-sha1 = "283c62220fca8c4afe36a62348d3e9a159af2ee9"
 
-    [[clm_data.download]]
-    sha256 = "830136abec15551a343b7884d657fb6a79b16a37237681a2becf65bd845aa692"
-    url = "https://caltech.box.com/shared/static/6pu2f6c99g29qawvjjh3j56drkonpd3z.gz"
+    [["clm_data_0.9x1.25".download]]
+    sha256 = "88d5899a729de800017a74bd8a7278582c2c55c0d8730a529bae384425d70e4e"
+    url = "https://caltech.box.com/shared/static/mxs3l1c1dppjwy81assk8w8ofn9d70pu.gz"
+["clm_data_0.125x0.125"]
+git-tree-sha1 = "6284ddefbc7937d9c1fb68fa731ff3f00b68e917"
 
+    [["clm_data_0.125x0.125".download]]
+    sha256 = "8d2a61baad53346515f4a66c4342f8aafce37ca9520020c17f99cc4f4aa98b15"
+    url = "https://caltech.box.com/shared/static/uteaw1l6fg7wmwhb3ey1c0jq4r8vg0ts.gz"
 [era5_land_forcing_data2008]
 git-tree-sha1 = "93d2e93f491e77cb8fba2a1b8b3946f38bde469e"
 [era5_land_forcing_data2008_lowres]

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -43,12 +43,17 @@ function modis_lai_forcing_data2008_path(; context = nothing)
 end
 
 """
-    clm_data__folder_path(; context)
+    clm_data__folder_path(; context, lowres = false)
 
-Return the path to the folder that contains the clm data.
+Return the path to the folder that contains the clm data. If the lowres flag is set to true,
+the 0.9x1.25 version of the data is returned. Otherwise, the 0.125x0.125 version is returned.
 """
-function clm_data_folder_path(; context = nothing)
-    return @clima_artifact("clm_data", context)
+function clm_data_folder_path(; context = nothing, lowres = false)
+    if lowres
+        return @clima_artifact("clm_data_0.9x1.25", context)
+    else
+        return @clima_artifact("clm_data_0.125x0.125", context)
+    end
 end
 
 """

--- a/test/simulations/spatial_parameters.jl
+++ b/test/simulations/spatial_parameters.jl
@@ -87,3 +87,32 @@ end
 
 @test :G_Function ∈ propertynames(clm_parameters)
 @test axes(getproperty(clm_parameters, :G_Function).χl) == surface_space
+# test `use_lowres_clm` on the sphere domain, and then again with a sphere domain with 2x
+# the horizontal resolution. Then repeat with plane domains.
+@test ClimaLand.use_lowres_clm(surface_space)
+domain = ClimaLand.Domains.SphericalShell(;
+    radius = radius,
+    depth = depth,
+    nelements = (202, 2),
+    npolynomial = 1,
+)
+surface_space = domain.space.surface
+@test !ClimaLand.use_lowres_clm(surface_space)
+domain = ClimaLand.Domains.Plane(;
+    longlat = (-117.0, 34.0),
+    xlim = (0.0, FT(2e6)),
+    ylim = (0.0, 2FT(2e6)),
+    nelements = (10, 10),
+    npolynomial = 1,
+)
+surface_space = domain.space.surface
+@test ClimaLand.use_lowres_clm(surface_space)
+domain = ClimaLand.Domains.Plane(;
+    longlat = (-117.0, 34.0),
+    xlim = (0.0, FT(2e5)),
+    ylim = (0.0, 2FT(2e5)),
+    nelements = (10, 10),
+    npolynomial = 1,
+)
+surface_space = domain.space.surface
+@test !ClimaLand.use_lowres_clm(surface_space)


### PR DESCRIPTION
## Purpose 
Along with the accompanying ClimaArtifacts [PR](https://github.com/CliMA/ClimaArtifacts/pull/102), this
closes #999 



## Content

Adds a higher resolution clm data artifact, named
clm_data_0.125x0.125. The previous artifact is renamed
to clm_data_0.9x1.25.

The clm_data_folder_path function takes in the `lowres`
flag as a kwarg, and returns the correct folder based on
that.

This also adds the `lowres` kwarg to the
`clm_canopy_parameters` and `default_spatially_varying_soil_parameters`
functions. The default value of `lowres` is determined by the
`use_lowres_clm` function. If given a cubed sphere mesh, the function
compares the results of `ClimaCore.Meshes.element_horizontal_length_scale`
to the approximate horizontal scale of both clm data artifacts
in meters. If given a rectilinear mesh, it does the same but in
degrees.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
