### PR TITLE
Grab an extra year of data for era5 and modis LAI

### DIFF
--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -9,7 +9,7 @@ import LazyArtifacts
 """
     soil_ic_2008_50m_path(; context)
 
-Return the path to the file that contains the spun-up soil and snow initial 
+Return the path to the file that contains the spun-up soil and snow initial
 conditions for Jan 1, 2008.
 
 The soil domain has a depth of 50m; we have ensured that surface properties
@@ -35,10 +35,14 @@ end
 
 Find the appropriate files of ERA5 forcing data to run a simuation starting on
 `start_date` and ending on `final_date`.
+
+We add 1 year to the final date to ensure that everything between
+start_date and final_date is covered. (This is needed, e.g., if the last file
+is up to Dec 15th but we want to simulate past that date.)
 """
 function find_era5_year_paths(start_date, final_date; context = nothing)
     year0 = Dates.year(start_date)
-    yearf = Dates.year(final_date)
+    yearf = Dates.year(final_date) + 1
     era5_forty_yrs_path =
         era5_land_forcing_data_forty_years_folder_path(context = context)
     years = collect(
@@ -117,11 +121,15 @@ end
 
 Find the appropriate files of MODIS LAI data to run a simuation starting on
 `start_date` and ending on `final_date`.
+
+We add 1 year to the final date to ensure that everything between
+start_date and final_date is covered. (This is needed, e.g., if the last file
+is up to Dec 15th but we want to simulate past that date.)
 """
 function find_modis_year_paths(start_date, final_date; context = nothing)
     # Get the year of the start and final dates
     year0 = Dates.year(start_date)
-    yearf = Dates.year(final_date)
+    yearf = Dates.year(final_date) + 1
     modis_lai_data_path = modis_lai_forcing_data_path(context = context)
     years = collect(
         joinpath(modis_lai_data_path, "Yuan_et_al_$(year)_1x1.nc") for
@@ -464,7 +472,7 @@ end
 
 Construct the file path for the 60arcsecond orography data NetCDF file.
 
-Downloads the 60arc-second dataset by default. 
+Downloads the 60arc-second dataset by default.
 """
 function earth_orography_file_path(; context = nothing)
     filename = "ETOPO_2022_v1_60s_N90W180_surface.nc"
@@ -479,7 +487,7 @@ end
 
 Construct the file path for the 60arcsecond bedrock depth data NetCDF file.
 
-Downloads the 60arc-second dataset by default. 
+Downloads the 60arc-second dataset by default.
 """
 function bedrock_depth_file_path(; context = nothing)
     filename = "ETOPO_2022_v1_60s_N90W180_bed.nc"


### PR DESCRIPTION
It occurred to a user wanting to make a 2 year simulation from December to December, that the last December did not have data for LAI. This was due to the latest LAI data point being in November, and not extrapolated because the next year of LAI data was not loaded. To consistently fix this issue, we add a year of data to be read to interpolate the last month with the first month of the next year. We also did this for era5 data file, where this error could also occur.
