### PR TITLE
Change `ALL_DIAGNOSTICS` to contain tuple

### DIFF
--- a/docs/src/diagnostics/developers_diagnostics.md
+++ b/docs/src/diagnostics/developers_diagnostics.md
@@ -10,7 +10,8 @@ We want to provide users with default options, but also the possibility to defin
 Internally, this is done by using the [`ClimaDiagnostics.jl`](https://github.com/CliMA/ClimaDiagnostics.jl) package, that provides the functionality to produce a
 [`ClimaLand.Diagnostics`](https://github.com/CliMA/ClimaLand.jl/tree/main/src/Diagnostics/Diagnostics.jl) module in the src/Diagnostics.jl folder. In this folder,
  - `Diagnostics.jl` defines the module,
- - `diagnostic.jl` defines `ALL_DIAGNOSTICS`, a Dict containing all diagnostics variables defined in `define_diagnostics.jl`, it also defines the function
+ - `diagnostic.jl` defines `ALL_DIAGNOSTICS`, a Dict containing all diagnostics variables defined in `define_diagnostics.jl`,
+along with a boolean indicating if each diagnostic variable is a default. It also defines the function
  `add_diagnostic_variable!` which defines a method to add diagnostic variables to ALL\_DIAGNOSTICS, finally it contains a function `get_diagnostic_variable` which returns a
  `DiagnosticVariable` from its `short_name`, if it exists.
  - `define_diagnostics.jl`, mentioned above, contains a function `define_diagnostics!(land_model)` which contains all default diagnostic variables by calling.

--- a/docs/src/diagnostics/make_diagnostic_table.jl
+++ b/docs/src/diagnostics/make_diagnostic_table.jl
@@ -9,7 +9,8 @@ long_names = []
 units = []
 comments = []
 standard_names = []
-for d in values(CL.Diagnostics.ALL_DIAGNOSTICS)
+# ALL_DIAGNOSTICS has values of tuple (DiagnosticVariable, is_default_diagnostic)
+for (d, _) in values(CL.Diagnostics.ALL_DIAGNOSTICS)
     push!(short_names, d.short_name)
     push!(long_names, d.long_name)
     push!(units, d.units)

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -19,6 +19,7 @@ function define_diagnostics!(land_model)
         comments = "The fraction of downwelling shortwave radiation reflected by the land surface.",
         compute! = (out, Y, p, t) ->
             compute_sw_albedo!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Net radiation
@@ -30,6 +31,7 @@ function define_diagnostics!(land_model)
         comments = "Difference between downwelling and upwelling shortwave and longwave radiation at the land surface.",
         compute! = (out, Y, p, t) ->
             compute_net_radiation!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Bucket Surface temperature
@@ -41,6 +43,7 @@ function define_diagnostics!(land_model)
         comments = "Temperature of the bucket-land surface.",
         compute! = (out, Y, p, t) ->
             compute_surface_temperature!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Latent heat flux
@@ -52,6 +55,7 @@ function define_diagnostics!(land_model)
         comments = "Exchange of energy at the land-atmosphere interface due to water evaporation or sublimation.",
         compute! = (out, Y, p, t) ->
             compute_latent_heat_flux!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Aerodynamic resistance
@@ -63,6 +67,7 @@ function define_diagnostics!(land_model)
         comments = "Effiency of turbulent transport controlling the land-atmosphere exchange of sensible and latent heat.",
         compute! = (out, Y, p, t) ->
             compute_aerodynamic_resistance!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Sensible heat flux
@@ -74,6 +79,7 @@ function define_diagnostics!(land_model)
         comments = "Exchange of energy at the land-atmosphere interface due to temperature difference.",
         compute! = (out, Y, p, t) ->
             compute_sensible_heat_flux!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Vapor flux
@@ -85,6 +91,7 @@ function define_diagnostics!(land_model)
         comments = "Flux of water from the land surface to the atmosphere. E.g., evaporation or sublimation.",
         compute! = (out, Y, p, t) ->
             compute_vapor_flux!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Surface air density
@@ -96,6 +103,7 @@ function define_diagnostics!(land_model)
         comments = "Density of air at the land-atmosphere interface.",
         compute! = (out, Y, p, t) ->
             compute_surface_air_density!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     ## Stored in Y (prognostic or state variables) ##
@@ -109,6 +117,7 @@ function define_diagnostics!(land_model)
         comments = "Soil temperature at multiple soil depth. (depth resolved)",
         compute! = (out, Y, p, t) ->
             compute_soil_temperature!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Surbsurface water storage
@@ -120,6 +129,7 @@ function define_diagnostics!(land_model)
         comments = "Soil water content.",
         compute! = (out, Y, p, t) ->
             compute_subsurface_water_storage!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Surface water content
@@ -131,6 +141,7 @@ function define_diagnostics!(land_model)
         comments = "Water at the soil surface.",
         compute! = (out, Y, p, t) ->
             compute_surface_water_content!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Surface snow water content
@@ -142,6 +153,7 @@ function define_diagnostics!(land_model)
         comments = "Snow at the soil surface, expressed in water equivalent.",
         compute! = (out, Y, p, t) ->
             compute_snow_water_equivalent!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     ###### SoilCanopyModel ######
@@ -160,6 +172,7 @@ function define_diagnostics!(land_model)
         comments = "The fluorescence of leaves induced by solar radiation at 755nm. This quantity is correlated with photosynthesis activity.",
         compute! = (out, Y, p, t) ->
             compute_solar_induced_fluorescence!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     ### Canopy - Autotrophic respiration
@@ -172,6 +185,7 @@ function define_diagnostics!(land_model)
         comments = "The canopy autotrophic respiration, the sum of leaves, stems and roots respiration.",
         compute! = (out, Y, p, t) ->
             compute_autotrophic_respiration!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     ### Canopy - Conductance
@@ -184,6 +198,7 @@ function define_diagnostics!(land_model)
         comments = "The conductance of leaves. This depends on stomatal opening. It varies with factors such as soil moisture or atmospheric water demand.",
         compute! = (out, Y, p, t) ->
             compute_stomatal_conductance!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Canopy transpiration
@@ -195,6 +210,7 @@ function define_diagnostics!(land_model)
         comments = "The water evaporated from the canopy due to leaf transpiration (flux of water volume, m^3 of water per m^2 of ground).",
         compute! = (out, Y, p, t) ->
             compute_canopy_transpiration!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     ### Canopy - Energy
@@ -208,6 +224,7 @@ function define_diagnostics!(land_model)
         comments = "The energy used for canopy transpiration.",
         compute! = (out, Y, p, t) ->
             compute_canopy_latent_heat_flux!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Canopy sensible heat flux
@@ -219,6 +236,7 @@ function define_diagnostics!(land_model)
         comments = "The energy used for canopy temperature change.",
         compute! = (out, Y, p, t) ->
             compute_canopy_sensible_heat_flux!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     ### Canopy - Hydraulics
@@ -233,6 +251,7 @@ function define_diagnostics!(land_model)
         comments = "The water potential of a leaf.",
         compute! = (out, Y, p, t) ->
             compute_leaf_water_potential!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
     #=
         # Flux per ground area
@@ -256,6 +275,7 @@ function define_diagnostics!(land_model)
         comments = "Flux of water volume per m^2 of root per second, multiplied by the area index (root area/ground area).",
         compute! = (out, Y, p, t) ->
             compute_root_flux_per_ground_area!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Leaf area index
@@ -267,6 +287,7 @@ function define_diagnostics!(land_model)
         comments = "The area index of leaves, expressed in surface area of leaves per surface area of ground.",
         compute! = (out, Y, p, t) ->
             compute_leaf_area_index!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Moisture stress factor
@@ -278,6 +299,7 @@ function define_diagnostics!(land_model)
         comments = "Sensitivity of plants conductance to soil water content. Unitless",
         compute! = (out, Y, p, t) ->
             compute_moisture_stress_factor!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Root area index
@@ -289,6 +311,7 @@ function define_diagnostics!(land_model)
         comments = "The area index of roots, expressed in surface area of roots per surface area of ground.",
         compute! = (out, Y, p, t) ->
             compute_root_area_index!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Stem area index
@@ -300,6 +323,7 @@ function define_diagnostics!(land_model)
         comments = "The area index of stems, expressed in surface area of stems per surface area of ground.",
         compute! = (out, Y, p, t) ->
             compute_stem_area_index!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     ### Canopy - Photosynthesis
@@ -312,6 +336,7 @@ function define_diagnostics!(land_model)
         comments = "Net photosynthesis (carbon assimilation) of the canopy. This is equivalent to leaf net assimilation scaled to the canopy level.",
         compute! = (out, Y, p, t) ->
             compute_photosynthesis_net_canopy!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Leaf net photosynthesis
@@ -323,6 +348,7 @@ function define_diagnostics!(land_model)
         comments = "Net photosynthesis (carbon assimilation) of a leaf, computed for example by the Farquhar model.",
         compute! = (out, Y, p, t) ->
             compute_photosynthesis_net_leaf!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Leaf respiration
@@ -334,6 +360,7 @@ function define_diagnostics!(land_model)
         comments = "Leaf respiration, called dark respiration because usually measured in the abscence of radiation.",
         compute! = (out, Y, p, t) ->
             compute_respiration_leaf!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Vcmax25
@@ -344,6 +371,7 @@ function define_diagnostics!(land_model)
         units = "mol CO2 m^-2 s^-1",
         comments = "The parameter vcmax at 25 degree celsius. Important for the Farquhar model of leaf photosynthesis.",
         compute! = (out, Y, p, t) -> compute_vcmax25!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     ### Canopy - Radiative Transfer
@@ -356,6 +384,7 @@ function define_diagnostics!(land_model)
         comments = "The amount of near infrared radiation reaching the canopy.",
         compute! = (out, Y, p, t) ->
             compute_near_infrared_radiation_down!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # ANIR - absorbed near infrared radiation
@@ -367,6 +396,7 @@ function define_diagnostics!(land_model)
         comments = "The amount of near infrared radiation absorbed by the canopy.",
         compute! = (out, Y, p, t) ->
             compute_near_infrared_radiation_absorbed!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # RNIR - reflected near infrared radiation
@@ -384,6 +414,7 @@ function define_diagnostics!(land_model)
                 t,
                 land_model,
             ),
+        default_diagnostic = true,
     )
 
     # TNIR - transmitted near infrared radiation
@@ -401,6 +432,7 @@ function define_diagnostics!(land_model)
                 t,
                 land_model,
             ),
+        default_diagnostic = true,
     )
 
     # PAR - photosynthetically active radiation
@@ -418,6 +450,7 @@ function define_diagnostics!(land_model)
                 t,
                 land_model,
             ),
+        default_diagnostic = true,
     )
 
     # APAR - absorbed photosynthetically active radiation
@@ -435,6 +468,7 @@ function define_diagnostics!(land_model)
                 t,
                 land_model,
             ),
+        default_diagnostic = true,
     )
 
     # RPAR - reflected photosynthetically active radiation
@@ -452,6 +486,7 @@ function define_diagnostics!(land_model)
                 t,
                 land_model,
             ),
+        default_diagnostic = true,
     )
 
     # TPAR - transmitted photosynthetically active radiation
@@ -469,6 +504,7 @@ function define_diagnostics!(land_model)
                 t,
                 land_model,
             ),
+        default_diagnostic = true,
     )
 
     # Net longwave radiation
@@ -480,6 +516,7 @@ function define_diagnostics!(land_model)
         comments = "The net (down minus up) longwave radiation at the surface.",
         compute! = (out, Y, p, t) ->
             compute_radiation_longwave_net!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Net shortwave radiation
@@ -491,6 +528,7 @@ function define_diagnostics!(land_model)
         comments = "The net (down minus up) shortwave radiation at the surface.",
         compute! = (out, Y, p, t) ->
             compute_radiation_shortwave_net!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     ## Drivers Module ##
@@ -503,6 +541,7 @@ function define_diagnostics!(land_model)
         comments = "Mass of organic carbon per volume of soil. (depth resolved)",
         compute! = (out, Y, p, t) ->
             compute_soil_organic_carbon!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Air pressure
@@ -514,6 +553,7 @@ function define_diagnostics!(land_model)
         comments = "The air pressure.",
         compute! = (out, Y, p, t) ->
             compute_pressure!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Rainfall
@@ -525,6 +565,7 @@ function define_diagnostics!(land_model)
         comments = "Precipitation of liquid water volume (m^3 of water per m^2 of ground per second).",
         compute! = (out, Y, p, t) ->
             compute_rainfall!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Net longwave radiation
@@ -536,6 +577,7 @@ function define_diagnostics!(land_model)
         comments = "The downwelling longwave radiation at the surface.",
         compute! = (out, Y, p, t) ->
             compute_radiation_longwave_down!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Net shortwave radiation
@@ -547,6 +589,7 @@ function define_diagnostics!(land_model)
         comments = "The downwelling shortwave radiation at the surface.",
         compute! = (out, Y, p, t) ->
             compute_radiation_shortwave_down!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Snowfall
@@ -558,6 +601,7 @@ function define_diagnostics!(land_model)
         comments = "The precipitation of snow in liquid water volume (m^3 of water per m^2 of ground per second).",
         compute! = (out, Y, p, t) ->
             compute_snowfall!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Specific humidity
@@ -569,6 +613,7 @@ function define_diagnostics!(land_model)
         comments = "Ratio of water vapor mass to total moist air parcel mass.",
         compute! = (out, Y, p, t) ->
             compute_specific_humidity!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Wind speed
@@ -580,6 +625,7 @@ function define_diagnostics!(land_model)
         comments = "The average wind speed.",
         compute! = (out, Y, p, t) ->
             compute_wind_speed!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     ## Soil Module ##
@@ -592,6 +638,7 @@ function define_diagnostics!(land_model)
         comments = "The flux of liquid water volume into the soil (m^3 of water per m^2 of ground per second).",
         compute! = (out, Y, p, t) ->
             compute_infiltration!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Soil albedo
@@ -603,6 +650,7 @@ function define_diagnostics!(land_model)
         comments = "The mean of PAR and NIR albedo, which are calculated as α_soil_band = α_band_dry * (1 - S_e) + α_band_wet * S_e.",
         compute! = (out, Y, p, t) ->
             compute_soil_albedo!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
 
@@ -615,6 +663,7 @@ function define_diagnostics!(land_model)
         comments = "Soil hydraulic conductivity. (depth resolved)",
         compute! = (out, Y, p, t) ->
             compute_soil_hydraulic_conductivity!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Soil thermal conductivity
@@ -626,6 +675,7 @@ function define_diagnostics!(land_model)
         comments = "Soil thermal conductivity. (depth resolved)",
         compute! = (out, Y, p, t) ->
             compute_soil_thermal_conductivity!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Soil Water Potential
@@ -637,6 +687,7 @@ function define_diagnostics!(land_model)
         comments = "Soil water potential. (depth resolved)",
         compute! = (out, Y, p, t) ->
             compute_soil_water_potential!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Soil net radiation
@@ -648,6 +699,7 @@ function define_diagnostics!(land_model)
         comments = "Net radiation at the soil surface.",
         compute! = (out, Y, p, t) ->
             compute_soil_net_radiation!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     ### Soil - Turbulent Fluxes
@@ -661,6 +713,7 @@ function define_diagnostics!(land_model)
         comments = "Soil latent heat flux, the amount of liquid water evaporated by the soil, expressed in energy units (W m^-2).",
         compute! = (out, Y, p, t) ->
             compute_soil_latent_heat_flux!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Soil sensible heat flux
@@ -672,6 +725,7 @@ function define_diagnostics!(land_model)
         comments = "Soil sensible heat flux, the amount of energy exchanged between the soil and atmosphere to change the temperature of the soil.",
         compute! = (out, Y, p, t) ->
             compute_soil_sensible_heat_flux!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     ### Soil - SoilCO2
@@ -684,6 +738,7 @@ function define_diagnostics!(land_model)
         comments = "The CO2 efflux at the soil surface due to microbial decomposition of soil organic matter. This is not necessarily equal to CO2 production by microbes, as co2 diffusion through the soil pores takes time.",
         compute! = (out, Y, p, t) ->
             compute_heterotrophic_respiration!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Soil CO2 diffusivity
@@ -695,6 +750,7 @@ function define_diagnostics!(land_model)
         comments = "The diffusivity of CO2 in the porous phase of the soil. Depends on soil texture, moisture, and temperature. (depth resolved)",
         compute! = (out, Y, p, t) ->
             compute_soilco2_diffusivity!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Soil CO2 microbial source
@@ -706,6 +762,7 @@ function define_diagnostics!(land_model)
         comments = "The production of CO2 by microbes in the soil. Vary by layers of soil depth. (depth resolved)",
         compute! = (out, Y, p, t) ->
             compute_soilco2_source_microbe!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     ## Other ##
@@ -717,6 +774,7 @@ function define_diagnostics!(land_model)
         units = "W m^-2",
         comments = "Upwelling longwave radiation.",
         compute! = (out, Y, p, t) -> compute_lw_up!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Shortwave out
@@ -727,6 +785,7 @@ function define_diagnostics!(land_model)
         units = "W m^-2",
         comments = "Upwelling shortwave radiation",
         compute! = (out, Y, p, t) -> compute_sw_up!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Evapotranspiration
@@ -738,6 +797,7 @@ function define_diagnostics!(land_model)
         comments = "Total flux of water mass out of the surface.",
         compute! = (out, Y, p, t) ->
             compute_evapotranspiration!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Ecosystem respiration
@@ -749,6 +809,7 @@ function define_diagnostics!(land_model)
         comments = "Total respiration flux out of the surface.",
         compute! = (out, Y, p, t) ->
             compute_total_respiration!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Surface runoff
@@ -760,6 +821,7 @@ function define_diagnostics!(land_model)
         comments = "Water runoff at the surface, this is the water flowing horizontally above the ground.",
         compute! = (out, Y, p, t) ->
             compute_surface_runoff!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Subsurface runoff
@@ -771,6 +833,7 @@ function define_diagnostics!(land_model)
         comments = "Water runoff from below the surface",
         compute! = (out, Y, p, t) ->
             compute_subsurface_runoff!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Ground heat flux
@@ -782,6 +845,7 @@ function define_diagnostics!(land_model)
         comments = "Transfer of heat between the surface and deeper soil layers.",
         compute! = (out, Y, p, t) ->
             compute_ground_heat_flux!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     ## Stored in Y (prognostic or state variables) ##
@@ -795,6 +859,7 @@ function define_diagnostics!(land_model)
         comments = "Canopy temperature.",
         compute! = (out, Y, p, t) ->
             compute_canopy_temperature!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Soil CO2
@@ -805,6 +870,7 @@ function define_diagnostics!(land_model)
         units = "kg C m^3",
         comments = "Concentration of CO2 in the porous air space of the soil. (depth resolved)",
         compute! = (out, Y, p, t) -> compute_soilco2!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Soil water content
@@ -816,6 +882,7 @@ function define_diagnostics!(land_model)
         comments = "The volume of soil water per volume of soil. (depth resolved)",
         compute! = (out, Y, p, t) ->
             compute_soil_water_content!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     add_diagnostic_variable!(
@@ -826,6 +893,7 @@ function define_diagnostics!(land_model)
         comments = "The integrated water mass to a depth of 10cm",
         compute! = (out, Y, p, t) ->
             compute_10cm_water_mass!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Plant water content
@@ -852,6 +920,7 @@ function define_diagnostics!(land_model)
         comments = "The volume of soil ice per volume of soil. (depth resolved)",
         compute! = (out, Y, p, t) ->
             compute_soil_ice_content!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Soil internal energy
@@ -863,6 +932,7 @@ function define_diagnostics!(land_model)
         comments = "The energy per volume of soil. (depth resolved)",
         compute! = (out, Y, p, t) ->
             compute_soil_internal_energy!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # SWE
@@ -874,6 +944,7 @@ function define_diagnostics!(land_model)
         comments = "The height of liquid water if all snow melted",
         compute! = (out, Y, p, t) ->
             compute_snow_water_equivalent!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Snow depth
@@ -885,6 +956,7 @@ function define_diagnostics!(land_model)
         comments = "The snow depth",
         compute! = (out, Y, p, t) ->
             compute_snow_depth!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 
     # Snow cover fraction
@@ -896,5 +968,6 @@ function define_diagnostics!(land_model)
         comments = "The snow cover fraction",
         compute! = (out, Y, p, t) ->
             compute_snow_cover_fraction!(out, Y, p, t, land_model),
+        default_diagnostic = true,
     )
 end

--- a/test/diagnostics/diagnostics_tests.jl
+++ b/test/diagnostics/diagnostics_tests.jl
@@ -121,3 +121,40 @@ rn = get(simdir; short_name = "rn")
 @test readdir(tmpdir) == ["lhf_1h_average.nc", "rn_1h_average.nc"]
 @test length(rn.dims) == 3
 @test mean(rn.data) != 0.0
+# test that re defining default diagnostics with themselves does not issue warnings
+@test_nowarn ClimaLand.Diagnostics.define_diagnostics!(model)
+# test overwritting a non-default diagnsotic issues a warning
+@test_logs (
+    :warn,
+    "overwriting diagnostic `alpha` entry containing fields\n(\"alpha\", \"Albedo\", \"albedo\", \"\", \"\")",
+) ClimaLand.Diagnostics.add_diagnostic_variable!(
+    short_name = "alpha",
+    long_name = "Albedo",
+    standard_name = "albedo",
+    units = "",
+    compute! = (out, Y, p, t) -> compute_sw_albedo!(out, Y, p, t, land_model),
+)
+# test that overwritting a non default diagnsotic with a default issues warnings
+@test_logs (
+    :warn,
+    "overwriting diagnostic `alpha` entry containing fields\n(\"alpha\", \"Albedo\", \"albedo\", \"\", \"\")",
+) ClimaLand.Diagnostics.add_diagnostic_variable!(
+    short_name = "alpha",
+    long_name = "Albedo",
+    standard_name = "albedo",
+    units = "",
+    compute! = (out, Y, p, t) -> compute_sw_albedo!(out, Y, p, t, land_model),
+    default_diagnostic = true,
+)
+
+# test that overwritting a default diagnsotic with a non default does not issue warnings
+@test_logs (
+    :warn,
+    "overwriting diagnostic `alpha` entry containing fields\n(\"alpha\", \"Albedo\", \"albedo\", \"\", \"\")",
+) ClimaLand.Diagnostics.add_diagnostic_variable!(
+    short_name = "alpha",
+    long_name = "Albedo",
+    standard_name = "albedo",
+    units = "",
+    compute! = (out, Y, p, t) -> compute_sw_albedo!(out, Y, p, t, land_model),
+)


### PR DESCRIPTION
When a simulation is re-run by re-including the experiment script, many diagnostic overwrite warnings are logged

The many warnings occur when `default_diagnostics` is called, which repeatedly calls `add_diagnostic_variable!`.

This commit adds `default_diagnostics` as a kwarg to `add_diagnostic_variable!`, with a default value of false.

This adds the kwarg with a true value to
each call to `add_diagnostic_variable!` in `default_diagnostics`

This also changes `ALL_DIAGNOSTICS` to have keys that are tuples that contain the diagnostic variable and a boolean. The boolean indicates if the
diagnostic is a default diagnostic or not.

Finally, `add_diagnostic_variable!` is changed
to not issue an overwrite warning if overwriting
a default diagnostic with a default diagnostic.

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Closes #955 


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
