### PR TITLE
add DSS buffer for npoly > 0 only

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -109,10 +109,14 @@ steps:
         command: "julia --color=yes --project=.buildkite experiments/standalone/Soil/water_energy_conservation.jl"
         artifact_paths: "experiments/standalone/Soil/water_energy_conservation/output_active/*full_soil_*png"
 
-      - label: "Global Run CPU"
-        command: "julia --color=yes --project=.buildkite experiments/integrated/global/global_soil_canopy.jl"
+      - label: "Global Run CPU MPI"
+        command: "srun julia --color=yes --project=.buildkite experiments/integrated/global/global_soil_canopy.jl"
         artifact_paths: "experiments/integrated/global/output_active/*png"
+        env:
+          CLIMACOMMS_CONTEXT: "MPI"
         agents:
+          slurm_ntasks_per_node: 4
+          slurm_nodes: 1
           slurm_mem: 16G
 
       - label: "Canopy Implicit Stepping CPU"

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -244,18 +244,20 @@ sol = ClimaComms.@time ClimaComms.device() SciMLBase.solve(
 )
 
 # ClimaAnalysis
-simdir = ClimaAnalysis.SimDir(outdir)
+if ClimaComms.iamroot(context)
+    simdir = ClimaAnalysis.SimDir(outdir)
 
-for short_name in ClimaAnalysis.available_vars(simdir)
-    var = get(simdir; short_name)
-    times = var.dims["time"]
-    for t in times
-        fig = CairoMakie.Figure(size = (800, 600))
-        kwargs = ClimaAnalysis.has_altitude(var) ? Dict(:z => 1) : Dict()
-        viz.heatmap2D_on_globe!(
-            fig,
-            ClimaAnalysis.slice(var, time = t; kwargs...),
-        )
-        CairoMakie.save(joinpath(outdir, "$short_name.png"), fig)
+    for short_name in ClimaAnalysis.available_vars(simdir)
+        var = get(simdir; short_name)
+        times = var.dims["time"]
+        for t in times
+            fig = CairoMakie.Figure(size = (800, 600))
+            kwargs = ClimaAnalysis.has_altitude(var) ? Dict(:z => 1) : Dict()
+            viz.heatmap2D_on_globe!(
+                fig,
+                ClimaAnalysis.slice(var, time = t; kwargs...),
+            )
+            CairoMakie.save(joinpath(outdir, "$short_name.png"), fig)
+        end
     end
 end

--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -256,7 +256,7 @@ end
         sfc_cache,
 )
 
-A function which computes the total liquid water volume 
+A function which computes the total liquid water volume
 per unit area and updates
 `surface_field` in place, for the land model `land`, by calling
 the same function for the component models.

--- a/src/shared_utilities/utils.jl
+++ b/src/shared_utilities/utils.jl
@@ -61,10 +61,15 @@ function add_dss_buffer_to_aux(
     p::NamedTuple,
     domain::Union{Domains.Plane, Domains.SphericalSurface},
 )
-    buffer = ClimaCore.Spaces.create_dss_buffer(
-        ClimaCore.Fields.zeros(domain.space.surface),
-    )
-    return merge(p, (; dss_buffer_2d = buffer))
+    # With npolynomial = 0, we don't need DSS (and DSS will fail with MPI)
+    if domain.npolynomial == 0
+        return p
+    else
+        buffer = ClimaCore.Spaces.create_dss_buffer(
+            ClimaCore.Fields.zeros(domain.space.surface),
+        )
+        return merge(p, (; dss_buffer_2d = buffer))
+    end
 end
 
 """
@@ -87,13 +92,21 @@ function add_dss_buffer_to_aux(
     p::NamedTuple,
     domain::Union{Domains.HybridBox, Domains.SphericalShell},
 )
-    buffer_2d = ClimaCore.Spaces.create_dss_buffer(
-        ClimaCore.Fields.zeros(domain.space.surface),
-    )
-    buffer_3d = ClimaCore.Spaces.create_dss_buffer(
-        ClimaCore.Fields.zeros(domain.space.subsurface),
-    )
-    return merge(p, (; dss_buffer_3d = buffer_3d, dss_buffer_2d = buffer_2d))
+    # With npolynomial = 0, we don't need DSS (and DSS will fail with MPI)
+    if domain.npolynomial == 0
+        return p
+    else
+        buffer_2d = ClimaCore.Spaces.create_dss_buffer(
+            ClimaCore.Fields.zeros(domain.space.surface),
+        )
+        buffer_3d = ClimaCore.Spaces.create_dss_buffer(
+            ClimaCore.Fields.zeros(domain.space.subsurface),
+        )
+        return merge(
+            p,
+            (; dss_buffer_3d = buffer_3d, dss_buffer_2d = buffer_2d),
+        )
+    end
 end
 
 

--- a/test/integrated/pond_soil_lsm.jl
+++ b/test/integrated/pond_soil_lsm.jl
@@ -81,27 +81,8 @@ for FT in (Float32, Float64)
 
             if typeof(lsm_domain) <: ClimaLand.HybridBox
                 # test that the dss buffers are correctly added
-                @test propertynames(p) == (
-                    :soil_infiltration,
-                    :soil,
-                    :surface_water,
-                    :dss_buffer_3d,
-                    :dss_buffer_2d,
-                )
-                @test typeof(p.dss_buffer_3d) == typeof(
-                    ClimaCore.Spaces.create_dss_buffer(
-                        ClimaCore.Fields.zeros(
-                            land.soil.domain.space.subsurface,
-                        ),
-                    ),
-                )
-                @test typeof(p.dss_buffer_2d) == typeof(
-                    ClimaCore.Spaces.create_dss_buffer(
-                        ClimaCore.Fields.zeros(
-                            land.surface_water.domain.space.surface,
-                        ),
-                    ),
-                )
+                @test propertynames(p) ==
+                      (:soil_infiltration, :soil, :surface_water)
 
                 land_prognostic_vars = prognostic_vars(land)
                 land_prognostic_types = prognostic_types(land)

--- a/test/shared_utilities/utilities.jl
+++ b/test/shared_utilities/utilities.jl
@@ -141,9 +141,13 @@ end
         ylim = FT.((0.0, 1.0)),
         nelements = (2, 2),
         periodic = (true, true),
+        npolynomial = 1,
     )
-    domain2 =
-        ClimaLand.Domains.SphericalSurface(; radius = FT(2), nelements = 10)
+    domain2 = ClimaLand.Domains.SphericalSurface(;
+        radius = FT(2),
+        nelements = 10,
+        npolynomial = 1,
+    )
 
     domains = (domain1, domain2)
     for domain in domains
@@ -197,11 +201,13 @@ end
         zlim = FT.((0.0, 1.0)),
         nelements = (2, 2, 2),
         periodic = (true, true),
+        npolynomial = 1,
     )
     domain2 = ClimaLand.Domains.SphericalShell(;
         radius = FT(2),
         depth = FT(1.0),
         nelements = (10, 5),
+        npolynomial = 1,
     )
 
     domains = (domain1, domain2)
@@ -247,6 +253,38 @@ end
         @test Y.field == Y_copy.field
         @test Y.subfields.subfield1 == Y_copy.subfields.subfield1
         @test Y.subfields.subfield2 == Y_copy.subfields.subfield2
+    end
+end
+
+@testset "dss! - npolynomial = 0, FT = $FT" begin
+    # Test for Spaces.SpectralElementSpace2D
+    domain1 = ClimaLand.Domains.Plane(;
+        xlim = FT.((0.0, 1.0)),
+        ylim = FT.((0.0, 1.0)),
+        nelements = (2, 2),
+        periodic = (true, true),
+    )
+    domain2 =
+        ClimaLand.Domains.SphericalSurface(; radius = FT(2), nelements = 10)
+    domain3 = ClimaLand.Domains.HybridBox(;
+        xlim = FT.((0.0, 1.0)),
+        ylim = FT.((0.0, 1.0)),
+        zlim = FT.((0.0, 1.0)),
+        nelements = (2, 2, 2),
+        periodic = (true, true),
+    )
+    domain4 = ClimaLand.Domains.SphericalShell(;
+        radius = FT(2),
+        depth = FT(1.0),
+        nelements = (10, 5),
+    )
+
+    domains = (domain1, domain2, domain3, domain4)
+    for domain in domains
+        p = (;)
+        p = ClimaLand.add_dss_buffer_to_aux(p, domain)
+        @test !haskey(p, :dss_buffer_2d)
+        @test !haskey(p, :dss_buffer_3d)
     end
 end
 

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -87,29 +87,6 @@ for FT in (Float32, Float64)
                 :cosθs,
                 :frac_diff,
             )
-            # test if the correct dss buffers were added to aux.
-            # We only need to add a dss buffer when there is a horizontal
-            # space (spectral element space). So, we check that it is added
-            # in the case of the HybridBox and SphericalShell domains,
-            # and check that it is not added in the single column case.
-            if typeof(model.domain) <: Union{
-                ClimaLand.Domains.HybridBox,
-                ClimaLand.Domains.SphericalShell,
-            }
-                @test typeof(p.dss_buffer_3d) == typeof(
-                    ClimaCore.Spaces.create_dss_buffer(
-                        ClimaCore.Fields.zeros(bucket_domain.space.subsurface),
-                    ),
-                )
-                @test typeof(p.dss_buffer_2d) == typeof(
-                    ClimaCore.Spaces.create_dss_buffer(
-                        ClimaCore.Fields.zeros(bucket_domain.space.surface),
-                    ),
-                )
-            else
-                @test propertynames(p) == (:bucket, :drivers)
-            end
-
 
             Y.bucket.T .= init_temp.(coords.subsurface.z, FT(280))
             Y.bucket.W .= 0.0 # no moisture

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -240,7 +240,7 @@ import ClimaParams
             # Check that structure of Y is value (will error if not)
             @test !isnothing(zero(Y))
             @test typeof(canopy.energy) == PrescribedCanopyTempModel{FT}
-            @test propertynames(p) == (:canopy, :dss_buffer_2d, :drivers)
+            @test propertynames(p) == (:canopy, :drivers)
             @test propertynames(p.canopy) == (
                 :hydraulics,
                 :conductance,
@@ -795,7 +795,7 @@ end
 
             # Check that structure of Y is value (will error if not)
             @test !isnothing(zero(Y))
-            @test propertynames(p) == (:canopy, :dss_buffer_2d, :drivers)
+            @test propertynames(p) == (:canopy, :drivers)
             for component in ClimaLand.Canopy.canopy_components(canopy)
                 # Only hydraulics has a prognostic variable
                 if component == :hydraulics

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -363,17 +363,6 @@ for FT in (Float32, Float64)
                 ϑ_l_0 = augmented_liquid_fraction.(plant_ν, S_l)
 
                 Y, p, coords = initialize(model)
-                if typeof(domain) <: ClimaLand.Domains.Point
-                    @test propertynames(p) == (:canopy, :drivers)
-                elseif typeof(domain) <: ClimaLand.Domains.Plane
-                    @test propertynames(p) ==
-                          (:canopy, :dss_buffer_2d, :drivers)
-                    @test typeof(p.dss_buffer_2d) == typeof(
-                        ClimaCore.Spaces.create_dss_buffer(
-                            ClimaCore.Fields.zeros(domain.space.surface),
-                        ),
-                    )
-                end
 
                 dY = similar(Y)
                 for i in 1:(n_stem + n_leaf)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
In ClimaCoupler, our [MPI AMIP run fails](https://buildkite.com/clima/climacoupler-ci/builds/6511#0196b7ce-9284-4827-9e4b-bbe1f7d4ec0e) when we try to add a DSS buffer to the bucket model using a domain with `npolynomial = 0`. It doesn't really make sense to construct a DSS buffer in this case anyway, so here we check that `npolynomial > 0` before adding DSS buffers.

This PR also makes the CPU global run in buildkite run with MPI, so we have one MPI run in CI and can catch issues like this sooner.

## Content
- [x] add dss buffer if `npolynomial != 0`
- [x] make CPU global run in buildkite use MPI