### PR TITLE
Add flat noise weighted by lat to calibration

### DIFF
--- a/.buildkite/Project.toml
+++ b/.buildkite/Project.toml
@@ -46,7 +46,7 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
 ClimaAnalysis = "0.5.17"
-ClimaCalibrate = "0.0.16"
+ClimaCalibrate = "0.1.0"
 ClimaDiagnostics = "0.2.13"
 ClimaTimeSteppers = "0.7, 0.8"
 EnsembleKalmanProcesses = "2.4.1"

--- a/experiments/calibration/calibrate_land.jl
+++ b/experiments/calibration/calibrate_land.jl
@@ -6,9 +6,10 @@ const n_iterations = 10 # 1 iterations takes ~ 1.5 hour with current settings ((
 const spinup_period = Year(1)
 const start_date = DateTime(2008, 12, 01) # this is the start of the forward model spinup
 @assert month(start_date + spinup_period) == 12 "The start of your calibration period should be December."
-const nelements = (50, 15) # resolution - (horizontal elements (lon, lat), vertical elements (soil discretization))
-const dirname = "land_swu_zenith_only" # ideally, describe your calibration in a few words
+const nelements = (75, 15) # resolution - (horizontal elements (lon, lat), vertical elements (soil discretization))
+const dirname = "land_swu_zenith_only_antarctica" # ideally, describe your calibration in a few words
 const caldir = joinpath("/glade/campaign/univ/ucit0011/alexis/", dirname) # you might want to save somewhere else than login
+const flat_noise = 5 # in unit of your variable_list. TODO: make this a vector, same dim as variable_list
 # Don't forget to adjust your priors and forward_model files.
 
 
@@ -73,6 +74,8 @@ end
 # Locations used for calibration (currently all coordinates on land):
 include(joinpath(@__DIR__, "make_training_locations.jl"))
 training_locations = make_training_locations(nelements)
+training_locations = filter(loc -> loc[2] <= -60.0, training_locations) # Antartica only
+
 # potentially we can add regional runs or specific lon lat bands or filter (e.g., regions with snow)
 
 # NOTE: The noise is set in observationseries_era5.jl - adjust if needed.


### PR DESCRIPTION
This commit adds an option at the top level of calibration script to set a flat noise for the error covariance matrix (diagonal). This flat noise is weighted by latitudes, so that poles have higher noise, to avoid overfitting them as they have larger area with the default grid setup.

to do: training_location in calibrate_land.jl is currently set to Antartica only. Remove this before merging this PR.