### PR TITLE
fix bug with iwc name

### DIFF
--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -482,7 +482,7 @@ for (group_id, group) in
 end
 
 short_names =
-    ["gpp", "swc", "et", "ct", "swe", "si", "lwp", "iwc_1m", "trans", "msf"]
+    ["gpp", "swc", "et", "ct", "swe", "si", "lwp", "iwc", "trans", "msf"]
 
 include(
     joinpath(

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -323,6 +323,7 @@ function default_diagnostics(
             "lhf",
             "shf",
             "ghf",
+            "iwc",
         ]
     elseif output_vars == :short
         snowyland_diagnostics = [
@@ -342,7 +343,7 @@ function default_diagnostics(
             "trans",
             "msf",
             "lwp",
-            "iwc_1m",
+            "iwc",
         ]
     end
 

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -830,7 +830,7 @@ function define_diagnostics!(land_model)
     )
 
     add_diagnostic_variable!(
-        short_name = "iwc_1m",
+        short_name = "iwc",
         long_name = "Integrated Soil Water Content in first 1m",
         standard_name = "soil_1m_water_content",
         units = "m",


### PR DESCRIPTION
## Purpose 
Our diagnostics name "iwc_1m" fails in plotting because it is thought to be "iwc" at 1minute. This changes the name by removing "_1m".


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
