### PR TITLE
add compat for formatter

### DIFF
--- a/.dev/Project.toml
+++ b/.dev/Project.toml
@@ -1,2 +1,5 @@
 [deps]
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
+
+[compat]
+JuliaFormatter = "1"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
JuliaFormatter recently release v2. Our current files in main were all formatted with v1. This fixes our compat to v1 so that the formatting check in CI continues to pass. The alternative would be to reformat all files with v2, but this is something we would need to do whenever JuliaFormatter has a major release. Restricting to v1 is simpler in that sense.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated project configuration by adding a compatibility specification for the code formatting dependency to ensure smoother dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->