### PR TITLE
Update drivers more frequently, use default output, add report to soil long run

### DIFF
--- a/experiments/benchmarks/bucket.jl
+++ b/experiments/benchmarks/bucket.jl
@@ -147,7 +147,7 @@ function setup_prob(t0, tf, Δt; nelements = (200, 7))
         (t0, tf),
         p,
     )
-    updateat = collect(t0:(3Δt):tf)
+    updateat = collect(t0:Δt:tf)
     drivers = ClimaLand.get_drivers(model)
     updatefunc = ClimaLand.make_update_drivers(drivers)
     driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)

--- a/experiments/benchmarks/richards.jl
+++ b/experiments/benchmarks/richards.jl
@@ -186,7 +186,7 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
         (t0, tf),
         p,
     )
-    updateat = Array(t0:(2Δt):tf)
+    updateat = collect(t0:Δt:tf)
     drivers = ClimaLand.get_drivers(model)
     updatefunc = ClimaLand.make_update_drivers(drivers)
     driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)

--- a/experiments/benchmarks/snowy_land.jl
+++ b/experiments/benchmarks/snowy_land.jl
@@ -375,7 +375,7 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
         p,
     )
 
-    updateat = Array(t0:(3600 * 3):tf)
+    updateat = collect(t0:Δt:tf)
     drivers = ClimaLand.get_drivers(land)
     updatefunc = ClimaLand.make_update_drivers(drivers)
 

--- a/experiments/long_runs/bucket.jl
+++ b/experiments/long_runs/bucket.jl
@@ -125,7 +125,7 @@ function setup_prob(
         p,
     )
 
-    updateat = [promote(t0:(ITime(3600 * 3)):tf...)...]
+    updateat = collect(t0:Δt:tf)
     drivers = ClimaLand.get_drivers(bucket)
     updatefunc = ClimaLand.make_update_drivers(drivers)
 
@@ -137,7 +137,6 @@ function setup_prob(
         subsurface_space,
         outdir;
         start_date,
-        num_points = (570, 285, 50),
     )
 
     diags = ClimaLand.default_diagnostics(

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -410,7 +410,7 @@ function setup_prob(
         p,
     )
 
-    updateat = [promote(t0:(ITime(3600 * 3)):tf...)...]
+    updateat = collect(t0:Δt:tf)
     drivers = ClimaLand.get_drivers(land)
     updatefunc = ClimaLand.make_update_drivers(drivers)
 
@@ -422,7 +422,6 @@ function setup_prob(
         subsurface_space,
         outdir;
         start_date,
-        num_points = (570, 285, 15),
     )
 
     diags = ClimaLand.default_diagnostics(

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -193,6 +193,7 @@ function setup_prob(
     drivers = ClimaLand.get_drivers(soil)
     updatefunc = ClimaLand.make_update_drivers(drivers)
 
+    # This prints the estimated SYPD, time remaining, of the simulation
     walltime_info = WallTimeInfo()
     every1000steps(u, t, integrator) = mod(integrator.step, 1000) == 0
     report = let wt = walltime_info


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Update the drivers every step
use default diagnostics output
add wall report to long run
use same IC in snowy_land and regional run

SYPD is lower for the snowy land (e.g. 50 vs 60 at the end)
https://buildkite.com/clima/climaland-long-runs/builds/3967

The benchmarks are a little less clear:
this PR: 1.21 for Richards, 1.38 for snowy land
current main: https://buildkite.com/clima/climaland-benchmark/builds/3237 0.927 (Richards) 1.43 (snowy land)
Best performance seen (April 24): https://buildkite.com/clima/climaland-benchmark/builds/3225 (0.622 Richards, 0.88 snow land) after performance improvements and ClimaCore 0.14.31)
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
