### PR TITLE
dispatch on return_momentum_fluxes type in flux calculations

### DIFF
--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -298,6 +298,7 @@ function turbulent_fluxes!(
 
     dest .=
         turbulent_fluxes_at_a_point.(
+            Val(false), # return_momentum_fluxes
             T_sfc,
             q_sfc,
             ρ_sfc,
@@ -345,6 +346,7 @@ function coupler_compute_turbulent_fluxes!(
 
     dest .=
         turbulent_fluxes_at_a_point.(
+            Val(true), # return_momentum_fluxes
             T_sfc,
             q_sfc,
             ρ_sfc,
@@ -359,14 +361,39 @@ function coupler_compute_turbulent_fluxes!(
             model.parameters.z_0m,
             model.parameters.z_0b,
             model.parameters.earth_param_set,
-            return_momentum_fluxes = true,
         )
     return nothing
 end
 
+"""
+    turbulent_fluxes_at_a_point(return_momentum_fluxes, args...)
+
+This is a wrapper function that allows us to dispatch on the type of `return_momentum_fluxes`
+as we compute the turbulent fluxes pointwise. This is needed because space for the
+momentum fluxes is only allocated in the cache when running with a `CoupledAtmosphere`.
+The function `turbulent_fluxes_helper` does the actual flux computation.
+"""
+function turbulent_fluxes_at_a_point(
+    return_momentum_fluxes::Val{false},
+    args...,
+)
+    (LH, SH, Ẽ, r_ae, _, _) = turbulent_fluxes_helper(args...)
+    return (lhf = LH, shf = SH, vapor_flux = Ẽ, r_ae = r_ae)
+end
+function turbulent_fluxes_at_a_point(return_momentum_fluxes::Val{true}, args...)
+    (LH, SH, Ẽ, r_ae, ρτxz, ρτyz) = turbulent_fluxes_helper(args...)
+    return (
+        lhf = LH,
+        shf = SH,
+        vapor_flux = Ẽ,
+        r_ae = r_ae,
+        ρτxz = ρτxz,
+        ρτyz = ρτyz,
+    )
+end
 
 """
-    turbulent_fluxes_at_a_point(T_sfc::FT,
+    turbulent_fluxes_helper(T_sfc::FT,
                                 q_sfc::FT,
                                 ρ_sfc::FT,
                                 β_sfc::FT,
@@ -380,7 +407,6 @@ end
                                 z_0m::FT,
                                 z_0b::FT,
                                 earth_param_set::EP;
-                                return_momentum_fluxes = false,
                                ) where {FT <: AbstractFloat, P}
 
 Computes turbulent surface fluxes at a point on a surface given
@@ -405,7 +431,7 @@ from unit conversion of evaporation from a mass to a liquid water volume
 flux. When r_sfc is nonzero, an additional resistance is applied in series
 to the vapor flux (and hence also the latent heat flux).
 """
-function turbulent_fluxes_at_a_point(
+function turbulent_fluxes_helper(
     T_sfc::FT,
     q_sfc::FT,
     ρ_sfc::FT,
@@ -419,8 +445,7 @@ function turbulent_fluxes_at_a_point(
     gustiness::FT,
     z_0m::FT,
     z_0b::FT,
-    earth_param_set::EP;
-    return_momentum_fluxes = false,
+    earth_param_set::EP,
 ) where {FT <: AbstractFloat, EP}
     thermo_params = LP.thermodynamic_parameters(earth_param_set)
     ts_sfc = Thermodynamics.PhaseEquil_ρTq(thermo_params, ρ_sfc, T_sfc, q_sfc)
@@ -479,19 +504,7 @@ function turbulent_fluxes_at_a_point(
     # vapor flux in volume of liquid water with density 1000kg/m^3
     Ẽ = E / _ρ_liq
 
-    # Return the (unaltered) momentum fluxes if they are requested
-    if !return_momentum_fluxes
-        return (lhf = LH, shf = SH, vapor_flux = Ẽ, r_ae = r_ae)
-    else
-        return (
-            lhf = LH,
-            shf = SH,
-            vapor_flux = Ẽ,
-            r_ae = r_ae,
-            ρτxz = conditions.ρτxz,
-            ρτyz = conditions.ρτyz,
-        )
-    end
+    return (LH, SH, Ẽ, r_ae, conditions.ρτxz, conditions.ρτyz)
 end
 
 """

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -831,8 +831,6 @@ function ClimaLand.get_drivers(model::EnergyHydrology)
     end
 end
 
-
-
 function turbulent_fluxes!(
     dest,
     atmos::PrescribedAtmosphere,
@@ -863,6 +861,7 @@ function turbulent_fluxes!(
     )
     dest .=
         soil_turbulent_fluxes_at_a_point.(
+            Val(false), # return_momentum_fluxes
             T_sfc,
             θ_l_sfc,
             θ_i_sfc,
@@ -887,7 +886,45 @@ function turbulent_fluxes!(
 end
 
 """
-    soil_turbulent_fluxes_at_a_point(
+    soil_turbulent_fluxes_at_a_point(return_momentum_fluxes, args...;)
+
+This is a wrapper function that allows us to dispatch on the type of `return_momentum_fluxes`
+as we compute the soil turbulent fluxes pointwise. This is needed because space for the
+momentum fluxes is only allocated in the cache when running with a `CoupledAtmosphere`.
+The function `soil_turbulent_fluxes_helper` does the actual flux computation.
+"""
+function soil_turbulent_fluxes_at_a_point(
+    return_momentum_fluxes::Val{false},
+    args...,
+)
+    (LH, SH, Ẽ_l, r_ae, Ẽ_i, _, _) = soil_turbulent_fluxes_helper(args...)
+    return (
+        lhf = LH,
+        shf = SH,
+        vapor_flux_liq = Ẽ_l,
+        r_ae = r_ae,
+        vapor_flux_ice = Ẽ_i,
+    )
+end
+function soil_turbulent_fluxes_at_a_point(
+    return_momentum_fluxes::Val{true},
+    args...,
+)
+    (LH, SH, Ẽ_l, r_ae, Ẽ_i, ρτxz, ρτyz) =
+        soil_turbulent_fluxes_helper(args...)
+    return (
+        lhf = LH,
+        shf = SH,
+        vapor_flux_liq = Ẽ_l,
+        r_ae = r_ae,
+        vapor_flux_ice = Ẽ_i,
+        ρτxz = ρτxz,
+        ρτyz = ρτyz,
+    )
+end
+
+"""
+    soil_turbulent_fluxes_helper(
                                 T_sfc::FT,
                                 θ_l_sfc::FT,
                                 θ_i_sfc::FT,
@@ -907,7 +944,6 @@ end
                                 γ::FT,
                                 γT_ref,::FT
                                 earth_param_set::EP;
-                                return_momentum_fluxes = false,
                                ) where {FT <: AbstractFloat, C, EP}
 
 Computes turbulent surface fluxes for soil at a point on a surface given
@@ -926,7 +962,7 @@ a tuple with self explanatory keys. If the temperature is above the freezing poi
 the vapor flux comes from liquid water; if the temperature is below the freezing
 point, it comes from the soil ice.
 """
-function soil_turbulent_fluxes_at_a_point(
+function soil_turbulent_fluxes_helper(
     T_sfc::FT,
     θ_l_sfc::FT,
     θ_i_sfc::FT,
@@ -945,8 +981,7 @@ function soil_turbulent_fluxes_at_a_point(
     Ω::FT,
     γ::FT,
     γT_ref::FT,
-    earth_param_set::P;
-    return_momentum_fluxes = false,
+    earth_param_set::P,
 ) where {FT <: AbstractFloat, P}
     # Parameters
     surface_flux_params = LP.surface_fluxes_parameters(earth_param_set)
@@ -1094,26 +1129,7 @@ function soil_turbulent_fluxes_at_a_point(
     # Heat fluxes for soil
     LH::FT = _LH_v0 * (Ẽ_l + Ẽ_i) * _ρ_liq
 
-    # Return the (unaltered) momentum fluxes if they are requested
-    if !return_momentum_fluxes
-        return (
-            lhf = LH,
-            shf = SH,
-            vapor_flux_liq = Ẽ_l,
-            r_ae = r_ae,
-            vapor_flux_ice = Ẽ_i,
-        )
-    else
-        return (
-            lhf = LH,
-            shf = SH,
-            vapor_flux_liq = Ẽ_l,
-            r_ae = r_ae,
-            vapor_flux_ice = Ẽ_i,
-            ρτxz = conditions.ρτxz,
-            ρτyz = conditions.ρτyz,
-        )
-    end
+    return (LH, SH, Ẽ_l, r_ae, Ẽ_i, conditions.ρτxz, conditions.ρτyz)
 end
 
 """
@@ -1210,6 +1226,7 @@ function ClimaLand.coupler_compute_turbulent_fluxes!(
     )
     dest .=
         soil_turbulent_fluxes_at_a_point.(
+            Val(true), # return_momentum_fluxes
             T_sfc,
             θ_l_sfc,
             θ_i_sfc,
@@ -1229,7 +1246,6 @@ function ClimaLand.coupler_compute_turbulent_fluxes!(
             γ,
             γT_ref,
             Ref(earth_param_set),
-            return_momentum_fluxes = true,
         )
     return nothing
 end

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -272,6 +272,7 @@ function ClimaLand.turbulent_fluxes!(
     h_air = atmos.h
     dest .=
         canopy_turbulent_fluxes_at_a_point.(
+            Val(false), # return_momentum_fluxes
             T_sfc,
             h_sfc,
             r_stomata_canopy,
@@ -314,6 +315,7 @@ function ClimaLand.coupler_compute_turbulent_fluxes!(
     d_sfc = ClimaLand.displacement_height(model, Y, p)
     dest .=
         canopy_turbulent_fluxes_at_a_point.(
+            Val(true), # return_momentum_fluxes
             T_sfc,
             h_sfc,
             r_stomata_canopy,
@@ -327,13 +329,64 @@ function ClimaLand.coupler_compute_turbulent_fluxes!(
             model.parameters.z_0m,
             model.parameters.z_0b,
             Ref(model.parameters.earth_param_set),
-            return_momentum_fluxes = true,
         )
     return nothing
 end
 
 """
-    function canopy_turbulent_fluxes_at_a_point(
+    canopy_turbulent_fluxes_at_a_point(return_momentum_fluxes, args...)
+
+This is a wrapper function that allows us to dispatch on the type of `return_momentum_fluxes`
+as we compute the canopy turbulent fluxes pointwise. This is needed because space for the
+momentum fluxes is only allocated in the cache when running with a `CoupledAtmosphere`.
+The function `canopy_turbulent_fluxes_helper` does the actual flux computation.
+"""
+function canopy_turbulent_fluxes_at_a_point(
+    return_momentum_fluxes::Val{false},
+    args...,
+)
+    (LH, SH, Ẽ, r_ae, ∂LHF∂qc, ∂SHF∂Tc, _, _) =
+        canopy_turbulent_fluxes_helper(args...)
+    return (
+        lhf = LH,
+        shf = SH,
+        transpiration = Ẽ,
+        r_ae = r_ae,
+        ∂LHF∂qc = ∂LHF∂qc,
+        ∂SHF∂Tc = ∂SHF∂Tc,
+    )
+end
+function canopy_turbulent_fluxes_at_a_point(
+    return_momentum_fluxes::Val{true},
+    args...,
+)
+    (
+        lhf = LH,
+        shf = SH,
+        transpiration = Ẽ,
+        r_ae = r_ae,
+        ∂LHF∂qc = ∂LHF∂qc,
+        ∂SHF∂Tc = ∂SHF∂Tc,
+        ρτxz = conditions.ρτxz,
+        ρτyz = conditions.ρτyz,
+    )
+    (LH, SH, Ẽ, r_ae, ∂LHF∂qc, ∂SHF∂Tc, ρτxz, ρτyz) =
+        canopy_turbulent_fluxes_helper(args...)
+    return (
+        lhf = LH,
+        shf = SH,
+        transpiration = Ẽ,
+        r_ae = r_ae,
+        ∂LHF∂qc = ∂LHF∂qc,
+        ∂SHF∂Tc = ∂SHF∂Tc,
+        ρτxz = conditions.ρτxz,
+        ρτyz = conditions.ρτyz,
+    )
+end
+
+
+"""
+    function canopy_turbulent_fluxes_helper(
         T_sfc::FT,
         h_sfc::FT,
         r_stomata_canopy::FT,
@@ -347,7 +400,6 @@ end
         z_0m::FT,
         z_0b::FT,
         earth_param_set::EP;
-        return_momentum_fluxes = false,
     ) where {FT <: AbstractFloat, EP}
 
 Computes the turbulent surface fluxes for the canopy at a point
@@ -357,7 +409,7 @@ Note that an additiontal resistance is used in computing both
 evaporation and sensible heat flux, and this modifies the output
 of `SurfaceFluxes.surface_conditions`.
 """
-function canopy_turbulent_fluxes_at_a_point(
+function canopy_turbulent_fluxes_helper(
     T_sfc::FT,
     h_sfc::FT,
     r_stomata_canopy::FT,
@@ -371,7 +423,6 @@ function canopy_turbulent_fluxes_at_a_point(
     z_0m::FT,
     z_0b::FT,
     earth_param_set::EP;
-    return_momentum_fluxes = false,
 ) where {FT <: AbstractFloat, EP}
     thermo_params = LP.thermodynamic_parameters(earth_param_set)
     # The following will not run on GPU
@@ -452,28 +503,16 @@ function canopy_turbulent_fluxes_at_a_point(
         SH / ρ_sfc * ∂ρsfc∂Tc +
         SH / cp_m_sfc * ∂cp_m_sfc∂Tc
 
-    # Return the (unaltered) momentum fluxes if they are requested
-    if !return_momentum_fluxes
-        return (
-            lhf = LH,
-            shf = SH,
-            transpiration = Ẽ,
-            r_ae = r_ae,
-            ∂LHF∂qc = ∂LHF∂qc,
-            ∂SHF∂Tc = ∂SHF∂Tc,
-        )
-    else
-        return (
-            lhf = LH,
-            shf = SH,
-            transpiration = Ẽ,
-            r_ae = r_ae,
-            ∂LHF∂qc = ∂LHF∂qc,
-            ∂SHF∂Tc = ∂SHF∂Tc,
-            ρτxz = conditions.ρτxz,
-            ρτyz = conditions.ρτyz,
-        )
-    end
+    return (
+        lhf = LH,
+        shf = SH,
+        transpiration = Ẽ,
+        r_ae = r_ae,
+        ∂LHF∂qc = ∂LHF∂qc,
+        ∂SHF∂Tc = ∂SHF∂Tc,
+        ρτxz = conditions.ρτxz,
+        ρτyz = conditions.ρτyz,
+    )
 end
 
 """


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Our current `turbulent_fluxes_at_a_point` functions are not `isbits` (not GPU compatible) because the return type (4-Tuple vs 6-Tuple) depends on the value of an input (`return_momentum_fluxes`). This PR fixes this by changing `return_momentum_fluxes` from a `Boolean` to a `Val` that we can dispatch on, and it also pulls out a lot of the code in `turbulent_fluxes_at_a_point` into a shared function `turbulent_fluxes_helper` for the two cases.


## To-do
- [ ] test from ClimaCoupler (on GPU 😅)

## Content
- [x] change `return_momentum_fluxes` to a `Val`, dispatch on this in `turbulent_fluxes_at_a_point`
- [x] add `turbulent_fluxes_helper` function to do the shared computation
