### PR TITLE
Make npolynomial = 0 by default

### DIFF
--- a/experiments/benchmarks/bucket.jl
+++ b/experiments/benchmarks/bucket.jl
@@ -71,7 +71,6 @@ function setup_prob(t0, tf, Δt; nelements = (200, 7))
         radius = FT(6.3781e6),
         depth = soil_depth,
         nelements = nelements,
-        npolynomial = 1,
         dz_tuple = FT.((1.0, 0.05)),
     )
     start_date = DateTime(2005)

--- a/experiments/integrated/performance/integrated_timestep_test.jl
+++ b/experiments/integrated/performance/integrated_timestep_test.jl
@@ -139,7 +139,6 @@ land_domain = ClimaLand.Domains.SphericalShell(;
     radius = FT(6.3781e6),
     depth = soil_depth,
     nelements = (10, 5),
-    npolynomial = 1,
     dz_tuple = FT.((dz_bottom, dz_top)),
 );
 canopy_domain = ClimaLand.Domains.obtain_surface_domain(land_domain)

--- a/experiments/long_runs/bucket.jl
+++ b/experiments/long_runs/bucket.jl
@@ -68,7 +68,6 @@ function setup_prob(
         radius = radius,
         depth = depth,
         nelements = nelements,
-        npolynomial = 1,
         dz_tuple = FT.((1.0, 0.05)),
     )
     surface_space = domain.space.surface

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -77,7 +77,6 @@ function setup_prob(
         ylim = (delta_m, delta_m),
         zlim = (-depth, FT(0)),
         nelements = nelements,
-        npolynomial = 0,
         longlat = (center_long, center_lat),
         dz_tuple = FT.((10.0, 0.05)),
     )

--- a/experiments/standalone/Bucket/bucket_era5.jl
+++ b/experiments/standalone/Bucket/bucket_era5.jl
@@ -100,14 +100,12 @@ if regional_simulation
         zlim = (-soil_depth, FT(0.0)),
         longlat = (center_long, center_lat),
         nelements = (30, 30, 10),
-        npolynomial = 1,
     )
 else
     bucket_domain = ClimaLand.Domains.SphericalShell(;
         radius = FT(6.3781e6),
         depth = soil_depth,
         nelements = (30, 10),
-        npolynomial = 1,
         dz_tuple = FT.((1.0, 0.05)),
     )
 end

--- a/experiments/standalone/Bucket/global_bucket_function.jl
+++ b/experiments/standalone/Bucket/global_bucket_function.jl
@@ -76,7 +76,6 @@ bucket_domain = ClimaLand.Domains.SphericalShell(;
     radius = FT(6.3781e6),
     depth = soil_depth,
     nelements = (50, 10),
-    npolynomial = 1,
     dz_tuple = FT.((1.0, 0.05)),
 );
 surface_space = bucket_domain.space.surface

--- a/experiments/standalone/Bucket/global_bucket_temporalmap.jl
+++ b/experiments/standalone/Bucket/global_bucket_temporalmap.jl
@@ -94,7 +94,6 @@ function setup_prob(t0, tf, Δt, outdir)
         radius = FT(6.3781e6),
         depth = soil_depth,
         nelements = (10, 10), # this failed with (50,10)
-        npolynomial = 1,
         dz_tuple = FT.((1.0, 0.05)),
     )
     start_date = DateTime(2005)

--- a/src/shared_utilities/Domains.jl
+++ b/src/shared_utilities/Domains.jl
@@ -250,7 +250,7 @@ function Plane(;
     longlat = nothing,
     periodic::Tuple{Bool, Bool} = isnothing(longlat) ? (true, true) :
                                   (false, false),
-    npolynomial::Int,
+    npolynomial::Int = 0,
     comms_ctx = ClimaComms.context(),
     radius_earth = 6.378e6,
 ) where {FT}
@@ -419,7 +419,7 @@ function HybridBox(;
     ylim::Tuple{FT, FT},
     zlim::Tuple{FT, FT},
     nelements::Tuple{Int, Int, Int},
-    npolynomial::Int,
+    npolynomial::Int = 0,
     dz_tuple::Union{Tuple{FT, FT}, Nothing} = nothing,
     longlat = nothing,
     periodic::Tuple{Bool, Bool} = isnothing(longlat) ? (true, true) :
@@ -551,7 +551,7 @@ function SphericalShell(;
     radius::FT,
     depth::FT,
     nelements::Tuple{Int, Int},
-    npolynomial::Int,
+    npolynomial::Int = 0,
     dz_tuple::Union{Tuple{FT, FT}, Nothing} = nothing,
     comms_ctx = ClimaComms.context(),
 ) where {FT}
@@ -655,7 +655,7 @@ Outer constructor for the `SphericalSurface` domain, using keyword arguments.
 function SphericalSurface(;
     radius::FT,
     nelements::Int,
-    npolynomial::Int,
+    npolynomial::Int = 0,
     comms_ctx = ClimaComms.context(),
 ) where {FT}
     @assert 0 < radius

--- a/src/simulations/domains.jl
+++ b/src/simulations/domains.jl
@@ -5,6 +5,7 @@ import Interpolations
 import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
 import ClimaUtilities.Regridders: InterpolationsRegridder
 using ClimaCore: Spaces
+
 """
     global_domain(
     FT;
@@ -14,26 +15,24 @@ using ClimaCore: Spaces
     npolynomial = 0,
 )
 
-Helper function to create a SphericalShell domain
-with (101,15) elements, a depth of 50m, vertical
-layering ranging from 0.05m in depth at the surface
-to 10m at the bottom of the domain, with n_polynomial = 0
-and GL quadrature.
+Helper function to create a SphericalShell domain with (101,15) elements, a
+depth of 50m, vertical layering ranging from 0.05m in depth at the surface to
+10m at the bottom of the domain, with npolynomial = 0 and GL quadrature.
 
-`n_polynomial` determines the order of polynomial base to use for the spatial
+`npolynomial` determines the order of polynomial base to use for the spatial
 discretization, which is correlated to the spatial resolution of the domain.
 
-When `n_polynomial` is zero, the element is equivalent to a single point. In this
+When `npolynomial` is zero, the element is equivalent to a single point. In this
 case, the resolution of the model is sqrt((360*180)/(101*101*6)). The factor of 6 arises
 because there are 101x101 elements per side of the cubed sphere, meaning 6*101*101 for the
 entire globe. 
 
-When `n_polynomial` is greater than 1, a Gauss-Legendre-Lobotto quadrature
-is used, with `n_polynomial + 1` points along the element. In this case, there are
+When `npolynomial` is greater than 1, a Gauss-Legendre-Lobotto quadrature is
+used, with `npolynomial + 1` points along the element. In this case, there are
 always points two points on the boundaries for each direction with the other
 points in the interior. These points are not equally spaced.
 
-In practice, there is no reason to use `n_polynomial` greater than 1 in the current
+In practice, there is no reason to use `npolynomial` greater than 1 in the current
 version of ClimaLand. To increase resolution, we recommend increasing the number of elements
 rather than increasing the polynomial order.
 """

--- a/test/diagnostics/diagnostics_tests.jl
+++ b/test/diagnostics/diagnostics_tests.jl
@@ -45,7 +45,6 @@ bucket_domain = ClimaLand.SphericalShell(;
     radius = FT(100),
     depth = FT(3.5),
     nelements = (1, 10),
-    npolynomial = 1,
 )
 
 bucket_atmos, bucket_rad = ClimaLand.prescribed_analytic_forcing(FT)

--- a/test/integrated/pond_soil_lsm.jl
+++ b/test/integrated/pond_soil_lsm.jl
@@ -33,7 +33,6 @@ for FT in (Float32, Float64)
                 ylim = (FT(0), FT(1)),
                 zlim = (zmin, zmax),
                 nelements = (1, 1, nelems),
-                npolynomial = 1,
                 periodic = (true, true),
             ),
             Column(; zlim = (zmin, zmax), nelements = nelems),

--- a/test/integrated/soil_canopy_lsm.jl
+++ b/test/integrated/soil_canopy_lsm.jl
@@ -23,7 +23,6 @@ for FT in (Float32, Float64)
             radius = radius,
             depth = depth,
             nelements = nelements,
-            npolynomial = 1,
             dz_tuple = FT.((10.0, 0.1)),
         )
         hcm = vanGenuchten{FT}(; α = FT(0), n = FT(0))

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -185,7 +185,6 @@ for FT in (Float32, Float64)
             ylim = (ymin, ymax),
             zlim = (zmin, zmax),
             nelements = (nelems, nelems, nelems),
-            npolynomial = 2,
         )
 
         ν = FT(0.556)

--- a/test/shared_utilities/domains.jl
+++ b/test/shared_utilities/domains.jl
@@ -29,6 +29,9 @@ FT = Float32
     radius = FT(100)
     depth = FT(30)
     n_elements_sphere = (6, 20)
+
+    # NOTE: Here we set npoly_sphere to 3, instead of 0 to test that npoly != 0
+    # works as expected
     npoly_sphere = 3
     # Spherical Shell
     shell = SphericalShell(;
@@ -71,26 +74,21 @@ FT = Float32
         depth = FT(1.0),
         dz_tuple = FT.((0.3, 0.03)),
         nelements = (6, 10),
-        npolynomial = 3,
     )
     shell_coords_stretch = coordinates(shell_stretch).subsurface
     dz =
-        Array(parent(shell_coords_stretch.z))[:, 1, 4, 1, 216][2:end] .-
-        Array(parent(shell_coords_stretch.z))[:, 1, 4, 1, 216][1:(end - 1)]
+        Array(parent(shell_coords_stretch.z))[:, end, end, end, end][2:end] .-
+        Array(parent(shell_coords_stretch.z))[:, end, end, end, end][1:(end - 1)]
     @test abs(dz[1] - 0.3) < 1e-1
     @test abs(dz[end] - 0.03) < 1e-2
     @test shell.fields.Δz_min == minimum(shell.fields.Δz_top)
 
 
     # Spherical Surface
-    shell_surface = SphericalSurface(;
-        radius = radius,
-        nelements = n_elements_sphere[1],
-        npolynomial = npoly_sphere,
-    )
+    shell_surface =
+        SphericalSurface(; radius = radius, nelements = n_elements_sphere[1])
     @test shell_surface.radius == radius
     @test shell_surface.nelements == n_elements_sphere[1]
-    @test shell_surface.npolynomial == npoly_sphere
     shell_surface_coords = coordinates(shell_surface).surface
     @test eltype(shell_surface_coords) == ClimaCore.Geometry.LatLongPoint{FT}
     @test typeof(shell_surface_coords) <: ClimaCore.Fields.Field
@@ -106,7 +104,6 @@ FT = Float32
         ylim = ylim,
         zlim = zlim,
         nelements = nelements,
-        npolynomial = 0,
     )
     @test box.fields.depth == zlim[2] - zlim[1]
     @test box.fields.z ==
@@ -148,7 +145,6 @@ FT = Float32
         zlim = zlim,
         dz_tuple = FT.((0.3, 0.03)),
         nelements = nelements,
-        npolynomial = 0,
     )
     box_coords_stretch = coordinates(stretch_box).subsurface
     dz =
@@ -163,7 +159,6 @@ FT = Float32
         ylim = ylim,
         nelements = nelements[1:2],
         periodic = (true, true),
-        npolynomial = 0,
     )
     plane_coords = coordinates(xy_plane).surface
     @test eltype(plane_coords) == ClimaCore.Geometry.XYPoint{FT}
@@ -190,13 +185,8 @@ FT = Float32
         longlat[1] + dxlim[2] / FT(2π * radius_earth) * 360,
     )
 
-    longlat_plane = Plane(;
-        xlim = dxlim,
-        ylim = dylim,
-        longlat,
-        nelements = nelements[1:2],
-        npolynomial = 0,
-    )
+    longlat_plane =
+        Plane(; xlim = dxlim, ylim = dylim, longlat, nelements = nelements[1:2])
     plane_coords = coordinates(longlat_plane).surface
     @test eltype(plane_coords) == ClimaCore.Geometry.LatLongPoint{FT}
     @test typeof(plane_coords) <: ClimaCore.Fields.Field
@@ -215,7 +205,6 @@ FT = Float32
         zlim = zlim,
         longlat,
         nelements = nelements,
-        npolynomial = 0,
     )
     @test longlat_box.fields.depth == zlim[2] - zlim[1]
     @test longlat_box.fields.z ==

--- a/test/shared_utilities/drivers.jl
+++ b/test/shared_utilities/drivers.jl
@@ -31,7 +31,6 @@ FT = Float32
         ylim = FT.((1.0, 2.0)),
         nelements = (1, 1),
         periodic = (true, true),
-        npolynomial = 0,
     )
     coords = ClimaLand.Domains.coordinates(domain)
     zero_instance = ClimaCore.Fields.zeros(axes(coords.surface))
@@ -124,7 +123,6 @@ end
         ylim = FT.((1.0, 2.0)),
         zlim = FT.((1.0, 2.0)),
         nelements = (1, 1, 1),
-        npolynomial = 0,
     )
     coords = ClimaLand.Domains.coordinates(domain)
     sfc_instance = ClimaCore.Fields.zeros(axes(coords.surface)) .+ 10

--- a/test/shared_utilities/implicit_timestepping/richards_model.jl
+++ b/test/shared_utilities/implicit_timestepping/richards_model.jl
@@ -31,7 +31,6 @@ for FT in (Float32, Float64)
                 ylim = FT.((0, 1)),
                 zlim = (zmin, zmax),
                 nelements = (1, 1, nelems),
-                npolynomial = 3,
             ),
         ]
         top_state_bc = MoistureStateBC((p, t) -> ν - 1e-3)
@@ -158,7 +157,6 @@ for FT in (Float32, Float64)
                 ylim = FT.((0, 1)),
                 zlim = (zmin, zmax),
                 nelements = (1, 1, nelems),
-                npolynomial = 3,
             ),
         ]
         top_flux_bc = WaterFluxBC((p, t) -> -K_sat)

--- a/test/shared_utilities/utilities.jl
+++ b/test/shared_utilities/utilities.jl
@@ -141,13 +141,9 @@ end
         ylim = FT.((0.0, 1.0)),
         nelements = (2, 2),
         periodic = (true, true),
-        npolynomial = 1,
     )
-    domain2 = ClimaLand.Domains.SphericalSurface(;
-        radius = FT(2),
-        nelements = 10,
-        npolynomial = 3,
-    )
+    domain2 =
+        ClimaLand.Domains.SphericalSurface(; radius = FT(2), nelements = 10)
 
     domains = (domain1, domain2)
     for domain in domains
@@ -201,13 +197,11 @@ end
         zlim = FT.((0.0, 1.0)),
         nelements = (2, 2, 2),
         periodic = (true, true),
-        npolynomial = 1,
     )
     domain2 = ClimaLand.Domains.SphericalShell(;
         radius = FT(2),
         depth = FT(1.0),
         nelements = (10, 5),
-        npolynomial = 3,
     )
 
     domains = (domain1, domain2)
@@ -262,7 +256,6 @@ end
         radius = FT(2),
         depth = FT(1.0),
         nelements = (10, 5),
-        npolynomial = 3,
     )
 
     # Construct some fields
@@ -302,7 +295,7 @@ end
     ClimaComms.allowscalar(ClimaComms.device()) do
         parent(var1)[:, 1, 1, 1, 1] .= NaN
         parent(var2)[:, 1, 1, 1, 1] .= NaN
-        parent(var2)[:, 2, 1, 1, 1] .= NaN
+        parent(var2)[:, 1, 1, 1, 2] .= NaN
     end
 
     # Count and log the number of NaNs in the state (test verbose and non-verbose cases)

--- a/test/simulations/spatial_parameters.jl
+++ b/test/simulations/spatial_parameters.jl
@@ -27,7 +27,6 @@ domain = ClimaLand.Domains.SphericalShell(;
     radius = radius,
     depth = depth,
     nelements = (101, 15),
-    npolynomial = 1,
     dz_tuple = FT.((10.0, 0.05)),
 )
 surface_space = domain.space.surface
@@ -88,7 +87,6 @@ domain = ClimaLand.Domains.SphericalShell(;
     radius = radius,
     depth = depth,
     nelements = (202, 2),
-    npolynomial = 1,
 )
 surface_space = domain.space.surface
 @test !ClimaLand.use_lowres_clm(surface_space)
@@ -97,7 +95,6 @@ domain = ClimaLand.Domains.Plane(;
     xlim = (0.0, FT(2e6)),
     ylim = (0.0, 2FT(2e6)),
     nelements = (10, 10),
-    npolynomial = 1,
 )
 surface_space = domain.space.surface
 @test ClimaLand.use_lowres_clm(surface_space)
@@ -106,7 +103,6 @@ domain = ClimaLand.Domains.Plane(;
     xlim = (0.0, FT(2e5)),
     ylim = (0.0, 2FT(2e5)),
     nelements = (10, 10),
-    npolynomial = 1,
 )
 surface_space = domain.space.surface
 @test !ClimaLand.use_lowres_clm(surface_space)

--- a/test/standalone/Bucket/albedo_types.jl
+++ b/test/standalone/Bucket/albedo_types.jl
@@ -38,12 +38,7 @@ function create_domain_2d(FT)
     h = FT(3.5)
     ne = (2, 10)
     np = 2
-    return SphericalShell(;
-        radius = rad,
-        depth = h,
-        nelements = ne,
-        npolynomial = np,
-    )
+    return SphericalShell(; radius = rad, depth = h, nelements = ne)
 end
 
 """
@@ -201,7 +196,6 @@ end
             radius = FT(100.0),
             depth = FT(3.5),
             nelements = (2, 10),
-            npolynomial = 2,
         ),
     ]
 
@@ -293,7 +287,6 @@ for (name, infile_path, varname) in name_ds_var_list
                 radius = FT(100.0),
                 depth = FT(3.5),
                 nelements = (2, 10),
-                npolynomial = 2,
             ),
         ]
 

--- a/test/standalone/Bucket/restart.jl
+++ b/test/standalone/Bucket/restart.jl
@@ -23,7 +23,6 @@ bucket_domain = ClimaLand.SphericalShell(;
     radius = FT(100),
     depth = FT(3.5),
     nelements = (1, 10),
-    npolynomial = 1,
 )
 
 bucket_atmos, bucket_rad = ClimaLand.prescribed_analytic_forcing(FT)

--- a/test/standalone/Bucket/snow_bucket_tests.jl
+++ b/test/standalone/Bucket/snow_bucket_tests.jl
@@ -45,14 +45,12 @@ for FT in (Float32, Float64)
             ylim = (FT(-1), FT(0)),
             zlim = (FT(-100), FT(0)),
             nelements = (2, 2, 10),
-            npolynomial = 1,
             periodic = (true, true),
         ),
         SphericalShell(;
             radius = FT(100),
             depth = FT(3.5),
             nelements = (1, 10),
-            npolynomial = 1,
         ),
     ]
     init_temp(z::FT, value::FT) where {FT} = FT(value)

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -41,14 +41,12 @@ for FT in (Float32, Float64)
             ylim = (FT(-1), FT(0)),
             zlim = (FT(-100), FT(0)),
             nelements = (2, 2, 10),
-            npolynomial = 1,
             periodic = (true, true),
         ),
         SphericalShell(;
             radius = FT(100),
             depth = FT(3.5),
             nelements = (1, 10),
-            npolynomial = 1,
         ),
     ]
     init_temp(z::FT, value::FT) where {FT} = FT(value)

--- a/test/standalone/Snow/conservation.jl
+++ b/test/standalone/Snow/conservation.jl
@@ -21,7 +21,6 @@ for FT in (Float32, Float64)
         ylim = (cmin, cmax),
         zlim = (cmin, cmax),
         nelements = (nelems, nelems, nelems),
-        npolynomial = 0,
     )
 
     domains = [col, box]

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -25,7 +25,6 @@ for FT in (Float32, Float64)
                 ylim = FT.((-1.0, 0.0)),
                 zlim = FT.((-100.0, 0.0)),
                 nelements = (2, 2, 10),
-                npolynomial = 1,
                 periodic = (true, true),
             ),
         ]

--- a/test/standalone/Soil/conservation.jl
+++ b/test/standalone/Soil/conservation.jl
@@ -21,7 +21,6 @@ for FT in (Float32, Float64)
         ylim = (cmin, cmax),
         zlim = (cmin, cmax),
         nelements = (nelems, nelems, nelems),
-        npolynomial = 0,
     )
 
     domains = [col, box]

--- a/test/standalone/Soil/runoff.jl
+++ b/test/standalone/Soil/runoff.jl
@@ -26,7 +26,6 @@ end
         radius = FT(6300e3),
         depth = FT(50.0),
         nelements = (101, 15),
-        npolynomial = 1,
         dz_tuple = FT.((5.0, 0.05)),
     )
     surface_space = domain.space.surface
@@ -84,7 +83,6 @@ end
         radius = FT(6300e3),
         depth = FT(50.0),
         nelements = (101, 15),
-        npolynomial = 1,
         dz_tuple = FT.((5.0, 0.05)),
     )
     surface_space = domain.space.surface
@@ -192,7 +190,6 @@ end
         radius = FT(6300e3),
         depth = FT(50.0),
         nelements = (101, 15),
-        npolynomial = 1,
         dz_tuple = FT.((5.0, 0.05)),
     )
     surface_space = domain.space.surface

--- a/test/standalone/Soil/soil_bc.jl
+++ b/test/standalone/Soil/soil_bc.jl
@@ -25,7 +25,6 @@ for FT in (Float32, Float64)
             radius = FT(1.0),
             depth = FT(1.0),
             nelements = (1, 2),
-            npolynomial = 3,
         )
 
         coords = ClimaLand.Domains.coordinates(domain) # center coordinates

--- a/test/standalone/Soil/soil_test_3d.jl
+++ b/test/standalone/Soil/soil_test_3d.jl
@@ -29,7 +29,6 @@ for FT in (Float32, Float64)
             ylim = FT.((0, 1)),
             zlim = (zmin, zmax),
             nelements = (100, 2, 100),
-            npolynomial = 3,
         )
         top_flux_bc = WaterFluxBC((p, t) -> 0.0)
         bot_flux_bc = WaterFluxBC((p, t) -> 0.0)
@@ -266,7 +265,6 @@ for FT in (Float32, Float64)
             ylim = FT.((0, 1)),
             zlim = (zmin, zmax),
             nelements = (100, 2, 100),
-            npolynomial = 3,
         )
 
         zero_water_flux_bc = WaterFluxBC((p, t) -> 0.0)
@@ -371,7 +369,6 @@ for FT in (Float32, Float64)
             radius = FT(100.0),
             depth = FT(1.0),
             nelements = (1, 30),
-            npolynomial = 3,
         )
         top_flux_bc = WaterFluxBC((p, t) -> K_sat)
         bot_flux_bc = WaterFluxBC((p, t) -> K_sat)
@@ -451,13 +448,11 @@ end
         ylim = (zmin, zmax),
         zlim = (zmin, zmax),
         nelements = (100, 2, 100),
-        npolynomial = 3,
     )
     shell = ClimaLand.Domains.SphericalShell(;
         radius = FT(1),
         depth = FT(1),
         nelements = (2, 3),
-        npolynomial = 1,
     )
     column = ClimaLand.Domains.Column(; zlim = (zmin, zmax), nelements = 10)
     for d in [boxdomain, shell]

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -24,7 +24,6 @@ import ClimaParams
         domain = ClimaLand.Domains.SphericalSurface(;
             radius = FT(100.0),
             nelements = 10,
-            npolynomial = 1,
         )
         # create a field with both 1.0s and 0.0s
         mechanism_field = ClimaCore.Fields.Field(FT, domain.space.surface)
@@ -579,7 +578,6 @@ end
         domain = ClimaLand.Domains.SphericalSurface(;
             radius = FT(100.0),
             nelements = 10,
-            npolynomial = 1,
         )
         # create a field with both 1.0s and 0.0s
         mechanism_field = ClimaCore.Fields.Field(FT, domain.space.surface)
@@ -1180,7 +1178,6 @@ end
         domain = ClimaLand.Domains.SphericalSurface(;
             radius = FT(100.0),
             nelements = 10,
-            npolynomial = 1,
         )
         # create a field with both 1.0s and 0.0s
         mechanism_field = ClimaCore.Fields.Field(FT, domain.space.surface)

--- a/test/standalone/Vegetation/conservation.jl
+++ b/test/standalone/Vegetation/conservation.jl
@@ -24,7 +24,6 @@ for FT in (Float32, Float64)
         ylim = (cmin, cmax),
         zlim = (cmin, cmax),
         nelements = (nelems, nelems, nelems),
-        npolynomial = 0,
     )
 
     domains = [col, box]

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -109,7 +109,6 @@ for FT in (Float32, Float64)
                 ylim = FT.((0, 1)),
                 nelements = (2, 2),
                 periodic = (true, true),
-                npolynomial = 1,
             ),
         ]
 


### PR DESCRIPTION
We still had some experiments and tests with non-zero `npolynomial`. Diagnostics with the land-sea mask are correct only when `npolynomial` is zero, so this commit ensures that all our tests and experiments are using `npolynomial` of 0. This is also how we want to run `ClimaLand` in general, so there is little point in keeping `npolynomial != 0`.

I left one case with `npolynomial = 3` to check that it is still working.
