### PR TITLE
Fix calibration coastline errors

### DIFF
--- a/experiments/calibration/make_training_locations.jl
+++ b/experiments/calibration/make_training_locations.jl
@@ -2,25 +2,8 @@ using ClimaAnalysis
 using ClimaLand
 using ClimaLand.Artifacts
 using ClimaComms
+using ClimaCore
 ClimaComms.@import_required_backends
-
-"""
-    diagnostics_lat_lon(nelements)
-
-Return latitudes and longitude for the diagnostics of the land
-model run at a given resolution (`nelements`).
-"""
-function diagnostics_lat_lon(nelements)
-    radius = 0.1 # These don't matter
-    depth = 0.1 # These don't matter
-
-    domain = ClimaLand.Domains.SphericalShell(; radius, depth, nelements)
-    num_long, num_lat, _ =
-        ClimaLand.Diagnostics.default_diagnostic_num_points(domain)
-    longs = collect(range(-180.0, 180.0, length = num_long))
-    lats = collect(range(-90.0, 90.0, length = num_lat))
-    return lats, longs
-end
 
 """
     make_training_locations(nelements)
@@ -32,23 +15,35 @@ It assumes that the output is on the default grid, as determined by
 globe.
 
 # Notes
-- The function applies a land mask to identify suitable training locations
+- ClimaLand simulates only locations where its mask == 1 (based on a threshold set in the simulations). Since parameters are not defined over the ocean, this can lead to unphysical parameter combinations right at the coastline.
+- The interpolated diagnostics are not mask aware; this again means that grid points treated as land by the simulation are combined with grid points that are not acted on by the simulation (typically set to zero, but possibly undefined). Again the result is that grid points on the coastline are not guaranteed to be physically realistic.
+- Consequently, here we define the mask used to select calibration points using a more stringent criterion (essentially, that the grid point in the simulation is only comprised of land, and the point in the diagnostic is only comprised of land)
 """
 function make_training_locations(nelements)
-    lats, longs = diagnostics_lat_lon(nelements)
-    var = ClimaAnalysis.OutputVar(
-        Dict("long" => longs, "lat" => lats),
-        zeros(length(lats), length(longs)),
-    )
 
-    # Apply_oceanmask applies the mask over the ocean
-    vars_in_land = ClimaAnalysis.apply_oceanmask(var)
+    domain = ClimaLand.Domains.SphericalShell(; 0.1, 0.1, nelements) # values of radius and depth (set to 0.1) do not matter; we just need information from the domain in the latitude/longitude directions.
+    # If the default number of diagnostic latitude and longitude points is not used when running the simulations, this will need to be changed.
+    num_long, num_lat, _ =
+        ClimaLand.Diagnostics.default_diagnostic_num_points(domain)
+    longs = collect(range(-180.0, 180.0, length = num_long))
+    lats = collect(range(-90.0, 90.0, length = num_lat))
+
+    # We also need the mask in order to determine which points were treated as land by the simulation.
+    # We set the threshold of fractional area of land to be 0.99 here - cells with > 1% ocean are ignored in calibration.
+    mask = ClimaLand.landsea_mask(domain; threshold = 0.99)
+
+    # Interpolate the ClimaLand land sea mask (Field) to the diagnostics grid (matrix)
+    target_hcoords = [
+        ClimaCore.Geometry.LatLongPoint(lat, lon) for lat in lats, lon in longs
+    ]
+    # Select only locations where the interpolated mask is equal to 1
+    interpolated_mask =
+        Array(ClimaCore.Remapping.interpolate(mask; target_hcoords))
 
     training_locations = [
-        (lon, lat) for
-        (j, lon) in enumerate(ClimaAnalysis.longitudes(vars_in_land)) for
-        (i, lat) in enumerate(ClimaAnalysis.latitudes(vars_in_land)) if
-        !isnan(vars_in_land.data[i, j])
+        (lon, lat) for (j, lon) in enumerate(longs) for
+        (i, lat) in enumerate(lats) if !iszero(interpolated_mask[i, j])
     ]
+
     return training_locations
 end


### PR DESCRIPTION
Previously to this commit, we were using `ClimaAnalysis.apply_oceanmask`
to get locations (coordinates) on land to perform global calibration.
This was causing erroneous values at the coast, because it would
sometimes use ocean locations, as the ClimaAnalysis mask slightly differ
from the ClimaLand mask. Furthermore, we use a high threshold (0.99) for
the land mask to ensure only land pixels are used.

For example, longwave up at the coast had many zeros:
![image](https://github.com/user-attachments/assets/d786eeb1-2761-4020-8b4d-a4623e12b42f)

And, at the same locations, sensible heat had sometimes very large values 
![image](https://github.com/user-attachments/assets/b01054c0-ff09-4649-9a13-34909972351b)
