### PR TITLE
Add calibration job script example for slurm

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.4"
+julia_version = "1.11.5"
 manifest_format = "2.0"
-project_hash = "9186e81be1f5f72e1c1d7b9ef497374042fd12b7"
+project_hash = "c057205b5dfa45d173ab89f45dff9c1d2ab4a915"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "e2478490447631aedba0823d4d7a80b2cc8cdb32"
@@ -416,9 +416,9 @@ weakdeps = ["GeoMakie", "Makie"]
 
 [[deps.ClimaCalibrate]]
 deps = ["Dates", "Distributed", "Distributions", "EnsembleKalmanProcesses", "JLD2", "Logging", "Random", "TOML", "YAML"]
-git-tree-sha1 = "bb3ea48fed2c573027a006b0dae226297242c227"
+git-tree-sha1 = "572016a5f80ff774d188039512fb1121b3c469be"
 uuid = "4347a170-ebd6-470c-89d3-5c705c0cacc2"
-version = "0.0.16"
+version = "0.1.0"
 
     [deps.ClimaCalibrate.extensions]
     CESExt = "CalibrateEmulateSample"
@@ -2230,7 +2230,7 @@ version = "2.5.4+0"
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
-version = "0.8.1+4"
+version = "0.8.5+0"
 
 [[deps.OpenMPI_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML", "Zlib_jll"]

--- a/.buildkite/Project.toml
+++ b/.buildkite/Project.toml
@@ -46,7 +46,7 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
 ClimaAnalysis = "0.5.17"
-ClimaCalibrate = "0.0.16"
+ClimaCalibrate = "0.1"
 ClimaDiagnostics = "0.2.13"
 ClimaTimeSteppers = "0.7, 0.8"
 EnsembleKalmanProcesses = "2.4.1"

--- a/experiments/calibration/forward_model_bucket.jl
+++ b/experiments/calibration/forward_model_bucket.jl
@@ -1,5 +1,6 @@
 import SciMLBase
 import ClimaComms
+ENV["CLIMACOMMS_CONTEXT"] = "SINGLETON"
 ClimaComms.@import_required_backends
 import ClimaTimeSteppers as CTS
 using ClimaCore

--- a/experiments/calibration/slurm_calibration.sh
+++ b/experiments/calibration/slurm_calibration.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#SBATCH --job-name=slurm_calibration
+#SBATCH --output=output.txt
+#SBATCH --error=error.txt
+#SBATCH --time=12:00:00
+#SBATCH --ntasks=5
+#SBATCH --cpus-per-task=4
+#SBATCH --gpus-per-task=1
+
+# Set environment variables for CliMA
+export CLIMACOMMS_DEVICE="CUDA"
+export CLIMACOMMS_CONTEXT="SINGLETON"
+
+# Build and run the Julia code
+module load climacommon
+julia --project=.buildkite -e 'using Pkg; Pkg.instantiate(;verbose=true)'
+julia --project=.buildkite/ experiments/calibration/calibrate_land.jl


### PR DESCRIPTION
Content
- Added slurm script for calibration `experiments/calibration/slurm_calibration.sh` and tested it on `clima`
- Updated documentation
- Updated to ClimaCalibrate v0.1
- Set calibration to use bucket and shf/lhf diagnostics