### PR TITLE
add buoyancy flux to cache in coupled case

### DIFF
--- a/src/standalone/Snow/boundary_fluxes.jl
+++ b/src/standalone/Snow/boundary_fluxes.jl
@@ -164,7 +164,8 @@ boundary_var_types(::SnowModel{FT}, bc, ::ClimaLand.TopBoundary) where {FT} =
 An extension of the `boundary_var_types` method for AtmosDrivenSnowBC. This
 specifies the type of the additional variables.
 
-This method includes the additional momentum fluxes needed by the atmosphere.
+This method includes additional fluxes needed by the atmosphere:
+momentum fluxes (`ρτxz`, `ρτyz`) and the buoyancy flux (`buoy_flux`).
 These are updated in place when the coupler computes turbulent fluxes,
 rather than in `snow_boundary_fluxes!`.
 
@@ -179,7 +180,7 @@ boundary_var_types(
     ::ClimaLand.TopBoundary,
 ) where {FT} = (
     NamedTuple{
-        (:lhf, :shf, :vapor_flux, :r_ae, :ρτxz, :ρτyz),
-        Tuple{FT, FT, FT, FT, FT, FT},
+        (:lhf, :shf, :vapor_flux, :r_ae, :ρτxz, :ρτyz, :buoy_flux),
+        Tuple{FT, FT, FT, FT, FT, FT, FT},
     },
 )

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -768,7 +768,8 @@ An extension of the `boundary_var_types` method for AtmosDrivenFluxBC
 with coupled atmosphere and radiative fluxes. This specifies the type
 of the additional variables.
 
-This method includes the additional momentum fluxes needed by the atmosphere.
+This method includes additional fluxes needed by the atmosphere:
+momentum fluxes (`ρτxz`, `ρτyz`) and the buoyancy flux (`buoy_flux`).
 These are updated in place when the coupler computes turbulent fluxes,
 rather than in `soil_boundary_fluxes!`.
 
@@ -783,8 +784,17 @@ boundary_var_types(
     ::ClimaLand.TopBoundary,
 ) where {FT} = (
     NamedTuple{
-        (:lhf, :shf, :vapor_flux_liq, :r_ae, :vapor_flux_ice, :ρτxz, :ρτyz),
-        Tuple{FT, FT, FT, FT, FT, FT, FT},
+        (
+            :lhf,
+            :shf,
+            :vapor_flux_liq,
+            :r_ae,
+            :vapor_flux_ice,
+            :ρτxz,
+            :ρτyz,
+            :buoy_flux,
+        ),
+        Tuple{FT, FT, FT, FT, FT, FT, FT, FT},
     },
     FT,
     NamedTuple{(:water, :heat), Tuple{FT, FT}},


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add buoyancy flux (`buoy_flux`) to the cache of the soil, snow, and canopy models when running with a coupled atmosphere, along with the momentum fluxes which are already added in this case. These quantities are computed and returned in the respective `compute_turbulent_fluxes_at_a_point` methods.

closes #1119

## To-do
- [x] allocate space in caches for the new fields
- [x] return the new fields conditionally from flux calculation functions
- [x] rename `return_momentum_fluxes` option to `return_extra_fluxes`
- [x] test in coupled simulation - tested locally with https://github.com/CliMA/ClimaCoupler.jl/pull/1303