### PR TITLE
Improve stability of soil model

### DIFF
--- a/src/standalone/Soil/soil_hydrology_parameterizations.jl
+++ b/src/standalone/Soil/soil_hydrology_parameterizations.jl
@@ -113,7 +113,8 @@ A pointwise function returning the volumetric liquid fraction
 given the augmented liquid fraction and the effective porosity.
 """
 function volumetric_liquid_fraction(ϑ_l::FT, ν_eff::FT, θ_r::FT) where {FT}
-    ϑ_l_safe = max(ϑ_l, θ_r + eps(FT))
+    ϑ_l_safe = max(ϑ_l, θ_r + sqrt(eps(FT)))
+    ν_eff = max(ν_eff, θ_r + sqrt(eps(FT)))
     if ϑ_l_safe < ν_eff
         θ_l = ϑ_l_safe
     else
@@ -123,13 +124,14 @@ function volumetric_liquid_fraction(ϑ_l::FT, ν_eff::FT, θ_r::FT) where {FT}
 end
 
 """
-    effective_saturation(porosity::FT, ϑ_l::FT, θr::FT) where {FT}
+    effective_saturation(ν::FT, ϑ_l::FT, θr::FT) where {FT}
 
 A point-wise function computing the effective saturation.
 """
-function effective_saturation(porosity::FT, ϑ_l::FT, θr::FT) where {FT}
-    ϑ_l_safe = max(ϑ_l, θr + eps(FT))
-    S_l = (ϑ_l_safe - θr) / (porosity - θr)
+function effective_saturation(ν::FT, ϑ_l::FT, θr::FT) where {FT}
+    ϑ_l_safe = max(ϑ_l, θr + sqrt(eps(FT)))
+    ν = max(ν, θr + sqrt(eps(FT)))
+    S_l = (ϑ_l_safe - θr) / (ν - θr)
     return S_l
 end
 
@@ -197,7 +199,8 @@ function pressure_head(
     ν_eff::FT,
     S_s::FT,
 ) where {FT}
-    ϑ_l_safe = max(ϑ_l, θ_r + eps(FT))
+    ϑ_l_safe = max(ϑ_l, θ_r + sqrt(eps(FT)))
+    ν_eff = max(ν_eff, θ_r + sqrt(eps(FT)))
     S_l_eff = effective_saturation(ν_eff, ϑ_l_safe, θ_r)
     if S_l_eff <= FT(1.0)
         ψ = matric_potential(cm, S_l_eff)
@@ -214,6 +217,9 @@ Computes and returns the derivative of the pressure head
 with respect to ϑ for the van Genuchten formulation.
 """
 function dψdϑ(cm::vanGenuchten{FT}, ϑ, ν, θ_r, S_s) where {FT}
+    ϑ = max(ϑ, θ_r + sqrt(eps(FT)))
+    ν = max(ν, θ_r + sqrt(eps(FT)))
+
     S = effective_saturation(ν, ϑ, θ_r)
     (; α, m, n) = cm
     if S < 1.0
@@ -294,6 +300,8 @@ Computes and returns the derivative of the pressure head
 with respect to ϑ for the Brooks and Corey formulation.
 """
 function dψdϑ(cm::BrooksCorey{FT}, ϑ, ν, θ_r, S_s) where {FT}
+    ϑ = max(ϑ, θ_r + sqrt(eps(FT)))
+    ν = max(ν, θ_r + sqrt(eps(FT)))
     S = effective_saturation(ν, ϑ, θ_r)
     (; ψb, c) = cm
     if S < 1.0
@@ -347,6 +355,8 @@ function pressure_head(
     ν_eff::FT,
     S_s::FT,
 ) where {FT}
+    ϑ_l = max(ϑ_l, θ_r + sqrt(eps(FT)))
+    ν_eff = max(ν_eff, θ_r + sqrt(eps(FT)))
     S_l_eff = effective_saturation(ν_eff, ϑ_l, θ_r)
     if S_l_eff <= FT(1.0)
         ψ = matric_potential(cm, S_l_eff)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

This fixes the ~80 NaNs appearing in the soil long run, addressing an issue that occurs when the soil is frozen.

Soil is composed of a soil matrix and pore space: the pore space can be filled with water, ice, or gases. The quantities are measured in terms of volumetric fractions: V_x/V_soil. The symbol nu represents the porosity (V_pores/V_soil), while theta_l and theta_i represent the volume of liquid water or ice relative to soil. Neglecting deformation in the soil matrix, the presence of ice, or changes in density, the maximum value of theta_l = nu. We also allow for a "residual" water fraction: theta_r. This is inaccessible water that cannot be frozen or lost, so we have \theta_l \in (theta_r, \nu]. If we used values of theta_l outside this regime or == theta_r in many of our diagnostic functions, we would get domain errors.

The presence of ice adjusts this. In this case, the maximum volumetric fraction of water (neglecting again deformation in the matrix and compressiblity) is nu-theta_i, so \theta_l \in (theta_r, \nu - \theta_i], and we defined \nu-\theta_i as \nu_effective.

One other note: our prognistic variable is the "augmented" liquid fraction, vartheta_l. This extends the definition of theta_l so that we can model, in some way, saturated soils, and vartheta_l can be larger than the non-deformed soil porosity nu.

In our code, we define theta_l as the volumetric liquid fraction:
```
if vartheta_l < nu_eff
    theta_l = vartheta_l # if not saturated, volumetric = augmented liquid fraction
else
    theta_l = nu_eff # if saturated, volumetric = saturation
end
```
since nu_eff < nu this should always give theta_l < nu, so our downstream diagnostic functions should be OK. But, I was seeing examples there vartheta_l > theta_r, but theta_l was not. it turns out that theta_i > nu-theta_r in these cases. I think this could happen because if you take saturated soil, and freeze nu-theta_r of it, the resulting ice will have a larger volume.

So, we need to also clip nu_eff > theta_r. I also do this in the effective saturation function, which must scales theta_l - theta_r by nu - theta_i - theta_r, and which must in (0, 1]