### PR TITLE
Bump ClimaLandSimulationsCI ubuntu

### DIFF
--- a/.github/workflows/ClimaLandSimulations.yml
+++ b/.github/workflows/ClimaLandSimulations.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   lib-climalandsimulations:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     strategy:
       matrix:


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
ClimaLandSimulations CI has not been running because it uses the Ubuntu 20.04 Actions runner, which is 
no longer supported. 

This PR bumps the ubuntu runner to `ubuntu-22.04`, but we could also use `ubuntu-24.04` or `ubuntu-latest`.
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
