### PR TITLE
add mask to NaN checker

### DIFF
--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -45,16 +45,6 @@ steps:
         env:
           CLIMACOMMS_DEVICE: "CUDA"
 
-      - label: ":seedling: Soil-Canopy"
-        command:
-          - julia --color=yes --project=.buildkite experiments/long_runs/land.jl
-        artifact_paths: "land_longrun_gpu/*pdf"
-        agents:
-          slurm_gpus: 1
-          slurm_time: 15:00:00
-        env:
-          CLIMACOMMS_DEVICE: "CUDA"
-
       - label: ":sunglasses: California regional simulation"
         command:
           - julia --color=yes --project=.buildkite experiments/long_runs/land_region.jl

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,3 +1,24 @@
+[landsea_mask_30arcseconds]
+git-tree-sha1 = "517c925535981f9d17ac9e7a65e2c35c3ce9597d"
+
+    [[landsea_mask_30arcseconds.download]]
+    sha256 = "11eaf6b7606056d198f3735f7b76ead76269cced186de78075f415101cf39088"
+    url = "https://caltech.box.com/shared/static/z013ay1k6oqofnw69bv5held9x374sux.gz"
+
+[landsea_mask_60arcseconds]
+git-tree-sha1 = "10ed7ec61def091c44545825cfb4d9599216c3c8"
+
+    [[landsea_mask_60arcseconds.download]]
+    sha256 = "eb88455a39a00bfadb77effbc31a4df561158c0ca1578476edb683d45e3c49da"
+    url = "https://caltech.box.com/shared/static/vivf36pih7e0ttahqarc2nd5jxb4q8jr.gz"
+
+[landsea_mask_1deg]
+git-tree-sha1 = "cbbc6b3752d9cb9b667ec33cfbeb46819f8db418"
+
+    [[landsea_mask_1deg.download]]
+    sha256 = "3722b553c2fdf28a6574aea2e0b167d16ab050f34e5969ada45625b3a3ecb6da"
+    url = "https://caltech.box.com/shared/static/b3u4dv0dsoswvqgp8y63bzj7awbhwztd.gz"
+    
 [soil_ic_2008_50m]
 git-tree-sha1 = "ffa52ae695b5962fde4bab21187cc015b8f34f65"
 

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -370,9 +370,15 @@ function setup_prob(
     diag_cb = ClimaDiagnostics.DiagnosticsCallback(diagnostic_handler)
 
     driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
-
+    mask = ClimaLand.landsea_mask(surface_space)
     nancheck_freq = Dates.Month(1)
-    nancheck_cb = ClimaLand.NaNCheckCallback(nancheck_freq, start_date, t0, Δt)
+    nancheck_cb = ClimaLand.NaNCheckCallback(
+        nancheck_freq,
+        start_date,
+        t0,
+        Δt;
+        mask = mask,
+    )
     return prob, SciMLBase.CallbackSet(driver_cb, diag_cb, nancheck_cb)
 end
 

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -390,8 +390,15 @@ function setup_prob(
     end
     report_cb = SciMLBase.DiscreteCallback(every1000steps, report)
 
+    mask = ClimaLand.landsea_mask(surface_space)
     nancheck_freq = Dates.Month(1)
-    nancheck_cb = ClimaLand.NaNCheckCallback(nancheck_freq, start_date, t0, Δt)
+    nancheck_cb = ClimaLand.NaNCheckCallback(
+        nancheck_freq,
+        start_date,
+        t0,
+        Δt;
+        mask = mask,
+    )
 
     return prob,
     SciMLBase.CallbackSet(driver_cb, diag_cb, report_cb, nancheck_cb)

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -211,9 +211,15 @@ function setup_prob(
     diag_cb = ClimaDiagnostics.DiagnosticsCallback(diagnostic_handler)
 
     driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
-
+    mask = ClimaLand.landsea_mask(surface_space)
     nancheck_freq = Dates.Month(1)
-    nancheck_cb = ClimaLand.NaNCheckCallback(nancheck_freq, start_date, t0, Δt)
+    nancheck_cb = ClimaLand.NaNCheckCallback(
+        nancheck_freq,
+        start_date,
+        t0,
+        Δt;
+        mask = mask,
+    )
     return prob, SciMLBase.CallbackSet(driver_cb, diag_cb, nancheck_cb)
 end
 

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -374,6 +374,33 @@ function ilamb_dataset_path(filename; context = nothing)
 end
 
 """
+    landseamask_file_path(; resolution = "60arcs", context=nothing)
+
+Construct the file path for the landsea mask data NetCDF file,
+using 60arcseconds by default.
+
+The other options available include "30arcs" (30arcseconds) or "1deg" (1degree).
+"""
+function landseamask_file_path(; resolution = "60arcs", context = nothing)
+    @assert resolution in ["60arcs", "30arcs", "1deg"]
+    filename = "landsea_mask.nc"
+    if resolution == "60arcs"
+        return joinpath(
+            @clima_artifact("landsea_mask_60arcseconds", context),
+            filename,
+        )
+    elseif resolution == "30arcs"
+        return joinpath(
+            @clima_artifact("landsea_mask_30arcseconds", context),
+            filename,
+        )
+    else
+        return joinpath(@clima_artifact("landsea_mask_1deg", context), filename)
+    end
+
+end
+
+"""
     earth_orography_file_path(; context=nothing)
 
 Construct the file path for the 60arcsecond orography data NetCDF file.


### PR DESCRIPTION
## Purpose 
Adds land/sea mask that will be used Clima wide
uses this in the nanchecker
fixes a bug with the masked nanchecker where a 2d mask couldnt be used with a 3d field


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
