### PR TITLE
Set default snow parameters to calibrated values

### DIFF
--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -169,7 +169,7 @@ function setup_prob(
     SAI = FT(0.0) # m2/m2
     f_root_to_shoot = FT(3.5)
     RAI = FT(1.0)
-    K_sat_plant = FT(7e-8) # m/s 
+    K_sat_plant = FT(7e-8) # m/s
     ψ63 = FT(-4 / 0.0098) # / MPa to m
     Weibull_param = FT(4) # unitless
     a = FT(0.2 * 0.0098) # 1/m
@@ -316,11 +316,11 @@ function setup_prob(
     #    α_snow = Snow.ConstantAlbedoModel(FT(0.7))
     # Set β = 0 in order to regain model without density dependence
     α_snow = Snow.ZenithAngleAlbedoModel(
-        FT(0.64),
-        FT(0.06),
-        FT(2);
-        β = FT(0.4),
-        x0 = FT(0.2),
+        FT(0.7899), # Calibrated
+        FT(0.06575), # Calibrated
+        FT(17.92); # Calibrated
+        β = FT(0.7875), # Calibrated
+        x0 = FT(0.1046), # Calibrated
     )
     horz_degree_res =
         sum(ClimaLand.Domains.average_horizontal_resolution_degrees(domain)) / 2 # mean of resolution in latitude and longitude, in degrees

--- a/src/standalone/Snow/Snow.jl
+++ b/src/standalone/Snow/Snow.jl
@@ -83,12 +83,12 @@ end
     AbstractAlbedoModel{FT}
 
 Defines the model type for albedo parameterization
-for use within an `AbstractSnowModel` type. 
+for use within an `AbstractSnowModel` type.
 
-These parameterizations are stored in parameters.α_snow, and 
+These parameterizations are stored in parameters.α_snow, and
 are used to update the value of p.snow.α_snow (the broadband
 albedo of the snow at a point).
-stored 
+stored
 """
 abstract type AbstractAlbedoModel{FT <: AbstractFloat} end
 
@@ -110,8 +110,8 @@ Establishes the albedo parameterization where albedo
 depends on the cosine of the zenith angle of the sun, as
     α = f(x) * [α_0 + Δα*exp(-k*cos(θs))],
 
-where cos θs is the cosine of the zenith angle, α_0, Δα, and k 
-are free parameters. The factor out front is a function of 
+where cos θs is the cosine of the zenith angle, α_0, Δα, and k
+are free parameters. The factor out front is a function of
 x = ρ_snow/ρ_liq, of the form f(x) = min(1 - β(x-x0), 1). The parameters
 x0 ∈ [0,1] and β ∈ [0,1] are free. Choose β = 0 to remove this dependence on snow density.
 
@@ -136,8 +136,8 @@ function ZenithAngleAlbedoModel(
     α_0::FT,
     Δα::FT,
     k::FT;
-    β = FT(0),
-    x0 = FT(0.2),
+    β = FT(0.7875), # Calibrated value
+    x0 = FT(0.1046), # Calibrated value
 ) where {FT}
     @assert 0 ≤ x0 ≤ 1
     @assert 0 ≤ β ≤ 1
@@ -148,9 +148,9 @@ end
     AbstractSnowCoverFractionModel{FT}
 
 Defines the model type for snow cover parameterization
-for use within an `AbstractSnowModel` type. 
+for use within an `AbstractSnowModel` type.
 
-These parameterizations are stored in parameters.scf, and 
+These parameterizations are stored in parameters.scf, and
 are used to update the value of p.snow.snow_cover_fraction.
 """
 abstract type AbstractSnowCoverFractionModel{FT <: AbstractFloat} end
@@ -158,7 +158,7 @@ abstract type AbstractSnowCoverFractionModel{FT <: AbstractFloat} end
 """
     WuWuSnowCoverFractionModel{FT <: AbstractFloat} <: AbstractSnowCoverFractionModel{FT}
 
-Establishes the snow cover parameterization of Wu, Tongwen, and 
+Establishes the snow cover parameterization of Wu, Tongwen, and
 Guoxiong Wu. "An empirical formula to compute
 snow cover fraction in GCMs." Advances in Atmospheric Sciences
 21 (2004): 529-535,
@@ -171,7 +171,7 @@ horizontal resolution of the simulation, in degrees, and β0, β_min and γ
 are unitless. It is correct to think of β0, β_min, γ, and z0 as the free
 parameters, while horz_degree_res is provided and β_scf is determined.
 
-β0, β_min, γ, and β_scf must be > 0. 
+β0, β_min, γ, and β_scf must be > 0.
 
 From Wu and Wu et al, β0 ∼ 1.77 and γ ∼ 0.08, over a range of 1.5-4.5∘
 """
@@ -293,7 +293,11 @@ function SnowParameters{FT}(
     density::DM = MinimumDensityModel(FT(200)),
     z_0m = FT(0.0024),
     z_0b = FT(0.00024),
-    α_snow::AM = ConstantAlbedoModel(FT(0.8)),
+    α_snow::AM = ZenithAngleAlbedoModel(
+                                        FT(0.7899), # Calibrated α_0
+                                        FT(0.06575), # Calibrated Δα
+                                        FT(17.92), # Calibrated k
+                                       ), # β and x0 default values are calibrated as well
     ϵ_snow = FT(0.99),
     θ_r = FT(0.08),
     Ksat = FT(1e-3),


### PR DESCRIPTION
This commit sets alpha_0, Delta_alpha, k, beta,
and x0 to calibrated values in src/standalone/Snow/Snow.jl and experiments/long_runs/snowy_land.jl.