### PR TITLE
Make coupled drivers support full land model

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ ClimaLand.jl Release Notes
 main
 -------
 
+- update drivers to support running `LandModel` in coupled mode
+  PR[#1035](https://github.com/CliMA/ClimaLand.jl/pull/1035)
 
 v0.15.10
 --------

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -491,14 +491,13 @@ conditions when a canopy and Soil CO2  model is also included, though only
 the presence of the canopy modifies the soil BC.
 """
 function soil_boundary_fluxes!(
-    bc::AtmosDrivenFluxBC{<:PrescribedAtmosphere, <:PrescribedRadiativeFluxes},
+    bc::AtmosDrivenFluxBC,
     prognostic_land_components::Val{(:canopy, :snow, :soil, :soilco2)},
     soil::EnergyHydrology{FT},
     Y,
     p,
     t,
 ) where {FT}
-    bc = soil.boundary_conditions.top
     turbulent_fluxes!(p.soil.turbulent_fluxes, bc.atmos, soil, Y, p, t)
     # influx = maximum possible rate of infiltration given precip, snowmelt, evaporation/condensation
     # but if this exceeds infiltration capacity of the soil, runoff will
@@ -671,3 +670,11 @@ function ClimaLand.get_drivers(model::LandModel)
         model.soilco2.drivers.soc,
     )
 end
+
+"""
+    ClimaLand.surface_albedo(::LandModel, Y, p)
+
+Returns the surface albedo for the land model, which is computed
+from the ratio of the upwelling and downwelling shortwave radiation.
+"""
+ClimaLand.surface_albedo(::LandModel, Y, p) = p.α_sfc

--- a/src/integrated/land_radiation.jl
+++ b/src/integrated/land_radiation.jl
@@ -39,7 +39,7 @@ function Canopy.canopy_radiant_energy_fluxes!(
     p::NamedTuple,
     s::Union{PrognosticGroundConditions, PrognosticSoilConditions},
     canopy,
-    radiation::PrescribedRadiativeFluxes,
+    radiation::AbstractRadiativeDrivers,
     earth_param_set::PSE,
     Y::ClimaCore.Fields.FieldVector,
     t,

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -287,8 +287,6 @@ function lsm_radiant_energy_fluxes!(
     t,
 ) where {(FT)}
     canopy = land.canopy
-    canopy_bc = canopy.boundary_conditions
-    radiation = canopy_bc.radiation
     earth_param_set = canopy.parameters.earth_param_set
     _σ = LP.Stefan(earth_param_set)
     LW_d = p.drivers.LW_d
@@ -361,7 +359,7 @@ conditions when a canopy and Soil CO2  model is also included, though only
 the presence of the canopy modifies the soil BC.
 """
 function soil_boundary_fluxes!(
-    bc::AtmosDrivenFluxBC{<:PrescribedAtmosphere, <:PrescribedRadiativeFluxes},
+    bc::AtmosDrivenFluxBC,
     prognostic_land_components::Val{(:canopy, :soil, :soilco2)},
     soil::EnergyHydrology,
     Y,

--- a/src/integrated/soil_snow_model.jl
+++ b/src/integrated/soil_snow_model.jl
@@ -345,7 +345,7 @@ energy and water flux at the surface of the soil for use as boundary
 conditions, taking into account the presence of snow on the surface.
 """
 function soil_boundary_fluxes!(
-    bc::AtmosDrivenFluxBC{<:PrescribedAtmosphere, <:PrescribedRadiativeFluxes},
+    bc::AtmosDrivenFluxBC,
     prognostic_land_components::Val{(:snow, :soil)},
     soil::EnergyHydrology,
     Y,

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -413,6 +413,8 @@ end
                     t)
 
 Computes the turbulent surface fluxes terms at the ground for a coupled simulation.
+In this case, the coupler has already computed turbulent fluxes and updated
+them in each of the component models, so this function does nothing.
 """
 function ClimaLand.turbulent_fluxes!(
     dest,
@@ -422,10 +424,6 @@ function ClimaLand.turbulent_fluxes!(
     p,
     t,
 )
-    # coupler has done its thing behind the scenes already
-    model_name = ClimaLand.name(model)
-    model_cache = getproperty(p, model_name)
-    dest .= model_cache.turbulent_fluxes
     return nothing
 end
 
@@ -437,7 +435,7 @@ Container for the prescribed radiation functions needed to drive land models in 
 
 Note that some models require the zenith angle AND diffuse fraction. The diffuse fraction
 may be provided directly (of type TimeVaryingInput), or it may be computed empirically.
-In the latter case, it requires the thermodynamic parameters as well to compute. 
+In the latter case, it requires the thermodynamic parameters as well to compute.
 
 Therefore, the allowed combinations are:
 1. Zenith angle and diffuse fraction not needed: zenith angle=nothing, thermo_params=nothing, diffuse fraction=nothing
@@ -773,16 +771,16 @@ end
     specific_humidity_from_dewpoint(dewpoint_temperature, temperature, air_pressure, earth_param_set)
 
 Estimates the specific humidity given the dewpoint temperature, temperature of the air
-in Kelvin, and air pressure in Pa, along with the ClimaLand earth_param_set. This is useful 
+in Kelvin, and air pressure in Pa, along with the ClimaLand earth_param_set. This is useful
 for creating the PrescribedAtmosphere - which needs specific humidity - from ERA5 reanalysis data.
 
 We first compute the relative humidity using the Magnus formula, then the saturated vapor pressure, and then
 we compute q from vapor pressure and saturated vapor pressure.
 
-For more information on the Magnus formula, see e.g. 
-Lawrence, Mark G. (1 February 2005). 
-"The Relationship between Relative Humidity and the Dewpoint Temperature in Moist Air: 
-A Simple Conversion and Applications". 
+For more information on the Magnus formula, see e.g.
+Lawrence, Mark G. (1 February 2005).
+"The Relationship between Relative Humidity and the Dewpoint Temperature in Moist Air:
+A Simple Conversion and Applications".
 Bulletin of the American Meteorological Society. 86 (2): 225–234.
 """
 function specific_humidity_from_dewpoint(
@@ -815,13 +813,13 @@ end
 """
     rh_from_dewpoint(Td_C, T_C)
 
-Returns the relative humidity given the dewpoint temperature in Celsius and the 
+Returns the relative humidity given the dewpoint temperature in Celsius and the
 air temperature in Celsius, using the Magnus formula.
 
-For more information on the Magnus formula, see e.g. 
-Lawrence, Mark G. (1 February 2005). 
-"The Relationship between Relative Humidity and the Dewpoint Temperature in Moist Air: 
-A Simple Conversion and Applications". 
+For more information on the Magnus formula, see e.g.
+Lawrence, Mark G. (1 February 2005).
+"The Relationship between Relative Humidity and the Dewpoint Temperature in Moist Air:
+A Simple Conversion and Applications".
 Bulletin of the American Meteorological Society. 86 (2): 225–234.
 """
 function rh_from_dewpoint(Td_C::FT, T_C::FT) where {FT <: Real}
@@ -874,36 +872,16 @@ function initialize_drivers(a::PrescribedPrecipitation{FT}, coords) where {FT}
 end
 
 """
-    initialize_drivers(r::CoupledAtmosphere{FT}, coords) where {FT}
+    initialize_drivers(r::AbstractRadiativeDrivers{FT}, coords) where {FT}
 
-Creates and returns a NamedTuple for the `CoupledAtmosphere` driver,
-with variables `P_liq`, and `P_snow`. This is intended to be used in coupled
-simulations with ClimaCoupler.jl
-"""
-function ClimaLand.initialize_drivers(
-    a::CoupledAtmosphere{FT},
-    coords,
-) where {FT}
-    keys = (:P_liq, :P_snow)
-    types = ([FT for k in keys]...,)
-    domain_names = ([:surface for k in keys]...,)
-    model_name = :drivers
-    # intialize_vars packages the variables as a named tuple,
-    # as part of a named tuple with `model_name` as the key.
-    # Here we just want the variable named tuple itself
-    vars =
-        ClimaLand.initialize_vars(keys, types, domain_names, coords, model_name)
-    return vars.drivers
-end
+Creates and returns a NamedTuple for the radiative fluxes driver,
+with variables `SW_d`, `LW_d`, cosine of the zenith angle `cosθs`, and the
+diffuse fraction of shortwave radiation `frac_diff`.
 
+We require the same variables for both prescribed and coupled radiative drivers,
+so we can use the same function for both of them.
 """
-    initialize_drivers(r::PrescribedRadiativeFluxes{FT}, coords) where {FT}
-
-Creates and returns a NamedTuple for the `PrescribedRadiativeFluxes` driver,
- with variables `SW_d`, `LW_d`, cosine of the zenith angle `θ_s`, and the diffuse fraction
-of shortwave radiation `frac_diff`.
-"""
-function initialize_drivers(r::PrescribedRadiativeFluxes{FT}, coords) where {FT}
+function initialize_drivers(r::AbstractRadiativeDrivers{FT}, coords) where {FT}
     keys = (:SW_d, :LW_d, :cosθs, :frac_diff)
     types = ([FT for k in keys]...,)
     domain_names = ([:surface for k in keys]...,)
@@ -929,6 +907,30 @@ function initialize_drivers(
     keys = (:soc,)
     types = (FT,)
     domain_names = (:subsurface,)
+    model_name = :drivers
+    # intialize_vars packages the variables as a named tuple,
+    # as part of a named tuple with `model_name` as the key.
+    # Here we just want the variable named tuple itself
+    vars =
+        ClimaLand.initialize_vars(keys, types, domain_names, coords, model_name)
+    return vars.drivers
+end
+
+"""
+    initialize_drivers(r::CoupledAtmosphere{FT}, coords) where {FT}
+
+Creates and returns a NamedTuple for the `CoupledAtmosphere` driver,
+with variables `P_liq`, `P_snow`, `c_co2`, `T`, `P`, and `q`.
+
+This is intended to be used in coupled simulations with ClimaCoupler.jl
+"""
+function ClimaLand.initialize_drivers(
+    a::CoupledAtmosphere{FT},
+    coords,
+) where {FT}
+    keys = (:P_liq, :P_snow, :c_co2, :T, :P, :q)
+    types = ([FT for k in keys]...,)
+    domain_names = ([:surface for k in keys]...,)
     model_name = :drivers
     # intialize_vars packages the variables as a named tuple,
     # as part of a named tuple with `model_name` as the key.
@@ -1090,7 +1092,7 @@ end
                              time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
                              regridder_type = :InterpolationsRegridder)
 
-A helper function which constructs the `PrescribedAtmosphere` and `PrescribedRadiativeFluxes` 
+A helper function which constructs the `PrescribedAtmosphere` and `PrescribedRadiativeFluxes`
 from a file path pointing to the ERA5 data in a netcdf file, the surface_space, the start date,
 and the earth_param_set.
 """

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -808,7 +808,7 @@ Here, the soil boundary fluxes are computed as if the soil is run
 in standalone mode.
 """
 function soil_boundary_fluxes!(
-    bc::AtmosDrivenFluxBC{<:PrescribedAtmosphere, <:PrescribedRadiativeFluxes},
+    bc::AtmosDrivenFluxBC,
     prognostic_land_components::Val{(:soil,)},
     model::EnergyHydrology,
     Y,

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -455,8 +455,6 @@ function ClimaLand.make_update_aux(
         K = p.canopy.radiative_transfer.K
         @. K = extinction_coeff(p.canopy.radiative_transfer.G, cosθs)
 
-
-
         compute_fractional_absorbances!(
             p,
             RT,

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -142,7 +142,7 @@ The estimated PAR is half of the incident shortwave radiation.
 function compute_PAR!(
     par,
     model::AbstractRadiationModel,
-    solar_radiation::ClimaLand.PrescribedRadiativeFluxes,
+    solar_radiation::ClimaLand.AbstractRadiativeDrivers,
     p,
     t,
 )
@@ -165,7 +165,7 @@ The estimated PNIR is half of the incident shortwave radiation.
 function compute_NIR!(
     nir,
     model::AbstractRadiationModel,
-    solar_radiation::ClimaLand.PrescribedRadiativeFluxes,
+    solar_radiation::ClimaLand.AbstractRadiativeDrivers,
     p,
     t,
 )


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
closes #1041

This PR updates the behavior of the integrated land model in the case of coupled drivers (atmosphere and radiation), so that it works as expected in coupled simulations.

After this PR, `p.drivers` now contains the following fields: `(:P_liq, :P_snow, :c_co2, :T, :P, :q, :SW_d, :LW_d, :cosθs, :frac_diff, :soc)`.

This branch is tested by https://github.com/CliMA/ClimaCoupler.jl/pull/1199, where a `LandModel` is initialized with coupled drivers, and tested to verify the object is constructed correctly. The next step will be updating the turbulent flux calculations in ClimaCoupler to support `LandModel` and running a coupled simulation with the `LandModel`.

## Content
- extend functions to operate when using either prescribed or coupled drivers: `soil_boundary_fluxes!`, `initialize_drivers` for radiation, `compute_PAR`, `compute_NIR`
- update the `initialize_drivers` method for coupled atmosphere to allocate space for the needed fields
- add a function to return surface albedo of `LandModel`
- `turbulent_fluxes!` now does nothing in the coupled case


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
