### PR TITLE
explicit and implicit sources for soil

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ ClimaLand.jl Release Notes
 
 main
 -------
+- Add capability to step some sources implicitly PR[#1113](https://github.com/CliMA/ClimaLand.jl/pull/1113)
 
 v0.15.14
 -------

--- a/docs/list_tutorials.jl
+++ b/docs/list_tutorials.jl
@@ -43,5 +43,6 @@ tutorials = [
         "Intro to multi-component models" => "standalone/Usage/LSM_single_column_tutorial.jl",
         "Intro to ClimaLand Domains" => "standalone/Usage/domain_tutorial.jl",
         "Intro to forced site-level runs" => "shared_utilities/driver_tutorial.jl",
+        "Intro to implicit/explicit timestepping" => "shared_utilities/timestepping.jl",
     ],
 ]

--- a/docs/tutorials/shared_utilities/timestepping.jl
+++ b/docs/tutorials/shared_utilities/timestepping.jl
@@ -1,0 +1,74 @@
+# # Mixed implicit and explicit timestepping
+# The goal of this tutorial is to describe how
+# the timestepping of a ClimaLand model is carried out.
+# We will use forward and backward Euler as a demonstration,
+# but higher order methods are available in ClimaTimesteppers.
+
+# # Explicit vs. implicit stepping
+# Given a differential equation for a prognostic variable
+# Y
+
+# ```
+# \frac{d Y }{dt} = g(Y, t) + h(Y, t),
+# ```
+
+# an explicit (forward) Euler step would entail
+
+# ```
+# Y(t+\Delta t) = Y(t) + [g(Y(t), t) + h(Y(t),t)] \times \Delta t,
+# ```
+
+# while an implicit (backward) Euler step would entail
+
+# ```
+# Y(t+\Delta t) = Y(t) + [g(Y(t+\Delta t), t) + h(Y(t+\Delta t),t)] \times \Delta t,
+# ```
+
+# which reqires us to solve an implicit equation for  Y(t+ Δt). We
+# usually do so using Newton's method, which requires the derivative of
+# the entire right hand side with respect to the variable we are solving
+# for, `Y(t+ Δt)`. This is called the Jacobian.
+
+# Sometimes certain terms must be stepped implicit for numerical stability,
+# while others are more slowly varying or stable. In this case, a mixed
+# approach would be
+
+# ```
+# Y(t+\Delta t) = Y(t) + [g(Y(t+\Delta t), t) + h(Y(t),t)] \times \Delta t,
+# ```
+
+# assuming that `h` is the slow term, and `g` is the fast term. Note that
+# solving this implicit equation for `(Y(t+ Δt)` with Newton's method
+# would be similar to that of the fully implicit approach, but with an
+# approximated Jacobian (neglecting ∂h/∂Y).
+
+# If our timestepping scheme involves evaluating all right-hand-side
+# tendencies at the current (known) value of a prognostic variable,
+# we refer to that prognostic variable as explicit. If any of the
+# right-hand-side tendencies are evaluated at the next (unknown) value
+# of the prognostic variable, we refer to it as implicit. In the latter
+# case, the Jacobian would include a term like `∂ tendency/∂ variable`,
+# even if it is an approximate (not exact) form of the Jacobian.
+
+# # Implicit and explicit prognostic variables of the land model
+# We treat two prognostic variables of the soil model (ϑ_l,
+# ρe_int) and the canopy temperature implicitly, and 
+# the canopy water content, the soil ice content,
+# and all prognostic
+# variables of the snow model explicitly.
+
+# # Implicit vs explicit tendencies - not complete as of 4/23/25
+# Implicit:
+# - Vertical contribution of the divergence of the Darcy flux
+# - Vertical contribution of the divergence of diffusive heat flux
+# - Vertical contribution of the divergence of heat flux due to Darcy flow
+# - Canopy temperature (except root extraction of energy)
+# - SHF, LHF, evaporation, and sublimation of soil (note that these are explicit in θ_i!)
+# - Soil radiation (does not contribute to Jacobian)
+# - Subsurface runoff (this is computed in the same function the same time as surface runoff, but does not contribute to Jacobian.)
+
+# Explicit
+# - Phase changes in soil
+# - Root extraction
+# - all snow tendencies
+# - Darcy flux within the canopy

--- a/docs/tutorials/standalone/Soil/sublimation.jl
+++ b/docs/tutorials/standalone/Soil/sublimation.jl
@@ -158,7 +158,7 @@ init_soil!(Y, z, soil.parameters);
 # Timestepping:
 t0 = Float64(0)
 tf = Float64(24 * 3600 * 4)
-dt = Float64(5)
+dt = Float64(10)
 
 # We also set the initial conditions of the cache here:
 set_initial_cache! = make_set_initial_cache(soil)
@@ -175,7 +175,7 @@ timestepper = CTS.ARS111()
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
     CTS.NewtonsMethod(
-        max_iters = 1,
+        max_iters = 3,
         update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
     ),
 )

--- a/src/shared_utilities/Domains.jl
+++ b/src/shared_utilities/Domains.jl
@@ -935,7 +935,7 @@ function get_additional_coordinate_field_data(subsurface_space)
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     z_sfc = top_face_to_surface(z_face, surface_space)
     d = depth(subsurface_space)
-    Δz_min = minimum(Δz_top)
+    Δz_min = minimum(Δz)
     fields = (;
         z = z,
         Δz_top = Δz_top,

--- a/src/standalone/Soil/soil_heat_parameterizations.jl
+++ b/src/standalone/Soil/soil_heat_parameterizations.jl
@@ -20,7 +20,7 @@ Returns the thermal timescale for temperature differences across
 a typical thickness Δz to equilibrate.
 """
 function thermal_time(ρc::FT, Δz::FT, κ::FT) where {FT}
-    return ρc * Δz^2 / κ
+    return 3 * ρc * Δz^2 / κ
 end
 
 """

--- a/test/shared_utilities/domains.jl
+++ b/test/shared_utilities/domains.jl
@@ -41,7 +41,7 @@ FT = Float32
         nelements = n_elements_sphere,
         npolynomial = npoly_sphere,
     )
-    @test shell.fields.Δz_min == depth / 20 / 2
+    @test shell.fields.Δz_min == depth / 20
     @test shell.fields.depth == depth
     @test shell.fields.z ==
           ClimaCore.Fields.coordinate_field(shell.space.subsurface).z
@@ -82,7 +82,7 @@ FT = Float32
         Array(parent(shell_coords_stretch.z))[:, end, end, end, end][1:(end - 1)]
     @test abs(dz[1] - 0.3) < 1e-1
     @test abs(dz[end] - 0.03) < 1e-2
-    @test shell.fields.Δz_min == minimum(shell.fields.Δz_top)
+    @test shell.fields.Δz_min == minimum(shell.fields.Δz)
 
 
     # Spherical Surface

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -137,8 +137,6 @@ for FT in (Float32, Float64)
             @test propertynames(p.soil) == (
                 :total_water,
                 :total_energy,
-                :∫S_θ_liq_dz,
-                :∫S_ρe_int_dz,
                 :K,
                 :ψ,
                 :θ_l,

--- a/test/standalone/Soil/soil_parameterizations.jl
+++ b/test/standalone/Soil/soil_parameterizations.jl
@@ -324,7 +324,7 @@ for FT in (Float32, Float64)
 
         Δz = FT(1.0)
         τ = thermal_time(parameters.ρc_ds, Δz, parameters.κ_dry)
-        @test τ == parameters.ρc_ds * Δz^2 / parameters.κ_dry
+        @test τ == 3 * parameters.ρc_ds * Δz^2 / parameters.κ_dry
         θ_l = FT.([0.11, 0.15, ν])
         θ_i = FT(0.0)
         T = FT(270)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
As part of Issue #1106, this labels sources for the soil as explicit or implicit. 


## To-do



## Content
Adds a boolean tag "explicit" to each concrete soil source. This is set by default and is not meant to be altered by the user (similar how to certain tendency terms are implicitly treated or explicitly treated - it's meant to be hardcoded).
we now compute sources in the implicit tendency as well as the explicit tendency, according to this ^^
I went with a simple `if` statement after talking to Charlie, he felt it might be clearer than adding an additional function to dispatch off of the value of `explicit`, and shouldnt impact performance


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
