### PR TITLE
Spun up IC

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,3 +1,11 @@
+[soil_ic_2008_50m]
+git-tree-sha1 = "ffa52ae695b5962fde4bab21187cc015b8f34f65"
+
+    [[soil_ic_2008_50m.download]]
+    sha256 = "9546a70e1ac7c8dab0ddce232b64ef2716cc5b71065d8b6be400a5c0a90d42cc"
+    url = "https://caltech.box.com/shared/static/atiztw8uu2i78g2vd02n8onb68cer9tn.gz"
+
+
 [soilgrids]
 git-tree-sha1 = "f919da748cc973519fb136f4225cf343f5c3e41f"
 [soilgrids_lowres]

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -150,24 +150,16 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     )
 
     Y, p, cds = initialize(soil)
-    init_soil(ν, θ_r) = θ_r + (ν - θ_r) / 2
-    Y.soil.ϑ_l .= init_soil.(ν, θ_r)
-    Y.soil.θ_i .= FT(0.0)
-    T = FT(276.85)
-    ρc_s =
-        Soil.volumetric_heat_capacity.(
-            Y.soil.ϑ_l,
-            Y.soil.θ_i,
-            soil_params.ρc_ds,
-            soil_params.earth_param_set,
-        )
-    Y.soil.ρe_int .=
-        Soil.volumetric_internal_energy.(
-            Y.soil.θ_i,
-            ρc_s,
-            T,
-            soil_params.earth_param_set,
-        )
+
+    soil_ic_path =
+        ClimaLand.Artifacts.soil_ic_2008_50m_path(; context = context)
+    ClimaLand.set_soil_initial_conditions!(
+        Y,
+        ν,
+        θ_r,
+        subsurface_space,
+        soil_ic_path,
+    )
 
     set_initial_cache! = make_set_initial_cache(soil)
     exp_tendency! = make_exp_tendency(soil)
@@ -204,7 +196,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
         subsurface_space,
         outdir;
         start_date,
-        num_points = (570, 285, 50), # use default in `z`.
+        num_points = (570, 285, 15),
     )
 
     diags = ClimaLand.default_diagnostics(

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -5,6 +5,22 @@ import ClimaUtilities.ClimaArtifacts: @clima_artifact
 import LazyArtifacts
 
 using ArtifactWrappers
+
+"""
+    soil_ic_2008_50m_path(; context)
+
+Return the path to the file that contains the spun-up soil and snow initial 
+conditions for Jan 1, 2008.
+
+The soil domain has a depth of 50m; we have ensured that surface properties
+and fluxes are spun-up, but the deep soil water may not be.
+"""
+function soil_ic_2008_50m_path(; context = nothing)
+    dir = @clima_artifact("soil_ic_2008_50m", context)
+    return joinpath(dir, "soil_ic_2008_50m.nc")
+end
+
+
 """
     era5_land_forcing_data2008_path(; context, lowres=false)
 

--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -331,5 +331,6 @@ import .Diagnostics: default_diagnostics
 
 # Simulations
 include(joinpath("simulations", "spatial_parameters.jl"))
+include(joinpath("simulations", "initial_conditions.jl"))
 
 end

--- a/src/diagnostics/Diagnostics.jl
+++ b/src/diagnostics/Diagnostics.jl
@@ -14,6 +14,8 @@ import ..Soil: EnergyHydrology
 
 import ..Domains: top_center_to_surface
 
+import ..heaviside
+
 import ClimaDiagnostics:
     DiagnosticVariable, ScheduledDiagnostic, average_pre_output_hook!
 
@@ -21,6 +23,8 @@ import ClimaDiagnostics.Schedules:
     EveryStepSchedule, EveryDtSchedule, EveryCalendarDtSchedule
 
 import ClimaDiagnostics.Writers: HDF5Writer, NetCDFWriter, DictWriter
+
+import ClimaCore.Operators: column_integral_definite!
 
 include("diagnostic.jl")
 

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -328,24 +328,21 @@ function default_diagnostics(
         snowyland_diagnostics = [
             "gpp",
             "ct",
-            "lai",
             "swc",
             "si",
             "sie",
             "swu",
-            "swd",
             "lwu",
-            "lwd",
             "et",
-            "er",
             "sr",
             "ssr",
             "swe",
-            "snd",
             "shf",
             "lhf",
             "trans",
             "msf",
+            "lwp",
+            "iwc_1m",
         ]
     end
 

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -829,6 +829,16 @@ function define_diagnostics!(land_model)
             compute_soil_water_content!(out, Y, p, t, land_model),
     )
 
+    add_diagnostic_variable!(
+        short_name = "iwc_1m",
+        long_name = "Integrated Soil Water Content in first 1m",
+        standard_name = "soil_1m_water_content",
+        units = "m",
+        comments = "The integrated water content to a depth of 1m",
+        compute! = (out, Y, p, t) ->
+            compute_1m_water_content!(out, Y, p, t, land_model),
+    )
+
     # Plant water content
 
     #=

--- a/src/simulations/initial_conditions.jl
+++ b/src/simulations/initial_conditions.jl
@@ -1,0 +1,133 @@
+import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
+import ClimaUtilities.Regridders: InterpolationsRegridder
+import Interpolations
+regridder_type = :InterpolationsRegridder
+extrapolation_bc =
+    (Interpolations.Periodic(), Interpolations.Flat(), Interpolations.Flat())
+"""
+    set_soil_initial_conditions!(Y, ν, θ_r, subsurface_space, soil_ic_path)
+
+Sets the soil initial conditions, stored in `Y.soil.ϑ_l`, `Y.soil.θ_i`,
+`Y.soil.ρe_int`, and defined on the `subsurface_space`, using the values
+in the net cdf file stored at `soil_ic_path`.
+
+Since the values in the netcdf file have been interpolated once (to save the output),
+and interpolated again (onto the model grid), there is no guarantee that the liquid water
+content is above the residual. Although our model can simulate oversaturated soils, there
+is no guarantee that the initial conditions read in will be stable. Because of this,
+we enforce the constraint of ϑ_l > θ_r and θ_i + ϑ_l < ν.
+"""
+function set_soil_initial_conditions!(
+    Y,
+    ν,
+    θ_r,
+    subsurface_space,
+    soil_ic_path;
+    regridder_type = regridder_type,
+    extrapolation_bc = extrapolation_bc,
+)
+    Y.soil.ϑ_l .= SpaceVaryingInput(
+        soil_ic_path,
+        "swc",
+        subsurface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    Y.soil.θ_i .= SpaceVaryingInput(
+        soil_ic_path,
+        "si",
+        subsurface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+
+    Y.soil.ϑ_l .= enforce_residual_constraint.(Y.soil.ϑ_l, θ_r)
+    Y.soil.θ_i .= enforce_porosity_constraint.(Y.soil.ϑ_l, Y.soil.θ_i, ν, θ_r)
+    Y.soil.ρe_int .= SpaceVaryingInput(
+        soil_ic_path,
+        "sie",
+        subsurface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    return nothing
+end
+
+"""
+     enforce_residual_constraint(ϑ_l::FT ,θ_r::FT)
+
+Enforces the constraint that ϑ_l > θ_r by returning 1.01 θ_r
+if ϑ_l < θ_r, and ϑ_l otherwise.
+"""
+function enforce_residual_constraint(ϑ_l::FT, θ_r::FT) where {FT}
+    if ϑ_l < θ_r
+        return θ_r * FT(1.01)
+    else
+        return ϑ_l
+    end
+end
+
+"""
+    enforce_porosity_constraint(ϑ_l::FT, θ_i::FT, ν::FT, θ_r::FT)
+
+Enforces the constraint that ϑ_l + θ_i <= ν, by clipping the ice content to be
+99% (ν-ϑ_l), or leaving it unchanged if the constraint is already satisfied.
+"""
+function enforce_porosity_constraint(
+    ϑ_l::FT,
+    θ_i::FT,
+    ν::FT,
+    θ_r::FT,
+) where {FT}
+    if ϑ_l + θ_i > ν # if we exceed porosity
+        return FT(0.99) * (ν - ϑ_l) # clip ice content to 99% of available pore space
+    else
+        return θ_i
+    end
+end
+
+
+"""
+    set_snow_initial_conditions!(Y, p, surface_space, snow_ic_path, params)
+
+Sets the snow initial conditions, stored in `Y.snow.S`, `Y.snow.S_l`,
+`Y.snow.U`, and defined on the `surface_space`, using the values
+in the net cdf file stored at `snow_ic_path`.
+
+We assume that S_l = 0 and that the temperature of the snow has been updated
+in p.snow.T.
+"""
+function set_snow_initial_conditions!(
+    Y,
+    p,
+    surface_space,
+    snow_ic_path,
+    params;
+    regridder_type = regridder_type,
+    extrapolation_bc = extrapolation_bc,
+)
+    Y.snow.S .= SpaceVaryingInput(
+        snow_ic_path,
+        "swe",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    Y.snow.S_l .= 0
+    p.snow.T .= enforce_snow_temperature_constraint.(Y.snow.S, p.snow.T)
+    Y.snow.U .=
+        ClimaLand.Snow.energy_from_T_and_swe.(Y.snow.S, p.snow.T, params)
+    return nothing
+end
+"""
+    enforce_snow_temperature_constraint(S::FT, T::FT)
+
+Enforces the constraint that T < 273.15 if S > 0.
+"""
+function enforce_snow_temperature_constraint(S::FT, T::FT) where {FT}
+    if S > sqrt(eps(FT)) # if snow is on the ground
+        return min(T, FT(273))
+    else
+        return T
+    end
+end


### PR DESCRIPTION
## Purpose 
Add initial conditions for soil and snow. 

These are read from the netcdf file added to clima artifacts: https://github.com/CliMA/ClimaArtifacts/pull/107 and https://github.com/CliMA/ClimaArtifacts/pull/112

While the spin-up in ET seems to be reduced, the GPP spin-up is still there. it is hard to diagnose what state variable are not spun up yet to cause this. This also adds in diagnostics for lwp and total water content, to test what is leading to the slow spinup of GPP.

I also removed an allocation in the LAI diagnostic, and removed some diagnostics that we never use to test if have fewer makes it run faster


## To-do



## Content


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
