### PR TITLE
revert small changes that seemed to affect stability

### DIFF
--- a/src/simulations/spatial_parameters.jl
+++ b/src/simulations/spatial_parameters.jl
@@ -334,18 +334,12 @@ function default_spatially_varying_soil_parameters(
     μ = FT(-5.11)
     K_sat .= masked_to_value.(K_sat, soil_params_mask, 10.0^μ)
 
-    ν .= masked_to_value.(ν, soil_params_mask, 1)
+    ν .= masked_to_value.(ν, soil_params_mask, 0.48)
 
     θ_r .= masked_to_value.(θ_r, soil_params_mask, 0)
 
 
-    S_s =
-        masked_to_value.(
-            ClimaCore.Fields.zeros(subsurface_space) .+ FT(1e-3),
-            soil_params_mask,
-            1,
-        )
-
+    S_s = ClimaCore.Fields.zeros(subsurface_space) .+ FT(1e-3)
     soilgrids_artifact_path =
         ClimaLand.Artifacts.soil_grids_params_artifact_path(;
             lowres = true,

--- a/src/simulations/spatial_parameters.jl
+++ b/src/simulations/spatial_parameters.jl
@@ -1,4 +1,5 @@
 using ClimaComms
+using Statistics
 using ClimaUtilities.ClimaArtifacts
 import Interpolations
 import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
@@ -331,7 +332,7 @@ function default_spatially_varying_soil_parameters(
         regridder_kwargs = (; extrapolation_bc,),
     )
 
-    μ = FT(-6)
+    μ = FT(-5.11)
     K_sat .= masked_to_value.(K_sat, soil_params_mask, 10.0^μ)
 
     ν .= masked_to_value.(ν, soil_params_mask, 1)

--- a/src/simulations/spatial_parameters.jl
+++ b/src/simulations/spatial_parameters.jl
@@ -1,5 +1,4 @@
 using ClimaComms
-using Statistics
 using ClimaUtilities.ClimaArtifacts
 import Interpolations
 import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput

--- a/src/standalone/Soil/soil_heat_parameterizations.jl
+++ b/src/standalone/Soil/soil_heat_parameterizations.jl
@@ -20,7 +20,7 @@ Returns the thermal timescale for temperature differences across
 a typical thickness Δz to equilibrate.
 """
 function thermal_time(ρc::FT, Δz::FT, κ::FT) where {FT}
-    return 3 * ρc * Δz^2 / κ
+    return ρc * Δz^2 / κ
 end
 
 """


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
After PR #1113 , the number of NaNs in the full soil long run increased. It appears that that is due to the change in the phase change term (maybe? because changing this piece back reduces the number of NaNs). 


## To-do



## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
