### PR TITLE
make bc and sources default for soilco2

### DIFF
--- a/docs/tutorials/integrated/soil_canopy_tutorial.jl
+++ b/docs/tutorials/integrated/soil_canopy_tutorial.jl
@@ -173,24 +173,9 @@ soil_model_type = Soil.EnergyHydrology{FT}
 # to understand the parameterisation.
 # The domain is defined similarly to the soil domain described above.
 soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
-
 soilco2_ps = SoilCO2ModelParameters(FT);
-
-# soil microbes args
 Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
-
-soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
-soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> 0.0);
-soilco2_sources = (MicrobeProduction{FT}(),);
-
-soilco2_boundary_conditions = (; top = soilco2_top_bc, bottom = soilco2_bot_bc);
-
-soilco2_args = (;
-    boundary_conditions = soilco2_boundary_conditions,
-    sources = soilco2_sources,
-    domain = soil_domain,
-    parameters = soilco2_ps,
-);
+soilco2_args = (; domain = soil_domain, parameters = soilco2_ps)
 
 # Next we need to set up the [`CanopyModel`](https://clima.github.io/ClimaLand.jl/dev/APIs/canopy/Canopy/#Canopy-Model-Structs).
 # For more details on the specifics of this model see the previous tutorial.

--- a/experiments/benchmarks/snowy_land.jl
+++ b/experiments/benchmarks/snowy_land.jl
@@ -186,31 +186,15 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     z0_m = FT(0.13) * h_canopy
     z0_b = FT(0.1) * z0_m
 
-    soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
-
     soil_args = (domain = domain, parameters = soil_params)
     soil_model_type = Soil.EnergyHydrology{FT}
 
     # Soil microbes model
     soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
-
-    # soil microbes args
+    soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
     Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
 
-    # Set the soil CO2 BC to being atmospheric CO2
-    soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
-    soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2FluxBC((p, t) -> 0.0) # no flux
-    soilco2_sources = (Soil.Biogeochemistry.MicrobeProduction{FT}(),)
-
-    soilco2_boundary_conditions =
-        (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
-
-    soilco2_args = (;
-        boundary_conditions = soilco2_boundary_conditions,
-        sources = soilco2_sources,
-        domain = domain,
-        parameters = soilco2_ps,
-    )
+    soilco2_args = (; domain = domain, parameters = soilco2_ps)
 
     # Now we set up the canopy model, which we set up by component:
     # Component Types

--- a/experiments/calibration/forward_model_land.jl
+++ b/experiments/calibration/forward_model_land.jl
@@ -202,31 +202,14 @@ function setup_prob(
     z0_m = FT(0.13) * h_canopy
     z0_b = FT(0.1) * z0_m
 
-    soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
-
     soil_args = (domain = domain, parameters = soil_params)
     soil_model_type = Soil.EnergyHydrology{FT}
 
     # Soil microbes model
     soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
-
-    # soil microbes args
+    soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
     Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
-
-    # Set the soil CO2 BC to being atmospheric CO2
-    soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
-    soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2FluxBC((p, t) -> 0.0) # no flux
-    soilco2_sources = (Soil.Biogeochemistry.MicrobeProduction{FT}(),)
-
-    soilco2_boundary_conditions =
-        (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
-
-    soilco2_args = (;
-        boundary_conditions = soilco2_boundary_conditions,
-        sources = soilco2_sources,
-        domain = domain,
-        parameters = soilco2_ps,
-    )
+    soilco2_args = (; domain = domain, parameters = soilco2_ps)
 
     # Now we set up the canopy model, which we set up by component:
     # Component Types

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -137,24 +137,9 @@ soil_model_type = Soil.EnergyHydrology{FT}
 
 # Soil microbes model
 soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
-
-soilco2_ps = SoilCO2ModelParameters(FT)
-
+soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
 Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
-
-# Set the soil CO2 BC to being atmospheric CO2
-soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
-soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2FluxBC((p, t) -> 0.0) # no flux
-soilco2_sources = (MicrobeProduction{FT}(),)
-
-soilco2_boundary_conditions = (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
-
-soilco2_args = (;
-    boundary_conditions = soilco2_boundary_conditions,
-    sources = soilco2_sources,
-    domain = soil_domain,
-    parameters = soilco2_ps,
-)
+soilco2_args = (; domain = soil_domain, parameters = soilco2_ps)
 
 # Now we set up the canopy model, which we set up by component:
 # Component Types

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -96,24 +96,9 @@ soil_model_type = Soil.EnergyHydrology{FT}
 
 # Soil microbes model
 soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
-
-soilco2_ps = SoilCO2ModelParameters(FT)
-
+soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
 Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
-
-# Set the soil CO2 BC to being atmospheric CO2
-soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
-soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2FluxBC((p, t) -> 0.0) # no flux
-soilco2_sources = (MicrobeProduction{FT}(),)
-
-soilco2_boundary_conditions = (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
-
-soilco2_args = (;
-    boundary_conditions = soilco2_boundary_conditions,
-    sources = soilco2_sources,
-    domain = soil_domain,
-    parameters = soilco2_ps,
-)
+soilco2_args = (; domain = soil_domain, parameters = soilco2_ps)
 
 # Now we set up the canopy model, which we set up by component:
 # Component Types

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -68,23 +68,9 @@ soil_model_type = Soil.EnergyHydrology{FT}
 
 # Soil microbes model
 soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
-
-# soil microbes args
+soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
 Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
-
-# Set the soil CO2 BC to being atmospheric CO2
-soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
-soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2FluxBC((p, t) -> 0.0) # no flux
-soilco2_sources = (Soil.Biogeochemistry.MicrobeProduction{FT}(),)
-
-soilco2_boundary_conditions = (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
-
-soilco2_args = (;
-    boundary_conditions = soilco2_boundary_conditions,
-    sources = soilco2_sources,
-    domain = domain,
-    parameters = soilco2_ps,
-)
+soilco2_args = (; domain = domain, parameters = soilco2_ps)
 
 # Now we set up the canopy model, which we set up by component:
 # Component Types

--- a/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
+++ b/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
@@ -81,25 +81,9 @@ soil_model_type = Soil.EnergyHydrology{FT}
 
 # Soil microbes model
 soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
-
-soilco2_ps = SoilCO2ModelParameters(FT)
-
-# soil microbes args
+soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
 Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
-
-# Set the soil CO2 BC to being atmospheric CO2
-soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
-soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> 0.0)
-soilco2_sources = (MicrobeProduction{FT}(),)
-
-soilco2_boundary_conditions = (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
-
-soilco2_args = (;
-    boundary_conditions = soilco2_boundary_conditions,
-    sources = soilco2_sources,
-    domain = soil_domain,
-    parameters = soilco2_ps,
-)
+soilco2_args = (; domain = soil_domain, parameters = soilco2_ps)
 
 # Now we set up the canopy model, which we set up by component:
 # Component Types

--- a/experiments/integrated/performance/integrated_timestep_test.jl
+++ b/experiments/integrated/performance/integrated_timestep_test.jl
@@ -264,25 +264,9 @@ soil_model_type = Soil.EnergyHydrology{FT}
 
 # Soil microbes model
 soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
-
-soilco2_ps = SoilCO2ModelParameters(FT)
-
-# soil microbes args
+soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
 Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
-
-# Set the soil CO2 BC to being atmospheric CO2
-soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
-soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2StateBC((p, t) -> 0.0)
-soilco2_sources = (MicrobeProduction{FT}(),)
-
-soilco2_boundary_conditions = (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
-
-soilco2_args = (;
-    boundary_conditions = soilco2_boundary_conditions,
-    sources = soilco2_sources,
-    domain = soil_domain,
-    parameters = soilco2_ps,
-)
+soilco2_args = (; domain = soil_domain, parameters = soilco2_ps)
 
 # Now we set up the canopy model, which we set up by component:
 # Component Types

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -182,32 +182,15 @@ function setup_prob(
     z0_m = FT(0.13) * h_canopy
     z0_b = FT(0.1) * z0_m
 
-
-    soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
-
     soil_args = (domain = domain, parameters = soil_params)
     soil_model_type = Soil.EnergyHydrology{FT}
 
     # Soil microbes model
     soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
-
-    # soil microbes args
+    soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
     Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
 
-    # Set the soil CO2 BC to being atmospheric CO2
-    soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
-    soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2FluxBC((p, t) -> 0.0) # no flux
-    soilco2_sources = (Soil.Biogeochemistry.MicrobeProduction{FT}(),)
-
-    soilco2_boundary_conditions =
-        (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
-
-    soilco2_args = (;
-        boundary_conditions = soilco2_boundary_conditions,
-        sources = soilco2_sources,
-        domain = domain,
-        parameters = soilco2_ps,
-    )
+    soilco2_args = (; domain = domain, parameters = soilco2_ps)
 
     # Now we set up the canopy model, which we set up by component:
     # Component Types

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -192,31 +192,15 @@ function setup_prob(
     z0_m = FT(0.13) * h_canopy
     z0_b = FT(0.1) * z0_m
 
-    soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
-
     soil_args = (domain = domain, parameters = soil_params)
     soil_model_type = Soil.EnergyHydrology{FT}
 
     # Soil microbes model
     soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
-
-    # soil microbes args
+    soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
     Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
 
-    # Set the soil CO2 BC to being atmospheric CO2
-    soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
-    soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2FluxBC((p, t) -> 0.0) # no flux
-    soilco2_sources = (Soil.Biogeochemistry.MicrobeProduction{FT}(),)
-
-    soilco2_boundary_conditions =
-        (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
-
-    soilco2_args = (;
-        boundary_conditions = soilco2_boundary_conditions,
-        sources = soilco2_sources,
-        domain = domain,
-        parameters = soilco2_ps,
-    )
+    soilco2_args = (; domain = domain, parameters = soilco2_ps)
 
     # Now we set up the canopy model, which we set up by component:
     # Component Types

--- a/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
+++ b/lib/ClimaLandSimulations/src/Fluxnet/run_fluxnet.jl
@@ -67,20 +67,7 @@ function run_fluxnet(
 
     # soil microbes args
     Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
-
-    soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
-    soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2FluxBC((p, t) -> 0.0) # no flux
-    soilco2_sources = (MicrobeProduction{FT}(),)
-
-    soilco2_boundary_conditions =
-        (; top = soilco2_top_bc, bottom = CO2 = soilco2_bot_bc)
-
-    soilco2_args = (;
-        boundary_conditions = soilco2_boundary_conditions,
-        sources = soilco2_sources,
-        domain = soil_domain,
-        parameters = soilco2_ps,
-    )
+    soilco2_args = (; domain = soil_domain, parameters = soilco2_ps)
 
     # Now we set up the canopy model, which we set up by component:
     # Component Types

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -170,7 +170,19 @@ function LandModel{FT}(;
         soil_organic_carbon,
         atmos,
     )
-    soilco2 = soilco2_type(; soilco2_args..., drivers = soilco2_drivers)
+    # Set the soil CO2 BC to being atmospheric CO2
+    soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
+    soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2FluxBC((p, t) -> 0.0) # no flux
+    soilco2_sources = (Soil.Biogeochemistry.MicrobeProduction{FT}(),)
+
+    soilco2_boundary_conditions =
+        (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
+    soilco2 = soilco2_type(;
+        boundary_conditions = soilco2_boundary_conditions,
+        sources = soilco2_sources,
+        soilco2_args..., # adds domain, params
+        drivers = soilco2_drivers,
+    )
 
     args = (soilco2, soil, canopy, snow)
     return LandModel{FT, typeof.(args)...}(args...)

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -146,7 +146,19 @@ function SoilCanopyModel{FT}(;
         soil_organic_carbon,
         atmos,
     )
-    soilco2 = soilco2_type(; soilco2_args..., drivers = soilco2_drivers)
+    # Set the soil CO2 BC to being atmospheric CO2
+    soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
+    soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2FluxBC((p, t) -> 0.0) # no flux
+    soilco2_sources = (Soil.Biogeochemistry.MicrobeProduction{FT}(),)
+
+    soilco2_boundary_conditions =
+        (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
+    soilco2 = soilco2_type(;
+        boundary_conditions = soilco2_boundary_conditions,
+        sources = soilco2_sources,
+        soilco2_args...,
+        drivers = soilco2_drivers,
+    )
 
     return SoilCanopyModel{FT, typeof(soilco2), typeof(soil), typeof(canopy)}(
         soilco2,

--- a/test/integrated/full_land_utils.jl
+++ b/test/integrated/full_land_utils.jl
@@ -160,31 +160,14 @@ function global_land_model(
     z0_m = FT(0.13) * h_canopy
     z0_b = FT(0.1) * z0_m
 
-    soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
-
     soil_args = (domain = domain, parameters = soil_params)
     soil_model_type = Soil.EnergyHydrology{FT}
 
     # Soil microbes model
     soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
-
-    # soil microbes args
+    soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
     Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
-
-    # Set the soil CO2 BC to being atmospheric CO2
-    soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
-    soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2FluxBC((p, t) -> 0.0) # no flux
-    soilco2_sources = (Soil.Biogeochemistry.MicrobeProduction{FT}(),)
-
-    soilco2_boundary_conditions =
-        (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
-
-    soilco2_args = (;
-        boundary_conditions = soilco2_boundary_conditions,
-        sources = soilco2_sources,
-        domain = domain,
-        parameters = soilco2_ps,
-    )
+    soilco2_args = (; domain = domain, parameters = soilco2_ps)
 
     # Now we set up the canopy model, which we set up by component:
     # Component Types

--- a/test/integrated/soil_canopy_lsm.jl
+++ b/test/integrated/soil_canopy_lsm.jl
@@ -56,18 +56,13 @@ for FT in (Float32, Float64)
             z_0b = FT(0),
         )
         soil_args = (domain = domain, parameters = soil_params)
-        soilco2_top_bc = Soil.Biogeochemistry.AtmosCO2StateBC()
-        soilco2_bot_bc = Soil.Biogeochemistry.SoilCO2FluxBC((p, t) -> 0.0) # no flux
-        soilco2_sources = ()
-        soilco2_boundary_conditions =
-            (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
-        soilco2_ps = SoilCO2ModelParameters(FT; D_ref = FT(0.0))
-        soilco2_args = (;
-            boundary_conditions = soilco2_boundary_conditions,
-            sources = soilco2_sources,
-            domain = domain,
-            parameters = soilco2_ps,
+
+        soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
+        Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(
+            TimeVaryingInput((t) -> 5),
         )
+        soilco2_args = (; domain = domain, parameters = soilco2_ps)
+
         canopy_component_types = (;
             autotrophic_respiration = Canopy.AutotrophicRespirationModel{FT},
             radiative_transfer = Canopy.TwoStreamModel{FT},


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
In our land models (soilco2 + canopy +soil or soilco2 + canopy+soil+snow), we always run with atmospheric forcing, and we set up the boundary conditions/fluxes for the components in the LandModel constructor. This PR makes it so that we do the same for soilco2.

This removes some flexibility, but it does not make sense to change the BC for soil co2 from what we already set it to be in every example. Moving it to the constructor makes sense.

Furthermore, we always specify the same source for soilco2, and it doesnt make sense to run without this source, so this PR also moves that to the constructor.

This is useful for simplifying our LandModel setup. Now every component model takes in as external args the domain and their own parameters.
## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
