### PR TITLE
relax SoilDrivers atmos type annotation; compute SnowModel humidity in model-specific method

### DIFF
--- a/src/standalone/Snow/Snow.jl
+++ b/src/standalone/Snow/Snow.jl
@@ -50,7 +50,7 @@ for use within an `AbstractSnowModel` type. Currently we support a
 `MinimumDensityModel` model and the `NeuralDepthModel`.
 
 Since depth and bulk density are related via SWE, and SWE is a prognostic variable
-of the snow model, only depth or bulk density can be independently modeled at one time. 
+of the snow model, only depth or bulk density can be independently modeled at one time.
 This is why they are treated as a single "density model" even if the parameterization is actually
 a model for snow depth.
 The snow depth/density model can be diagnostic or introduce additional prognostic variables.
@@ -203,7 +203,7 @@ prognostic_vars(m::SnowModel) =
 
 """
     density_prog_vars(::AbstractDensityModel)
-    
+
 A default method for adding prognostic variables to the snow model as required
 by the density model choice.
 """
@@ -221,7 +221,7 @@ prognostic_types(m::SnowModel{FT}) where {FT} =
 
 """
     density_prog_vars(::AbstractDensityModel)
-    
+
 A default method for specifying variable types of the prognostic variables required
 by the density model choice, similar to `prognostic_types()`.
 """
@@ -240,7 +240,7 @@ prognostic_domain_names(m::SnowModel) =
 
 """
     density_prog_vars(::AbstractDensityModel)
-    
+
 A default method for specifying variable domain names of the prognostic variables required
 by the density model choice, similar to `prognostic_domain_names()`.
 """
@@ -253,7 +253,7 @@ Returns the auxiliary variable names for the snow model. These
 include the specific humidity at the surface of the snow `(`q_sfc`, unitless),
 the mass fraction in liquid water (`q_l`, unitless),
 the thermal conductivity (`κ`, W/m/K),
-the bulk temperature (`T`, K), the surface temperature (`T_sfc`, K), the snow depth (`z_snow`, m), 
+the bulk temperature (`T`, K), the surface temperature (`T_sfc`, K), the snow depth (`z_snow`, m),
 the bulk snow density (`ρ_snow`, kg/m^3)
 the SHF, LHF, and vapor flux (`turbulent_fluxes.shf`, etc),
 the net radiation (`R_n, J/m^2/s)`, the energy flux in liquid water runoff
@@ -354,12 +354,6 @@ function ClimaLand.make_update_aux(model::SnowModel{FT}) where {FT}
 
         @. p.snow.T_sfc = snow_surface_temperature(p.snow.T)
 
-        @. p.snow.q_sfc = snow_surface_specific_humidity(
-            p.snow.T_sfc,
-            p.snow.q_l,
-            p.drivers.thermal_state,
-            parameters,
-        )
         @. p.snow.water_runoff = compute_water_runoff(
             Y.snow.S,
             Y.snow.S_l,
@@ -467,9 +461,9 @@ end
 """
      clip_total_snow_energy_flux(U, S, total_energy_flux, total_water_flux, Δt)
 
-A helper function which clips the total energy flux such that 
-snow energy per unit ground area U will not become positive, and 
-which ensures that if the snow water equivalent S goes to zero in a step, 
+A helper function which clips the total energy flux such that
+snow energy per unit ground area U will not become positive, and
+which ensures that if the snow water equivalent S goes to zero in a step,
 U will too.
 """
 function clip_total_snow_energy_flux(

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -15,9 +15,9 @@ export snow_surface_temperature,
 """
     snow_cover_fraction(x::FT; z0 = FT(1e-1), α = FT(2))::FT where {FT}
 
-Returns the snow cover fraction from snow depth `z`, from 
-Wu, Tongwen, and Guoxiong Wu. "An empirical formula to compute 
-snow cover fraction in GCMs." Advances in Atmospheric Sciences 
+Returns the snow cover fraction from snow depth `z`, from
+Wu, Tongwen, and Guoxiong Wu. "An empirical formula to compute
+snow cover fraction in GCMs." Advances in Atmospheric Sciences
 21 (2004): 529-535.
 """
 function snow_cover_fraction(z::FT; z0 = FT(1e-1), α = FT(2))::FT where {FT}
@@ -87,6 +87,13 @@ water.
 
 """
 function ClimaLand.surface_specific_humidity(model::SnowModel, Y, p, _...)
+    @. p.snow.q_sfc = snow_surface_specific_humidity(
+        p.snow.T_sfc,
+        p.snow.q_l,
+        p.drivers.thermal_state,
+        model.parameters,
+    )
+
     return p.snow.q_sfc
 end
 
@@ -314,8 +321,8 @@ end
 """
      phase_change_flux(U::FT, S::FT, q_l::FT, energy_flux::FT, parameters) where {FT}
 
-Computes the volume flux of liquid water undergoing phase change, given the 
-applied energy flux and current state of U,S,q_l. 
+Computes the volume flux of liquid water undergoing phase change, given the
+applied energy flux and current state of U,S,q_l.
 """
 function phase_change_flux(
     U::FT,

--- a/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
+++ b/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
@@ -285,13 +285,13 @@ struct SoilDrivers{
     FT,
     MET <: AbstractSoilDriver,
     SOC <: PrescribedSoilOrganicCarbon{FT},
-    ATM <: PrescribedAtmosphere{FT},
+    ATM <: Union{PrescribedAtmosphere{FT}, CoupledAtmosphere{FT}},
 }
     "Soil temperature and moisture drivers - Prescribed or Prognostic"
     met::MET
     "Soil SOM driver - Prescribed only"
     soc::SOC
-    "Prescribed atmospheric variables"
+    "Prescribed or coupled atmospheric variables"
     atmos::ATM
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
To couple the full LandModel with ClimaAtmos, there are a handful of miscellaneous changes to the ClimaLand code that need to be made. This PR makes a couple of them (see Content below for details).

These changes shouldn't be behavior changing.

Part of #1038 

## Content
- [x] relax the type restriction for SoilDrivers to allow a `CoupledAtmosphere` in addition to `PrescribedAtmosphere` ([here](https://github.com/CliMA/ClimaLand.jl/blob/b8c7255f446d0fe766d0196ca581deb74cd29ec4/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl#L288))
  - without this, we can't set up a SoilCO2Model with a CoupledAtmosphere
- [x] move `snow_surface_specific_humidity` call out of `update_aux!` and into `surface_specific_humidity`, which  
  - can't access `p.drivers.thermal_state` in `CoupledAtmosphere` case, so the call to `snow_surface_specific_humidity` needs to be within a function where we've dispatched on the atmos type. `surface_specific_humidity` is only called in the `turbulent_fluxes!` method for `PrescribedAtmosphere`, so moving it there fixes this


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
