### PR TITLE
Compute zenith angles for CoupledRadiativeFluxes

### DIFF
--- a/docs/src/APIs/shared_utilities.md
+++ b/docs/src/APIs/shared_utilities.md
@@ -1,8 +1,9 @@
-<!-- # Shared Utilities
+# Shared Utilities
 
 ```@meta
 CurrentModule = ClimaLand
 ```
+
 ## Domains
 
 ```@docs
@@ -67,6 +68,7 @@ ClimaLand.total_liq_water_vol_per_area!
 ```
 
 ## Drivers
+
 ```@docs
 ClimaLand.PrescribedAtmosphere
 ClimaLand.PrescribedPrecipitation
@@ -83,4 +85,5 @@ ClimaLand.surface_air_density
 ClimaLand.surface_temperature
 ClimaLand.surface_resistance
 ClimaLand.surface_specific_humidity
-``` -->
+ClimaLand.default_zenith_angle
+```

--- a/docs/tutorials/shared_utilities/driver_tutorial.jl
+++ b/docs/tutorials/shared_utilities/driver_tutorial.jl
@@ -81,30 +81,14 @@ diffuse_fraction = TimeVaryingInput(seconds, diffuse_fraction);
 # To do so, we use the `Insolation` package as follows:
 earth_param_set = LP.LandParameters(Float64);
 insol_params = earth_param_set.insol_params # parameters of Earth's orbit required to compute the insolation
-function zenith_angle(
-    t,
-    start_date;
-    latitude = lat,
-    longitude = long,
-    insol_params = insol_params,
-)
-    current_datetime = start_date + Dates.Second(round(t)) # Time in UTC
-
-    d, δ, η_UTC = (Insolation.helper_instantaneous_zenith_angle(
-        current_datetime,
-        start_date,
+zenith_angle =
+    (t, s) -> default_zenith_angle(
+        t,
+        s;
         insol_params,
-    ))
-
-
-    return Insolation.instantaneous_zenith_angle(
-        d,
-        δ,
-        η_UTC,
-        longitude,
-        latitude,
-    )[1]
-end;
+        longitude = long,
+        latitude = lat,
+    );
 
 # Lastly, we store the interpolators for downwelling fluxes and the zenith angle function
 # in the `PrescribedRadiativeFluxes` struct.

--- a/experiments/integrated/fluxnet/met_drivers_FLUXNET.jl
+++ b/experiments/integrated/fluxnet/met_drivers_FLUXNET.jl
@@ -163,36 +163,14 @@ atmos = ClimaLand.PrescribedAtmosphere(
     c_co2 = atmos_co2,
 )
 
-function zenith_angle(
-    t,
-    start_date;
-    latitude = lat,
-    longitude = long,
-    insol_params::Insolation.Parameters.InsolationParameters{FT} = earth_param_set.insol_params,
-) where {FT}
-    # This should be time in UTC
-    current_datetime = start_date + Dates.Second(round(t))
-
-    # Orbital Data uses Float64, so we need to convert to our sim FT
-    d, δ, η_UTC =
-        FT.(
-            Insolation.helper_instantaneous_zenith_angle(
-                current_datetime,
-                start_date,
-                insol_params,
-            )
-        )
-
-    FT(
-        Insolation.instantaneous_zenith_angle(
-            d,
-            δ,
-            η_UTC,
-            longitude,
-            latitude,
-        )[1],
+zenith_angle =
+    (t, s) -> default_zenith_angle(
+        t,
+        s;
+        insol_params = earth_param_set.insol_params,
+        longitude = long,
+        latitude = lat,
     )
-end
 radiation = ClimaLand.PrescribedRadiativeFluxes(
     FT,
     SW_IN,

--- a/experiments/standalone/Snow/process_snowmip.jl
+++ b/experiments/standalone/Snow/process_snowmip.jl
@@ -56,36 +56,14 @@ LW_d = TimeVaryingInput(seconds, LWdown; context)
 
 start_date = timestamp[mask][1]
 
-function zenith_angle(
-    t,
-    start_date;
-    latitude = FT(lat),
-    longitude = FT(long),
-    insol_params::Insolation.Parameters.InsolationParameters{FT} = param_set.insol_params,
-) where {FT}
-    # This should be time in UTC
-    current_datetime = start_date + Dates.Second(round(t))
-
-    # Orbital Data uses Float64, so we need to convert to our sim FT
-    d, δ, η_UTC =
-        FT.(
-            Insolation.helper_instantaneous_zenith_angle(
-                current_datetime,
-                start_date,
-                insol_params,
-            )
-        )
-
-    FT(
-        Insolation.instantaneous_zenith_angle(
-            d,
-            δ,
-            η_UTC,
-            longitude,
-            latitude,
-        )[1],
+zenith_angle =
+    (t, s) -> ClimaLand.default_zenith_angle(
+        t,
+        s;
+        insol_params = earth_param_set.insol_params,
+        latitude = FT(lat),
+        longitude = FT(long),
     )
-end
 
 radiation = ClimaLand.PrescribedRadiativeFluxes(
     FT,

--- a/src/shared_utilities/utils.jl
+++ b/src/shared_utilities/utils.jl
@@ -276,6 +276,7 @@ Constructs a DiscreteCallback which updates the cache `p.drivers` at each time
 specified by `updateat`, using the function `updatefunc` which takes as arguments (p,t).
 """
 function DriverUpdateCallback(updateat::Vector{FT}, updatefunc) where {FT}
+    issorted(updateat) || error("updateat must be sorted in ascending order")
     cond = update_condition(updateat)
     affect! = DriverAffect(updateat, updatefunc)
 
@@ -374,7 +375,8 @@ the callback. This implementation simply checks if the current time of the
 simulation is within the (inclusive) bounds of `updateat`.
 """
 update_condition(updateat) =
-    (_, t, _) -> t >= minimum(updateat) && t <= maximum(updateat)
+    (_, t, _) ->
+        !isempty(updateat) && t >= minimum(updateat) && t <= maximum(updateat)
 """
     SavingAffect{saveatType}
 

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -75,31 +75,17 @@ import ClimaParams
             )
             lat = FT(0.0) # degree
             long = FT(-180) # degree
+            start_date = DateTime(2005)
 
-            function zenith_angle(
-                t,
-                start_date;
-                latitude = lat,
-                longitude = long,
-                insol_params = earth_param_set.insol_params,
-            )
-                current_datetime = start_date + Dates.Second(round(t))
-                d, δ, η_UTC =
-                    FT.(
-                        Insolation.helper_instantaneous_zenith_angle(
-                            current_datetime,
-                            start_date,
-                            insol_params,
-                        )
-                    )
-                return Insolation.instantaneous_zenith_angle(
-                    d,
-                    δ,
-                    η_UTC,
-                    longitude,
-                    latitude,
-                )[1]
-            end
+            zenith_angle =
+                (t, s) -> default_zenith_angle(
+                    t,
+                    s;
+                    insol_params = earth_param_set.insol_params,
+                    latitude = lat,
+                    longitude = long,
+                )
+
 
             function shortwave_radiation(
                 t;
@@ -123,7 +109,6 @@ import ClimaParams
             P_atmos = t -> 1e5 # Pa
             h_atmos = h_int # m
             c_atmos = (t) -> 4.11e-4 # mol/mol
-            start_date = DateTime(2005)
             atmos = PrescribedAtmosphere(
                 TimeVaryingInput(liquid_precip),
                 TimeVaryingInput(snow_precip),
@@ -630,31 +615,16 @@ end
             )
             lat = FT(0.0) # degree
             long = FT(-180) # degree
+            start_date = DateTime(2005)
 
-            function zenith_angle(
-                t,
-                start_date;
-                latitude = lat,
-                longitude = long,
-                insol_params = earth_param_set.insol_params,
-            )
-                current_datetime = start_date + Dates.Second(round(t))
-                d, δ, η_UTC =
-                    FT.(
-                        Insolation.helper_instantaneous_zenith_angle(
-                            current_datetime,
-                            start_date,
-                            insol_params,
-                        )
-                    )
-                return Insolation.instantaneous_zenith_angle(
-                    d,
-                    δ,
-                    η_UTC,
-                    longitude,
-                    latitude,
-                )[1]
-            end
+            zenith_angle =
+                (t, s) -> default_zenith_angle(
+                    t,
+                    s;
+                    insol_params = earth_param_set.insol_params,
+                    latitude = lat,
+                    longitude = long,
+                )
 
             function shortwave_radiation(
                 t;
@@ -678,7 +648,6 @@ end
             P_atmos = t -> 1e5 # Pa
             h_atmos = h_int # m
             c_atmos = (t) -> 4.11e-4 # mol/mol
-            start_date = DateTime(2005)
             atmos = PrescribedAtmosphere(
                 TimeVaryingInput(liquid_precip),
                 TimeVaryingInput(snow_precip),
@@ -900,31 +869,17 @@ end
         )
         lat = FT(0.0) # degree
         long = FT(-180) # degree
+        start_date = DateTime(2005)
 
-        function zenith_angle(
-            t,
-            start_date;
-            latitude = lat,
-            longitude = long,
-            insol_params = earth_param_set.insol_params,
-        )
-            current_datetime = start_date + Dates.Second(round(t))
-            d, δ, η_UTC =
-                FT.(
-                    Insolation.helper_instantaneous_zenith_angle(
-                        current_datetime,
-                        start_date,
-                        insol_params,
-                    )
-                )
-            return Insolation.instantaneous_zenith_angle(
-                d,
-                δ,
-                η_UTC,
-                longitude,
-                latitude,
-            )[1]
-        end
+        zenith_angle =
+            (t, s) -> default_zenith_angle(
+                t,
+                s;
+                insol_params = earth_param_set.insol_params,
+                latitude = lat,
+                longitude = long,
+            )
+
 
         function shortwave_radiation(
             t;
@@ -948,7 +903,6 @@ end
         P_atmos = t -> 1e5 # Pa
         h_atmos = h_int # m
         c_atmos = (t) -> 4.11e-4 # mol/mol
-        start_date = DateTime(2005)
         atmos = PrescribedAtmosphere(
             TimeVaryingInput(liquid_precip),
             TimeVaryingInput(snow_precip),
@@ -1261,31 +1215,16 @@ end
             )
             lat = FT(0.0) # degree
             long = FT(-180) # degree
+            start_date = DateTime(2005)
 
-            function zenith_angle(
-                t,
-                start_date;
-                latitude = lat,
-                longitude = long,
-                insol_params = earth_param_set.insol_params,
-            )
-                current_datetime = start_date + Dates.Second(round(t))
-                d, δ, η_UTC =
-                    FT.(
-                        Insolation.helper_instantaneous_zenith_angle(
-                            current_datetime,
-                            start_date,
-                            insol_params,
-                        )
-                    )
-                return Insolation.instantaneous_zenith_angle(
-                    d,
-                    δ,
-                    η_UTC,
-                    longitude,
-                    latitude,
-                )[1]
-            end
+            zenith_angle =
+                (t, s) -> default_zenith_angle(
+                    t,
+                    s;
+                    insol_params = earth_param_set.insol_params,
+                    latitude = lat,
+                    longitude = long,
+                )
 
             function shortwave_radiation(
                 t;
@@ -1309,7 +1248,6 @@ end
             P_atmos = t -> 1e5 # Pa
             h_atmos = h_int # m
             c_atmos = (t) -> 4.11e-4 # mol/mol
-            start_date = DateTime(2005)
             atmos = PrescribedAtmosphere(
                 TimeVaryingInput(liquid_precip),
                 TimeVaryingInput(snow_precip),

--- a/test/standalone/Vegetation/conservation.jl
+++ b/test/standalone/Vegetation/conservation.jl
@@ -34,30 +34,15 @@ for FT in (Float32, Float64)
     "Radiation"
     SW_d = TimeVaryingInput((t) -> eltype(t)(20.0))
     LW_d = TimeVaryingInput((t) -> eltype(t)(20.0))
-    function zenith_angle(
-        t,
-        start_date;
-        latitude = FT(40.0),
-        longitude = FT(-120.0),
-        insol_params = earth_param_set.insol_params,
-    )
-        current_datetime = start_date + Dates.Second(round(t))
-        d, δ, η_UTC =
-            FT.(
-                Insolation.helper_instantaneous_zenith_angle(
-                    current_datetime,
-                    start_date,
-                    insol_params,
-                )
-            )
-        return Insolation.instantaneous_zenith_angle(
-            d,
-            δ,
-            η_UTC,
-            longitude,
-            latitude,
-        )[1]
-    end
+    zenith_angle =
+        (t, s) -> default_zenith_angle(
+            t,
+            s;
+            insol_params = earth_param_set.insol_params,
+            latitude = FT(40.0),
+            longitude = FT(-120.0),
+        )
+
     rad = PrescribedRadiativeFluxes(
         FT,
         SW_d,

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -138,31 +138,17 @@ for FT in (Float32, Float64)
         )
         lat = FT(0.0) # degree
         long = FT(-180) # degree
+        start_date = DateTime(2005)
 
-        function zenith_angle(
-            t,
-            start_date;
-            latitude = lat,
-            longitude = long,
-            insol_params = earth_param_set.insol_params,
-        )
-            current_datetime = start_date + Dates.Second(round(t))
-            d, δ, η_UTC =
-                FT.(
-                    Insolation.helper_instantaneous_zenith_angle(
-                        current_datetime,
-                        start_date,
-                        insol_params,
-                    )
-                )
-            return Insolation.instantaneous_zenith_angle(
-                d,
-                δ,
-                η_UTC,
-                longitude,
-                latitude,
-            )[1]
-        end
+        zenith_angle =
+            (t, s) -> default_zenith_angle(
+                t,
+                s;
+                insol_params = earth_param_set.insol_params,
+                latitude = lat,
+                longitude = long,
+            )
+
 
         function shortwave_radiation(
             t;
@@ -186,7 +172,6 @@ for FT in (Float32, Float64)
         P_atmos = t -> 1e5 # Pa
         h_atmos = h_int # m
         c_atmos = (t) -> 4.11e-4 # mol/mol
-        start_date = DateTime(2005)
         atmos = PrescribedAtmosphere(
             TimeVaryingInput(liquid_precip),
             TimeVaryingInput(snow_precip),
@@ -433,31 +418,16 @@ for FT in (Float32, Float64)
         )
         lat = FT(0.0) # degree
         long = FT(-180) # degree
+        start_date = DateTime(2005)
 
-        function zenith_angle(
-            t,
-            start_date;
-            latitude = lat,
-            longitude = long,
-            insol_params = earth_param_set.insol_params,
-        )
-            current_datetime = start_date + Dates.Second(round(t))
-            d, δ, η_UTC =
-                FT.(
-                    Insolation.helper_instantaneous_zenith_angle(
-                        current_datetime,
-                        start_date,
-                        insol_params,
-                    )
-                )
-            return Insolation.instantaneous_zenith_angle(
-                d,
-                δ,
-                η_UTC,
-                longitude,
-                latitude,
-            )[1]
-        end
+        zenith_angle =
+            (t, s) -> default_zenith_angle(
+                t,
+                s;
+                insol_params = earth_param_set.insol_params,
+                latitude = lat,
+                longitude = long,
+            )
 
         function shortwave_radiation(
             t;
@@ -481,7 +451,6 @@ for FT in (Float32, Float64)
         P_atmos = t -> 1e5 # Pa
         h_atmos = h_int # m
         c_atmos = (t) -> 4.11e-4 # mol/mol
-        start_date = DateTime(2005)
         atmos = PrescribedAtmosphere(
             TimeVaryingInput(liquid_precip),
             TimeVaryingInput(snow_precip),


### PR DESCRIPTION
Related coupler [PR](https://github.com/CliMA/ClimaCoupler.jl/pull/1330)


`p.drivers.cos\thetas` is currently updated by the coupler
when using `CoupledRadiativeFluxes`.

This commit updates the value in `update_drivers!` instead.
To do this, the commit changes `CoupledRadiativeFluxes`
to contain a function that calculates zenith angle in radians
given time from sim start date and sim start date.

This adds an additional constructor for `CoupledRadiativeFluxes`,
which takes in a start date, latitude, and longitude
(and optionally insolation params), and
returns a struct with a zenith calculation function that uses
Insolation.jl to compute zenith angle for the provided lat and lon.

The default function used to compute the zenith angle
also replaces the duplicate defintions of `zenith_function`
used with `PrescribedRadiativeFluxes` and `prescribed_forcing_era5`.

Backwards compatibilty with ClimaCoupler is preserved.


Additionally, this PR fixes a minor bug in the `DriverUpdateCallback`, which happens when the simulation steps beyond the last time in the `updateat` vector.





<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Alongside changes to the coupler, this will close [issue](https://github.com/CliMA/ClimaCoupler.jl/issues/1260)


## To-do

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
