### PR TITLE
Adds functions for models to compute total energy and water volume(mass) per area

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@ ClimaLand.jl Release Notes
 
 main
 -------
-
+- adds functions which compute total energy and water content per
+  unit ground area PR[#1071](https://github.com/CliMA/ClimaLand.jl/pull/1071)
 
 v0.15.11
 --------

--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -63,6 +63,8 @@ ClimaLand.make_jacobian
 ClimaLand.make_compute_jacobian
 ClimaLand.set_dfluxBCdY!
 ClimaLand.get_drivers
+ClimaLand.total_energy_per_area!
+ClimaLand.total_liq_water_vol_per_area!
 ```
 
 ## Drivers

--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -209,6 +209,80 @@ Returns the component names of the `land` model, by calling
 """
 land_components(land::AbstractLandModel) = propertynames(land)
 
+"""
+    total_energy_per_area!(
+        surface_field,
+        land::AbstractLandModel,
+        Y,
+        p,
+        t,
+        sfc_cache,
+)
+
+A function which computes the total energy per unit area and updates
+`surface_field` in place, for the land model `land`, by calling
+the same function for the component models.
+
+The `sfc_cache` field is available as scratch space.
+"""
+function total_energy_per_area!(
+    surface_field,
+    land::AbstractLandModel,
+    Y,
+    p,
+    t,
+    sfc_cache,
+)
+    components = land_components(land)
+    sfc_cache .*= 0
+    surface_field .*= 0
+    for component in components
+        total_energy_per_area!(sfc_cache, getproperty(land, component), Y, p, t)
+        surface_field .+= sfc_cache
+    end
+end
+
+"""
+    total_liq_water_vol_per_area!(
+        surface_field,
+        land::AbstractLandModel,
+        Y,
+        p,
+        t,
+        sfc_cache,
+)
+
+A function which computes the total liquid water volume 
+per unit area and updates
+`surface_field` in place, for the land model `land`, by calling
+the same function for the component models.
+
+The `sfc_cache` field is available as scratch space.
+"""
+function total_liq_water_vol_per_area!(
+    surface_field,
+    land::AbstractLandModel,
+    Y,
+    p,
+    t,
+    sfc_cache,
+)
+    components = land_components(land)
+    sfc_cache .*= 0
+    surface_field .*= 0
+    for component in components
+        total_liq_water_vol_per_area!(
+            sfc_cache,
+            getproperty(land, component),
+            Y,
+            p,
+            t,
+        )
+        surface_field .+= sfc_cache
+    end
+end
+
+
 function prognostic_vars(land::AbstractLandModel)
     components = land_components(land)
     prognostic_list = map(components) do model

--- a/src/shared_utilities/models.jl
+++ b/src/shared_utilities/models.jl
@@ -21,7 +21,9 @@ export AbstractModel,
     make_update_cache,
     add_drivers_to_cache,
     get_drivers,
-    name
+    name,
+    total_liq_water_vol_per_area!,
+    total_energy_per_area!
 
 import ClimaComms
 import .Domains: coordinates
@@ -466,3 +468,28 @@ function ClimaComms.device(model::AbstractModel)
         )
     end
 end
+
+"""
+    total_liq_water_vol_per_area!(cache, model::AbstractModel, Y, p, t)
+
+A function which updates `cache` in place with the total liquid water volume
+per unit ground area for the `model`, computed from `Y`, `p`, and `t`.
+
+While water mass is the fundamentally conserved quantity, soil modelling represents
+water by an equivalent water volume using the density of water and ice at standard
+temperature and pressure. Because of that, we report here the total volume of water
+present in a model (per unit area) that would arise if all the water was in liquid phase.
+This can be converted to a mass using the density of liquid water.
+
+This includes the water in multiple phases. For example, if ice is present, the water
+volume is computed using ratio of the density of ice to the density of liquid water.
+"""
+function total_liq_water_vol_per_area!(cache, model::AbstractModel, Y, p, t) end
+
+"""
+    total_energy_per_area!(cache, model::AbstractModel, Y, p, t)
+
+A function which updates `cache` in place with the total energy
+per unit ground area for the `model`, computed from `Y`, `p`, and `t`.
+"""
+function total_energy_per_area!(cache, model::AbstractModel, Y, p, t) end

--- a/src/standalone/Snow/Snow.jl
+++ b/src/standalone/Snow/Snow.jl
@@ -30,7 +30,9 @@ import ClimaLand:
     surface_height,
     surface_albedo,
     surface_emissivity,
-    get_drivers
+    get_drivers,
+    total_energy_per_area!,
+    total_liq_water_vol_per_area!
 export SnowParameters, SnowModel, AtmosDrivenSnowBC, snow_boundary_fluxes!
 
 """
@@ -496,4 +498,58 @@ end
 
 include("./snow_parameterizations.jl")
 include("./boundary_fluxes.jl")
+
+"""
+    ClimaLand.total_liq_water_vol_per_area!(
+        surface_field,
+        model::SnowModel,
+        Y,
+        p,
+        t,
+)
+
+A function which updates `surface_field` in place with the value for
+the total liquid water volume per unit ground area for the `SnowModel`.
+
+This has already accounted for the area fraction of snow in the definition
+of S; it also accounts for both liquid and frozen water present in the snow,
+as the snow water equivalent is already the total liquid water volume present in the snow
+if all the snow melted, per unit ground area.
+"""
+function ClimaLand.total_liq_water_vol_per_area!(
+    surface_field,
+    model::SnowModel,
+    Y,
+    p,
+    t,
+)
+    surface_field .= Y.snow.S
+    return nothing
+end
+
+"""
+    ClimaLand.total_energy_per_area!(
+        surface_field,
+        model::SnowModel,
+        Y,
+        p,
+        t,
+)
+
+A function which updates `surface_field` in place with the value for
+the total energy per unit ground area for the `SnowModel`.
+
+This has already accounted for the area fraction of snow in the definition
+of S.
+"""
+function ClimaLand.total_energy_per_area!(
+    surface_field,
+    model::SnowModel,
+    Y,
+    p,
+    t,
+)
+    surface_field .= Y.snow.U
+    return nothing
+end
 end

--- a/src/standalone/Soil/Soil.jl
+++ b/src/standalone/Soil/Soil.jl
@@ -93,7 +93,9 @@ import ClimaLand:
     surface_height,
     surface_resistance,
     turbulent_fluxes!,
-    get_drivers
+    get_drivers,
+    total_liq_water_vol_per_area!,
+    total_energy_per_area!
 export RichardsModel,
     RichardsParameters,
     EnergyHydrology,

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -1098,3 +1098,58 @@ function soil_turbulent_fluxes_at_a_point(
         vapor_flux_ice = Ẽ_i,
     )
 end
+
+"""
+    ClimaLand.total_liq_water_vol_per_area!(
+        surface_field,
+        model::EnergyHydrology,
+        Y,
+        p,
+        t,
+)
+
+A function which updates `surface_field` in place with the value for
+the total liquid water volume per unit ground area for the `EnergyHydrology`.
+
+The water in all phases is accounted for by converting ice volume to liquid water
+volume using the ratio of the density of ice to the density of water.
+"""
+function ClimaLand.total_liq_water_vol_per_area!(
+    surface_field,
+    model::EnergyHydrology,
+    Y,
+    p,
+    t,
+)
+    earth_param_set = model.parameters.earth_param_set
+    _ρ_liq = LP.ρ_cloud_liq(earth_param_set)
+    _ρ_ice = LP.ρ_cloud_ice(earth_param_set)
+    ClimaCore.Operators.column_integral_definite!(
+        surface_field,
+        Y.soil.ϑ_l .+ Y.soil.θ_i .* _ρ_ice ./ _ρ_liq, # this line allocates
+    )
+    return nothing
+end
+
+"""
+    ClimaLand.total_energy_per_area!(
+        surface_field,
+        model::EnergyHydrology,
+        Y,
+        p,
+        t,
+)
+
+A function which updates `surface_field` in place with the value for
+the total energy per unit ground area for the `EnergyHydrology`.
+"""
+function ClimaLand.total_energy_per_area!(
+    surface_field,
+    model::EnergyHydrology,
+    Y,
+    p,
+    t,
+)
+    ClimaCore.Operators.column_integral_definite!(surface_field, Y.soil.ρe_int)
+    return nothing
+end

--- a/src/standalone/Soil/rre.jl
+++ b/src/standalone/Soil/rre.jl
@@ -456,3 +456,26 @@ function ClimaLand.get_drivers(model::RichardsModel)
         return ()
     end
 end
+
+"""
+    ClimaLand.total_liq_water_vol_per_area!(
+        surface_field,
+        model::RichardsModel,
+        Y,
+        p,
+        t,
+)
+
+A function which updates `surface_field` in place with the value for
+the total liquid water volume per unit ground area for the `RichardsModel`.
+"""
+function ClimaLand.total_liq_water_vol_per_area!(
+    surface_field,
+    model::RichardsModel,
+    Y,
+    p,
+    t,
+)
+    ClimaCore.Operators.column_integral_definite!(surface_field, Y.soil.ϑ_l)
+    return nothing
+end

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -25,7 +25,9 @@ import ClimaLand:
     make_compute_exp_tendency,
     make_compute_imp_tendency,
     make_compute_jacobian,
-    get_drivers
+    get_drivers,
+    total_liq_water_vol_per_area!,
+    total_energy_per_area!
 
 using ClimaLand.Domains: Point, Plane, SphericalSurface
 export SharedCanopyParameters, CanopyModel, set_canopy_prescribed_field!
@@ -693,4 +695,61 @@ end
 include("./canopy_boundary_fluxes.jl")
 #Make the canopy model broadcastable
 Base.broadcastable(C::CanopyModel) = tuple(C)
+
+"""
+    ClimaLand.total_energy_per_area!(
+        surface_field,
+        model::CanopyModel,
+        Y,
+        p,
+        t,
+)
+
+A function which updates `surface_field` in place with the value for
+the total energy per unit ground area for the `CanopyModel`.
+
+This acts by calling the method for the energy component of
+the canopy model.
+"""
+function ClimaLand.total_energy_per_area!(
+    surface_field,
+    model::CanopyModel,
+    Y,
+    p,
+    t,
+)
+    ClimaLand.total_energy_per_area!(surface_field, model.energy, Y, p, t)
+end
+
+"""
+    ClimaLand.total_liq_water_vol_per_area!(
+        surface_field,
+        model::CanopyModel,
+        Y,
+        p,
+        t,
+)
+
+A function which updates `surface_field` in place with the value for
+the total liquid water volume per unit ground area for the `CanopyModel`.
+
+This acts by calling the method for the PlantHydraulics component of
+the canopy model.
+"""
+function ClimaLand.total_liq_water_vol_per_area!(
+    surface_field,
+    model::CanopyModel,
+    Y,
+    p,
+    t,
+)
+    ClimaLand.total_liq_water_vol_per_area!(
+        surface_field,
+        model.hydraulics,
+        Y,
+        p,
+        t,
+    )
+end
+
 end

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -346,7 +346,6 @@ function canopy_turbulent_fluxes_at_a_point(
         Thermodynamics.Liquid(),
     )
     ts_sfc = Thermodynamics.PhaseEquil_ρTq(thermo_params, ρ_sfc, T_sfc, q_sfc)
-
     state_sfc = SurfaceFluxes.StateValues(FT(0), SVector{2, FT}(0, 0), ts_sfc)
 
     # State containers
@@ -371,7 +370,6 @@ function canopy_turbulent_fluxes_at_a_point(
     T_int = Thermodynamics.air_temperature(thermo_params, ts_in)
     Rm_int = Thermodynamics.gas_constant_air(thermo_params, ts_in)
     ρ_air = Thermodynamics.air_density(thermo_params, ts_in)
-
     r_b_leaf::FT = FT(1 / 0.01 * (ustar / 0.04)^(-1 / 2)) # CLM 5, tech note Equation 5.122
     r_b_canopy_lai = r_b_leaf / LAI
     r_b_canopy_total = r_b_leaf / (LAI + SAI)

--- a/test/integrated/full_land.jl
+++ b/test/integrated/full_land.jl
@@ -1,0 +1,150 @@
+using ClimaComms
+using Dates
+using Test
+import ClimaParams as CP
+using ClimaLand
+import ClimaLand.Parameters as LP
+using ClimaCore
+include("full_land_setup.jl")
+context = ClimaComms.context()
+nelements = (101, 15)
+start_date = DateTime(2008)
+Δt = 450.0
+t0 = 0.0
+
+FT = Float64
+earth_param_set = LP.LandParameters(FT)
+
+f_over = FT(3.28) # 1/m
+R_sb = FT(1.484e-4 / 1000) # m/s
+scalar_soil_params = (; f_over, R_sb)
+
+α_snow = FT(0.67)
+scalar_snow_params = (; α_snow, Δt)
+
+# Energy Balance model
+ac_canopy = FT(2.5e3)
+# Plant Hydraulics and general plant parameters
+K_sat_plant = FT(5e-9) # m/s # seems much too small?
+ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value is -4 MPa
+Weibull_param = FT(4) # unitless, Holtzman's original c param value
+a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
+plant_ν = FT(1.44e-4)
+plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
+h_leaf = FT(1.0)
+scalar_canopy_params = (;
+    ac_canopy,
+    K_sat_plant,
+    a,
+    ψ63,
+    Weibull_param,
+    plant_ν,
+    plant_S_s,
+    h_leaf,
+)
+
+domain = ClimaLand.global_domain(FT; nelements = nelements)
+surface_space = domain.space.surface
+start_date = DateTime(2008)
+# Forcing data
+era5_ncdata_path = joinpath(
+    ClimaLand.Artifacts.era5_land_forcing_data2008_folder_path(;
+        context,
+        lowres = true,
+    ),
+    "era5_2008_1.0x1.0_lowres.nc",
+)
+forcing = ClimaLand.prescribed_forcing_era5(
+    joinpath(era5_ncdata_path),
+    surface_space,
+    start_date,
+    earth_param_set,
+    FT,
+)
+LAI = ClimaLand.prescribed_lai_modis(
+    joinpath(
+        ClimaLand.Artifacts.modis_lai_forcing_data_path(; context),
+        "Yuan_et_al_2008_1x1.nc",
+    ),
+    domain.space.surface,
+    start_date,
+)
+
+land = global_land_model(
+    FT,
+    scalar_soil_params,
+    scalar_canopy_params,
+    scalar_snow_params,
+    earth_param_set;
+    context = context,
+    domain = domain,
+    forcing = forcing,
+    LAI = LAI,
+)
+
+Y, p, cds = initialize(land)
+
+# Soil IC
+ϑ_l0 = land.soil.parameters.ν ./ 2
+θ_i0 = land.soil.parameters.ν ./ 5
+T = FT(270.0)
+ρc_s = @. Soil.volumetric_heat_capacity(
+    ϑ_l0,
+    θ_i0,
+    land.soil.parameters.ρc_ds,
+    earth_param_set,
+)
+ρe_int0 = @. Soil.volumetric_internal_energy(θ_i0, ρc_s, T, earth_param_set)
+Y.soil.ϑ_l .= ϑ_l0
+Y.soil.θ_i .= θ_i0
+
+Y.soil.ρe_int = ρe_int0
+
+# Canopy IC
+ϑ0 = land.canopy.hydraulics.parameters.ν / 2
+CTemp0 = FT(290.5)
+
+Y.canopy.hydraulics.ϑ_l.:1 .= ϑ0
+
+Y.canopy.energy.T .= CTemp0
+
+# Snow IC
+S0 = FT(0.5)
+S_l0 = FT(0.3)
+STemp0 = FT(270)
+U0 = Snow.energy_from_T_and_swe(S0, STemp0, land.snow.parameters)
+
+Y.snow.S .= S0
+Y.snow.S_l .= S_l0
+Y.snow.U .= U0
+
+t0 = 0.0
+set_initial_cache! = make_set_initial_cache(land)
+set_initial_cache!(p, Y, t0)
+
+# Check total
+area_index = p.canopy.hydraulics.area_index.leaf
+h_canopy = land.canopy.hydraulics.compartment_surfaces[end]
+ρ_ice = LP.ρ_cloud_ice(earth_param_set)
+ρ_liq = LP.ρ_cloud_liq(earth_param_set)
+int_cache = ClimaCore.Fields.zeros(domain.space.surface)
+ClimaCore.Operators.column_integral_definite!(
+    int_cache,
+    @. (ϑ_l0 + θ_i0 * ρ_ice / ρ_liq)
+)
+soil_exp = int_cache
+canopy_exp = @. area_index * h_canopy .* ϑ0
+snow_exp = S0
+total_water = ClimaCore.Fields.zeros(domain.space.surface)
+cache = ClimaCore.Fields.zeros(domain.space.surface)
+ClimaLand.total_liq_water_vol_per_area!(total_water, land, Y, p, t0, cache)
+@test all(parent(total_water) .≈ parent(snow_exp .+ canopy_exp .+ soil_exp))
+
+int_cache .*= 0
+ClimaCore.Operators.column_integral_definite!(int_cache, ρe_int0)
+soil_exp = int_cache
+canopy_exp = @. area_index * land.canopy.energy.parameters.ac_canopy * CTemp0
+snow_exp = U0
+total_energy = ClimaCore.Fields.zeros(domain.space.surface)
+ClimaLand.total_energy_per_area!(total_energy, land, Y, p, t0, cache)
+@test all(parent(total_energy) .≈ parent(snow_exp .+ canopy_exp .+ soil_exp))

--- a/test/integrated/full_land_setup.jl
+++ b/test/integrated/full_land_setup.jl
@@ -1,0 +1,294 @@
+using Dates
+import ClimaUtilities.TimeVaryingInputs: TimeVaryingInput
+
+using ClimaLand
+using ClimaLand.Snow
+using ClimaLand.Soil
+using ClimaLand.Canopy
+import ClimaLand
+
+"""
+     global_land_model(FT,
+                       context,
+                       scalar_soil_params,
+                       scalar_canopy_params,
+                       scalar_snow_params,
+                       earth_param_set;
+                       context = nothing,
+                       domain = ClimaLand.global_domain(FT; context = context),
+                       forcing = ClimaLand.prescribed_forcing_era5(ClimaLand.Artifacts.era5_land_forcing_data2008_folder_path(; context),
+                                                                   domain.space.surface,
+                                                                   DateTime(2008),
+                                                                   earth_param_set,
+                                                                   FT),
+                       LAI = ClimaLand.prescribed_lai_modis(ClimaLand.Artifacts.modis_lai_forcing_data_path(DateTime(2008); context),
+                                                            domain.space.surface,
+                                                            DateTime(2008))
+                           )
+
+An helper function for creating a land model corresponding to a global simulation of the snow, soil, and canopy models.
+
+While not explicitly an outer constructor, this creates and returns `LandModel` struct. This is meant as a helper for setting up a standard 
+global land model easily, and is useful for testing. Note that the user can construct any land model they 
+wish by using the default (inner) constructor method for `LandModel`, or using the alternate outer constructor method defined in src/integrated/land.jl.
+
+Over time, all scalar parameters will be moved to ClimaParameters, so that only a single parameter set `earth_param_set` is passed.
+"""
+function global_land_model(
+    FT,
+    scalar_soil_params,
+    scalar_canopy_params,
+    scalar_snow_params,
+    earth_param_set;
+    context = nothing,
+    domain = ClimaLand.global_domain(FT; context = context),
+    forcing = ClimaLand.prescribed_forcing_era5(
+        joinpath(
+            ClimaLand.Artifacts.era5_land_forcing_data2008_folder_path(;
+                context,
+            ),
+            "era5_2008_1.0x1.0.nc",
+        ),
+        domain.space.surface,
+        DateTime(2008),
+        earth_param_set,
+        FT,
+    ),
+    LAI = ClimaLand.prescribed_lai_modis(
+        joinpath(
+            ClimaLand.Artifacts.modis_lai_forcing_data_path(; context),
+            "Yuan_et_al_2008_1x1.nc",
+        ),
+        domain.space.surface,
+        DateTime(2008),
+    ),
+)
+    # Unpack forcing
+    (atmos, radiation) = forcing
+
+    # Unpack scalar parameters
+    (; α_snow, Δt) = scalar_snow_params
+    (; f_over, R_sb) = scalar_soil_params
+    (;
+        ac_canopy,
+        K_sat_plant,
+        a,
+        ψ63,
+        Weibull_param,
+        plant_ν,
+        plant_S_s,
+        h_leaf,
+    ) = scalar_canopy_params
+
+    # Construct spatially varying parameters.
+    surface_space = domain.space.surface
+    subsurface_space = domain.space.subsurface
+
+    spatially_varying_soil_params =
+        ClimaLand.default_spatially_varying_soil_parameters(
+            subsurface_space,
+            surface_space,
+            FT,
+        )
+    (;
+        ν,
+        ν_ss_om,
+        ν_ss_quartz,
+        ν_ss_gravel,
+        hydrology_cm,
+        K_sat,
+        S_s,
+        θ_r,
+        PAR_albedo_dry,
+        NIR_albedo_dry,
+        PAR_albedo_wet,
+        NIR_albedo_wet,
+        f_max,
+    ) = spatially_varying_soil_params
+    soil_params = Soil.EnergyHydrologyParameters(
+        FT;
+        ν,
+        ν_ss_om,
+        ν_ss_quartz,
+        ν_ss_gravel,
+        hydrology_cm,
+        K_sat,
+        S_s,
+        θ_r,
+        PAR_albedo_dry = PAR_albedo_dry,
+        NIR_albedo_dry = NIR_albedo_dry,
+        PAR_albedo_wet = PAR_albedo_wet,
+        NIR_albedo_wet = NIR_albedo_wet,
+    )
+    runoff_model = ClimaLand.Soil.Runoff.TOPMODELRunoff{FT}(;
+        f_over = f_over,
+        f_max = f_max,
+        R_sb = R_sb,
+    )
+
+    # Spatially varying canopy parameters from CLM
+    clm_parameters = ClimaLand.clm_canopy_parameters(surface_space)
+    (;
+        Ω,
+        rooting_depth,
+        is_c3,
+        Vcmax25,
+        g1,
+        G_Function,
+        α_PAR_leaf,
+        τ_PAR_leaf,
+        α_NIR_leaf,
+        τ_NIR_leaf,
+    ) = clm_parameters
+
+    conductivity_model =
+        Canopy.PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+    retention_model = Canopy.PlantHydraulics.LinearRetentionCurve{FT}(a)
+    SAI = FT(0.0) # m2/m2
+    RAI = FT(1.0)
+    n_stem = 0
+    n_leaf = 1
+    h_stem = FT(0.0)
+    zmax = FT(0.0)
+
+    h_canopy = h_stem + h_leaf
+    compartment_midpoints =
+        n_stem > 0 ? [h_stem / 2, h_stem + h_leaf / 2] : [h_leaf / 2]
+    compartment_surfaces =
+        n_stem > 0 ? [zmax, h_stem, h_canopy] : [zmax, h_leaf]
+
+    z0_m = FT(0.13) * h_canopy
+    z0_b = FT(0.1) * z0_m
+
+    soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
+
+    soil_args = (domain = domain, parameters = soil_params)
+    soil_model_type = Soil.EnergyHydrology{FT}
+
+    # Soil microbes model
+    soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
+
+    # soil microbes args
+    Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
+
+    # Set the soil CO2 BC to being atmospheric CO2
+    soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
+    soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2FluxBC((p, t) -> 0.0) # no flux
+    soilco2_sources = (Soil.Biogeochemistry.MicrobeProduction{FT}(),)
+
+    soilco2_boundary_conditions =
+        (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
+
+    soilco2_args = (;
+        boundary_conditions = soilco2_boundary_conditions,
+        sources = soilco2_sources,
+        domain = domain,
+        parameters = soilco2_ps,
+    )
+
+    # Now we set up the canopy model, which we set up by component:
+    # Component Types
+    canopy_component_types = (;
+        autotrophic_respiration = Canopy.AutotrophicRespirationModel{FT},
+        radiative_transfer = Canopy.TwoStreamModel{FT},
+        photosynthesis = Canopy.FarquharModel{FT},
+        conductance = Canopy.MedlynConductanceModel{FT},
+        hydraulics = Canopy.PlantHydraulicsModel{FT},
+        energy = Canopy.BigLeafEnergyModel{FT},
+    )
+    # Individual Component arguments
+    # Set up autotrophic respiration
+    autotrophic_respiration_args =
+        (; parameters = Canopy.AutotrophicRespirationParameters(FT))
+    # Set up radiative transfer
+    radiative_transfer_args = (;
+        parameters = Canopy.TwoStreamParameters(
+            FT;
+            Ω,
+            α_PAR_leaf,
+            τ_PAR_leaf,
+            α_NIR_leaf,
+            τ_NIR_leaf,
+            G_Function,
+        )
+    )
+    # Set up conductance
+    conductance_args =
+        (; parameters = Canopy.MedlynConductanceParameters(FT; g1))
+    # Set up photosynthesis
+    photosynthesis_args =
+        (; parameters = Canopy.FarquharParameters(FT, is_c3; Vcmax25 = Vcmax25))
+    # Set up plant hydraulics
+    ai_parameterization = Canopy.PrescribedSiteAreaIndex{FT}(LAI, SAI, RAI)
+
+    plant_hydraulics_ps = Canopy.PlantHydraulics.PlantHydraulicsParameters(;
+        ai_parameterization = ai_parameterization,
+        ν = plant_ν,
+        S_s = plant_S_s,
+        rooting_depth = rooting_depth,
+        conductivity_model = conductivity_model,
+        retention_model = retention_model,
+    )
+    plant_hydraulics_args = (
+        parameters = plant_hydraulics_ps,
+        n_stem = n_stem,
+        n_leaf = n_leaf,
+        compartment_midpoints = compartment_midpoints,
+        compartment_surfaces = compartment_surfaces,
+    )
+
+    energy_args = (parameters = Canopy.BigLeafEnergyParameters{FT}(ac_canopy),)
+
+    # Canopy component args
+    canopy_component_args = (;
+        autotrophic_respiration = autotrophic_respiration_args,
+        radiative_transfer = radiative_transfer_args,
+        photosynthesis = photosynthesis_args,
+        conductance = conductance_args,
+        hydraulics = plant_hydraulics_args,
+        energy = energy_args,
+    )
+
+    # Other info needed
+    shared_params = Canopy.SharedCanopyParameters{FT, typeof(earth_param_set)}(
+        z0_m,
+        z0_b,
+        earth_param_set,
+    )
+
+    canopy_model_args = (;
+        parameters = shared_params,
+        domain = ClimaLand.obtain_surface_domain(domain),
+    )
+
+    # Snow model
+    snow_parameters = SnowParameters{FT}(
+        Δt;
+        earth_param_set = earth_param_set,
+        α_snow = α_snow,
+    )
+    snow_args = (;
+        parameters = snow_parameters,
+        domain = ClimaLand.obtain_surface_domain(domain),
+    )
+    snow_model_type = Snow.SnowModel
+
+    land_input = (
+        atmos = atmos,
+        radiation = radiation,
+        runoff = runoff_model,
+        soil_organic_carbon = Csom,
+    )
+    return LandModel{FT}(;
+        soilco2_type = soilco2_type,
+        soilco2_args = soilco2_args,
+        land_args = land_input,
+        soil_model_type = soil_model_type,
+        soil_args = soil_args,
+        canopy_component_types = canopy_component_types,
+        canopy_component_args = canopy_component_args,
+        canopy_model_args = canopy_model_args,
+        snow_args = snow_args,
+        snow_model_type = snow_model_type,
+    )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,9 @@ end
 @safetestset "Neural Snow model tools tests" begin
     include("standalone/Snow/tool_tests.jl")
 end
+@safetestset "Snow integrated water and energy content" begin
+    include("standalone/Snow/conservation.jl")
+end
 
 # Standalone Soil model tests
 @safetestset "Soil Biogeochemistry module tests" begin
@@ -75,6 +78,9 @@ end
 @safetestset "Soil integration tests" begin
     include("standalone/Soil/soiltest.jl")
 end
+@safetestset "Soil integrated water and energy content" begin
+    include("standalone/Soil/conservation.jl")
+end
 
 # Standalone Surface Water model tests
 @safetestset "Pond module tests" begin
@@ -94,6 +100,9 @@ end
 @safetestset "Two Stream model tests" begin
     include("standalone/Vegetation/test_two_stream.jl")
 end
+@safetestset "Canopy integrated water and energy content" begin
+    include("standalone/Vegetation/conservation.jl")
+end
 
 # Integrated LSM tests
 @safetestset "Integrated LSM unit tests" begin
@@ -110,6 +119,10 @@ end
 end
 @safetestset "Integrated soil and snow" begin
     include("integrated/soil_snow.jl")
+end
+
+@safetestset "Full Land Model" begin
+    include("integrated/full_land.jl")
 end
 
 # Simulations

--- a/test/standalone/Snow/conservation.jl
+++ b/test/standalone/Snow/conservation.jl
@@ -1,0 +1,87 @@
+using Test
+using Dates
+import ClimaComms
+ClimaComms.@import_required_backends
+using ClimaCore
+import ClimaParams as CP
+using ClimaLand
+using ClimaLand.Snow
+using ClimaLand.Domains: Column, HybridBox
+
+import ClimaLand
+import ClimaLand.Parameters as LP
+
+for FT in (Float32, Float64)
+    cmax = FT(0)
+    cmin = FT(-2)
+    nelems = 10
+    col = Column(; zlim = (cmin, cmax), nelements = nelems)
+    box = ClimaLand.Domains.HybridBox(;
+        xlim = (cmin, cmax),
+        ylim = (cmin, cmax),
+        zlim = (cmin, cmax),
+        nelements = (nelems, nelems, nelems),
+        npolynomial = 0,
+    )
+
+    domains = [col, box]
+
+    t0 = 0.0
+
+    earth_param_set = LP.LandParameters(FT)
+
+    start_date = DateTime(2005)
+    Δt = FT(180.0)
+    parameters = SnowParameters{FT}(Δt; earth_param_set = earth_param_set)
+    "Radiation"
+    SW_d = TimeVaryingInput((t) -> eltype(t)(20.0))
+    LW_d = TimeVaryingInput((t) -> eltype(t)(20.0))
+    rad = ClimaLand.PrescribedRadiativeFluxes(FT, SW_d, LW_d, start_date)
+    "Atmos"
+    precip = TimeVaryingInput((t) -> eltype(t)(0)) # no precipitation
+    T_atmos = TimeVaryingInput((t) -> eltype(t)(290.0))
+    u_atmos = TimeVaryingInput((t) -> eltype(t)(10.0))
+    q_atmos = TimeVaryingInput((t) -> eltype(t)(0.0003))
+    h_atmos = FT(3)
+    P_atmos = TimeVaryingInput((t) -> eltype(t)(101325))
+    atmos = ClimaLand.PrescribedAtmosphere(
+        precip,
+        precip,
+        T_atmos,
+        u_atmos,
+        q_atmos,
+        P_atmos,
+        start_date,
+        h_atmos,
+        earth_param_set,
+    )
+
+    @testset "Snow model total energy and water, FT = $FT" begin
+        for domain in domains
+            snow = Snow.SnowModel(
+                parameters = parameters,
+                domain = ClimaLand.Domains.obtain_surface_domain(domain),
+                boundary_conditions = Snow.AtmosDrivenSnowBC(atmos, rad),
+            )
+
+            Y, p, cds = initialize(snow)
+            S0 = FT(0.5)
+            S_l0 = FT(0.3)
+            Temp0 = FT(270)
+            U0 = Snow.energy_from_T_and_swe.(S0, Temp0, snow.parameters)
+
+            Y.snow.S .= S0
+            Y.snow.S_l .= S_l0
+            Y.snow.U .= U0
+
+            set_initial_cache! = make_set_initial_cache(snow)
+            set_initial_cache!(p, Y, t0)
+            total_water = ClimaCore.Fields.zeros(domain.space.surface)
+            ClimaLand.total_liq_water_vol_per_area!(total_water, snow, Y, p, t0)
+            @test all(parent(total_water) .≈ S0)
+            total_energy = ClimaCore.Fields.zeros(domain.space.surface)
+            ClimaLand.total_energy_per_area!(total_energy, snow, Y, p, t0)
+            @test all(parent(total_energy) .≈ U0)
+        end
+    end
+end

--- a/test/standalone/Soil/conservation.jl
+++ b/test/standalone/Soil/conservation.jl
@@ -1,0 +1,128 @@
+using Test
+import ClimaComms
+ClimaComms.@import_required_backends
+using Statistics
+using ClimaCore
+import ClimaParams as CP
+using ClimaLand
+using ClimaLand.Soil
+using ClimaLand.Domains: Column, HybridBox
+
+import ClimaLand
+import ClimaLand.Parameters as LP
+
+for FT in (Float32, Float64)
+    cmax = FT(0)
+    cmin = FT(-2)
+    nelems = 10
+    col = Column(; zlim = (cmin, cmax), nelements = nelems)
+    box = ClimaLand.Domains.HybridBox(;
+        xlim = (cmin, cmax),
+        ylim = (cmin, cmax),
+        zlim = (cmin, cmax),
+        nelements = (nelems, nelems, nelems),
+        npolynomial = 0,
+    )
+
+    domains = [col, box]
+    ν = FT(0.495)
+    K_sat = FT(0.0443 / 3600 / 100) # m/s
+    S_s = FT(1e-3) #inverse meters
+    vg_n = FT(2.0)
+    vg_α = FT(2.6) # inverse meters
+    hcm = vanGenuchten{FT}(; α = vg_α, n = vg_n)
+    θ_r = FT(0)
+    ν_ss_om = FT(0.0)
+    ν_ss_quartz = FT(1.0)
+    ν_ss_gravel = FT(0.0)
+    water_flux_bc = WaterFluxBC((p, t) -> 0.0)
+    heat_flux_bc = HeatFluxBC((p, t) -> 0.0)
+    t0 = 0.0
+    @testset "Richards total water, FT = $FT" begin
+        sources = ()
+        params = Soil.RichardsParameters(;
+            ν = ν,
+            hydrology_cm = hcm,
+            K_sat = K_sat,
+            S_s = S_s,
+            θ_r = θ_r,
+        )
+        boundary_fluxes = (; top = water_flux_bc, bottom = water_flux_bc)
+        for domain in domains
+            soil = Soil.RichardsModel{FT}(;
+                parameters = params,
+                domain = domain,
+                boundary_conditions = boundary_fluxes,
+                sources = sources,
+            )
+
+            Y, p, cds = initialize(soil)
+            Y.soil.ϑ_l .= ν / 2
+            set_initial_cache! = make_set_initial_cache(soil)
+            set_initial_cache!(p, Y, t0)
+            total_water = ClimaCore.Fields.zeros(soil.domain.space.surface)
+            ClimaLand.total_liq_water_vol_per_area!(total_water, soil, Y, p, t0)
+            expected = ν / 2 * (cmax - cmin)
+            @test all(parent(total_water) .≈ expected)
+        end
+    end
+    @testset "Energy Hydrology total energy and water, FT = $FT" begin
+        sources = (Soil.PhaseChange{FT}(),)
+        params = Soil.EnergyHydrologyParameters(
+            FT;
+            ν,
+            ν_ss_om,
+            ν_ss_quartz,
+            ν_ss_gravel,
+            hydrology_cm = hcm,
+            K_sat,
+            S_s,
+            θ_r,
+        )
+        boundary_fluxes = (;
+            top = WaterHeatBC(; water = water_flux_bc, heat = heat_flux_bc),
+            bottom = WaterHeatBC(; water = water_flux_bc, heat = heat_flux_bc),
+        )
+        for domain in domains
+            soil = Soil.EnergyHydrology{FT}(;
+                parameters = params,
+                domain = domain,
+                boundary_conditions = boundary_fluxes,
+                sources = sources,
+            )
+
+            Y, p, cds = initialize(soil)
+            ϑ_l0 = ν / 2
+            θ_i0 = ν / 5
+            T = FT(270.0)
+            ρc_s = Soil.volumetric_heat_capacity(
+                ϑ_l0,
+                θ_i0,
+                params.ρc_ds,
+                params.earth_param_set,
+            )
+            ρe_int0 =
+                Soil.volumetric_internal_energy.(
+                    θ_i0,
+                    ρc_s,
+                    T,
+                    params.earth_param_set,
+                )
+            Y.soil.ϑ_l .= ϑ_l0
+            Y.soil.θ_i .= θ_i0
+
+            Y.soil.ρe_int = ρe_int0
+            set_initial_cache! = make_set_initial_cache(soil)
+            set_initial_cache!(p, Y, t0)
+            total_water = ClimaCore.Fields.zeros(soil.domain.space.surface)
+            total_energy = ClimaCore.Fields.zeros(soil.domain.space.surface)
+            ClimaLand.total_liq_water_vol_per_area!(total_water, soil, Y, p, t0)
+            ρ_ice = LP.ρ_cloud_ice(params.earth_param_set)
+            ρ_liq = LP.ρ_cloud_liq(params.earth_param_set)
+            expected = (ϑ_l0 + θ_i0 * ρ_ice / ρ_liq) * (cmax - cmin)
+            @test all(parent(total_water) .≈ expected)
+            ClimaLand.total_energy_per_area!(total_energy, soil, Y, p, t0)
+            @test all(parent(total_energy) .≈ ρe_int0 .* (cmax - cmin))
+        end
+    end
+end

--- a/test/standalone/Vegetation/conservation.jl
+++ b/test/standalone/Vegetation/conservation.jl
@@ -1,0 +1,231 @@
+using Test
+using Dates
+using StaticArrays
+using Insolation
+import ClimaComms
+ClimaComms.@import_required_backends
+using ClimaCore
+import ClimaParams as CP
+using ClimaLand
+using ClimaLand.Canopy
+using ClimaLand.Canopy.PlantHydraulics
+using ClimaLand.Domains: Column, HybridBox
+
+import ClimaLand
+import ClimaLand.Parameters as LP
+
+for FT in (Float32, Float64)
+    cmax = FT(0)
+    cmin = FT(-2)
+    nelems = 10
+    col = Column(; zlim = (cmin, cmax), nelements = nelems)
+    box = ClimaLand.Domains.HybridBox(;
+        xlim = (cmin, cmax),
+        ylim = (cmin, cmax),
+        zlim = (cmin, cmax),
+        nelements = (nelems, nelems, nelems),
+        npolynomial = 0,
+    )
+
+    domains = [col, box]
+    t0 = 0.0
+    earth_param_set = LP.LandParameters(FT)
+    start_date = DateTime(2005)
+    Δt = FT(180.0)
+    "Radiation"
+    SW_d = TimeVaryingInput((t) -> eltype(t)(20.0))
+    LW_d = TimeVaryingInput((t) -> eltype(t)(20.0))
+    function zenith_angle(
+        t,
+        start_date;
+        latitude = FT(40.0),
+        longitude = FT(-120.0),
+        insol_params = earth_param_set.insol_params,
+    )
+        current_datetime = start_date + Dates.Second(round(t))
+        d, δ, η_UTC =
+            FT.(
+                Insolation.helper_instantaneous_zenith_angle(
+                    current_datetime,
+                    start_date,
+                    insol_params,
+                )
+            )
+        return Insolation.instantaneous_zenith_angle(
+            d,
+            δ,
+            η_UTC,
+            longitude,
+            latitude,
+        )[1]
+    end
+    rad = PrescribedRadiativeFluxes(
+        FT,
+        SW_d,
+        LW_d,
+        start_date;
+        θs = zenith_angle,
+        earth_param_set = earth_param_set,
+    )
+    "Atmos"
+    precip = TimeVaryingInput((t) -> eltype(t)(0)) # no precipitation
+    T_atmos = TimeVaryingInput((t) -> eltype(t)(290.0))
+    u_atmos = TimeVaryingInput((t) -> eltype(t)(2.0))
+    q_atmos = TimeVaryingInput((t) -> eltype(t)(0.011))
+    h_atmos = FT(3)
+    P_atmos = TimeVaryingInput((t) -> eltype(t)(101325))
+    atmos = ClimaLand.PrescribedAtmosphere(
+        precip,
+        precip,
+        T_atmos,
+        u_atmos,
+        q_atmos,
+        P_atmos,
+        start_date,
+        h_atmos,
+        earth_param_set,
+    )
+
+    ld = FT(0.5)
+    α_PAR_leaf = FT(0.2)
+    α_NIR_leaf = α_PAR_leaf
+    is_c3 = FT(1.0)
+    Vcmax25 = FT(5e-6)
+    g1 = FT(120)
+    G_Function = ConstantGFunction(ld)
+    RTparams = BeerLambertParameters(FT; α_PAR_leaf, α_NIR_leaf, G_Function)
+    photosynthesis_params = FarquharParameters(FT, is_c3; Vcmax25)
+    stomatal_g_params = MedlynConductanceParameters(FT; g1)
+    stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
+    photosynthesis_model = FarquharModel{FT}(photosynthesis_params)
+    rt_model = BeerLambertModel{FT}(RTparams)
+    energy_model = BigLeafEnergyModel{FT}(BigLeafEnergyParameters{FT}())
+    thermo_params = LP.thermodynamic_parameters(earth_param_set)
+    LAI = FT(8.0) # m2 [leaf] m-2 [ground]
+    z_0m = FT(0.1) # m, Roughness length for momentum - value from tall forest ChatGPT
+    z_0b = FT(0.1) # m, Roughness length for scalars - value from tall forest ChatGPT
+    h_int = FT(30.0) # m, "where measurements would be taken at a typical flux tower of a 20m canopy"
+    shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
+        z_0m,
+        z_0b,
+        earth_param_set,
+    )
+    autotrophic_parameters = AutotrophicRespirationParameters(FT)
+    autotrophic_respiration_model =
+        AutotrophicRespirationModel{FT}(autotrophic_parameters)
+    RAI = FT(1)
+    SAI = FT(1)
+    lai_fun = t -> LAI
+    ai_parameterization = PlantHydraulics.PrescribedSiteAreaIndex{FT}(
+        TimeVaryingInput(lai_fun),
+        SAI,
+        RAI,
+    )
+    K_sat_plant = FT(1.8e-8) # m/s
+    ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value
+    Weibull_param = FT(4) # unitless, Holtzman's original c param value
+    a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
+    plant_ν = FT(0.7) # m3/m3
+    plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
+    conductivity_model =
+        PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+    retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
+    rooting_depth = FT(0.5)
+    param_set = PlantHydraulics.PlantHydraulicsParameters(;
+        ai_parameterization = ai_parameterization,
+        ν = plant_ν,
+        S_s = plant_S_s,
+        rooting_depth = rooting_depth,
+        conductivity_model = conductivity_model,
+        retention_model = retention_model,
+    )
+    Δz = FT(1.0) # height of compartments
+    n_stem = Int64(2) # number of stem elements
+    n_leaf = Int64(1) # number of leaf elements
+    compartment_centers =
+        FT.(
+            Vector(
+                range(
+                    start = Δz / 2,
+                    step = Δz,
+                    stop = Δz * (n_stem + n_leaf) - (Δz / 2),
+                ),
+            ),
+        )
+    compartment_faces =
+        FT.(
+            Vector(
+                range(start = 0.0, step = Δz, stop = Δz * (n_stem + n_leaf)),
+            )
+        )
+
+    ψ_soil0 = FT(0.0)
+    T_soil0 = FT(290)
+    root_depths = SVector{10, FT}(-(10:-1:1.0) ./ 10.0 * 2.0 .+ 0.2 / 2.0)
+
+    soil_driver = PrescribedGroundConditions(
+        root_depths,
+        (t) -> ψ_soil0,
+        (t) -> T_soil0,
+        FT(0.2),
+        FT(0.4),
+        FT(0.98),
+    )
+    plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
+        parameters = param_set,
+        n_stem = n_stem,
+        n_leaf = n_leaf,
+        compartment_surfaces = compartment_faces,
+        compartment_midpoints = compartment_centers,
+    )
+    @testset "Canopy model total energy and water, FT = $FT" begin
+        for domain in domains
+            canopy = ClimaLand.Canopy.CanopyModel{FT}(;
+                parameters = shared_params,
+                domain = ClimaLand.Domains.obtain_surface_domain(domain),
+                radiative_transfer = rt_model,
+                photosynthesis = photosynthesis_model,
+                conductance = stomatal_model,
+                autotrophic_respiration = autotrophic_respiration_model,
+                energy = energy_model,
+                hydraulics = plant_hydraulics,
+                boundary_conditions = Canopy.AtmosDrivenCanopyBC(
+                    atmos,
+                    rad,
+                    soil_driver,
+                ),
+            )
+
+            Y, p, cds = initialize(canopy)
+            ϑ0 = plant_ν / 2
+            Temp0 = FT(290.5)
+
+            Y.canopy.hydraulics.ϑ_l.:1 .= ϑ0
+            Y.canopy.hydraulics.ϑ_l.:2 .= ϑ0
+            Y.canopy.hydraulics.ϑ_l.:3 .= ϑ0
+            Y.canopy.energy.T .= Temp0
+
+            set_initial_cache! = make_set_initial_cache(canopy)
+            set_initial_cache!(p, Y, t0)
+            total_energy = ClimaCore.Fields.zeros(domain.space.surface)
+            ClimaLand.total_energy_per_area!(total_energy, canopy, Y, p, t0)
+            @test all(
+                parent(total_energy) .≈
+                (LAI + SAI) * canopy.energy.parameters.ac_canopy * Temp0,
+            )
+
+            total_water = ClimaCore.Fields.zeros(domain.space.surface)
+            ClimaLand.total_liq_water_vol_per_area!(
+                total_water,
+                canopy,
+                Y,
+                p,
+                t0,
+            )
+            @test all(
+                parent(total_water) .≈
+                (LAI * n_leaf * Δz * ϑ0 + SAI * n_stem * Δz * ϑ0),
+            )
+        end
+    end
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add helper functions which compute the total water volume and energy per unit area on land.
partially closes Issue #1038 


## To-do
- Follow up PR - add conservation test
- Follow up PR: fix https://github.com/CliMA/ClimaLand.jl/issues/1078


## Content
Creates the `total_energy_per_area!` and `total_liq_water_vol_per_area!` functions for AbstractModels
Creates the specific method of these for: Richards, EnergyHydrology, Snow, Canopy
Tests these methods for standalone models
Creates a method for LandModels
Tests this method for the snowy land model


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
