### PR TITLE
add to snowy land diags shortlist

### DIFF
--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -335,11 +335,14 @@ function default_diagnostics(
             "swu",
             "swd",
             "lwu",
+            "lwd",
             "et",
             "er",
             "sr",
             "swe",
             "snd",
+            "shf",
+            "lhf",
         ]
     end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Adds LWD, SHF, LHF to snowy land default diagnostics shortlist. We need output of these from the global snowy land longrun to make plots for the paper. Alternatively, we could run the longruns with the option `output_vars = :long` and use the outputs from that run, but I'd rather have these vars output for each longrun, at least while we're working on the paper plots.