### PR TITLE
Additional years of MODIS LAI data

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -42,10 +42,10 @@ git-tree-sha1 = "df5ec5af1ea0793c0e7d49e60db5a938098e174f"
     url = "https://caltech.box.com/shared/static/m82r23e67x04a3hb6p79dfltlumvg9z0.gz"
 
 [modis_lai]
-git-tree-sha1 = "20ee5dc96fde9a15bd3c40e80ac5036a9a39e0cf"
+git-tree-sha1 = "81d4bc1b22e94d66eec3d80a2d21b5dd5303bf8f"
 
     [[modis_lai.download]]
-    sha256 = "e97bf4a8eeac7c32c00a7d27bf5ec957e9c800117d56e66c27a123171a1f1c04"
+    sha256 = "4a244428fe480aa05ff863af69299d2ed8ca66ed324b9e1bffcb440792fb4cce"
     url = "https://caltech.box.com/shared/static/99ktg026kciezykyegsawd1gjwj1du74.gz"
 
 [land_albedo]

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -236,7 +236,7 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
     modis_lai_artifact_path =
         ClimaLand.Artifacts.modis_lai_forcing_data2008_path(; context)
     modis_lai_ncdata_path =
-        joinpath(modis_lai_artifact_path, "Yuan_et_al_2011_1x1.nc")
+        joinpath(modis_lai_artifact_path, "Yuan_et_al_2008_1x1.nc")
     LAIfunction = ClimaLand.prescribed_lai_modis(
         modis_lai_ncdata_path,
         surface_space,

--- a/experiments/benchmarks/snowy_land.jl
+++ b/experiments/benchmarks/snowy_land.jl
@@ -234,7 +234,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     modis_lai_artifact_path =
         ClimaLand.Artifacts.modis_lai_forcing_data2008_path(; context)
     modis_lai_ncdata_path =
-        joinpath(modis_lai_artifact_path, "Yuan_et_al_2011_1x1.nc")
+        joinpath(modis_lai_artifact_path, "Yuan_et_al_2008_1x1.nc")
     LAIfunction = ClimaLand.prescribed_lai_modis(
         modis_lai_ncdata_path,
         surface_space,

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -127,7 +127,7 @@ photosynthesis_args =
 modis_lai_artifact_path =
     ClimaLand.Artifacts.modis_lai_forcing_data2008_path(; context)
 modis_lai_ncdata_path =
-    joinpath(modis_lai_artifact_path, "Yuan_et_al_2011_1x1.nc")
+    joinpath(modis_lai_artifact_path, "Yuan_et_al_2008_1x1.nc")
 LAIfunction = ClimaLand.prescribed_lai_modis(
     modis_lai_ncdata_path,
     surface_space,

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -235,7 +235,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     modis_lai_artifact_path =
         ClimaLand.Artifacts.modis_lai_forcing_data2008_path(; context)
     modis_lai_ncdata_path =
-        joinpath(modis_lai_artifact_path, "Yuan_et_al_2011_1x1.nc")
+        joinpath(modis_lai_artifact_path, "Yuan_et_al_2008_1x1.nc")
     LAIfunction = ClimaLand.prescribed_lai_modis(
         modis_lai_ncdata_path,
         surface_space,

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -238,7 +238,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
     modis_lai_artifact_path =
         ClimaLand.Artifacts.modis_lai_forcing_data2008_path(; context)
     modis_lai_ncdata_path =
-        joinpath(modis_lai_artifact_path, "Yuan_et_al_2011_1x1.nc")
+        joinpath(modis_lai_artifact_path, "Yuan_et_al_2008_1x1.nc")
     LAIfunction = ClimaLand.prescribed_lai_modis(
         modis_lai_ncdata_path,
         surface_space,

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -238,7 +238,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     modis_lai_artifact_path =
         ClimaLand.Artifacts.modis_lai_forcing_data2008_path(; context)
     modis_lai_ncdata_path =
-        joinpath(modis_lai_artifact_path, "Yuan_et_al_2011_1x1.nc")
+        joinpath(modis_lai_artifact_path, "Yuan_et_al_2008_1x1.nc")
     LAIfunction = ClimaLand.prescribed_lai_modis(
         modis_lai_ncdata_path,
         surface_space,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR is a trivial adjustment to the MODIS LAI artifact entry in `artifacts.toml` for the newly updated MODIS LAI artifact. The new artifact includes data for all years 2000-2020.

Corresponding changes in ClimaArtifacts are [here](https://github.com/CliMA/ClimaArtifacts/pull/109)


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
 - One-line change to `Artifacts.toml`


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
