### PR TITLE
Performance improvements

### DIFF
--- a/experiments/benchmarks/bucket.jl
+++ b/experiments/benchmarks/bucket.jl
@@ -23,7 +23,8 @@ import ClimaUtilities.TimeVaryingInputs: TimeVaryingInput
 
 import ClimaTimeSteppers as CTS
 import NCDatasets
-using ClimaCore
+import ClimaCore
+@show pkgversion(ClimaCore)
 import ClimaLand
 using ClimaParams
 using ClimaLand.Bucket:
@@ -66,13 +67,10 @@ function setup_prob(t0, tf, Δt; nelements = (200, 7))
     # We set up the problem in a function so that we can make multiple copies (for profiling)
 
     # Set up simulation domain
-    soil_depth = FT(3.5)
-    bucket_domain = ClimaLand.Domains.SphericalShell(;
-        radius = FT(6.3781e6),
-        depth = soil_depth,
-        nelements = nelements,
-        dz_tuple = FT.((1.0, 0.05)),
-    )
+    dz_tuple = FT.((1.0, 0.05))
+    depth = FT(3.5)
+    bucket_domain =
+        ClimaLand.global_domain(FT; nelements, dz_tuple, depth = depth)
     start_date = DateTime(2005)
 
     # Initialize parameters
@@ -259,7 +257,7 @@ if profiler == "flamegraph"
     end
 
     if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaland-benchmark"
-        PREVIOUS_BEST_TIME = 1.69
+        PREVIOUS_BEST_TIME = 0.533
         if average_timing_s > PREVIOUS_BEST_TIME + std_timing_s
             @info "Possible performance regression, previous average time was $(PREVIOUS_BEST_TIME)"
         elseif average_timing_s < PREVIOUS_BEST_TIME - std_timing_s

--- a/experiments/benchmarks/richards.jl
+++ b/experiments/benchmarks/richards.jl
@@ -36,7 +36,8 @@ ClimaComms.@import_required_backends
 import ClimaUtilities.TimeVaryingInputs: TimeVaryingInput
 import ClimaUtilities.Regridders: InterpolationsRegridder
 import ClimaTimeSteppers as CTS
-using ClimaCore
+import ClimaCore
+@show pkgversion(ClimaCore)
 using ClimaParams
 
 import ClimaLand
@@ -305,7 +306,7 @@ if profiler == "flamegraph"
     end
 
     if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaland-benchmark"
-        PREVIOUS_BEST_TIME = 1.49
+        PREVIOUS_BEST_TIME = 0.6
         if average_timing_s > PREVIOUS_BEST_TIME + std_timing_s
             @info "Possible performance regression, previous average time was $(PREVIOUS_BEST_TIME)"
         elseif average_timing_s < PREVIOUS_BEST_TIME - std_timing_s

--- a/experiments/benchmarks/snowy_land.jl
+++ b/experiments/benchmarks/snowy_land.jl
@@ -30,7 +30,8 @@ import SciMLBase
 import ClimaComms
 ClimaComms.@import_required_backends
 import ClimaTimeSteppers as CTS
-using ClimaCore
+import ClimaCore
+@show pkgversion(ClimaCore)
 using ClimaUtilities.ClimaArtifacts
 
 import ClimaUtilities.TimeVaryingInputs:
@@ -490,7 +491,7 @@ if profiler == "flamegraph"
         @info "Saved allocation flame to $alloc_flame_file"
     end
     if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaland-benchmark"
-        PREVIOUS_BEST_TIME = 3.29
+        PREVIOUS_BEST_TIME = 0.74
         if average_timing_s > PREVIOUS_BEST_TIME + std_timing_s
             @info "Possible performance regression, previous average time was $(PREVIOUS_BEST_TIME)"
         elseif average_timing_s < PREVIOUS_BEST_TIME - std_timing_s

--- a/experiments/long_runs/bucket.jl
+++ b/experiments/long_runs/bucket.jl
@@ -14,7 +14,8 @@ import SciMLBase
 import ClimaComms
 ClimaComms.@import_required_backends
 import ClimaTimeSteppers as CTS
-using ClimaCore
+import ClimaCore
+@show pkgversion(ClimaCore)
 using ClimaUtilities.ClimaArtifacts
 import Interpolations
 import ClimaUtilities.TimeVaryingInputs:

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -19,7 +19,8 @@ import SciMLBase
 import ClimaComms
 ClimaComms.@import_required_backends
 import ClimaTimeSteppers as CTS
-using ClimaCore
+import ClimaCore
+@show pkgversion(ClimaCore)
 using ClimaUtilities.ClimaArtifacts
 
 import ClimaDiagnostics

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -19,7 +19,8 @@ import SciMLBase
 import ClimaComms
 ClimaComms.@import_required_backends
 import ClimaTimeSteppers as CTS
-using ClimaCore
+import ClimaCore
+@show pkgversion(ClimaCore)
 using ClimaUtilities.ClimaArtifacts
 import ClimaUtilities.OnlineLogging: WallTimeInfo, report_walltime
 import ClimaUtilities.TimeManager: ITime, date

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -18,7 +18,8 @@ import SciMLBase
 import ClimaComms
 ClimaComms.@import_required_backends
 import ClimaTimeSteppers as CTS
-using ClimaCore
+import ClimaCore
+@show pkgversion(ClimaCore)
 using ClimaUtilities.ClimaArtifacts
 
 using ClimaDiagnostics

--- a/src/shared_utilities/Domains.jl
+++ b/src/shared_utilities/Domains.jl
@@ -169,7 +169,12 @@ function Column(;
     subsurface_space =
         ClimaCore.Spaces.CenterFiniteDifferenceSpace(device, mesh)
     surface_space = obtain_surface_space(subsurface_space)
-    space = (; surface = surface_space, subsurface = subsurface_space)
+    subsurface_face_space = obtain_face_space(subsurface_space)
+    space = (;
+        surface = surface_space,
+        subsurface = subsurface_space,
+        subsurface_face = subsurface_face_space,
+    )
     fields = get_additional_coordinate_field_data(subsurface_space)
     return Column{FT}(
         zlim,
@@ -470,7 +475,12 @@ function HybridBox(;
     )
 
     surface_space = obtain_surface_space(subsurface_space)
-    space = (; surface = surface_space, subsurface = subsurface_space)
+    subsurface_face_space = obtain_face_space(subsurface_space)
+    space = (;
+        surface = surface_space,
+        subsurface = subsurface_space,
+        subsurface_face = subsurface_face_space,
+    )
     fields = get_additional_coordinate_field_data(subsurface_space)
     return HybridBox{FT}(
         horzdomain.xlim,
@@ -593,7 +603,12 @@ function SphericalShell(;
         vert_center_space,
     )
     surface_space = obtain_surface_space(subsurface_space)
-    space = (; surface = surface_space, subsurface = subsurface_space)
+    subsurface_face_space = obtain_face_space(subsurface_space)
+    space = (;
+        surface = surface_space,
+        subsurface = subsurface_space,
+        subsurface_face = subsurface_face_space,
+    )
     fields = get_additional_coordinate_field_data(subsurface_space)
     return SphericalShell{FT}(
         radius,

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -883,7 +883,7 @@ top boundary.
 These variables are updated in place in `boundary_flux!`.
 """
 boundary_vars(bc::MoistureStateBC, ::ClimaLand.TopBoundary) =
-    (:top_bc, :top_bc_wvec, :dfluxBCdY)
+    (:top_bc, :top_bc_wvec, :dfluxBCdY, :topBC_scratch)
 
 """
     boundary_var_domain_names(::MoistureStateBC, ::ClimaLand.TopBoundary)
@@ -892,7 +892,7 @@ An extension of the `boundary_var_domain_names` method for MoistureStateBC at th
 top boundary.
 """
 boundary_var_domain_names(bc::MoistureStateBC, ::ClimaLand.TopBoundary) =
-    (:surface, :surface, :surface)
+    (:surface, :surface, :surface, :subsurface_face)
 """
     boundary_var_types(::RichardsModel{FT},
                         ::MoistureStateBC,
@@ -909,6 +909,7 @@ boundary_var_types(
 ) where {FT} = (
     FT,
     ClimaCore.Geometry.WVector{FT},
+    ClimaCore.Geometry.Covariant3Vector{FT},
     ClimaCore.Geometry.Covariant3Vector{FT},
 )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,7 @@ end
 @safetestset "Soil CO2 parameterization tests" begin
     include("standalone/Soil/Biogeochemistry/co2_parameterizations.jl")
 end
+
 @safetestset "Soil climate drivers tests" begin
     include("standalone/Soil/climate_drivers.jl")
 end

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -142,6 +142,8 @@ for FT in (Float32, Float64)
                 :θ_l,
                 :T,
                 :κ,
+                :bidiag_matrix_scratch,
+                :full_bidiag_matrix_scratch,
                 :turbulent_fluxes,
                 :R_n,
                 :top_bc,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR computes intermediate quantities in the soil Jacobian for the Richards and EnergyHydrology model. This circumvents performance issues in ClimaCore when many matrix field broadcast operations are fused.

This improves the Richards benchmark time from 1.5s to 0.6s, and the snowy land benchmark time from 3.29s to 0.741s. It changes the long run SYPD as:
snowy land model: 20 SYPD -> ~60 SYPD


## To-do
- understand why more NaNs appear in the full soil long run (this is due to PR #1113; not this current PR)

## Content
- adds bidiagonal matrix row fields to scratch space for the soil model, uses these in the jacobian computation
- does the same with a covariant3vector field
- updates benchmark times


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
