### PR TITLE
Fix CI failure modes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -193,7 +193,7 @@ steps:
         agents:
           slurm_ntasks: 1
           slurm_gpus: 1
-          slurm_mem: 4G
+          slurm_mem: 16G
         env:
           CLIMACOMMS_DEVICE: "CUDA"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -193,6 +193,7 @@ steps:
         agents:
           slurm_ntasks: 1
           slurm_gpus: 1
+          slurm_mem: 4G
         env:
           CLIMACOMMS_DEVICE: "CUDA"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: ci ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         version:
           - '1.10'


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Windows CI tests are failing for an upstream issue. We switched them to be not required to merge a PR, but when they fail, they cancel the other CI tasks (ubuntu, mac). This changes our CI so that even if they fail, the others keep running.
It is meant as a temporary fix until we add back in the requirement for windows CI to pass

Our GPU run of the unit tests is also failing, due to out of memory. This increases the memory from the default (2G to 4G)



