### PR TITLE
Automatically pick mask resolution

### DIFF
--- a/experiments/long_runs/land.jl
+++ b/experiments/long_runs/land.jl
@@ -373,7 +373,7 @@ function setup_prob(
     diag_cb = ClimaDiagnostics.DiagnosticsCallback(diagnostic_handler)
 
     driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
-    mask = ClimaLand.landsea_mask(surface_space)
+    mask = ClimaLand.landsea_mask(domain)
     nancheck_freq = Dates.Month(1)
     nancheck_cb = ClimaLand.NaNCheckCallback(
         nancheck_freq,

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -430,7 +430,7 @@ function setup_prob(
     end
     report_cb = SciMLBase.DiscreteCallback(every1000steps, report)
 
-    mask = ClimaLand.landsea_mask(surface_space)
+    mask = ClimaLand.landsea_mask(domain)
     nancheck_freq = Dates.Month(1)
     nancheck_cb = ClimaLand.NaNCheckCallback(
         nancheck_freq,

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -217,7 +217,7 @@ function setup_prob(
     diag_cb = ClimaDiagnostics.DiagnosticsCallback(diagnostic_handler)
 
     driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
-    mask = ClimaLand.landsea_mask(surface_space)
+    mask = ClimaLand.landsea_mask(domain)
     nancheck_freq = Dates.Month(1)
     nancheck_cb = ClimaLand.NaNCheckCallback(
         nancheck_freq,

--- a/src/simulations/domains.jl
+++ b/src/simulations/domains.jl
@@ -39,7 +39,6 @@ rather than increasing the polynomial order.
 function global_domain(
     FT;
     apply_mask = true,
-    mask_resolution = "60arcs",
     mask_threshold = 0.5,
     nelements = (101, 15),
     dz_tuple = (10.0, 0.05),
@@ -63,11 +62,7 @@ function global_domain(
     )
     if apply_mask
         surface_space = domain.space.surface # 2d space
-        binary_mask = landsea_mask(
-            surface_space;
-            resolution = mask_resolution,
-            threshold = mask_threshold,
-        )
+        binary_mask = landsea_mask(domain; threshold = mask_threshold)
         Spaces.set_mask!(surface_space, binary_mask)
     end
 

--- a/test/shared_utilities/domains.jl
+++ b/test/shared_utilities/domains.jl
@@ -16,7 +16,8 @@ using ClimaLand.Domains:
     obtain_face_space,
     obtain_surface_domain,
     get_Δz,
-    top_face_to_surface
+    top_face_to_surface,
+    average_horizontal_resolution_degrees
 
 FT = Float32
 @testset "Clima Core Domains, FT = $FT" begin
@@ -98,6 +99,9 @@ FT = Float32
     @test ClimaComms.context(shell_surface) == ClimaComms.context()
     @test ClimaComms.device(shell_surface) == ClimaComms.device()
 
+    @test average_horizontal_resolution_degrees(shell_surface) ==
+          (180 / (2 * n_elements_sphere[1]), 180 / (2n_elements_sphere[1]))
+
     # HybridBox
     box = HybridBox(;
         xlim = xlim,
@@ -171,6 +175,8 @@ FT = Float32
     @test typeof(xy_plane.space.surface) <:
           ClimaCore.Spaces.SpectralElementSpace2D
 
+    @test_throws ErrorException average_horizontal_resolution_degrees(xy_plane)
+
     # Plane latlong
     dxlim = (FT(50_000), FT(80_000))
     dylim = (FT(30_000), FT(40_000))
@@ -197,6 +203,12 @@ FT = Float32
     @test longlat_plane.periodic == (false, false)
     @test typeof(longlat_plane.space.surface) <:
           ClimaCore.Spaces.SpectralElementSpace2D
+
+    expected_resolution_x = (xlim_longlat[2] - xlim_longlat[1]) / nelements[1]
+    expected_resolution_y = (ylim_longlat[2] - ylim_longlat[1]) / nelements[2]
+
+    @test average_horizontal_resolution_degrees(longlat_plane) ==
+          (expected_resolution_x, expected_resolution_y)
 
     # Box latlong
     longlat_box = HybridBox(;
@@ -243,6 +255,9 @@ FT = Float32
         0,
         (; surface = longlat_box.space.surface),
     )
+
+    @test average_horizontal_resolution_degrees(longlat_box) ==
+          (expected_resolution_x, expected_resolution_y)
 
     # Column
 


### PR DESCRIPTION
All the information needed to select the resolution for the land-sea mask is in the space. This commit automatically select the correct file to use when working with land-sea masks.
