### PR TITLE
Diffuse fraction from ERA5

### DIFF
--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -342,6 +342,8 @@ function default_diagnostics(
             "msf",
             "lwp",
             "iwc",
+            "swd",
+            "lwd",
         ]
     end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Include the option to get the diffuse fraction directly from the prescribed forcing, rather than computing it empirically.


## To-do


## Content
- rename empirical diffuse function for clarity
- add diffuse fraction to PrescribedRadiation and allow it to be nothing vs TimeVaryingInput


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
