### PR TITLE
Update ERA5 LAI artifact

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -107,8 +107,8 @@ git-tree-sha1 = "839224a62b59d73073bdb9a5c55d3dc75e30fe33"
     url = "https://caltech.box.com/shared/static/eii2bfwfp47axfeuysgxlgzbczz27u5g.gz"
 
 [era5_lai_covers]
-git-tree-sha1 = "dd651b30b448740bdfef8e9cb7835bcd55ddf72f"
+git-tree-sha1 = "1e77fc84a027da43f1bf6ebe0a53849595a2be22"
 
     [[era5_lai_covers.download]]
-    sha256 = "2c5bcbd0823e037c5fcd67444b2cbdd2f054906752af6e8574a2975ede7f8160"
-    url = "https://caltech.box.com/shared/static/vf5ts11u2o5yjb1jmr387audnephnftr.gz"
+    sha256 = "0331e3a2fc2cb53b0f1d9c5a84f49989da0b506258edc229da161e9ca4a61457"
+    url = "https://caltech.box.com/shared/static/uzuzk5wh8r9q477jbrusfg1sr0ytzem9.gz"


### PR DESCRIPTION
The SHA256 and link change when updating in ClimaArtifacts.

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
