### PR TITLE
Remove `obtain_face_space` function

### DIFF
--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -14,7 +14,6 @@ ClimaLand.Domains.Column
 ClimaLand.Domains.Plane
 ClimaLand.Domains.Point
 ClimaLand.Domains.coordinates
-ClimaLand.Domains.obtain_face_space
 ClimaLand.Domains.obtain_surface_space
 ClimaLand.Domains.obtain_surface_domain
 ClimaLand.Domains.top_center_to_surface

--- a/src/integrated/pond_soil_model.jl
+++ b/src/integrated/pond_soil_model.jl
@@ -122,7 +122,7 @@ Defined such that positive means into soil.
 """
 function infiltration_capacity(Y::ClimaCore.Fields.FieldVector, p::NamedTuple)
     FT = eltype(Y.soil.ϑ_l)
-    face_space = ClimaLand.Domains.obtain_face_space(axes(Y.soil.ϑ_l))
+    face_space = ClimaCore.Spaces.face_space(axes(Y.soil.ϑ_l))
     N = ClimaCore.Spaces.nlevels(face_space)
     space = axes(Y.surface_water.η)
     z = ClimaCore.Fields.coordinate_field(axes(Y.soil.ϑ_l)).z

--- a/src/shared_utilities/Domains.jl
+++ b/src/shared_utilities/Domains.jl
@@ -169,7 +169,7 @@ function Column(;
     subsurface_space =
         ClimaCore.Spaces.CenterFiniteDifferenceSpace(device, mesh)
     surface_space = obtain_surface_space(subsurface_space)
-    subsurface_face_space = obtain_face_space(subsurface_space)
+    subsurface_face_space = ClimaCore.Spaces.face_space(subsurface_space)
     space = (;
         surface = surface_space,
         subsurface = subsurface_space,
@@ -475,7 +475,7 @@ function HybridBox(;
     )
 
     surface_space = obtain_surface_space(subsurface_space)
-    subsurface_face_space = obtain_face_space(subsurface_space)
+    subsurface_face_space = ClimaCore.Spaces.face_space(subsurface_space)
     space = (;
         surface = surface_space,
         subsurface = subsurface_space,
@@ -603,7 +603,7 @@ function SphericalShell(;
         vert_center_space,
     )
     surface_space = obtain_surface_space(subsurface_space)
-    subsurface_face_space = obtain_face_space(subsurface_space)
+    subsurface_face_space = ClimaCore.Spaces.face_space(subsurface_space)
     space = (;
         surface = surface_space,
         subsurface = subsurface_space,
@@ -736,14 +736,6 @@ function obtain_surface_domain(s::SphericalShell{FT}) where {FT}
 end
 
 """
-    obtain_face_space(cs::ClimaCore.Spaces.AbstractSpace)
-
-Returns the face space, if applicable, for the center space `cs`.
-"""
-obtain_face_space(cs::ClimaCore.Spaces.AbstractSpace) =
-    @error("No face space is defined for this space.")
-
-"""
     obtain_surface_space(cs::ClimaCore.Spaces.AbstractSpace)
 
 Returns the surface space, if applicable, for the center space `cs`.
@@ -751,25 +743,6 @@ Returns the surface space, if applicable, for the center space `cs`.
 obtain_surface_space(cs::ClimaCore.Spaces.AbstractSpace) =
     @error("No surface space is defined for this space.")
 
-"""
-    obtain_face_space(cs::ClimaCore.Spaces.CenterExtrudedFiniteDifferenceSpace)
-
-Returns the face space for the CenterExtrudedFiniteDifferenceSpace `cs`.
-"""
-function obtain_face_space(
-    cs::ClimaCore.Spaces.CenterExtrudedFiniteDifferenceSpace,
-)
-    return ClimaCore.Spaces.FaceExtrudedFiniteDifferenceSpace(cs)
-end
-
-"""
-    obtain_face_space(cs::ClimaCore.Spaces.CenterFiniteDifferenceSpace)
-
-Returns the face space corresponding to the CenterFiniteDifferenceSpace `cs`.
-"""
-function obtain_face_space(cs::ClimaCore.Spaces.CenterFiniteDifferenceSpace)
-    return ClimaCore.Spaces.FaceFiniteDifferenceSpace(cs)
-end
 
 """
     obtain_surface_space(cs::ClimaCore.Spaces.CenterExtrudedFiniteDifferenceSpace)
@@ -788,7 +761,7 @@ end
 Returns the top level of the face space corresponding to the CenterFiniteDifferenceSpace `cs`.
 """
 function obtain_surface_space(cs::ClimaCore.Spaces.CenterFiniteDifferenceSpace)
-    fs = obtain_face_space(cs)
+    fs = ClimaCore.Spaces.face_space(cs)
     return ClimaCore.Spaces.level(
         fs,
         ClimaCore.Utilities.PlusHalf(ClimaCore.Spaces.nlevels(fs) - 1),
@@ -891,7 +864,7 @@ both as Fields. It also returns the widths of each layer as a field.
 """
 function get_Δz(z::ClimaCore.Fields.Field)
     # Extract the differences between levels of the face space
-    fs = obtain_face_space(axes(z))
+    fs = ClimaCore.Spaces.face_space(axes(z))
     z_face = ClimaCore.Fields.coordinate_field(fs).z
     Δz_face = ClimaCore.Fields.Δz_field(z_face)
     Δz_top = ClimaCore.Fields.level(
@@ -936,7 +909,7 @@ A helper function which returns additional fields and field data corresponding t
 domains which have a subsurface_space (Column, HybridBox, SphericalShell).
 The fields are the center coordinates of the subsurface space, the spacing between
 the top center and top surface and bottom center and bottom surface, as well as the
-field corresponding to the surface height z and layer widths. The field data are the 
+field corresponding to the surface height z and layer widths. The field data are the
 depth of the domain and the minimum top layer thickness over the entire domain.
 
 We allocate these once, upon domain construction, so that they are accessible
@@ -946,7 +919,7 @@ function get_additional_coordinate_field_data(subsurface_space)
     surface_space = obtain_surface_space(subsurface_space)
     z = ClimaCore.Fields.coordinate_field(subsurface_space).z
     Δz_top, Δz_bottom, Δz = get_Δz(z)
-    face_space = obtain_face_space(subsurface_space)
+    face_space = ClimaCore.Spaces.face_space(subsurface_space)
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     z_sfc = top_face_to_surface(z_face, surface_space)
     d = depth(subsurface_space)
@@ -1060,7 +1033,6 @@ end
 export AbstractDomain
 export Column, Plane, HybridBox, Point, SphericalShell, SphericalSurface
 export coordinates,
-    obtain_face_space,
     obtain_surface_space,
     top_center_to_surface,
     bottom_center_to_surface,

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -388,9 +388,12 @@ function ClimaLand.set_dfluxBCdY!(
 
 
     # Get the local geometry of the face space, then extract the top level
-    levels = ClimaCore.Spaces.nlevels(Domains.obtain_face_space(axes(p.soil.K)))
+    levels =
+        ClimaCore.Spaces.nlevels(ClimaCore.Spaces.face_space(axes(p.soil.K)))
     local_geometry_faceN = ClimaCore.Fields.level(
-        Fields.local_geometry_field(Domains.obtain_face_space(axes(p.soil.K))),
+        Fields.local_geometry_field(
+            ClimaCore.Spaces.face_space(axes(p.soil.K)),
+        ),
         levels - ClimaCore.Utilities.half,
     )
 

--- a/test/shared_utilities/domains.jl
+++ b/test/shared_utilities/domains.jl
@@ -13,7 +13,6 @@ using ClimaLand.Domains:
     SphericalSurface,
     coordinates,
     obtain_surface_space,
-    obtain_face_space,
     obtain_surface_domain,
     get_Δz,
     top_face_to_surface,
@@ -45,7 +44,7 @@ FT = Float32
     @test shell.fields.depth == depth
     @test shell.fields.z ==
           ClimaCore.Fields.coordinate_field(shell.space.subsurface).z
-    face_space = obtain_face_space(shell.space.subsurface)
+    face_space = ClimaCore.Spaces.face_space(shell.space.subsurface)
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     @test shell.fields.z_sfc == top_face_to_surface(z_face, shell.space.surface)
     Δz_top, Δz_bottom, Δz = get_Δz(shell.fields.z)
@@ -112,7 +111,7 @@ FT = Float32
     @test box.fields.depth == zlim[2] - zlim[1]
     @test box.fields.z ==
           ClimaCore.Fields.coordinate_field(box.space.subsurface).z
-    face_space = obtain_face_space(box.space.subsurface)
+    face_space = ClimaCore.Spaces.face_space(box.space.subsurface)
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     @test box.fields.z_sfc == top_face_to_surface(z_face, box.space.surface)
     Δz_top, Δz_bottom, Δz = get_Δz(box.fields.z)
@@ -221,7 +220,7 @@ FT = Float32
     @test longlat_box.fields.depth == zlim[2] - zlim[1]
     @test longlat_box.fields.z ==
           ClimaCore.Fields.coordinate_field(longlat_box.space.subsurface).z
-    face_space = obtain_face_space(longlat_box.space.subsurface)
+    face_space = ClimaCore.Spaces.face_space(longlat_box.space.subsurface)
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     @test longlat_box.fields.z_sfc ==
           top_face_to_surface(z_face, longlat_box.space.surface)
@@ -265,7 +264,7 @@ FT = Float32
     @test z_column.fields.z ==
           ClimaCore.Fields.coordinate_field(z_column.space.subsurface).z
     @test z_column.fields.depth == zlim[2] - zlim[1]
-    face_space = obtain_face_space(z_column.space.subsurface)
+    face_space = ClimaCore.Spaces.face_space(z_column.space.subsurface)
     z_face = ClimaCore.Fields.coordinate_field(face_space).z
     @test z_column.fields.z_sfc ==
           top_face_to_surface(z_face, z_column.space.surface)

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -191,9 +191,8 @@ for FT in (Float32, Float64)
             @test p.drivers.P == zeros(space) .+ FT(101325)
             @test p.drivers.LW_d == zeros(space) .+ FT(5.67e-8 * 280.0^4.0)
             @test p.drivers.SW_d == zeros(space) .+ FT(500)
-            face_space = ClimaLand.Domains.obtain_face_space(
-                model.domain.space.subsurface,
-            )
+            face_space =
+                ClimaCore.Spaces.face_space(model.domain.space.subsurface)
             N = ClimaCore.Spaces.nlevels(face_space)
             surface_space = model.domain.space.surface
             z_sfc = ClimaCore.Fields.Field(


### PR DESCRIPTION

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This functionality of  `obtain_face_space` now exists as an exported method from ClimaCore.



## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
Removes `obtain_face_space` and replaces all calls with `ClimaCore.Spaces.face_space`

 `ClimaCore.Spaces.face_space` also gives an informative error when called on a non vertical/extruded space.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
