### PR TITLE
Fix global average in make_figures

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.3"
 manifest_format = "2.0"
-project_hash = "3f4ceb30ba99ebd32a38b3cd7ce9703605f14393"
+project_hash = "821ecdf7b522fefb9425acdf4347d3bca9c939c5"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "e2478490447631aedba0823d4d7a80b2cc8cdb32"
@@ -376,9 +376,9 @@ weakdeps = ["SparseArrays"]
 
 [[deps.ClimaAnalysis]]
 deps = ["Artifacts", "Dates", "Interpolations", "NCDatasets", "NaNStatistics", "OrderedCollections", "Reexport", "Statistics", "Unitful"]
-git-tree-sha1 = "266bf6208c54827b621e4131550b5d975f7beb80"
+git-tree-sha1 = "1cae1cd626bd636bba0e1a4a681e0296372848bc"
 uuid = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
-version = "0.5.13"
+version = "0.5.15"
 weakdeps = ["GeoMakie", "Makie"]
 
     [deps.ClimaAnalysis.extensions]

--- a/.buildkite/Project.toml
+++ b/.buildkite/Project.toml
@@ -43,7 +43,7 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [compat]
-ClimaAnalysis = "0.5.12"
+ClimaAnalysis = "0.5.15"
 ClimaTimeSteppers = "0.7, 0.8"
 Statistics = "1"
 Flux = "~0.14"

--- a/experiments/long_runs/figures_function.jl
+++ b/experiments/long_runs/figures_function.jl
@@ -34,15 +34,13 @@ function make_figures(
             # i represent a year, from 1 to last year
             # for more details on the ClimaAnalysis functions, see ClimaAnalysis docs.
             var_global_average = [
-                ClimaAnalysis.average_lon(
-                    ClimaAnalysis.weighted_average_lat(
-                        ClimaAnalysis.apply_oceanmask(
-                            ClimaAnalysis.window(
-                                var_sliced,
-                                "time",
-                                left = (i - 1) * 366 * 86400 + 30 * 86400, # 1 year left of year i, in seconds.
-                                right = i * 366 * 86400, # 1 year right of year i, in seconds
-                            ),
+                ClimaAnalysis.weighted_average_lonlat(
+                    ClimaAnalysis.apply_oceanmask(
+                        ClimaAnalysis.window(
+                            var_sliced,
+                            "time",
+                            left = (i - 1) * 366 * 86400 + 30 * 86400, # 1 year left of year i, in seconds.
+                            right = i * 366 * 86400, # 1 year right of year i, in seconds
                         ),
                     ),
                 ).data for i in range(


### PR DESCRIPTION
This PR changes `make_figures` to use `Var.weighted_average_lonlat` instead of composing two averaging functions along the longitude dimension and latitude dimension.
