### PR TITLE
Add boundary fluxes terms to the soil jacobian when running with prescribed atmos

### DIFF
--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -198,10 +198,9 @@ lsm_aux_vars(m::LandModel) = (
     :atmos_energy_flux,
     :atmos_water_flux,
     :ground_heat_flux,
-    :effective_soil_sfc_T,
+    :dghfdT_soil,
     :sfc_scratch,
     :subsfc_scratch,
-    :effective_soil_sfc_depth,
     :T_sfc,
     :ϵ_sfc,
     :α_sfc,
@@ -215,7 +214,6 @@ The types of the additional auxiliary variables that are
 included in the land model.
 """
 lsm_aux_types(m::LandModel{FT}) where {FT} = (
-    FT,
     FT,
     FT,
     FT,
@@ -259,7 +257,6 @@ lsm_aux_domain_names(m::LandModel) = (
     :surface,
     :surface,
     :subsurface,
-    :surface,
     :surface,
     :surface,
     :surface,
@@ -526,6 +523,15 @@ function soil_boundary_fluxes!(
         ) +
         p.excess_heat_flux +
         p.snow.snow_cover_fraction * p.ground_heat_flux
+
+    # ρc_sfc is stored in scratch! after we use it below, it may be overwritten
+    ρc_sfc = ClimaLand.Soil.get_ρc_sfc(Y, p, soil.parameters)
+    # Get the local geometry of the face space, then extract the top level
+    local_geometry_faceN =
+        ClimaLand.get_local_geometry_faceN(soil.domain.space.subsurface)
+    @. p.soil.dfluxBCdY.heat =
+        covariant3_unit_vector(local_geometry_faceN) * 0 / ρc_sfc # ∂F∂T ∂T∂ρe
+    @. p.soil.dfluxBCdY.water = covariant3_unit_vector(local_geometry_faceN) * 0
     return nothing
 end
 

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -388,12 +388,8 @@ function ClimaLand.set_dfluxBCdY!(
 
 
     # Get the local geometry of the face space, then extract the top level
-    levels = ClimaCore.Spaces.nlevels(Domains.obtain_face_space(axes(p.soil.K)))
-    local_geometry_faceN = ClimaCore.Fields.level(
-        Fields.local_geometry_field(Domains.obtain_face_space(axes(p.soil.K))),
-        levels - ClimaCore.Utilities.half,
-    )
-
+    local_geometry_faceN =
+        ClimaLand.get_local_geometry_faceN(model.domain.space.subsurface)
     # Update dfluxBCdY at the top boundary in place
     # Calculate the value and convert it to a Covariant3Vector
     @. p.soil.dfluxBCdY =
@@ -402,20 +398,6 @@ function ClimaLand.set_dfluxBCdY!(
     return nothing
 end
 
-"""
-    covariant3_unit_vector(local_geometry)
-
-A function to compute the unit vector in the direction of the normal
-to the surface.
-
-Adapted from ClimaAtmos.jl's unit_basis_vector_data function.
-"""
-function covariant3_unit_vector(local_geometry)
-    FT = Geometry.undertype(typeof(local_geometry))
-    data =
-        FT(1) / Geometry._norm(Geometry.Covariant3Vector(FT(1)), local_geometry)
-    return Geometry.Covariant3Vector(data)
-end
 
 # BC type for the soil heat equation
 """
@@ -696,6 +678,7 @@ These variables are updated in place in `soil_boundary_fluxes!`.
 """
 boundary_vars(bc::AtmosDrivenFluxBC, ::ClimaLand.TopBoundary) = (
     :turbulent_fluxes,
+    :dfluxBCdY,
     :R_n,
     :top_bc,
     :top_bc_wvec,
@@ -724,6 +707,7 @@ boundary_var_domain_names(bc::AtmosDrivenFluxBC, ::ClimaLand.TopBoundary) = (
     :surface,
     :surface,
     :surface,
+    :surface,
     :subsurface,
     Runoff.runoff_var_domain_names(bc.runoff)...,
 )
@@ -743,8 +727,15 @@ boundary_var_types(
     ::ClimaLand.TopBoundary,
 ) where {FT} = (
     NamedTuple{
-        (:lhf, :shf, :vapor_flux_liq, :r_ae, :vapor_flux_ice),
-        Tuple{FT, FT, FT, FT, FT},
+        (:lhf, :shf, :vapor_flux_liq, :r_ae, :vapor_flux_ice, :dlhfdT, :dshfdT),
+        Tuple{FT, FT, FT, FT, FT, FT, FT},
+    },
+    NamedTuple{
+        (:water, :heat),
+        Tuple{
+            ClimaCore.Geometry.Covariant3Vector{FT},
+            ClimaCore.Geometry.Covariant3Vector{FT},
+        },
     },
     FT,
     NamedTuple{(:water, :heat), Tuple{FT, FT}},
@@ -840,7 +831,33 @@ function soil_boundary_fluxes!(
     @. p.soil.top_bc.water = p.soil.infiltration
     @. p.soil.top_bc.heat =
         p.soil.R_n + p.soil.turbulent_fluxes.lhf + p.soil.turbulent_fluxes.shf
+
+    # Compute terms needed for derivatives
+    # ρc_sfc is stored in scratch! after we use it below, it may be overwritten
+    ρc_sfc = get_ρc_sfc(Y, p, model.parameters)
+    # Get the local geometry of the face space, then extract the top level
+    local_geometry_faceN =
+        ClimaLand.get_local_geometry_faceN(model.domain.space.subsurface)
+    @. p.soil.dfluxBCdY.heat =
+        covariant3_unit_vector(local_geometry_faceN) * (0 / ρc_sfc) # replace 0 with ∂F∂T when ready
+    @. p.soil.dfluxBCdY.water = covariant3_unit_vector(local_geometry_faceN) * 0
     return nothing
+end
+
+"""
+    get_ρc_sfc(Y, p, parameters)
+
+Helper function for computing the surface volumetric heat capacity. This function
+should not allocate, but note that if p.soil.sub_sfc_scratch may be overwritten
+at any time.
+"""
+function get_ρc_sfc(Y, p, parameters)
+    ρc = p.soil.sub_sfc_scratch
+    (; ρc_ds, earth_param_set) = parameters
+    @. ρc =
+        volumetric_heat_capacity(p.soil.θ_l, Y.soil.θ_i, ρc_ds, earth_param_set)
+    ρc_sfc = ClimaLand.Domains.top_center_to_surface(ρc)
+    return ρc_sfc
 end
 
 """

--- a/test/integrated/soil_snow.jl
+++ b/test/integrated/soil_snow.jl
@@ -98,10 +98,9 @@ for lsm_aux_var in (
     :atmos_energy_flux,
     :atmos_water_flux,
     :ground_heat_flux,
-    :effective_soil_sfc_T,
     :sfc_scratch,
     :subsfc_scratch,
-    :effective_soil_sfc_depth,
+    :dghfdT_soil,
 )
     @test lsm_aux_var ∈ propertynames(p)
 end

--- a/test/shared_utilities/implicit_timestepping/energy_hydrology_model.jl
+++ b/test/shared_utilities/implicit_timestepping/energy_hydrology_model.jl
@@ -7,6 +7,7 @@ import ClimaParams as CP
 using ClimaLand
 using ClimaLand.Domains: Column
 using ClimaLand.Soil
+using Dates
 
 import ClimaLand
 import ClimaLand.Parameters as LP
@@ -167,5 +168,216 @@ for FT in (Float32, Float64)
         # Check the main diagonal, entry corresponding to top of column
         @test Array(parent(jac_ρeϑ.entries.:2))[end] .≈
               dtγ * (-ρe_liq_ic * K_ic / dz^2 * dψdϑ_ic) - I
+
+        @test ~(:dfluxBCdY ∈ propertynames(p.soil))
     end
+
+    @testset "Jacobian boundary terms, Atmos Driven, FT = $FT" begin
+        earth_param_set = LP.LandParameters(FT)
+        zmax = FT(0)
+        zmin = FT(-1.5)
+        nelems = 150
+        domain =
+            ClimaLand.Domains.Column(; zlim = (zmin, zmax), nelements = nelems)
+        ν = FT(0.495)
+        K_sat = FT(0.0443 / 3600 / 100) # m/s
+        S_s = FT(1e-3) #inverse meters
+        vg_n = FT(2.0)
+        vg_α = FT(2.6) # inverse meters
+        vg_m = FT(1) - FT(1) / vg_n
+        hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
+        θ_r = FT(0.1)
+        S_c = hcm.S_c
+
+        ν_ss_om = FT(0.0)
+        ν_ss_quartz = FT(1.0)
+        ν_ss_gravel = FT(0.0)
+        emissivity = FT(0.99)
+        z_0m = FT(0.001)
+        z_0b = z_0m
+        # Radiation
+        start_date = DateTime(2005)
+        SW_d = (t) -> 500
+        LW_d = (t) -> 5.67e-8 * 280.0^4.0
+        radiation = PrescribedRadiativeFluxes(
+            FT,
+            TimeVaryingInput(SW_d),
+            TimeVaryingInput(LW_d),
+            start_date,
+        )
+        # Atmos
+        precip = (t) -> 1e-8
+        precip_snow = (t) -> 0
+        T_atmos = (t) -> 285
+        u_atmos = (t) -> 3
+        q_atmos = (t) -> 0.005
+        h_atmos = FT(3)
+        P_atmos = (t) -> 101325
+        atmos = PrescribedAtmosphere(
+            TimeVaryingInput(precip),
+            TimeVaryingInput(precip_snow),
+            TimeVaryingInput(T_atmos),
+            TimeVaryingInput(u_atmos),
+            TimeVaryingInput(q_atmos),
+            TimeVaryingInput(P_atmos),
+            start_date,
+            h_atmos,
+            earth_param_set,
+        )
+        top_bc = ClimaLand.Soil.AtmosDrivenFluxBC(atmos, radiation)
+        zero_water_flux = WaterFluxBC((p, t) -> 0.0)
+        zero_heat_flux = HeatFluxBC((p, t) -> 0.0)
+        boundary_fluxes = (;
+            top = top_bc,
+            bottom = WaterHeatBC(;
+                water = zero_water_flux,
+                heat = zero_heat_flux,
+            ),
+        )
+        NIR_albedo_dry = fill(FT(0.4), domain.space.surface)
+        PAR_albedo_dry = fill(FT(0.2), domain.space.surface)
+        NIR_albedo_wet = fill(FT(0.3), domain.space.surface)
+        PAR_albedo_wet = fill(FT(0.1), domain.space.surface)
+        params = ClimaLand.Soil.EnergyHydrologyParameters(
+            FT;
+            ν,
+            ν_ss_om,
+            ν_ss_quartz,
+            ν_ss_gravel,
+            hydrology_cm = hcm,
+            K_sat,
+            S_s,
+            θ_r,
+            NIR_albedo_dry,
+            PAR_albedo_dry,
+            NIR_albedo_wet,
+            PAR_albedo_wet,
+            emissivity,
+            z_0m,
+            z_0b,
+        )
+        soil = Soil.EnergyHydrology{FT}(;
+            parameters = params,
+            domain = domain,
+            boundary_conditions = boundary_fluxes,
+            sources = (),
+        )
+        Y, p, coords = initialize(soil)
+        ϑ_l0 = FT(0.24)
+        θ_i0 = FT(0)
+        Y.soil.ϑ_l .= ϑ_l0
+        Y.soil.θ_i .= θ_i0
+        T = FT(280)
+        ρc_s = Soil.volumetric_heat_capacity(
+            ϑ_l0,
+            θ_i0,
+            params.ρc_ds,
+            params.earth_param_set,
+        )
+        Y.soil.ρe_int =
+            Soil.volumetric_internal_energy.(
+                θ_i0,
+                ρc_s,
+                T,
+                params.earth_param_set,
+            )
+        t = 0.0
+        update_drivers! = make_update_drivers((atmos, radiation))
+        update_drivers!(p, t)
+        # We do not set the initial aux state here because we want to test that it is updated correctly in the jacobian correctly.
+        jacobian = ClimaLand.FieldMatrixWithSolver(Y)
+        jac_tendency! = make_jacobian(soil)
+        dtγ = FT(1.0)
+        jac_tendency!(jacobian, Y, p, dtγ, t)
+
+        K_ic =
+            impedance_factor(θ_i0 / (ϑ_l0 + θ_i0 - θ_r), params.Ω) *
+            viscosity_factor(T, params.γ, params.γT_ref) *
+            hydraulic_conductivity(
+                hcm,
+                K_sat,
+                effective_saturation(ν, ϑ_l0, θ_r),
+            )
+        dz = FT(0.01)
+        dψdϑ_ic = dψdϑ(hcm, ϑ_l0, ν, θ_r, S_s)
+        jac_ϑ_l = jacobian.matrix[
+            MatrixFields.@name(soil.ϑ_l),
+            MatrixFields.@name(soil.ϑ_l)
+        ]
+        # Check the main diagonal, entry corresponding to bottom of column
+        @test Array(parent(jac_ϑ_l.entries.:2))[1] .≈
+              dtγ * (-K_ic / dz^2 * dψdϑ_ic) - I
+        # Check the main diagonal, entries corresponding to interior of domain
+        @test all(
+            Array(parent(jac_ϑ_l.entries.:2))[2:(end - 1)] .≈
+            dtγ * (-2 * K_ic / dz^2 * dψdϑ_ic) - I,
+        )
+        # Check the main diagonal, entry corresponding to top of column
+        @test Array(parent(jac_ϑ_l.entries.:2))[end] .≈
+              dtγ * (-K_ic / dz^2 * dψdϑ_ic) - I
+
+        jac_ρe = jacobian.matrix[
+            MatrixFields.@name(soil.ρe_int),
+            MatrixFields.@name(soil.ρe_int)
+        ]
+        κ_ic = thermal_conductivity(
+            soil.parameters.κ_dry,
+            kersten_number(
+                θ_i0,
+                relative_saturation(ϑ_l0, θ_i0, ν),
+                params.α,
+                params.β,
+                ν_ss_om,
+                ν_ss_quartz,
+                ν_ss_gravel,
+            ),
+            κ_sat(ϑ_l0, θ_i0, params.κ_sat_unfrozen, params.κ_sat_frozen),
+        )
+        dz = FT(0.01)
+        dTdρ_ic =
+            1 / volumetric_heat_capacity(
+                ϑ_l0,
+                θ_i0,
+                params.ρc_ds,
+                params.earth_param_set,
+            )
+        # Check the main diagonal, entry corresponding to bottom of column
+        @test Array(parent(jac_ρe.entries.:2))[1] .≈
+              dtγ * (-κ_ic / dz^2 * dTdρ_ic) - I
+        # Check the main diagonal, entries corresponding to interior of domain
+        @test all(
+            Array(parent(jac_ρe.entries.:2))[2:(end - 1)] .≈
+            dtγ * (-2 * κ_ic / dz^2 * dTdρ_ic) - I,
+        )
+        # Check the main diagonal, entry corresponding to top of column
+        ∂F∂T = 0
+        dfluxBCdY_heat = ∂F∂T * dTdρ_ic
+        @test Array(parent(jac_ρe.entries.:2))[end] .≈
+              dtγ * (-κ_ic / dz^2 * dTdρ_ic - dfluxBCdY_heat / dz) - I
+
+        # Off diagonal blocks, ∂T_ρe_int/∂ϑ_l
+        jac_ρeϑ = jacobian.matrix[
+            MatrixFields.@name(soil.ρe_int),
+            MatrixFields.@name(soil.ϑ_l)
+        ]
+
+        ρe_liq_ic = ClimaLand.Soil.volumetric_internal_energy_liq(
+            T,
+            params.earth_param_set,
+        )
+        # Check the main diagonal, entry corresponding to bottom of column
+        @test Array(parent(jac_ρeϑ.entries.:2))[1] .≈
+              dtγ * (-ρe_liq_ic * K_ic / dz^2 * dψdϑ_ic) - I
+        # Check the main diagonal, entries corresponding to interior of domain
+        @test all(
+            Array(parent(jac_ρeϑ.entries.:2))[2:(end - 1)] .≈
+            dtγ * (-2 * ρe_liq_ic * K_ic / dz^2 * dψdϑ_ic) - I,
+        )
+        # Check the main diagonal, entry corresponding to top of column
+        @test Array(parent(jac_ρeϑ.entries.:2))[end] .≈
+              dtγ * (-ρe_liq_ic * K_ic / dz^2 * dψdϑ_ic) - I
+
+        @test :dfluxBCdY ∈ propertynames(p.soil)
+    end
+
 end


### PR DESCRIPTION
## Purpose 
Adds infrastructure for adding d(boundary flux)/dY to the Jacobian for the soil model when Atmos-Driven fluxes are used.

Currently sets the contributions to zero, no change in simulations are expected. I turned on the "run benchmarks" to see if there is any impact.


## To-do



## Content
Adds space to the cache for dLHFdT, dSHFdT, dGHFdT. Currently only the last one is updated/nonzero. The other two are set to zero

These terms will then be used in dFlux/dT dT/d rho e. We allocated space for those in the cache, but they are currently set to zero.

These terms are then added into the jacobian for the soil model.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
