### PR TITLE
add global heatmaps, bias plots, seasonal cycle plots to longruns

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.3"
 manifest_format = "2.0"
-project_hash = "3f4ceb30ba99ebd32a38b3cd7ce9703605f14393"
+project_hash = "ff55f579bdc785e1d8b4b219e86fee530635079c"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "e2478490447631aedba0823d4d7a80b2cc8cdb32"
@@ -376,9 +376,9 @@ weakdeps = ["SparseArrays"]
 
 [[deps.ClimaAnalysis]]
 deps = ["Artifacts", "Dates", "Interpolations", "NCDatasets", "NaNStatistics", "OrderedCollections", "Reexport", "Statistics", "Unitful"]
-git-tree-sha1 = "266bf6208c54827b621e4131550b5d975f7beb80"
+git-tree-sha1 = "b1fe8286ebb9433f3f2691064e0c27e827bc3cd7"
 uuid = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
-version = "0.5.13"
+version = "0.5.14"
 weakdeps = ["GeoMakie", "Makie"]
 
     [deps.ClimaAnalysis.extensions]

--- a/.buildkite/Project.toml
+++ b/.buildkite/Project.toml
@@ -43,7 +43,7 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [compat]
-ClimaAnalysis = "0.5.12"
+ClimaAnalysis = "0.5.14"
 ClimaTimeSteppers = "0.7, 0.8"
 Statistics = "1"
 Flux = "~0.14"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -18,7 +18,7 @@ git-tree-sha1 = "cbbc6b3752d9cb9b667ec33cfbeb46819f8db418"
     [[landsea_mask_1deg.download]]
     sha256 = "3722b553c2fdf28a6574aea2e0b167d16ab050f34e5969ada45625b3a3ecb6da"
     url = "https://caltech.box.com/shared/static/b3u4dv0dsoswvqgp8y63bzj7awbhwztd.gz"
-    
+
 [soil_ic_2008_50m]
 git-tree-sha1 = "fd9cda235e203b4235136b6dcdcd07af788c00f6"
 
@@ -68,6 +68,13 @@ git-tree-sha1 = "df5ec5af1ea0793c0e7d49e60db5a938098e174f"
     [[era5_land_forcing_data2008_lai.download]]
     sha256 = "a83bf28a7a864db285e41289031a9761c2a426373a6efecd04b866a0b5374cef"
     url = "https://caltech.box.com/shared/static/m82r23e67x04a3hb6p79dfltlumvg9z0.gz"
+
+[era5_monthly_averages_2008]
+git-tree-sha1 = "b448a55e214a03b4e69bde4f54f3c01a02b74b69"
+
+    [[era5_monthly_averages_2008.download]]
+    sha256 = "c8292040efa26f7dbeaf59f7177d8bfadcead74adc10c4c96678104cbd57a09e"
+    url = "https://caltech.box.com/shared/static/lra5npgeygoi0xb376hi4blik44550u0.gz"
 
 [modis_lai]
 git-tree-sha1 = "81d4bc1b22e94d66eec3d80a2d21b5dd5303bf8f"

--- a/experiments/long_runs/data_global_plots.jl
+++ b/experiments/long_runs/data_global_plots.jl
@@ -1,0 +1,406 @@
+using ClimaAnalysis
+
+"""
+    get_sim_var_dict(simdir)
+
+Returns a dictionary of functions that load in simulation data from `simdir`.
+
+These include the following variables:
+- lhf: latent heat flux (W/m²)
+- shf: sensible heat flux (W/m²)
+- lwu: upward longwave radiation (W/m²)
+- swu: upward shortwave radiation (W/m²)
+- lwd: downward longwave radiation (W/m²)
+- swd: downward shortwave radiation (W/m²)
+- lwn: net longwave radiation (W/m²)
+- swn: net shortwave radiation (W/m²)
+"""
+function get_sim_var_dict(simdir)
+    # Dict for loading in simulation data
+    sim_var_dict = Dict{String, Any}()
+
+    # Read in LHF
+    sim_var_dict["lhf"] =
+        () -> begin
+            sim_var_lhf = get(simdir, short_name = "lhf") # units (W/m²)
+            sim_var_lhf.attributes["long_name"] = "Latent heat flux"
+            sim_var_lhf.attributes["units"] = "W m⁻²"
+            return sim_var_lhf
+        end
+
+    # Read in SHF
+    sim_var_dict["shf"] =
+        () -> begin
+            sim_var_shf = get(simdir, short_name = "shf") # units (W/m²)
+            sim_var_shf.attributes["long_name"] = "Sensible heat flux"
+            sim_var_shf.attributes["units"] = "W m⁻²"
+            return sim_var_shf
+        end
+
+    # Read in LWU
+    sim_var_dict["lwu"] =
+        () -> begin
+            sim_var_lwu = get(simdir, short_name = "lwu") # units (W/m²)
+            sim_var_lwu.attributes["long_name"] = "Upward longwave radiation"
+            sim_var_lwu.attributes["units"] = "W m⁻²"
+            return sim_var_lwu
+        end
+
+    # Read in SWU
+    sim_var_dict["swu"] =
+        () -> begin
+            sim_var_swu = get(simdir, short_name = "swu") # units (W/m²)
+            sim_var_swu.attributes["long_name"] = "Upward shortwave radiation"
+            sim_var_swu.attributes["units"] = "W m⁻²"
+            return sim_var_swu
+        end
+
+    # Read in LWD
+    sim_var_dict["lwd"] =
+        () -> begin
+            sim_var_lwd = get(simdir, short_name = "lwd") # units (W/m²)
+            sim_var_lwd.attributes["long_name"] = "Downward longwave radiation"
+            sim_var_lwd.attributes["units"] = "W m⁻²"
+            return sim_var_lwd
+        end
+
+    # Read in SWD
+    sim_var_dict["swd"] =
+        () -> begin
+            sim_var_swd = get(simdir, short_name = "swd") # units (W/m²)
+            sim_var_swd.attributes["long_name"] = "Upward shortwave radiation"
+            sim_var_swd.attributes["units"] = "W m⁻²"
+            return sim_var_swd
+        end
+
+    # Compute LWN = LWD - LWU
+    sim_var_dict["lwn"] =
+        () -> begin
+            lwd = sim_var_dict["lwd"]()
+            lwu = sim_var_dict["lwu"]()
+            lwn = lwd - lwu
+            lwn.attributes["long_name"] = "Net longwave radiation"
+            lwn.attributes["units"] = "W m⁻²"
+            lwn.attributes["start_date"] = lwu.attributes["start_date"]
+            return lwn
+        end
+
+    # Compute SWN = SWD - SWU
+    sim_var_dict["swn"] =
+        () -> begin
+            swd = sim_var_dict["swd"]()
+            swu = sim_var_dict["swu"]()
+            swn = swd - swu
+            swn.attributes["long_name"] = "Net shortwave radiation"
+            swn.attributes["units"] = "W m⁻²"
+            swn.attributes["start_date"] = swu.attributes["start_date"]
+            return swn
+        end
+
+    return sim_var_dict
+end
+
+"""
+    get_obs_var_dict()
+
+Returns a dictionary of functions that load in observational data.
+All data is in hourly intervals.
+
+The following variables come from the monthly ERA5 dataset (`era5_monthly_averages_2008`):
+- lhf: latent heat flux (W/m²)
+- shf: sensible heat flux (W/m²)
+- lwu: upward longwave radiation (W/m²)
+- swu: upward shortwave radiation (W/m²)
+
+The following variables come from the hourly ERA5 dataset (`era5_land_forcing_data2008`),
+and are averaged to monthly intervals:
+- lwd: downward longwave radiation (W/m²)
+- swd: downward shortwave radiation (W/m²)
+
+From these, we compute:
+- lwn: net longwave radiation (W/m²)
+- swn: net shortwave radiation (W/m²)
+"""
+function get_obs_var_dict()
+    # contains monthly mslhf, msshf, msuwlwrf, msuwswrf
+    era5_data_path = joinpath(
+        ClimaLand.Artifacts.era5_monthly_averages_2008_folder_path(),
+        "era5_monthly_surface_fluxes_200801-200812.nc",
+    )
+    # contains hourly msdwlwrf, msdwswrf (these take a long time to load)
+    era5_land_forcing_data_path = joinpath(
+        ClimaLand.Artifacts.era5_land_forcing_data2008_folder_path(
+            lowres = false,
+        ),
+        "era5_2008_1.0x1.0.nc",
+    )
+
+    # Dict for loading in observational data
+    obs_var_dict = Dict{String, Any}()
+    obs_var_dict["lhf"] =
+        (start_date) -> begin
+            obs_var = ClimaAnalysis.OutputVar(
+                era5_data_path,
+                "mslhf",
+                new_start_date = start_date,
+                shift_by = Dates.firstdayofmonth,
+            ) # units (W/m² = J/m²s)
+            obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
+
+            # Add attributes and make values positive to account for convention difference
+            attribs = Dict(
+                "short_name" => "lhf",
+                "long_name" => "Latent heat flux",
+                "units" => "W m⁻²",
+                "start_date" => start_date,
+            )
+
+            # Copy data at lon = 0 to lon = 360 to avoid white lines
+            push!(obs_var.dims[ClimaAnalysis.longitude_name(obs_var)], 360)
+            new_data =
+                -1 * cat(obs_var.data, obs_var.data[[1], :, :], dims = 1)
+            obs_var_pos = ClimaAnalysis.OutputVar(
+                attribs,
+                obs_var.dims,
+                obs_var.dim_attributes,
+                new_data,
+            )
+            return obs_var_pos
+        end
+
+    # Read in SHF
+    obs_var_dict["shf"] =
+        (start_date) -> begin
+            obs_var = ClimaAnalysis.OutputVar(
+                era5_data_path,
+                "msshf",
+                new_start_date = start_date,
+                shift_by = Dates.firstdayofmonth,
+            ) # units (W/m² = J/m²s)
+            obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
+
+            # Add attributes and make values positive to account for convention difference
+            attribs = Dict(
+                "short_name" => "shf",
+                "long_name" => "Sensible heat flux",
+                "units" => "W m⁻²",
+                "start_date" => start_date,
+            )
+            # Copy data at lon = 0 to lon = 360 to avoid white lines
+            push!(obs_var.dims[ClimaAnalysis.longitude_name(obs_var)], 360)
+            new_data =
+                -1 * cat(obs_var.data, obs_var.data[[1], :, :], dims = 1)
+            obs_var_pos = ClimaAnalysis.OutputVar(
+                attribs,
+                obs_var.dims,
+                obs_var.dim_attributes,
+                new_data,
+            )
+
+            return obs_var_pos
+        end
+
+    # Read in LWU
+    obs_var_dict["lwu"] =
+        (start_date) -> begin
+            obs_var = ClimaAnalysis.OutputVar(
+                era5_data_path,
+                "msuwlwrf",
+                new_start_date = start_date,
+                shift_by = Dates.firstdayofmonth,
+            ) # units (W/m²)
+            obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
+
+            # Copy data at lon = 0 to lon = 360 to avoid white lines
+            push!(obs_var.dims[ClimaAnalysis.longitude_name(obs_var)], 360)
+            new_data = cat(obs_var.data, obs_var.data[[1], :, :], dims = 1)
+
+            # Manually set attributes
+            attribs = Dict(
+                "short_name" => "lwu",
+                "long_name" => "Upward longwave radiation",
+                "units" => "W m⁻²",
+                "start_date" => start_date,
+            )
+
+            obs_var_shifted = ClimaAnalysis.OutputVar(
+                attribs,
+                obs_var.dims,
+                obs_var.dim_attributes,
+                new_data,
+            )
+            return obs_var_shifted
+        end
+
+    # Read in SWU
+    obs_var_dict["swu"] =
+        (start_date) -> begin
+            obs_var = ClimaAnalysis.OutputVar(
+                era5_data_path,
+                "msuwswrf",
+                new_start_date = start_date,
+                shift_by = Dates.firstdayofmonth,
+            ) # units (W/m²)
+            obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
+
+            # Copy data at lon = 0 to lon = 360 to avoid white lines
+            push!(obs_var.dims[ClimaAnalysis.longitude_name(obs_var)], 360)
+            new_data = cat(obs_var.data, obs_var.data[[1], :, :], dims = 1)
+            # Manually set attributes
+            attribs = Dict(
+                "short_name" => "swu",
+                "long_name" => "Upward shortwave radiation",
+                "units" => "W m⁻²",
+                "start_date" => start_date,
+            )
+
+            obs_var_shifted = ClimaAnalysis.OutputVar(
+                attribs,
+                obs_var.dims,
+                obs_var.dim_attributes,
+                new_data,
+            )
+            return obs_var_shifted
+        end
+
+    # Read in LWD
+    obs_var_dict["lwd"] =
+        (start_date) -> begin
+            obs_var = ClimaAnalysis.OutputVar(
+                era5_land_forcing_data_path,
+                "msdwlwrf",
+                new_start_date = start_date,
+                shift_by = Dates.firstdayofmonth,
+            ) # units (W/m²)
+            obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
+
+            # Copy data at lon = 0 to lon = 360 to avoid white lines
+            push!(obs_var.dims[ClimaAnalysis.longitude_name(obs_var)], 360)
+            new_data = cat(obs_var.data, obs_var.data[[1], :, :], dims = 1)
+            # Manually set attributes
+            attribs = Dict(
+                "short_name" => "lwd",
+                "long_name" => "Downward longwave radiation",
+                "units" => "W m⁻²",
+                "start_date" => start_date,
+            )
+
+            obs_var_shifted = ClimaAnalysis.OutputVar(
+                attribs,
+                obs_var.dims,
+                obs_var.dim_attributes,
+                new_data,
+            )
+            return obs_var_shifted
+        end
+
+    # Read in SWD
+    obs_var_dict["swd"] =
+        (start_date) -> begin
+            obs_var = ClimaAnalysis.OutputVar(
+                era5_land_forcing_data_path,
+                "msdwswrf",
+                new_start_date = start_date,
+                shift_by = Dates.firstdayofmonth,
+            ) # units (W/m²)
+            obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
+
+            # Copy data at lon = 0 to lon = 360 to avoid white lines
+            push!(obs_var.dims[ClimaAnalysis.longitude_name(obs_var)], 360)
+            new_data = cat(obs_var.data, obs_var.data[[1], :, :], dims = 1)
+            # Manually set attributes
+            attribs = Dict(
+                "short_name" => "swd",
+                "long_name" => "Downward shortwave radiation",
+                "units" => "W m⁻²",
+                "start_date" => start_date,
+            )
+
+            obs_var_shifted = ClimaAnalysis.OutputVar(
+                attribs,
+                obs_var.dims,
+                obs_var.dim_attributes,
+                new_data,
+            )
+            return obs_var_shifted
+        end
+
+
+    # Compute LWN = LWD - LWU
+    obs_var_dict["lwn"] =
+        (start_date) -> begin
+            # LWD is very large because it's hourly, so it takes a while to load
+            lwd = obs_var_dict["lwd"](start_date)
+            lwu = obs_var_dict["lwu"](start_date)
+
+            monthly_times = lwu.dims["time"]
+            lwd_monthly_data = similar(lwu.data)
+            # average hourly LWD data to monthly so we can compare with monthly LWU
+            for (idx, time) in enumerate(monthly_times)
+                # collect all hourly time indices in this month
+                time_idxs = findall(x -> (x == time), lwd.dims["time"])
+
+                # average hourly data to monthly
+                lwd_monthly_data[:, :, idx] =
+                    mean(lwd.data[:, :, time_idxs], dims = 3)
+            end
+
+            # Compute LWN = LWD - LWU
+            lwn_data = lwd_monthly_data - lwu.data
+
+            attribs = Dict(
+                "short_name" => "lwn",
+                "long_name" => "Net longwave radiation",
+                "units" => "W m⁻²",
+                "start_date" => start_date,
+            )
+
+            lwn = ClimaAnalysis.OutputVar(
+                attribs,
+                lwu.dims,
+                lwu.dim_attributes,
+                lwn_data,
+            )
+            return lwn
+        end
+
+    # Compute SWN = SWD - SWU
+    obs_var_dict["swn"] =
+        (start_date) -> begin
+            # SWD is very large because it's hourly, so it takes a while to load
+            swd = obs_var_dict["swd"](start_date)
+            swu = obs_var_dict["swu"](start_date)
+
+            monthly_times = swu.dims["time"]
+            swd_monthly_data = similar(swu.data)
+            # average hourly SWD data to monthly so we can compare with monthly SWU
+            for (idx, time) in enumerate(monthly_times)
+                # collect all hourly time indices in this month
+                time_idxs = findall(x -> (x == time), swd.dims["time"])
+
+                # average hourly data to monthly
+                swd_monthly_data[:, :, idx] =
+                    mean(swd.data[:, :, time_idxs], dims = 3)
+            end
+
+            # Compute SWN = SWD - SWU
+            swn_data = swd_monthly_data - swu.data
+
+            attribs = Dict(
+                "short_name" => "swn",
+                "long_name" => "Net shortwave radiation",
+                "units" => "W m⁻²",
+                "start_date" => start_date,
+            )
+
+            swn = ClimaAnalysis.OutputVar(
+                attribs,
+                swu.dims,
+                swu.dim_attributes,
+                swn_data,
+            )
+            return swn
+        end
+
+    return obs_var_dict
+end

--- a/experiments/long_runs/global_plots.jl
+++ b/experiments/long_runs/global_plots.jl
@@ -1,0 +1,507 @@
+using ClimaUtilities.ClimaArtifacts
+import ClimaDiagnostics
+import ClimaAnalysis as CAN
+import ClimaAnalysis.Visualize as viz
+import ClimaUtilities
+import ClimaUtilities.ClimaArtifacts: @clima_artifact
+import ClimaParams as CP
+using ClimaLand
+using ClimaLand.Snow
+using ClimaLand.Soil
+using ClimaLand.Canopy
+import ClimaLand
+import ClimaLand.Parameters as LP
+using CairoMakie
+import GeoMakie
+using Dates
+using Statistics
+
+# Load functions to access the data
+include("data_global_plots.jl")
+
+"""
+    make_global_plots(
+        data_dir;
+        root_save_path = pwd(),
+        plot_net_radiation = false,
+    )
+
+Make a set of global plots comparing simulation data to observational data.
+The plots include contour plots of the annually averaged simulation and
+observational data, as well as a bias plot.
+
+By default, the plots use the second year of data from the simulation; this
+can be changed by modifying the `year_ind` variable. The observational data
+plotted is from 2008.
+
+Also by default, the plots include the following variables:
+- Latent heat flux (LE)
+- Sensible heat flux (H)
+- Upward longwave radiation (LWᵤ)
+- Upward shortwave radiation (SWᵤ)
+
+If `plot_net_radiation = true`, LWᵤ and SWᵤ are replaced with net
+radiation fluxes (LWₙ, SWₙ).
+This isn't done by default because the net radiation flux observation data
+takes some time to compute, since it uses the downward radiative fluxes,
+which come from a large hourly dataset.
+"""
+function make_global_plots(
+    data_dir;
+    root_save_path = pwd(),
+    plot_net_radiation = false,
+)
+    # Get information about the variables to plot
+    short_names, title_stubs, levels_dict = get_var_info(plot_net_radiation)
+
+    # Load the data
+    sim_var_dict = get_sim_var_dict(CAN.SimDir(data_dir))
+    obs_var_dict = get_obs_var_dict()
+
+    # Create figure for all plots
+    num_cols = 3
+    fig = CairoMakie.Figure(
+        size = (500 * num_cols, 405 * length(short_names)),
+        figure_padding = 50,
+    )
+
+    for (idx, short_name) in enumerate(short_names)
+        # Plot figures in odd rows, colorbars in even rows
+        fig_row = (idx - 1) * 2 + 1
+
+        # Access simulation and observation data for this variable
+        sim_var = CAN.apply_oceanmask(
+            CAN.shift_to_start_of_previous_month(sim_var_dict[short_name]()),
+        )
+        sim_var_times = CAN.times(sim_var)
+        obs_var = CAN.apply_oceanmask(
+            obs_var_dict[short_name](sim_var.attributes["start_date"]),
+        )
+
+        # Check that the variables are 2D (+time)
+        length(sim_var.dims) == 3 ||
+            error("Can only plot 2D simulation variables")
+        length(obs_var.dims) == 3 ||
+            error("Can only plot 2D observational variables")
+
+        title_stub = title_stubs[short_name]
+        units_label = "(" * sim_var.attributes["units"] * ")"
+
+        # Select the time window of data to plot
+        # Use data from year 1 of the simulation
+        year_ind = 1
+        sim_var_window = CAN.window(
+            sim_var,
+            "time",
+            left = (year_ind - 1) * 366 * 86400 + 30 * 86400, # 1 year left of year_ind, in seconds.
+            right = year_ind * 366 * 86400, # 1 year right of year_ind, in seconds
+        )
+
+        obs_var_window = CAN.window(
+            obs_var,
+            "time",
+            left = 0, # observation data starts at 2008
+            right = 366 * 86400, # 1 year of observation data, in seconds
+        )
+
+        # Load the visualization mask
+        mask = viz.oceanmask()
+
+        ### GLOBAL HEATMAPS (plotted by default)
+        # Average the data over this window of time
+        sim_var_annual_average = CAN.average_time(sim_var_window)
+        obs_var_annual_average = CAN.average_time(obs_var_window)
+
+        # Get colorbar limits to share between heatmaps
+        clims, levels, nlevels =
+            get_clims(sim_var_annual_average, obs_var_annual_average)
+
+        # Make colorbar tick labels
+        ticklabels = map(x -> string(x), levels)
+        ticks = (levels, ticklabels)
+
+        # Choose colormap based on variable
+        # Treat SHF differently because we include negative and positive values
+        if short_name in ["shf"]
+            # Make sure that 0 is at the center
+            cmap = viz._constrained_cmap(
+                Makie.cgrad(:PRGn_9).colors,
+                clims[1],
+                clims[2];
+                categorical = true,
+            )
+        else
+            cmap = Makie.cgrad(
+                :Greens_4,
+                nlevels - 1;
+                categorical = true,
+                rev = false,
+            )
+        end
+
+        # Plot simulation data heatmap
+        sim_title =
+            fig_row == 1 ?
+            CairoMakie.rich("ClimaLand, annually averaged", fontsize = 28) : "" # title of the figure
+        p_loc_sim = [fig_row, 1] # column 1
+        label = "$title_stub $units_label"
+        plot_var_contour!(
+            fig,
+            sim_var_annual_average,
+            p_loc_sim,
+            sim_title,
+            levels,
+            cmap,
+            mask,
+            ticks,
+            label,
+        )
+
+        # Plot observational data heatmap
+        obs_title =
+            fig_row == 1 ?
+            CairoMakie.rich("ERA5, annually averaged", fontsize = 28) : "" # title of the figure
+        p_loc_obs = [fig_row, 2] # column 2
+        plot_var_contour!(
+            fig,
+            obs_var_annual_average,
+            p_loc_obs,
+            obs_title,
+            levels,
+            cmap,
+            mask,
+            ticks,
+            label,
+        )
+
+        ### GLOBAL BIAS PLOTS
+        # Compute the bias
+        apply_mask = CAN.apply_oceanmask
+        bias_var = CAN.bias(
+            sim_var_annual_average,
+            obs_var_annual_average,
+            mask = apply_mask,
+        )
+        global_bias = round(bias_var.attributes["global_bias"], sigdigits = 3)
+        rmse = round(
+            CAN.global_rmse(
+                sim_var_annual_average,
+                obs_var_annual_average,
+                mask = apply_mask,
+            ),
+            sigdigits = 3,
+        )
+        # units = CAN.units(bias_var)
+        # bias_var.attributes["long_name"] *= " (RMSE: $rmse $units, Global bias: $global_bias $units)"
+
+        # Set up colormap
+        levels_bias = levels_dict["$(short_name)_bias"]
+        clims_bias = (levels_bias[1], levels_bias[end])
+        color_scheme = :vik
+        min_level, max_level = clims_bias
+        # Make sure that 0 is at the center
+        cmap = Visualize._constrained_cmap(
+            Makie.cgrad(color_scheme).colors,
+            min_level,
+            max_level;
+            categorical = true,
+        )
+
+        # Set up plot parameters
+        bias_title =
+            fig_row == 1 ?
+            CairoMakie.rich("ClimaLand vs ERA5 bias", fontsize = 28) : "" # title of the figure
+        ticklabels = map(x -> string(Int(round(x))), levels_bias)#; digits = digits_to_round)), levels)
+        ticks = (levels_bias, ticklabels)
+        p_loc_bias = [fig_row, 3] # column 3
+
+        # Plot the bias contour plot
+        plot_var_contour!(
+            fig,
+            bias_var,
+            p_loc_bias,
+            bias_title,
+            levels_bias,
+            cmap,
+            mask,
+            ticks,
+            label,
+        )
+    end
+    # Save the figure
+    save_name = joinpath(root_save_path, "global_plots_bias.png")
+    CairoMakie.save(save_name, fig)
+    @show save_name
+    return nothing
+end
+
+function make_seasonal_plots(
+    data_dir;
+    root_save_path = pwd(),
+    plot_net_radiation = false,
+)
+    # Get information about the variables to plot
+    short_names, title_stubs, levels_dict = get_var_info(plot_net_radiation)
+
+    # Load the data
+    sim_var_dict = get_sim_var_dict(CAN.SimDir(data_dir))
+    obs_var_dict = get_obs_var_dict()
+
+    # create figure for all plots
+    num_cols = 2
+    num_rows = 2
+    fig = CairoMakie.Figure(size = (550num_cols, 350num_rows))
+
+    for (idx, short_name) in enumerate(short_names)
+        # Determine row and column index for 2x2 grid plotting
+        row_idx = mod(idx, 2) + 1 # odd var idx in even rows, offset by 1 for title
+        col_idx = idx <= fld(length(short_names), 2) ? 1 : 2 # first half of vars in first column (floor division)
+
+        # Access simulation and observation data for this variable
+        sim_var = CAN.apply_oceanmask(
+            CAN.shift_to_start_of_previous_month(sim_var_dict[short_name]()),
+        )
+        sim_var_times = CAN.times(sim_var)
+        obs_var = CAN.apply_oceanmask(
+            obs_var_dict[short_name](sim_var.attributes["start_date"]),
+        )
+        title_stub = title_stubs[short_name]
+        units_label = "(" * sim_var.attributes["units"] * ")"
+        label = "$title_stub $units_label"
+
+        # Check that the times are aligned between simulation and observation data
+        @assert all(
+            sim_var.dims["time"][1:12] - obs_var.dims["time"][1:12] .== 0,
+        )
+
+        # At each point in time, compute the global average of the variable
+        n_months = 12
+        sim_var_global_average = zeros(n_months)
+        obs_var_global_average = zeros(n_months)
+        for i in 1:n_months
+            # This assumes all variables are 2D (no z dimension)
+            sim_slice_args = Dict(:time => sim_var_times[i])
+            obs_slice_args = Dict(:time => sim_var_times[i])
+
+            sim_var_sliced = CAN.slice(sim_var; sim_slice_args...)
+            sim_var_masked = CAN.apply_oceanmask(sim_var_sliced)
+            sim_var_global_average[i] =
+                CAN.weighted_average_lonlat(sim_var_masked).data[1]
+
+            obs_var_sliced = CAN.slice(obs_var; obs_slice_args...)
+            obs_var_masked = CAN.apply_oceanmask(obs_var_sliced)
+            obs_var_global_average[i] =
+                CAN.weighted_average_lonlat(obs_var_masked).data[1]
+        end
+
+        month_names = [
+            "Jan",
+            "Feb",
+            "Mar",
+            "Apr",
+            "May",
+            "Jun",
+            "Jul",
+            "Aug",
+            "Sep",
+            "Oct",
+            "Nov",
+            "Dec",
+        ]
+
+        # Set up axis
+        ax = Axis(
+            fig[row_idx, col_idx], # last column
+            ylabel = label,
+            height = 250,
+            xgridvisible = false,
+            ygridvisible = false,
+            xticks = (1:1:12, month_names),
+        )
+
+        # Plot simulation data
+        CairoMakie.lines!(
+            ax,
+            sim_var_global_average,
+            color = :blue,
+            linewidth = 3,
+            label = "ClimaLand",
+        )
+
+        # Plot observational data
+        CairoMakie.scatter!(
+            ax,
+            obs_var_global_average,
+            color = :orange,
+            label = "ERA5",
+        )
+
+        # Add legend to top left plot
+        row_idx == col_idx == 1 &&
+            CairoMakie.axislegend(ax, position = :rt, labelsize = 18)
+
+    end
+    # Add title at the end so it spans all columns
+    Label(
+        fig[0, :],
+        "ClimaLand vs ERA5 seasonal cycle",
+        fontsize = 24,
+        font = "TeX Gyre Heros Bold Makie",
+    )
+
+    save_name = joinpath(root_save_path, "seasonal_cycle.png")
+    CairoMakie.save(save_name, fig)
+    @show save_name
+    return nothing
+end
+
+"""
+    get_var_info(plot_net_radiation)
+
+Get information about the variables to plot, including variable names,
+titles to use, and bias colorbar levels. Only plot net radiation fluxes
+if explicitly requested, since they take some time to compute.
+"""
+function get_var_info(plot_net_radiation)
+    short_names =
+        plot_net_radiation ? ["lhf", "shf", "lwn", "swn"] :
+        ["lhf", "shf", "lwu", "swu"]
+
+    title_stubs = Dict(
+        "lhf" => "LE", #"Latent heat flux",
+        "shf" => "H", #"Sensible heat flux",
+        "lwu" => "LWᵤ", #"Upward longwave radiation",
+        "swu" => "SWᵤ", #"Upward shortwave radiation",
+        "lwn" => "LWₙ", #"Net longwave radiation",
+        "swn" => "SWₙ", #"Net shortwave radiation",
+    )
+
+    # These have been estimated by visual inspection, and may need to be adjusted
+    levels_dict = Dict(
+        "lhf_bias" => collect(-50:10:30),
+        "shf_bias" => collect(-30:10:50),
+        "lwu_bias" => collect(-40:5:20),
+        "swu_bias" => collect(-20:5:40),
+        "lwn_bias" => collect(-40:5:40),
+        "swn_bias" => collect(-40:5:40),
+    )
+
+    return short_names, title_stubs, levels_dict
+end
+
+# TODO this function can be replaced by `CAN.weighted_average_latlon(masked_var)` once a release is made
+function compute_global_average(masked_var)
+    latitude_name = ClimaAnalysis.latitude_name(masked_var)
+    lon_name = ClimaAnalysis.longitude_name(masked_var)
+
+    land_data = ClimaAnalysis.apply_oceanmask(masked_var).data
+    lat_data = masked_var.dims[latitude_name]
+    mask = .~isnan.(land_data)
+    nlon = length(masked_var.dims[lon_name])
+    resized_lat_data = transpose(repeat(lat_data, 1, nlon))
+
+    return sum(land_data[mask] .* cosd.(resized_lat_data[mask])) /
+           sum(cosd.(resized_lat_data[mask]))
+end
+
+"""
+    get_clims(sim_var, obs_var)
+
+Get colorbar limits to use for heatmaps of the simulation and observation data.
+We want to use the same colorbar limits for both heatmaps, so that the colors are
+consistent between the two. To do this, we combine the data from both and
+use the 5th and 95th percentiles of the combined data as the limits.
+Depending on the range of the data, we use a step size of 10 or 40 for the colorbar levels.
+
+Returns:
+    clims::Tuple{Int, Int} - The colorbar limits to use for the heatmaps
+    levels::Vector{Int} - The levels to use for the colorbar
+    nlevels::Int - The number of levels in the colorbar
+"""
+function get_clims(sim_var, obs_var)
+    # This is a hacky way to remove NaNs in data, but it works for now
+    sim_var_no_nans = deepcopy(sim_var.data)
+    obs_var_no_nans = deepcopy(obs_var.data)
+    sim_var_no_nans[isnan.(sim_var_no_nans)] .= 0
+    obs_var_no_nans[isnan.(obs_var_no_nans)] .= 0
+
+    # Combine the simulation and observation data
+    combined_data = vcat(vec(sim_var_no_nans), vec(obs_var_no_nans))
+
+    # Use the 5th and 95th percentiles as the colorbar limits
+    min = Int(round(quantile(combined_data, 0.05); digits = -1))
+    max = Int(round(quantile(combined_data, 0.95); digits = -1))
+
+    # Choose the step size for colorbar levels based on the range of the data
+    diff = max - min
+    step_size = diff < 150 ? 10 : 40
+
+    max = (diff % step_size != 0) ? max + step_size - (diff % step_size) : max
+    clims = (min, max)
+    levels = collect(min:step_size:max)
+    nlevels = length(levels)
+
+    return clims, levels, nlevels
+end
+
+"""
+    plot_var_contour!(fig, var, p_loc, title, levels, cmap, mask, ticks, label)
+
+Plot a heatmap of the variable `var` on the figure `fig` at position `p_loc`.
+The heatmap is plotted with the given `levels` and `cmap`, and the `mask` is overlaid.
+A colorbar is added to the figure with the given `ticks` and `label`.
+"""
+function plot_var_contour!(
+    fig,
+    var::CAN.OutputVar,
+    p_loc,
+    title,
+    levels,
+    cmap,
+    mask,
+    ticks,
+    label,
+)
+    ax = GeoMakie.GeoAxis(
+        fig[p_loc[1], p_loc[2]];
+        title = title,
+        xticklabelsvisible = false, # don't show lat labels
+        yticklabelsvisible = false, # don't show lon labels
+        xgridvisible = false, # don't show lat grid
+        ygridvisible = false, # don't show lon grid
+        height = 235,
+        # ylabel = label, # plot variable label on y-axis for leftmost column (sim)
+        # ylabelvisible = true,
+        # ylabelpadding = 0,
+    )
+    lon = CAN.longitudes(var)
+    lat = CAN.latitudes(var)
+    plot = Makie.contourf!(
+        ax,
+        lon,
+        lat,
+        var.data;
+        rasterize = true,
+        levels = levels,
+        colormap = cmap,
+        extendhigh = :auto,
+        extendlow = :auto,
+    )
+    Makie.poly!(ax, mask; color = :white) # plot mask
+    Makie.lines!(ax, GeoMakie.coastlines(); color = :black) # plot coastlines
+
+    # Add colorbar
+    Makie.Colorbar(
+        fig[p_loc[1] + 1, p_loc[2]], # place colorbar below plot
+        plot,
+        label = label,
+        vertical = false, # horizontal colorbar
+        flipaxis = false, # label underneath colorbar
+        labelsize = 20,
+        width = 400, # a little smaller
+        tellwidth = false; # make colorbar width indep of plot width
+        alignmode = Mixed(top = -20),
+        ticks = ticks,
+    )
+    Makie.rowgap!(fig.layout, 0) # move colorbar closer to plot
+end

--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -427,12 +427,9 @@ setup_and_solve_problem(; greet = true);
 # read in diagnostics and make some plots!
 #### ClimaAnalysis ####
 short_names = ["gpp", "swc", "et", "ct"]
-include(
-    joinpath(
-        pkgdir(ClimaLand),
-        "experiments",
-        "long_runs",
-        "figures_function.jl",
-    ),
-)
+include(joinpath(@__DIR__, "figures_function.jl"))
 make_figures(root_path, outdir, short_names)
+
+include(joinpath(@__DIR__, "global_plots"))
+make_global_plots(outdir, root_path, plot_net_radiation = true)
+make_seasonal_plots(outdir, root_path, plot_net_radiation = true)

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -496,17 +496,14 @@ short_names = [
     "msf",
 ]
 
-include(
-    joinpath(
-        pkgdir(ClimaLand),
-        "experiments",
-        "long_runs",
-        "figures_function.jl",
-    ),
-)
+include(joinpath(@__DIR__, "figures_function.jl"))
 make_figures(root_path, outdir, short_names)
 
-include("leaderboard/leaderboard.jl")
+include(joinpath(@__DIR__, "leaderboard", "leaderboard.jl"))
 diagnostics_folder_path = outdir
 leaderboard_base_path = root_path
 compute_leaderboard(leaderboard_base_path, diagnostics_folder_path)
+
+include(joinpath(@__DIR__, "global_plots.jl"))
+make_global_plots(outdir, root_path, plot_net_radiation = true)
+make_seasonal_plots(outdir, root_path, plot_net_radiation = true)

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -11,7 +11,7 @@ using ArtifactWrappers
 """
     soil_ic_2008_50m_path(; context)
 
-Return the path to the file that contains the spun-up soil and snow initial 
+Return the path to the file that contains the spun-up soil and snow initial
 conditions for Jan 1, 2008.
 
 The soil domain has a depth of 50m; we have ensured that surface properties
@@ -71,6 +71,15 @@ function era5_land_forcing_data2008_folder_path(;
     else
         return @clima_artifact("era5_land_forcing_data2008", context)
     end
+end
+
+"""
+    era5_monthly_averages_2008_path(; context, lowres=false)
+Return the path to the directory that contains the ERA5 forcing data for 2008.
+Optionally, you can pass the lowres=true keyword to download a lower spatial resolution version of the data.
+"""
+function era5_monthly_averages_2008_folder_path(; context = nothing)
+    return @clima_artifact("era5_monthly_averages_2008", context)
 end
 
 """
@@ -461,7 +470,7 @@ end
 
 Construct the file path for the 60arcsecond orography data NetCDF file.
 
-Downloads the 60arc-second dataset by default. 
+Downloads the 60arc-second dataset by default.
 """
 function earth_orography_file_path(; context = nothing)
     filename = "ETOPO_2022_v1_60s_N90W180_surface.nc"
@@ -476,7 +485,7 @@ end
 
 Construct the file path for the 60arcsecond bedrock depth data NetCDF file.
 
-Downloads the 60arc-second dataset by default. 
+Downloads the 60arc-second dataset by default.
 """
 function bedrock_depth_file_path(; context = nothing)
     filename = "ETOPO_2022_v1_60s_N90W180_bed.nc"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
https://github.com/CliMA/ClimaLand.jl/pull/1018/ added some useful plotting functions to make plots for the ClimaLand paper, for variables LE, H, LW_net, SW_net, LW_u, SW_u. This PR cleans those up and reduces some dependencies on ClimaAnalysis that required changes in that package.

Note that downward longwave and shortwave radiative fluxes come from a different artifact than the other quantities. This artifact contains hourly data so it's much larger than the artifact containing monthly data we use for the other variables. The hourly data gets averaged to monthly intervals to match the other data, but this takes some time to run. Because of this, by default upward LW and SW are plotted; net LW and SW can be selected by setting `plot_net_radiation = true`, but this takes longer to produce the plots. In the future this could be fixed by adding downward LW and SW to the monthly artifact and re-generating it.
 
## Content
- [x] add functions to get simulation data and observation data from ERA5
- [x] add function to generate global heatmaps and bias plots vs ERA5
- [x] add function to generate seasonal cycle plot
- [x] make these plots by default for all longruns
