### PR TITLE
Use GL vs GLL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ ClimaLand.jl Release Notes
 
 main
 -------
+- use GL vs GLL quadrature; speeds up simulation 2x globally
+  PR[#1051](https://github.com/CliMA/ClimaLand.jl/pull/1051)
 - Use MODIS LAI by default in experiments and longruns
   PR[#973](https://github.com/CliMA/ClimaLand.jl/pull/973)
 - Revert PR993 changes to runoff

--- a/experiments/benchmarks/bucket.jl
+++ b/experiments/benchmarks/bucket.jl
@@ -46,7 +46,7 @@ earth_param_set = ClimaLand.Parameters.LandParameters(FT);
 outdir = "bucket_benchmark_$(device_suffix)"
 !ispath(outdir) && mkpath(outdir)
 
-function setup_prob(t0, tf, Δt; nelements = (101, 7))
+function setup_prob(t0, tf, Δt; nelements = (200, 7))
     # We set up the problem in a function so that we can make multiple copies (for profiling)
 
     # Set up simulation domain
@@ -147,7 +147,7 @@ function setup_simulation(; greet = false)
     t0 = 0.0
     tf = 7 * 86400
     Δt = 3600.0
-    nelements = (101, 7)
+    nelements = (200, 7)
     if greet
         @info "Run: Bucket with temporal map"
         @info "Resolution: $nelements"
@@ -244,7 +244,7 @@ if ClimaComms.device() isa ClimaComms.CUDADevice
 end
 
 if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaland-benchmark"
-    PREVIOUS_BEST_TIME = 0.477
+    PREVIOUS_BEST_TIME = 1.69
     if average_timing_s > PREVIOUS_BEST_TIME + std_timing_s
         @info "Possible performance regression, previous average time was $(PREVIOUS_BEST_TIME)"
     elseif average_timing_s < PREVIOUS_BEST_TIME - std_timing_s

--- a/experiments/benchmarks/land.jl
+++ b/experiments/benchmarks/land.jl
@@ -58,15 +58,7 @@ outdir = "land_benchmark_$(device_suffix)"
 
 function setup_prob(t0, tf, Δt; nelements = (101, 15))
     earth_param_set = LP.LandParameters(FT)
-    radius = FT(6378.1e3)
-    depth = FT(50)
-    domain = ClimaLand.Domains.SphericalShell(;
-        radius = radius,
-        depth = depth,
-        nelements = nelements,
-        npolynomial = 1,
-        dz_tuple = FT.((10.0, 0.05)),
-    )
+    domain = ClimaLand.global_domain(FT; nelements)
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface
 
@@ -467,7 +459,7 @@ if ClimaComms.device() isa ClimaComms.CUDADevice
 end
 
 if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaland-benchmark"
-    PREVIOUS_BEST_TIME = 6.1
+    PREVIOUS_BEST_TIME = 3.93
     if average_timing_s > PREVIOUS_BEST_TIME + std_timing_s
         @info "Possible performance regression, previous average time was $(PREVIOUS_BEST_TIME)"
     elseif average_timing_s < PREVIOUS_BEST_TIME - std_timing_s

--- a/experiments/benchmarks/richards.jl
+++ b/experiments/benchmarks/richards.jl
@@ -59,14 +59,8 @@ outdir = "richards_benchmark_$(device_suffix)"
 !ispath(outdir) && mkpath(outdir)
 
 function setup_prob(t0, tf, Δt; nelements = (101, 15))
-    soil_depth = FT(50)
-    domain = ClimaLand.Domains.SphericalShell(;
-        radius = FT(6.3781e6),
-        depth = soil_depth,
-        nelements = nelements,
-        npolynomial = 1,
-        dz_tuple = FT.((10.0, 0.1)),
-    )
+    dz_tuple = (10.0, 0.1)
+    domain = ClimaLand.global_domain(FT; nelements, dz_tuple)
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface
 
@@ -295,7 +289,7 @@ if ClimaComms.device() isa ClimaComms.CUDADevice
 end
 
 if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaland-benchmark"
-    PREVIOUS_BEST_TIME = 5.8
+    PREVIOUS_BEST_TIME = 2.99
     if average_timing_s > PREVIOUS_BEST_TIME + std_timing_s
         @info "Possible performance regression, previous average time was $(PREVIOUS_BEST_TIME)"
     elseif average_timing_s < PREVIOUS_BEST_TIME - std_timing_s

--- a/experiments/benchmarks/snowy_land.jl
+++ b/experiments/benchmarks/snowy_land.jl
@@ -54,15 +54,7 @@ outdir = "snowy_land_benchmark_$(device_suffix)"
 
 function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     earth_param_set = LP.LandParameters(FT)
-    radius = FT(6378.1e3)
-    depth = FT(50)
-    domain = ClimaLand.Domains.SphericalShell(;
-        radius = radius,
-        depth = depth,
-        nelements = nelements,
-        npolynomial = 1,
-        dz_tuple = FT.((10.0, 0.05)),
-    )
+    domain = ClimaLand.global_domain(FT; nelements = nelements)
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface
 
@@ -478,7 +470,7 @@ if ClimaComms.device() isa ClimaComms.CUDADevice
 end
 
 if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaland-benchmark"
-    PREVIOUS_BEST_TIME = 6.5
+    PREVIOUS_BEST_TIME = 3.98
     if average_timing_s > PREVIOUS_BEST_TIME + std_timing_s
         @info "Possible performance regression, previous average time was $(PREVIOUS_BEST_TIME)"
     elseif average_timing_s < PREVIOUS_BEST_TIME - std_timing_s

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -36,16 +36,9 @@ device_suffix =
 
 FT = Float64
 earth_param_set = LP.LandParameters(FT)
-radius = FT(6378.1e3);
-depth = FT(50)
 nelements = (50, 10)
-domain = ClimaLand.Domains.SphericalShell(;
-    radius = radius,
-    depth = depth,
-    nelements = nelements,
-    npolynomial = 1,
-    dz_tuple = FT.((10.0, 0.1)),
-);
+dz_tuple = (10.0, 0.1)
+domain = ClimaLand.global_domain(FT; nelements, dz_tuple)
 surface_space = domain.space.surface
 subsurface_space = domain.space.subsurface
 

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -58,15 +58,7 @@ outdir =
 
 function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     earth_param_set = LP.LandParameters(FT)
-    radius = FT(6378.1e3)
-    depth = FT(50)
-    domain = ClimaLand.Domains.SphericalShell(;
-        radius = radius,
-        depth = depth,
-        nelements = nelements,
-        npolynomial = 1,
-        dz_tuple = FT.((10.0, 0.05)),
-    )
+    domain = ClimaLand.global_domain(FT; nelements)
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface
 

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -9,7 +9,7 @@
 # Simulation Setup
 # Number of spatial elements: 10x10 in horizontal, 15 in vertical
 # Soil depth: 50 m
-# Simulation duration: 4 years
+# Simulation duration: 2 years
 # Timestep: 450 s
 # Timestepper: ARS111
 # Fixed number of iterations: 3
@@ -69,7 +69,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (10, 10, 15))
         ylim = (delta_m, delta_m),
         zlim = (-depth, FT(0)),
         nelements = nelements,
-        npolynomial = 1,
+        npolynomial = 0,
         longlat = (center_long, center_lat),
         dz_tuple = FT.((10.0, 0.05)),
     )

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -61,15 +61,7 @@ outdir =
 
 function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     earth_param_set = LP.LandParameters(FT)
-    radius = FT(6378.1e3)
-    depth = FT(50)
-    domain = ClimaLand.Domains.SphericalShell(;
-        radius = radius,
-        depth = depth,
-        nelements = nelements,
-        npolynomial = 1,
-        dz_tuple = FT.((10.0, 0.05)),
-    )
+    domain = ClimaLand.global_domain(FT; nelements = nelements)
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface
 

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -56,15 +56,7 @@ outdir =
 
 function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     earth_param_set = LP.LandParameters(FT)
-    radius = FT(6378.1e3)
-    depth = FT(50)
-    domain = ClimaLand.Domains.SphericalShell(;
-        radius = radius,
-        depth = depth,
-        nelements = nelements,
-        npolynomial = 1,
-        dz_tuple = FT.((10.0, 0.05)),
-    )
+    domain = ClimaLand.global_domain(FT; nelements)
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface
 

--- a/experiments/standalone/Soil/richards_runoff.jl
+++ b/experiments/standalone/Soil/richards_runoff.jl
@@ -31,15 +31,9 @@ outdir = generate_output_path(
 )
 !ispath(outdir) && mkpath(outdir)
 FT = Float64
-radius = FT(6378.1e3);
-depth = FT(50)
-domain = ClimaLand.Domains.SphericalShell(;
-    radius = radius,
-    depth = depth,
-    nelements = (101, 15),
-    npolynomial = 1,
-    dz_tuple = FT.((10.0, 0.1)),
-);
+dz_tuple = (10.0, 0.1)
+domain = ClimaLand.global_domain(FT; dz_tuple, npolynomial = 1)
+
 surface_space = domain.space.surface
 subsurface_space = domain.space.subsurface
 spatially_varying_soil_params =

--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -332,5 +332,6 @@ import .Diagnostics: default_diagnostics
 # Simulations
 include(joinpath("simulations", "spatial_parameters.jl"))
 include(joinpath("simulations", "initial_conditions.jl"))
+include(joinpath("simulations", "domains.jl"))
 
 end

--- a/src/shared_utilities/Domains.jl
+++ b/src/shared_utilities/Domains.jl
@@ -583,7 +583,11 @@ function SphericalShell(;
     horzdomain = ClimaCore.Domains.SphereDomain(radius)
     horzmesh = ClimaCore.Meshes.EquiangularCubedSphere(horzdomain, nelements[1])
     horztopology = ClimaCore.Topologies.Topology2D(comms_ctx, horzmesh)
-    quad = ClimaCore.Spaces.Quadratures.GLL{npolynomial + 1}()
+    if npolynomial == 0
+        quad = ClimaCore.Spaces.Quadratures.GL{npolynomial + 1}()
+    else
+        quad = ClimaCore.Spaces.Quadratures.GLL{npolynomial + 1}()
+    end
     horzspace = ClimaCore.Spaces.SpectralElementSpace2D(horztopology, quad)
 
     subsurface_space = ClimaCore.Spaces.ExtrudedFiniteDifferenceSpace(
@@ -649,7 +653,11 @@ function SphericalSurface(;
     horzdomain = ClimaCore.Domains.SphereDomain(radius)
     horzmesh = Meshes.EquiangularCubedSphere(horzdomain, nelements)
     horztopology = Topologies.Topology2D(comms_ctx, horzmesh)
-    quad = Spaces.Quadratures.GLL{npolynomial + 1}()
+    if npolynomial == 0
+        quad = ClimaCore.Spaces.Quadratures.GL{npolynomial + 1}()
+    else
+        quad = ClimaCore.Spaces.Quadratures.GLL{npolynomial + 1}()
+    end
     horzspace = Spaces.SpectralElementSpace2D(horztopology, quad)
     space = (; surface = horzspace)
     return SphericalSurface{FT}(radius, nelements, npolynomial, space)

--- a/src/simulations/domains.jl
+++ b/src/simulations/domains.jl
@@ -1,0 +1,53 @@
+using ClimaLand
+
+"""
+    global_domain(
+    FT;
+    nelements = (101, 15),
+    dz_tuple = (10.0, 0.05),
+    depth = 50.0,
+    npolynomial = 0,
+)
+
+Helper function to create a SphericalShell domain
+with (101,15) elements, a depth of 50m, vertical
+layering ranging from 0.05m in depth at the surface
+to 10m at the bottom of the domain, with n_polynomial = 0
+and GL quadrature.
+
+`n_polynomial` determines the order of polynomial base to use for the spatial
+discretization, which is correlated to the spatial resolution of the domain.
+
+When `n_polynomial` is zero, the element is equivalent to a single point. In this
+case, the resolution of the model is sqrt((360*180)/(101*101*6)). The factor of 6 arises
+because there are 101x101 elements per side of the cubed sphere, meaning 6*101*101 for the
+entire globe. 
+
+When `n_polynomial` is greater than 1, a Gauss-Legendre-Lobotto quadrature
+is used, with `n_polynomial + 1` points along the element. In this case, there are
+always points two points on the boundaries for each direction with the other
+points in the interior. These points are not equally spaced.
+
+In practice, there is no reason to use `n_polynomial` greater than 1 in the current
+version of ClimaLand. To increase resolution, we recommend increasing the number of elements
+rather than increasing the polynomial order.
+"""
+function global_domain(
+    FT;
+    nelements = (101, 15),
+    dz_tuple = (10.0, 0.05),
+    depth = 50.0,
+    npolynomial = 0,
+)
+    radius = FT(6378.1e3)
+    dz_tuple = FT.(dz_tuple)
+    depth = FT(depth)
+    domain = ClimaLand.Domains.SphericalShell(;
+        radius,
+        depth,
+        nelements,
+        npolynomial,
+        dz_tuple,
+    )
+    return domain
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Changes to GL quadrature instead of GLL.

Based on this long run (which I made this branch from): https://buildkite.com/clima/climaland-long-runs/builds/3656 
this halves the time.
## To-do


## Content
Creates a global_domain function which many scripts can use and modify, but which uses our default.
uses n_polynomial = 0

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
