### PR TITLE
Finding regression

### DIFF
--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -13,8 +13,8 @@ steps:
     command:
       - echo "--- Instantiate"
 
-      - "julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
-      - "julia --project -e 'using Pkg; Pkg.status()'"
+      # - "julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      # - "julia --project -e 'using Pkg; Pkg.status()'"
 
       - julia --project=.buildkite -e 'using Pkg; Pkg.instantiate(;verbose=true)'
       - julia --project=.buildkite -e 'using Pkg; Pkg.precompile()'
@@ -45,42 +45,42 @@ steps:
         env:
           CLIMACOMMS_DEVICE: "CUDA"
 
-      - label: ":seedling: Soil-Canopy"
-        command:
-          - julia --color=yes --project=.buildkite experiments/long_runs/land.jl
-        artifact_paths: "land_longrun_gpu/*pdf"
-        agents:
-          slurm_gpus: 1
-          slurm_time: 15:00:00
-        env:
-          CLIMACOMMS_DEVICE: "CUDA"
+      # - label: ":seedling: Soil-Canopy"
+      #   command:
+      #     - julia --color=yes --project=.buildkite experiments/long_runs/land.jl
+      #   artifact_paths: "land_longrun_gpu/*pdf"
+      #   agents:
+      #     slurm_gpus: 1
+      #     slurm_time: 15:00:00
+      #   env:
+      #     CLIMACOMMS_DEVICE: "CUDA"
 
-      - label: ":sunglasses: California regional simulation"
-        command:
-          - julia --color=yes --project=.buildkite experiments/long_runs/land_region.jl
-        artifact_paths: "california_longrun_gpu/*pdf"
-        agents:
-          slurm_gpus: 1
-          slurm_time: 00:30:00
-        env:
-          CLIMACOMMS_DEVICE: "CUDA"
+      # - label: ":sunglasses: California regional simulation"
+      #   command:
+      #     - julia --color=yes --project=.buildkite experiments/long_runs/land_region.jl
+      #   artifact_paths: "california_longrun_gpu/*pdf"
+      #   agents:
+      #     slurm_gpus: 1
+      #     slurm_time: 00:30:00
+      #   env:
+      #     CLIMACOMMS_DEVICE: "CUDA"
 
-      - label: "Soil"
-        command:
-          - julia --color=yes --project=.buildkite experiments/long_runs/soil.jl
-        artifact_paths: "soil_longrun_gpu/*pdf"
-        agents:
-          slurm_gpus: 1
-          slurm_time: 15:00:00
-        env:
-          CLIMACOMMS_DEVICE: "CUDA"
+      # - label: "Soil"
+      #   command:
+      #     - julia --color=yes --project=.buildkite experiments/long_runs/soil.jl
+      #   artifact_paths: "soil_longrun_gpu/*pdf"
+      #   agents:
+      #     slurm_gpus: 1
+      #     slurm_time: 15:00:00
+      #   env:
+      #     CLIMACOMMS_DEVICE: "CUDA"
 
-      - label: "Global bucket simulation"
-        command:
-          - julia --color=yes --project=.buildkite experiments/long_runs/bucket.jl
-        artifact_paths: "bucket_longrun_gpu/*pdf"
-        agents:
-          slurm_gpus: 1
-          slurm_time: 00:30:00
-        env:
-          CLIMACOMMS_DEVICE: "CUDA"
+      # - label: "Global bucket simulation"
+      #   command:
+      #     - julia --color=yes --project=.buildkite experiments/long_runs/bucket.jl
+      #   artifact_paths: "bucket_longrun_gpu/*pdf"
+      #   agents:
+      #     slurm_gpus: 1
+      #     slurm_time: 00:30:00
+      #   env:
+      #     CLIMACOMMS_DEVICE: "CUDA"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -37,10 +37,10 @@ git-tree-sha1 = "df5ec5af1ea0793c0e7d49e60db5a938098e174f"
     url = "https://caltech.box.com/shared/static/m82r23e67x04a3hb6p79dfltlumvg9z0.gz"
 
 [modis_lai]
-git-tree-sha1 = "20ee5dc96fde9a15bd3c40e80ac5036a9a39e0cf"
+git-tree-sha1 = "81d4bc1b22e94d66eec3d80a2d21b5dd5303bf8f"
 
     [[modis_lai.download]]
-    sha256 = "e97bf4a8eeac7c32c00a7d27bf5ec957e9c800117d56e66c27a123171a1f1c04"
+    sha256 = "4a244428fe480aa05ff863af69299d2ed8ca66ed324b9e1bffcb440792fb4cce"
     url = "https://caltech.box.com/shared/static/99ktg026kciezykyegsawd1gjwj1du74.gz"
 
 [land_albedo]
@@ -100,3 +100,10 @@ git-tree-sha1 = "839224a62b59d73073bdb9a5c55d3dc75e30fe33"
     [[ilamb_data.download]]
     sha256 = "64a9a344ebfbb0113014178a1f93a655c401431565907c07fd33aff8860b62d6"
     url = "https://caltech.box.com/shared/static/eii2bfwfp47axfeuysgxlgzbczz27u5g.gz"
+
+[era5_lai_covers]
+git-tree-sha1 = "1e77fc84a027da43f1bf6ebe0a53849595a2be22"
+
+    [[era5_lai_covers.download]]
+    sha256 = "0331e3a2fc2cb53b0f1d9c5a84f49989da0b506258edc229da161e9ca4a61457"
+    url = "https://caltech.box.com/shared/static/uzuzk5wh8r9q477jbrusfg1sr0ytzem9.gz"

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -417,7 +417,7 @@ function setup_and_solve_problem(; greet = false)
     hours = 60minutes # hours in seconds
     days = 24hours # days in seconds
     years = 366days # years in seconds - 366 to make sure we capture at least full years
-    tf = 2years # 2 years in seconds
+    tf = 450.0 * 9000.0 # 2years # 2 years in seconds
     Δt = 450.0
     nelements = (101, 15)
     if greet
@@ -443,68 +443,68 @@ function setup_and_solve_problem(; greet = false)
 end
 
 setup_and_solve_problem(; greet = true);
-# read in diagnostics and make some plots!
-#### ClimaAnalysis ####
-simdir = ClimaAnalysis.SimDir(outdir)
-short_names_bio = ["gpp", "ct", "lai"]
-short_names_water = ["swc", "si", "sr", "swe"]
-short_names_other = ["swu", "lwu", "et"]
-group_names = ["bio", "water", "other"]
-months_id = [1, 4, 7, 10]
-for (group_id, group) in
-    enumerate([short_names_bio, short_names_water, short_names_other])
-    fig =
-        CairoMakie.Figure(size = (600 * length(months_id), 300 * length(group)))
-    for (var_id, short_name) in enumerate(group)
-        var = get(simdir; short_name)
-        times = ClimaAnalysis.times(var)
-        CairoMakie.Label(
-            fig[var_id, 0],
-            short_name,
-            tellheight = false,
-            tellwidth = false,
-            fontsize = 20,
-        )
-        for (t_id, t) in pairs(times[months_id])
-            layout = fig[var_id, t_id] = CairoMakie.GridLayout()
-            kwargs = ClimaAnalysis.has_altitude(var) ? Dict(:z => 1) : Dict()
-            ClimaAnalysis.Visualize.heatmap2D_on_globe!(
-                layout,
-                ClimaAnalysis.slice(var, time = t; kwargs...),
-                mask = ClimaAnalysis.Visualize.oceanmask(),
-                more_kwargs = Dict(
-                    :mask => ClimaAnalysis.Utils.kwargs(color = :white),
-                ),
-            )
-        end
-    end
-    months = Dates.monthname.(1:12) .|> x -> x[1:3]
-    for (idx, m_id) in enumerate(months_id)
-        CairoMakie.Label(
-            fig[0, idx],
-            months[m_id],
-            tellwidth = false,
-            fontsize = 20,
-        )
-    end
-    group_name = group_names[group_id]
+# # read in diagnostics and make some plots!
+# #### ClimaAnalysis ####
+# simdir = ClimaAnalysis.SimDir(outdir)
+# short_names_bio = ["gpp", "ct", "lai"]
+# short_names_water = ["swc", "si", "sr", "swe"]
+# short_names_other = ["swu", "lwu", "et"]
+# group_names = ["bio", "water", "other"]
+# months_id = [1, 4, 7, 10]
+# for (group_id, group) in
+#     enumerate([short_names_bio, short_names_water, short_names_other])
+#     fig =
+#         CairoMakie.Figure(size = (600 * length(months_id), 300 * length(group)))
+#     for (var_id, short_name) in enumerate(group)
+#         var = get(simdir; short_name)
+#         times = ClimaAnalysis.times(var)
+#         CairoMakie.Label(
+#             fig[var_id, 0],
+#             short_name,
+#             tellheight = false,
+#             tellwidth = false,
+#             fontsize = 20,
+#         )
+#         for (t_id, t) in pairs(times[months_id])
+#             layout = fig[var_id, t_id] = CairoMakie.GridLayout()
+#             kwargs = ClimaAnalysis.has_altitude(var) ? Dict(:z => 1) : Dict()
+#             ClimaAnalysis.Visualize.heatmap2D_on_globe!(
+#                 layout,
+#                 ClimaAnalysis.slice(var, time = t; kwargs...),
+#                 mask = ClimaAnalysis.Visualize.oceanmask(),
+#                 more_kwargs = Dict(
+#                     :mask => ClimaAnalysis.Utils.kwargs(color = :white),
+#                 ),
+#             )
+#         end
+#     end
+#     months = Dates.monthname.(1:12) .|> x -> x[1:3]
+#     for (idx, m_id) in enumerate(months_id)
+#         CairoMakie.Label(
+#             fig[0, idx],
+#             months[m_id],
+#             tellwidth = false,
+#             fontsize = 20,
+#         )
+#     end
+#     group_name = group_names[group_id]
 
-    CairoMakie.save(joinpath(root_path, "$(group_name).png"), fig)
-end
+#     CairoMakie.save(joinpath(root_path, "$(group_name).png"), fig)
+# end
 
-short_names = ["gpp", "swc", "et", "ct", "swe", "si"]
+# short_names = ["gpp", "swc", "et", "ct", "swe", "si"]
 
-include(
-    joinpath(
-        pkgdir(ClimaLand),
-        "experiments",
-        "long_runs",
-        "figures_function.jl",
-    ),
-)
-make_figures(root_path, outdir, short_names)
+# include(
+#     joinpath(
+#         pkgdir(ClimaLand),
+#         "experiments",
+#         "long_runs",
+#         "figures_function.jl",
+#     ),
+# )
+# make_figures(root_path, outdir, short_names)
 
-include("leaderboard/leaderboard.jl")
-diagnostics_folder_path = outdir
-leaderboard_base_path = root_path
-compute_leaderboard(leaderboard_base_path, diagnostics_folder_path)
+# include("leaderboard/leaderboard.jl")
+# diagnostics_folder_path = outdir
+# leaderboard_base_path = root_path
+# compute_leaderboard(leaderboard_base_path, diagnostics_folder_path)

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -525,12 +525,12 @@ function soil_boundary_fluxes!(
         p.snow.snow_cover_fraction * p.ground_heat_flux
 
     # ρc_sfc is stored in scratch! after we use it below, it may be overwritten
-    ρc_sfc = ClimaLand.Soil.get_ρc_sfc(Y, p, soil.parameters)
+    # ρc_sfc = ClimaLand.Soil.get_ρc_sfc(Y, p, soil.parameters)
     # Get the local geometry of the face space, then extract the top level
     local_geometry_faceN =
         ClimaLand.get_local_geometry_faceN(soil.domain.space.subsurface)
-    @. p.soil.dfluxBCdY.heat =
-        covariant3_unit_vector(local_geometry_faceN) * 0 / ρc_sfc # ∂F∂T ∂T∂ρe
+    p.soil.dfluxBCdY.heat .=
+        covariant3_unit_vector.(local_geometry_faceN) .* 0 ./ ClimaLand.Soil.get_ρc_sfc(Y, p, soil.parameters) # ∂F∂T ∂T∂ρe
     @. p.soil.dfluxBCdY.water = covariant3_unit_vector(local_geometry_faceN) * 0
     return nothing
 end

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -386,12 +386,12 @@ function soil_boundary_fluxes!(
 
     # Compute terms needed for derivatives
     # ρc_sfc is stored in scratch! after we use it below, it may be overwritten
-    ρc_sfc = ClimaLand.Soil.get_ρc_sfc(Y, p, soil.parameters)
+    # ρc_sfc = ClimaLand.Soil.get_ρc_sfc(Y, p, soil.parameters)
     # Get the local geometry of the face space, then extract the top level
     local_geometry_faceN =
         ClimaLand.get_local_geometry_faceN(soil.domain.space.subsurface)
-    @. p.soil.dfluxBCdY.heat =
-        covariant3_unit_vector(local_geometry_faceN) * (0) / ρc_sfc # ∂F∂T ∂T∂ρe
+    p.soil.dfluxBCdY.heat .=
+        covariant3_unit_vector.(local_geometry_faceN) .* (0) ./ ClimaLand.Soil.get_ρc_sfc(Y, p, soil.parameters) # ∂F∂T ∂T∂ρe
     @. p.soil.dfluxBCdY.water = covariant3_unit_vector(local_geometry_faceN) * 0
     return nothing
 end

--- a/src/integrated/soil_snow_model.jl
+++ b/src/integrated/soil_snow_model.jl
@@ -382,12 +382,12 @@ function soil_boundary_fluxes!(
 
     # Compute terms needed for derivatives
     # ρc_sfc is stored in scratch! after we use it below, it may be overwritten
-    ρc_sfc = ClimaLand.Soil.get_ρc_sfc(Y, p, soil.parameters)
+    # ρc_sfc = ClimaLand.Soil.get_ρc_sfc(Y, p, soil.parameters)
     # Get the local geometry of the face space, then extract the top level
     local_geometry_faceN =
         ClimaLand.get_local_geometry_faceN(soil.domain.space.subsurface)
-    @. p.soil.dfluxBCdY.heat =
-        covariant3_unit_vector(local_geometry_faceN) * 0 / ρc_sfc # ∂F∂T ∂T∂ρe
+    p.soil.dfluxBCdY.heat .=
+        covariant3_unit_vector.(local_geometry_faceN) .* 0 ./ ClimaLand.Soil.get_ρc_sfc(Y, p, soil.parameters) # ∂F∂T ∂T∂ρe
     @. p.soil.dfluxBCdY.water = covariant3_unit_vector(local_geometry_faceN) * 0
     return nothing
 end

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -834,12 +834,12 @@ function soil_boundary_fluxes!(
 
     # Compute terms needed for derivatives
     # ρc_sfc is stored in scratch! after we use it below, it may be overwritten
-    ρc_sfc = get_ρc_sfc(Y, p, model.parameters)
+    # ρc_sfc = get_ρc_sfc(Y, p, model.parameters)
     # Get the local geometry of the face space, then extract the top level
     local_geometry_faceN =
         ClimaLand.get_local_geometry_faceN(model.domain.space.subsurface)
-    @. p.soil.dfluxBCdY.heat =
-        covariant3_unit_vector(local_geometry_faceN) * (0 / ρc_sfc) # replace 0 with ∂F∂T when ready
+    p.soil.dfluxBCdY.heat .=
+        covariant3_unit_vector(local_geometry_faceN) .* (0 ./ get_ρc_sfc(Y, p, model.parameters)) # replace 0 with ∂F∂T when ready
     @. p.soil.dfluxBCdY.water = covariant3_unit_vector(local_geometry_faceN) * 0
     return nothing
 end

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -249,15 +249,15 @@ for FT in (Float32, Float64)
             expected_energy_flux = @. R_n_copy + conditions.lhf + conditions.shf
             @test computed_energy_flux == expected_energy_flux
 
-            ρc_sfc = ClimaLand.Soil.get_ρc_sfc(Y, p, model.parameters)
+            # ρc_sfc = ClimaLand.Soil.get_ρc_sfc(Y, p, model.parameters)
             # Get the local geometry of the face space, then extract the top level
             local_geometry_faceN = ClimaLand.get_local_geometry_faceN(
                 model.domain.space.subsurface,
             )
 
             expected_dflux_heat =
-                @. ClimaLand.covariant3_unit_vector(local_geometry_faceN) *
-                   (0 / ρc_sfc)
+                 ClimaLand.covariant3_unit_vector.(local_geometry_faceN) .*
+                   (0 ./ ClimaLand.Soil.get_ρc_sfc(Y, p, model.parameters))
             expected_dflux_water =
                 @. ClimaLand.covariant3_unit_vector(local_geometry_faceN) * 0
             @test all(


### PR DESCRIPTION
This is being used to find regression according to #1055 

We are only running for 5000 steps and recording the SPYD.

reverts runoff change from PR 993, adds to diagnostics (1069th commit) [commit](https://github.com/CliMA/ClimaLand.jl/commit/3be98289ab7dfada71ea5ff9066884fb900c2af1)
- 9000 steps -> 8.873 SYPD

fix bug with iwc (1088th commit) [commit](https://github.com/CliMA/ClimaLand.jl/commit/c8fb12ce3c7dc36e4d25edff61ac3a83c5a0be3a)
- 9000 steps -> 6.827 SYPD

Fix CI failure modes (1078th commit) [commit](https://github.com/CliMA/ClimaLand.jl/commit/389b3f7d275375f3adfc5e5591a500e86828a552)
- 9000 steps -> 6.504 SYPD

Merge pull request #1028 from CliMA/kp/lai (1074th commit) [commit](https://github.com/CliMA/ClimaLand.jl/commit/797a9b78253c61e9973d1808877145ef5c301155)
- 9000 steps -> 6.639 SYPD

infrastructure for adding boundary flux contributions to jacobian for soil (1071th commit) [commit](https://github.com/CliMA/ClimaLand.jl/commit/aa053c08cfe9fbe2cb937c2947b0ae3f12d87a04)
- 9000 steps -> 6.559 SYPD

Unless "clean up plots (#1019)" is the commit that is causing the regression, the commit that is causing the regression is the commit above.

Started with (1071th commit) [commit](https://github.com/CliMA/ClimaLand.jl/commit/aa053c08cfe9fbe2cb937c2947b0ae3f12d87a04) and remove this
```
MatrixFields.LowerDiagonalMatrixRow(
                        topBC_op_heat(
                            Geometry.Covariant3Vector(
                                zero(interpc2f_op(p.soil.T)),
                            ),
                        ),
                    )
```
in `energy_hydrology.jl` which increases SYPD by 6.54 to 7.13.