### PR TITLE
Use EKP.ObservationSeries.metadata

### DIFF
--- a/.buildkite/Project.toml
+++ b/.buildkite/Project.toml
@@ -46,9 +46,9 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
 ClimaAnalysis = "0.5.17"
-ClimaTimeSteppers = "0.7, 0.8"
+ClimaCalibrate = "0.0.16"
 ClimaDiagnostics = "0.2.13"
-ClimaCalibrate = "0.0.15"
+ClimaTimeSteppers = "0.7, 0.8"
 EnsembleKalmanProcesses = "2.4.1"
 Flux = "0.15"
 Statistics = "1"

--- a/experiments/calibration/observationseries_era5.jl
+++ b/experiments/calibration/observationseries_era5.jl
@@ -161,7 +161,7 @@ obs_y = [
                     "covariances" => LinearAlgebra.Diagonal(
                         results[:seasonal_vars][var_name][i],
                     ),
-                    "names" => "$(var)_$(lon)_$(lat)_$(y)",
+                    "names" => "$(var_name)_$(lon)_$(lat)_$(y)",
                 ),
             ) for var_name in variable_list
         ]) for (i, (lon, lat)) in enumerate(training_locations)
@@ -182,7 +182,14 @@ function create_minibatches(obs_y, valid_years; m_size = 1)
         [collect(((i - 1) * m_size + 1):(i * m_size)) for i in 1:n_samples]
     minibatcher = EKP.FixedMinibatcher(given_batches)
     o_names = [string(y) for y in valid_years]
-    observationseries = EKP.ObservationSeries(obs_y, minibatcher, o_names)
+    observationseries = EKP.ObservationSeries(
+        Dict(
+            "observations" => obs_y,
+            "minibatcher" => minibatcher,
+            "names" => o_names,
+            "metadata" => [prior, variable_list, training_locations],
+        ),
+    )
     return observationseries
 end
 


### PR DESCRIPTION
Save prior, variable_list and training_locations in
observationseries metadata. This is helpful to not have
to load these files separately to explore results.
It also ensure the right prior and variable_list is used.