### PR TITLE
Update climacommon to 2025_03_18

### DIFF
--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: clima
   slurm_mem: 8G
-  modules: climacommon/2024_12_16
+  modules: climacommon/2025_03_18
 
 env:
   JULIA_CUDA_MEMORY_POOL: "cuda"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_mem: 12G
-  modules: climacommon/2024_12_16
+  modules: climacommon/2025_03_18
 
 env:
   JULIA_NVTX_CALLBACKS: gc

--- a/.buildkite/target/pipeline.yml
+++ b/.buildkite/target/pipeline.yml
@@ -1,6 +1,6 @@
 agents:
   queue: clima
-  modules: climacommon/2024_12_16
+  modules: climacommon/2025_03_18
 
 env:
   JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/default"


### PR DESCRIPTION
🤖 Beep boop. I am GabrieleBOT. 🤖

I received an update so that I can inform you directly of the changes (but feel free to check the [release notes](https://github.com/CliMA/ClimaModules/blob/main/NEWS.md)).

The most recent version of climacommon uses the newly released Julia 1.11.4.

This version is needed to use CUDA 5.7, so I would recommend updating.