### PR TITLE
Checking conservation for soil

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -179,7 +179,7 @@ steps:
         agents:
           slurm_ntasks: 1
           slurm_gpus: 1
-          slurm_mem: 16G
+          slurm_mem: 32G
         env:
           CLIMACOMMS_DEVICE: "CUDA"
 

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -207,6 +207,8 @@ function setup_prob(
         start_date;
         output_writer = nc_writer,
         average_period = :monthly,
+        conservation = true,
+        conservation_period = Day(10),
     )
 
     diagnostic_handler =
@@ -278,3 +280,6 @@ include(
     ),
 )
 make_figures(root_path, outdir, short_names)
+
+## Conservation
+check_conservation(root_path, outdir)

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -224,6 +224,8 @@ function default_diagnostics(
     start_date;
     output_writer,
     average_period = :daily,
+    conservation = false,
+    conservation_period = Day(10),
 ) where {FT}
 
     define_diagnostics!(land_model)
@@ -241,7 +243,26 @@ function default_diagnostics(
             monthly_averages(FT, soil_diagnostics...; output_writer, start_date)
     end
 
-    return [default_outputs...]
+    if conservation
+        additional_diags = ["epa", "epac", "wvpa", "wvpac"]
+        additional_outputs = vcat(
+            map(additional_diags) do short_name
+                output_schedule_func =
+                    conservation_period isa Period ?
+                    EveryCalendarDtSchedule(conservation_period; start_date) : EveryDtSchedule(conservation_period)
+                return ScheduledDiagnostic(
+                    variable = get_diagnostic_variable(short_name),
+                    compute_schedule_func = EveryStepSchedule(),
+                    output_schedule_func = output_schedule_func,
+                    output_writer = output_writer,
+                )
+            end...,
+        )
+    else
+        additional_outputs = []
+    end
+
+    return [default_outputs..., additional_outputs...]
 end
 
 # Land Model

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -5,6 +5,46 @@ Calls `add_diagnostic_variable!` for all available variables specializing the
 compute function for `land_model`.
 """
 function define_diagnostics!(land_model)
+    ### Conservation ###
+    add_diagnostic_variable!(
+        short_name = "epa",
+        long_name = "Energy per unit ground area",
+        standard_name = "energy_per_area",
+        units = "J m^-2",
+        comments = "Vertically integrated volumetric energy per area",
+        compute! = (out, Y, p, t) ->
+            compute_energy_per_area!(out, Y, p, t, land_model),
+    )
+
+    add_diagnostic_variable!(
+        short_name = "wvpa",
+        long_name = "Water volume per unit ground area",
+        standard_name = "water_volume_per_area",
+        units = "m^3 m^-2",
+        comments = "Vertically integrated volumetric water per area",
+        compute! = (out, Y, p, t) ->
+            compute_water_volume_per_area!(out, Y, p, t, land_model),
+    )
+
+    add_diagnostic_variable!(
+        short_name = "epac",
+        long_name = "Energy per unit ground area change",
+        standard_name = "energy_per_area_change",
+        units = "J m^-2",
+        comments = "Expected change in vertically integrated volumetric energy per area",
+        compute! = (out, Y, p, t) ->
+            compute_energy_per_area_change!(out, Y, p, t, land_model),
+    )
+
+    add_diagnostic_variable!(
+        short_name = "wvpac",
+        long_name = "Water volume per unit ground area change",
+        standard_name = "water_volume_per_area_change",
+        units = "m^3 m^-2",
+        comments = "Expected change in vertically integrated volumetric water per area",
+        compute! = (out, Y, p, t) ->
+            compute_water_volume_per_area_change!(out, Y, p, t, land_model),
+    )
 
     ### BucketModel ###
 

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -40,6 +40,11 @@ macro diagnostic_compute(name, model, compute)
     )
 end
 
+### Conservation ##
+@diagnostic_compute "water_volume_per_area" EnergyHydrology p.soil.total_water
+@diagnostic_compute "energy_per_area" EnergyHydrology p.soil.total_energy
+@diagnostic_compute "water_volume_per_area_change" EnergyHydrology Y.soil.∫F_vol_liq_water_dt
+@diagnostic_compute "energy_per_area_change" EnergyHydrology Y.soil.∫F_e_dt
 
 
 ### BucketModel ###

--- a/src/shared_utilities/implicit_timestepping.jl
+++ b/src/shared_utilities/implicit_timestepping.jl
@@ -92,9 +92,16 @@ function FieldMatrixWithSolver(Y::ClimaCore.Fields.FieldVector)
     is_in_Y(var) = MatrixFields.has_field(Y, var)
 
     # Define the implicit and explicit variables of any model we use
+    # By implicit vars, we mean variables that contribute nonzero elements to *tendency
+    # jacobian* ∂X_t_i/∂X_j,
+    # and by explicit we mean the corresponding *tendency jacobian* entries would be zero.
+    # The full jacobian used by the model is Δt ∂X_t_i/∂X_j - δ_{i,j}, so
+    # explicit variables have a full jacobian equal to minus the identity matrix.
     implicit_vars =
         (@name(soil.ϑ_l), @name(soil.ρe_int), @name(canopy.energy.T))
     explicit_vars = (
+        @name(soil.∫F_vol_liq_water_dt),
+        @name(soil.∫F_e_dt),
         @name(soilco2.C),
         @name(soil.θ_i),
         @name(canopy.hydraulics.ϑ_l),

--- a/src/standalone/Soil/Runoff/Runoff.jl
+++ b/src/standalone/Soil/Runoff/Runoff.jl
@@ -289,7 +289,8 @@ function ClimaLand.source!(
     ϑ_l = Y.soil.ϑ_l
     h∇ = p.soil.h∇
     ϵ = eps(FT)
-    @. dY.soil.ϑ_l -= (p.soil.R_ss / max(h∇, ϵ)) * p.soil.is_saturated  # apply only to saturated layers
+    @. dY.soil.ϑ_l -= (p.soil.R_ss / max(h∇, ϵ)) * p.soil.is_saturated # apply only to saturated layers
+    @. p.soil.∫S_θ_liq_dz -= p.soil.R_ss # the integral is designed to be this flux
 end
 
 """

--- a/test/shared_utilities/implicit_timestepping/richards_model.jl
+++ b/test/shared_utilities/implicit_timestepping/richards_model.jl
@@ -68,9 +68,17 @@ for FT in (Float32, Float64)
 
             @test jacobian.solver isa MatrixFields.FieldMatrixSolver
             @test jacobian.solver.alg isa MatrixFields.BlockDiagonalSolve
-            @test jacobian.matrix.keys.values ==
-                  ((MatrixFields.@name(soil.ϑ_l), MatrixFields.@name(soil.ϑ_l)),)
-
+            @test jacobian.matrix.keys.values == (
+                (MatrixFields.@name(soil.ϑ_l), MatrixFields.@name(soil.ϑ_l)),
+                (
+                    MatrixFields.@name(soil.∫F_vol_liq_water_dt),
+                    MatrixFields.@name(soil.∫F_vol_liq_water_dt)
+                ),
+            )
+            @test jacobian.matrix[
+                MatrixFields.@name(soil.∫F_vol_liq_water_dt),
+                MatrixFields.@name(soil.∫F_vol_liq_water_dt)
+            ] == -I
             jac_ϑ_l = jacobian.matrix[
                 MatrixFields.@name(soil.ϑ_l),
                 MatrixFields.@name(soil.ϑ_l)

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -136,6 +136,10 @@ for FT in (Float32, Float64)
             @test propertynames(p.soil.turbulent_fluxes) ==
                   (:lhf, :shf, :vapor_flux_liq, :r_ae, :vapor_flux_ice)
             @test propertynames(p.soil) == (
+                :total_water,
+                :total_energy,
+                :∫S_θ_liq_dz,
+                :∫S_ρe_int_dz,
                 :K,
                 :ψ,
                 :θ_l,

--- a/test/standalone/Soil/conservation.jl
+++ b/test/standalone/Soil/conservation.jl
@@ -10,6 +10,68 @@ using ClimaLand.Domains: Column, HybridBox
 
 import ClimaLand
 import ClimaLand.Parameters as LP
+struct FakeSource{FT} <: AbstractSoilSource{FT} end
+
+import ClimaLand.source!
+# These allocate, but we dont mind here.
+"""
+ClimaLand.source!(
+    dY::ClimaCore.Fields.FieldVector,
+    src::FakeSource{FT},
+    Y::ClimaCore.Fields.FieldVector,
+    p::NamedTuple,
+    model::RichardsModel{FT},
+) where {FT}
+
+Updates dY.soil.ϑ_l in place at every level with the source for volumetric liquid water
+ (S_ϑ_l(z)), and  updates p.soil.∫S_ϑ_l_dz in place with the column integral of S_ϑ_l.
+"""
+function ClimaLand.source!(
+    dY::ClimaCore.Fields.FieldVector,
+    src::FakeSource{FT},
+    Y::ClimaCore.Fields.FieldVector,
+    p::NamedTuple,
+    model::RichardsModel{FT},
+) where {FT}
+    source = ClimaLand.Fields.zeros(model.domain.space.subsurface) .- FT(1e-5)
+    @. dY.soil.ϑ_l += source
+    tmp = ClimaCore.Fields.zeros(model.domain.space.surface)
+    ClimaCore.Operators.column_integral_definite!(tmp, source)
+    @. p.soil.∫S_θ_liq_dz += tmp
+end
+
+"""
+ClimaLand.source!(
+    dY::ClimaCore.Fields.FieldVector,
+    src::FakeSource{FT},
+    Y::ClimaCore.Fields.FieldVector,
+    p::NamedTuple,
+    model::EnergyHydrology{FT},
+) where {FT}
+
+Updates dY.soil.X in place at every level with the source for X (S_X), and 
+updates p.soil.∫S_X_dz in place with the column integral of the source
+for X, where X refers to ϑ_l, θ_i, or ρe_int.
+"""
+function ClimaLand.source!(
+    dY::ClimaCore.Fields.FieldVector,
+    src::FakeSource{FT},
+    Y::ClimaCore.Fields.FieldVector,
+    p::NamedTuple,
+    model::EnergyHydrology{FT},
+) where {FT}
+    earth_param_set = model.parameters.earth_param_set
+    _ρ_l = LP.ρ_cloud_liq(earth_param_set)
+    _ρ_i = LP.ρ_cloud_ice(earth_param_set)
+    source = ClimaLand.Fields.zeros(model.domain.space.subsurface) .- FT(1e-5)
+    @. dY.soil.ϑ_l += source
+    @. dY.soil.θ_i += source * (_ρ_l / _ρ_i)
+    tmp = ClimaCore.Fields.zeros(model.domain.space.surface)
+    ClimaCore.Operators.column_integral_definite!(tmp, source)
+    @. p.soil.∫S_θ_liq_dz += tmp
+    @. p.soil.∫S_ρe_int_dz = 0
+end
+
 
 for FT in (Float32, Float64)
     cmax = FT(0)
@@ -35,11 +97,13 @@ for FT in (Float32, Float64)
     ν_ss_om = FT(0.0)
     ν_ss_quartz = FT(1.0)
     ν_ss_gravel = FT(0.0)
-    water_flux_bc = WaterFluxBC((p, t) -> 0.0)
-    heat_flux_bc = HeatFluxBC((p, t) -> 0.0)
+    top_water_flux_bc = WaterFluxBC((p, t) -> 1.0)
+    top_heat_flux_bc = HeatFluxBC((p, t) -> 1.0)
+    bot_water_flux_bc = WaterFluxBC((p, t) -> -1.0)
+    bot_heat_flux_bc = HeatFluxBC((p, t) -> -1.0)
     t0 = 0.0
     @testset "Richards total water, FT = $FT" begin
-        sources = ()
+        sources = (FakeSource{FT}(),)
         params = Soil.RichardsParameters(;
             ν = ν,
             hydrology_cm = hcm,
@@ -47,7 +111,8 @@ for FT in (Float32, Float64)
             S_s = S_s,
             θ_r = θ_r,
         )
-        boundary_fluxes = (; top = water_flux_bc, bottom = water_flux_bc)
+        boundary_fluxes =
+            (; top = top_water_flux_bc, bottom = bot_water_flux_bc)
         for domain in domains
             soil = Soil.RichardsModel{FT}(;
                 parameters = params,
@@ -63,11 +128,28 @@ for FT in (Float32, Float64)
             total_water = ClimaCore.Fields.zeros(soil.domain.space.surface)
             ClimaLand.total_liq_water_vol_per_area!(total_water, soil, Y, p, t0)
             expected = ν / 2 * (cmax - cmin)
-            @test all(parent(total_water) .≈ expected)
+            @test maximum(abs.(total_water .- expected)) < sqrt(eps(FT))
+
+            dY = similar(Y)
+            exp_tendency! = make_exp_tendency(soil)
+            exp_tendency!(dY, Y, p, t0)
+            @test dY.soil.∫F_vol_liq_water_dt == p.soil.∫S_θ_liq_dz
+            @test maximum(
+                abs.(
+                    p.soil.∫S_θ_liq_dz .- (
+                        ClimaCore.Fields.zeros(domain.space.surface) .+
+                        FT(((cmax - cmin) * -1e-5))
+                    )
+                ),
+            ) < sqrt(eps(FT))
+            imp_tendency! = make_imp_tendency(soil)
+            imp_tendency!(dY, Y, p, t0)
+            @test dY.soil.∫F_vol_liq_water_dt ==
+                  ClimaCore.Fields.zeros(domain.space.surface) .- FT(2.0)
         end
     end
     @testset "Energy Hydrology total energy and water, FT = $FT" begin
-        sources = (Soil.PhaseChange{FT}(),)
+        sources = (Soil.PhaseChange{FT}(), FakeSource{FT}())
         params = Soil.EnergyHydrologyParameters(
             FT;
             ν,
@@ -80,8 +162,14 @@ for FT in (Float32, Float64)
             θ_r,
         )
         boundary_fluxes = (;
-            top = WaterHeatBC(; water = water_flux_bc, heat = heat_flux_bc),
-            bottom = WaterHeatBC(; water = water_flux_bc, heat = heat_flux_bc),
+            top = WaterHeatBC(;
+                water = top_water_flux_bc,
+                heat = top_heat_flux_bc,
+            ),
+            bottom = WaterHeatBC(;
+                water = bot_water_flux_bc,
+                heat = bot_heat_flux_bc,
+            ),
         )
         for domain in domains
             soil = Soil.EnergyHydrology{FT}(;
@@ -101,13 +189,12 @@ for FT in (Float32, Float64)
                 params.ρc_ds,
                 params.earth_param_set,
             )
-            ρe_int0 =
-                Soil.volumetric_internal_energy.(
-                    θ_i0,
-                    ρc_s,
-                    T,
-                    params.earth_param_set,
-                )
+            ρe_int0 = Soil.volumetric_internal_energy(
+                θ_i0,
+                ρc_s,
+                T,
+                params.earth_param_set,
+            )
             Y.soil.ϑ_l .= ϑ_l0
             Y.soil.θ_i .= θ_i0
 
@@ -120,9 +207,54 @@ for FT in (Float32, Float64)
             ρ_ice = LP.ρ_cloud_ice(params.earth_param_set)
             ρ_liq = LP.ρ_cloud_liq(params.earth_param_set)
             expected = (ϑ_l0 + θ_i0 * ρ_ice / ρ_liq) * (cmax - cmin)
-            @test all(parent(total_water) .≈ expected)
+            @test maximum(abs.(total_water .- expected)) <
+                  sqrt(eps(FT)) * expected
             ClimaLand.total_energy_per_area!(total_energy, soil, Y, p, t0)
-            @test all(parent(total_energy) .≈ ρe_int0 .* (cmax - cmin))
+            @test maximum(abs.(total_energy .- (ρe_int0 * (cmax - cmin)))) <
+                  sqrt(eps(FT)) * abs(ρe_int0 * (cmax - cmin))
+
+            dY = similar(Y)
+            exp_tendency! = make_exp_tendency(soil)
+            exp_tendency!(dY, Y, p, t0)
+            # test that ∫ dY = -[F_sfc - F_bot] + ∫Sdz
+            cache = ClimaCore.Fields.zeros(soil.domain.space.surface)
+            ClimaCore.Operators.column_integral_definite!(
+                cache,
+                dY.soil.ϑ_l .+ ρ_ice / ρ_liq .* dY.soil.θ_i,
+            )
+            @test maximum(cache .- FT(((cmax - cmin) * -1e-5)) .* 2) <
+                  10 * eps(FT) # This should hold to near floating point precision
+            cache .*= 0
+            ClimaCore.Operators.column_integral_definite!(cache, dY.soil.ρe_int)
+            @test maximum(cache) < 10 * eps(FT) # This should hold to near floating point precision
+            # Test that tendencies for total change in energy and mass  were set properly
+            @test dY.soil.∫F_vol_liq_water_dt == p.soil.∫S_θ_liq_dz
+            @test dY.soil.∫F_e_dt == p.soil.∫S_ρe_int_dz
+            @test maximum(
+                abs.(
+                    p.soil.∫S_θ_liq_dz .- (
+                        ClimaCore.Fields.zeros(domain.space.surface) .+
+                        FT(((cmax - cmin) * -1e-5))
+                    )
+                ),
+            ) < sqrt(eps(FT)) * abs(FT(((cmax - cmin) * -1e-5)))
+            imp_tendency! = make_imp_tendency(soil)
+            imp_tendency!(dY, Y, p, t0)
+            # test that ∫ dY = -[F_sfc - F_bot] + ∫Sdz
+            cache .*= 0
+            ClimaCore.Operators.column_integral_definite!(
+                cache,
+                dY.soil.ϑ_l .+ ρ_ice / ρ_liq .* dY.soil.θ_i,
+            )
+            @test maximum(cache .- (-FT(2))) < 10 * eps(FT) # This should hold to near floating point precision
+            cache .*= 0
+            ClimaCore.Operators.column_integral_definite!(cache, dY.soil.ρe_int)
+            @test maximum(cache .- (-FT(2))) < 10 * eps(FT) # This should hold to near floating point precision
+            # Test that tendencies for total change in energy and mass  were set properly
+            @test dY.soil.∫F_vol_liq_water_dt ==
+                  ClimaCore.Fields.zeros(domain.space.surface) .- FT(2.0)
+            @test dY.soil.∫F_e_dt ==
+                  ClimaCore.Fields.zeros(domain.space.surface) .- FT(2.0)
         end
     end
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Adds a prognostic variable for accumulating fluxes in time for the soil model. This can be used to check conservation error in our timestepping scheme, as shown in the diagnostic plots for the soil model.

Dennis pointed out that we can test conservation of the discrete equations by looking at vertical integrals of tendencies, and comparing to the flux difference between the top and bottom of the domain. Since RK schemes are linear combinations of these tendencies, the timestepping should also "conserve" aside from additional discretization error in time

For example:

`\partial_t x  = -\partial_z(F_x) + S_x` PDE we currently solve
 dX/dt = `\int [-(F_x(top)- F_x(bottom)) + \int S_x dz]` # Equation 1, for conservation that we are adding in this PR;
where X is the vertically integrated volumetric content of energy or water volume, and x is the volumetric content(z).

Subtleties:
- Liquid water and energy have their divergence of flux terms stepped implicitly, so we computed the contributions of the RHS of Equation 1 due to boundary fluxes in the implicit tendency for X.
- I added an additional cache variable which stores the expected vertical integral of sources, and it is computed in the explicit tendency of Equation 1. (All source terms are stepped explicitly)
- we do not include \partial X_t/\partial theta in the Jacobian.

This is what is happening now in this PR (with ARS 111):
`X_{i+1} - X_{i} = [-F_{i+1}(top) + F_{i+1}(bottom) + (\int S dz)_i] * \Delta t`

@gemini-code-assist ignore


## To-do
- Add conservation flag to model which adds the variables or not, and steps them or not (Future PR, or skip if it doesnt slow stuff down much)


## Content
- adds X as a prognostic variable (not with this name - open to naming changes)
- computes contributions of dX/dt as described above
- correctly handles source terms in addition to fluxes
- adds diagnostics
- adds a helper plotting function with tracks conservation given the output diagnostics (see plots below)
- adds tests for the functions
- checks conservation in some of our tutorials and experiment runs

## Plots
Output from global soil long run:

<img width="728" alt="Screenshot 2025-04-03 at 7 03 45 AM" src="https://github.com/user-attachments/assets/44019004-f6b1-4052-9dca-c4f304d83935" />

<img width="728" alt="Screenshot 2025-04-03 at 7 04 03 AM" src="https://github.com/user-attachments/assets/7c5f12f0-c07b-4340-b15e-954ceb34602b" />


where not that the water value itself should be O(1) and the energy should be O(1e9)
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.