### PR TITLE
Fix bottom boundary condition

### DIFF
--- a/docs/src/APIs/Soil.md
+++ b/docs/src/APIs/Soil.md
@@ -72,6 +72,7 @@ ClimaLand.Soil.HeatFluxBC
 ClimaLand.Soil.WaterFluxBC
 ClimaLand.Soil.TemperatureStateBC
 ClimaLand.Soil.FreeDrainage
+ClimaLand.Soil.EnergyWaterFreeDrainage
 ClimaLand.Soil.RichardsAtmosDrivenFluxBC
 ClimaLand.Soil.AtmosDrivenFluxBC
 ClimaLand.Soil.WaterHeatBC

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -122,13 +122,8 @@ function setup_model(FT, start_date, domain, earth_param_set)
         (:soil,),
     )
     zero_flux = Soil.HeatFluxBC((p, t) -> 0.0)
-    boundary_conditions = (;
-        top = top_bc,
-        bottom = Soil.WaterHeatBC(;
-            water = Soil.FreeDrainage(),
-            heat = zero_flux,
-        ),
-    )
+    boundary_conditions =
+        (; top = top_bc, bottom = Soil.EnergyWaterFreeDrainage())
     soil = soil_model_type(;
         boundary_conditions = boundary_conditions,
         sources = sources,

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -114,13 +114,8 @@ function LandModel{FT}(;
     )
 
     zero_flux = Soil.HeatFluxBC((p, t) -> 0.0)
-    boundary_conditions = (;
-        top = top_bc,
-        bottom = Soil.WaterHeatBC(;
-            water = Soil.FreeDrainage(),
-            heat = zero_flux,
-        ),
-    )
+    boundary_conditions =
+        (; top = top_bc, bottom = Soil.EnergyWaterFreeDrainage())
     soil = soil_model_type(;
         boundary_conditions = boundary_conditions,
         sources = sources,

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -89,13 +89,8 @@ function SoilCanopyModel{FT}(;
         prognostic_land_components,
     )
     zero_flux = Soil.HeatFluxBC((p, t) -> 0.0)
-    boundary_conditions = (;
-        top = top_bc,
-        bottom = Soil.WaterHeatBC(;
-            water = Soil.FreeDrainage(),
-            heat = zero_flux,
-        ),
-    )
+    boundary_conditions =
+        (; top = top_bc, bottom = Soil.EnergyWaterFreeDrainage())
     soil = soil_model_type(;
         boundary_conditions = boundary_conditions,
         sources = sources,

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -10,6 +10,7 @@ using ClimaCore: Geometry
 export TemperatureStateBC,
     MoistureStateBC,
     FreeDrainage,
+    EnergyWaterFreeDrainage,
     HeatFluxBC,
     WaterFluxBC,
     AtmosDrivenFluxBC,
@@ -48,9 +49,14 @@ end
 
 """
     FreeDrainage <: AbstractWaterBC
+
 A concrete type of soil boundary condition, for use at
 the BottomBoundary only, where the flux is set to be
-`F = -K∇h = -K`.
+`F = -K∇h = -K`. 
+
+This is not tied to any boundary condition for the heat equation. 
+To account for the energy flux resulting from free drainage of liquid
+water, please see `EnergyWaterFreeDrainage`.
 """
 struct FreeDrainage <: AbstractWaterBC end
 
@@ -567,6 +573,39 @@ struct WaterHeatBC{W <: AbstractWaterBC, H <: AbstractHeatBC} <:
 end
 function WaterHeatBC(; water, heat)
     return WaterHeatBC{typeof(water), typeof(heat)}(water, heat)
+end
+
+"""
+    EnergyWaterFreeDrainage <: AbstractEnergyHydrologyBC
+
+A concrete type of soil boundary condition, for use at
+the BottomBoundary only, where the fluxes are set to be
+`F_liq = -K∇h = -K`, `F_energy = -K ρe_liq`.
+
+That is, this enforces that the free drainage boundary condition
+for liquid water is paired the the corresponding loss of energy
+that that entails.
+"""
+struct EnergyWaterFreeDrainage <: AbstractEnergyHydrologyBC end
+
+function soil_boundary_fluxes!(
+    bc::EnergyWaterFreeDrainage,
+    boundary::ClimaLand.BottomBoundary,
+    soil::EnergyHydrology,
+    Δz,
+    Y,
+    p,
+    t,
+)
+    FT = eltype(Δz)
+    K_c = Fields.level(p.soil.K, 1)
+    T_c = Fields.level(p.soil.T, 1)
+    @. p.soil.bottom_bc.water = -1 * K_c
+    @. p.soil.bottom_bc.heat =
+        -1 *
+        K_c *
+        volumetric_internal_energy_liq(T_c, soil.parameters.earth_param_set)
+    return nothing
 end
 
 """


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
To debug NaNs in the soil model, I restricted the domain depth to 10 m, since that led to more NaNs earlier. I saw in this long run: https://buildkite.com/clima/climaland-long-runs/builds/4009 that the NaNs were appearing in 1 year over South America and Indonesia. I then debugged the ones over South America. 12 NaNs appeared by the end of the simulation.
![image](https://github.com/user-attachments/assets/cb9cfcdf-c4ef-45a6-9416-926ac12b3fa7)

The NaNs were appearing first in the bottom of the domain. Very weird behavior was showing up: water was leaving the domain (as expected from the BC of free drainage), but the temperature in the bottom was increasing (to unphysical levels). This is tied to inconsistent boundary conditions: if water leaves the domain but energy does not, the temperature has to increase to compensate.

This PR adds that change in. I checked here: https://buildkite.com/clima/climaland-long-runs/builds/4011 that the NaNs are gone.
![image](https://github.com/user-attachments/assets/f739259b-4aca-4997-a540-4178fb17eb14)


I then reverted the domain depth back to 50m. In the next land 10 year long runs, this hopefully will improve stability, since we also saw NaNs in similar locations. At that point, we can decide to make the domain shallower and continue debugging NaNs as makes sense.


Note that a future PR will modify the top bc to account for this type of error also: precipitation is a flux of water into the domain, and this should change the energy flux also.
https://github.com/CliMA/ClimaLand.jl/issues/1163
