### PR TITLE
Add energy from precipitation

### DIFF
--- a/docs/src/APIs/Snow.md
+++ b/docs/src/APIs/Snow.md
@@ -23,8 +23,8 @@ ClimaLand.Snow.compute_water_runoff
 ClimaLand.Snow.energy_from_q_l_and_swe
 ClimaLand.Snow.energy_from_T_and_swe
 ClimaLand.Snow.snow_cover_fraction
-ClimaLand.Snow.volumetric_energy_flux_falling_rain
-ClimaLand.Snow.volumetric_energy_flux_falling_snow
+ClimaLand.Snow.energy_flux_falling_rain
+ClimaLand.Snow.energy_flux_falling_snow
 ```
 
 ## Computing fluxes for snow

--- a/experiments/integrated/fluxnet/fluxnet_simulation.jl
+++ b/experiments/integrated/fluxnet/fluxnet_simulation.jl
@@ -13,7 +13,7 @@ timestepper = CTS.ARS111();
 ode_algo = CTS.IMEXAlgorithm(
     timestepper,
     CTS.NewtonsMethod(
-        max_iters = 6,
+        max_iters = 3,
         update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
     ),
 );

--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -391,7 +391,11 @@ using .Pond
 import .Pond: surface_runoff
 include("standalone/Soil/Soil.jl")
 using .Soil
-import .Soil: soil_boundary_fluxes!, sublimation_source
+import .Soil:
+    soil_boundary_fluxes!,
+    sublimation_source,
+    compute_liquid_influx,
+    compute_infiltration_energy_flux
 import .Soil.Biogeochemistry: soil_temperature, soil_moisture
 include("standalone/Snow/Snow.jl")
 using .Snow

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -480,27 +480,45 @@ the presence of the canopy modifies the soil BC.
 function soil_boundary_fluxes!(
     bc::AtmosDrivenFluxBC,
     prognostic_land_components::Val{(:canopy, :snow, :soil, :soilco2)},
-    soil::EnergyHydrology{FT},
+    soil::EnergyHydrology,
     Y,
     p,
     t,
-) where {FT}
+)
     turbulent_fluxes!(p.soil.turbulent_fluxes, bc.atmos, soil, Y, p, t)
-    # influx = maximum possible rate of infiltration given precip, snowmelt, evaporation/condensation
-    # but if this exceeds infiltration capacity of the soil, runoff will
-    # be generated.
-    # Use top_bc.water as temporary storage to avoid allocation
-    influx = p.soil.top_bc.water
-    @. influx =
-        p.snow.water_runoff * p.snow.snow_cover_fraction +
+    # Liquid influx is a combination of precipitation and snowmelt in general
+    liquid_influx =
+        Soil.compute_liquid_influx(p, soil, prognostic_land_components)
+    # This partitions the influx into runoff and infiltration
+    Soil.update_infiltration_water_flux!(
+        p,
+        bc.runoff,
+        liquid_influx,
+        Y,
+        t,
+        soil,
+    )
+    # This computes the energy of the infiltrating water
+    infiltration_energy_flux = Soil.compute_infiltration_energy_flux(
+        p,
+        bc.runoff,
+        bc.atmos,
+        prognostic_land_components,
+        liquid_influx,
+        soil,
+        Y,
+        t,
+    )
+    @. p.soil.top_bc.water =
+        p.soil.infiltration +
         p.excess_water_flux +
         (1 - p.snow.snow_cover_fraction) *
-        (p.drivers.P_liq + p.soil.turbulent_fluxes.vapor_flux_liq)
-    # The update_runoff! function computes how much actually infiltrates
-    # given influx and our runoff model bc.runoff, and updates
-    # p.soil.infiltration in place
-    Soil.Runoff.update_runoff!(p, bc.runoff, influx, Y, t, soil)
-    @. p.soil.top_bc.water = p.soil.infiltration
+        p.soil.turbulent_fluxes.vapor_flux_liq
+    # The actual boundary condition is a mix of liquid water infiltration and
+    # evaporation. The infiltration already has accounted for snow cover fraction,
+    # because the influx it is computed from has accounted for that.
+    # The last term, `excess water flux`, arises when snow melts in a timestep but
+    # has a nonzero sublimation which was applied for the entire step.
     @. p.soil.top_bc.heat =
         (1 - p.snow.snow_cover_fraction) * (
             p.soil.R_n +
@@ -508,8 +526,65 @@ function soil_boundary_fluxes!(
             p.soil.turbulent_fluxes.shf
         ) +
         p.excess_heat_flux +
-        p.snow.snow_cover_fraction * p.ground_heat_flux
+        p.snow.snow_cover_fraction * p.ground_heat_flux +
+        infiltration_energy_flux
+
     return nothing
+end
+
+"""
+   compute_liquid_influx(p,
+                         model,
+                         prognostic_land_components::Val{(:canopy, :snow, :soil, :soilco2)},
+    ) 
+
+Returns the liquid water volume flux at the surface of the soil; uses
+the same method as the soil+snow integrated model.
+"""
+function Soil.compute_liquid_influx(
+    p,
+    model,
+    prognostic_land_components::Val{(:canopy, :snow, :soil, :soilco2)},
+)
+    Soil.compute_liquid_influx(p, model, Val((:snow, :soil)))
+end
+
+"""
+    compute_infiltration_energy_flux(
+        p,
+        runoff,
+        atmos,
+        prognostic_land_components:::Val{(:canopy, :snow, :soil, :soilco2)},
+        liquid_influx,
+        model::EnergyHydrology,
+        Y,
+        t,
+    )
+
+Computes the energy associated with infiltration of
+liquid water into the soil; uses the same method as
+the soil+snow integrated model.
+"""
+function Soil.compute_infiltration_energy_flux(
+    p,
+    runoff,
+    atmos,
+    prognostic_land_components::Val{(:canopy, :snow, :soil, :soilco2)},
+    liquid_influx,
+    model::EnergyHydrology,
+    Y,
+    t,
+)
+    Soil.compute_infiltration_energy_flux(
+        p,
+        runoff,
+        atmos,
+        Val((:snow, :soil)),
+        liquid_influx,
+        model,
+        Y,
+        t,
+    )
 end
 
 function snow_boundary_fluxes!(
@@ -536,19 +611,19 @@ function snow_boundary_fluxes!(
             p.snow.water_runoff
         ) * p.snow.snow_cover_fraction
 
-    ρe_flux_falling_snow =
-        Snow.volumetric_energy_flux_falling_snow(bc.atmos, p, model.parameters)
-    ρe_flux_falling_rain =
-        Snow.volumetric_energy_flux_falling_rain(bc.atmos, p, model.parameters)
+    e_flux_falling_snow =
+        Snow.energy_flux_falling_snow(bc.atmos, p, model.parameters)
+    e_flux_falling_rain =
+        Snow.energy_flux_falling_rain(bc.atmos, p, model.parameters)
 
     # positive fluxes are TOWARDS atmos, but R_n positive if snow absorbs energy
     @. p.snow.total_energy_flux =
-        ρe_flux_falling_snow +
+        e_flux_falling_snow +
         (
             p.snow.turbulent_fluxes.lhf +
             p.snow.turbulent_fluxes.shf +
             p.snow.R_n - p.snow.energy_runoff - p.ground_heat_flux +
-            ρe_flux_falling_rain
+            e_flux_falling_rain
         ) * p.snow.snow_cover_fraction
     return nothing
 end

--- a/src/standalone/Snow/boundary_fluxes.jl
+++ b/src/standalone/Snow/boundary_fluxes.jl
@@ -121,18 +121,18 @@ function snow_boundary_fluxes!(
             p.snow.water_runoff
         ) * p.snow.snow_cover_fraction
 
-    ρe_flux_falling_snow =
-        volumetric_energy_flux_falling_snow(bc.atmos, p, model.parameters)
-    ρe_flux_falling_rain =
-        volumetric_energy_flux_falling_rain(bc.atmos, p, model.parameters)
+    e_flux_falling_snow =
+        energy_flux_falling_snow(bc.atmos, p, model.parameters)
+    e_flux_falling_rain =
+        energy_flux_falling_rain(bc.atmos, p, model.parameters)
 
     # positive fluxes are TOWARDS atmos
     @. p.snow.total_energy_flux =
-        ρe_flux_falling_snow +
+        e_flux_falling_snow +
         (
             p.snow.turbulent_fluxes.lhf +
             p.snow.turbulent_fluxes.shf +
-            p.snow.R_n - p.snow.energy_runoff + ρe_flux_falling_rain
+            p.snow.R_n - p.snow.energy_runoff + e_flux_falling_rain
         ) * p.snow.snow_cover_fraction
     return nothing
 

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -12,8 +12,8 @@ export snow_surface_temperature,
     snow_bulk_density,
     phase_change_flux,
     update_snow_albedo!,
-    volumetric_energy_flux_falling_snow,
-    volumetric_energy_flux_falling_rain
+    energy_flux_falling_snow,
+    energy_flux_falling_rain
 
 """
     update_snow_albedo!(α, m::ConstantAlbedoModel, Y, p, t, earth_param_set)
@@ -480,13 +480,13 @@ function energy_from_T_and_swe(S::FT, T::FT, parameters) where {FT}
 end
 
 """
-    volumetric_energy_flux_falling_snow(atmos, p, parameters)
+    energy_flux_falling_snow(atmos, p, parameters)
 
-Returns the volumetric energy flux of falling snow for a PrescribedAtmosphere,
+Returns the energy flux of falling snow for a PrescribedAtmosphere,
 approximated as ρe_snow * P_snow, where ρe_snow = -LH_f0 * _ρ_liq. 
 This is a negative internal energy, due the to negative contribution of
 the latent heat of melting to the energy of the snow,
- and it neglects the sensible heat portion of the snow. The overall flux
+ and it neglects the sensible heat portion of the snow. The energy
  is per unit volume of liquid water, and P_snow is expressed as 
 the volume flux of liquid water resulting from the snow.
 
@@ -494,25 +494,25 @@ This method can be extended to coupled simulations, where atmos is of type
 CoupledAtmosphere, and the energy flux of the falling snow is passed in the
 cache `p`. In that case, this should specify `atmos::PrescribedAtmosphere`.
 """
-function volumetric_energy_flux_falling_snow(atmos, p, parameters)
+function energy_flux_falling_snow(atmos, p, parameters)
     _LH_f0 = LP.LH_f0(parameters.earth_param_set)
     _ρ_liq = LP.ρ_cloud_liq(parameters.earth_param_set)
     ρe_snow = -_LH_f0 * _ρ_liq
-    return @. lazy(ρe_snow * p.drivers.P_snow) # per unit vol of liquid water
+    return @. lazy(ρe_snow * p.drivers.P_snow)
 end
 
 """
-    volumetric_energy_flux_falling_rain(atmos, p, parameters)
+    energy_flux_falling_rain(atmos, p, parameters)
 
-Returns the volumetric energy flux of falling rain for a PrescribedAtmosphere,
-approximated as ρ_l e_l(T_atmos) * P_liq. This is per unit volume of liquid water, 
+Returns the energy flux of falling rain for a PrescribedAtmosphere,
+approximated as ρ_l e_l(T_atmos) * P_liq. The energy is per unit volume of liquid water, 
 and P_liq is expressed as the volume flux of liquid water resulting from the rain.
 
 This method can be extended to coupled simulations, where atmos is of type
 CoupledAtmosphere, and the energy flux of the falling rain is passed in the
 cache `p`.  In that case, this should specify `atmos::PrescribedAtmosphere`.
 """
-function volumetric_energy_flux_falling_rain(atmos, p, parameters)
+function energy_flux_falling_rain(atmos, p, parameters)
     return @. lazy(
         volumetric_internal_energy_liq(p.drivers.T, parameters) *
         p.drivers.P_liq,

--- a/src/standalone/Soil/Runoff/Runoff.jl
+++ b/src/standalone/Soil/Runoff/Runoff.jl
@@ -13,9 +13,8 @@ export TOPMODELRunoff,
     TOPMODELSubsurfaceRunoff,
     subsurface_runoff_source,
     topmodel_ss_flux,
-    update_runoff!,
+    update_infiltration_water_flux!,
     is_saturated
-
 
 """
     AbstractRunoffModel
@@ -26,7 +25,7 @@ the following boundary condition types:
 - `ClimaLand.Soil.RichardsAtmosDrivenFluxBC`.
 It must have methods for
 - `subsurface_runoff_source` (defined in this module)
-- `update_runoff!` (defined in this module)
+- `update_infiltration_water_flux!` (defined in this module)
 - `ClimaLand.source!`.
 Please see the documentation for these for more details.
 
@@ -43,7 +42,6 @@ model `runoff`.
 """
 subsurface_runoff_source(runoff::AbstractRunoffModel) = runoff.subsurface_source
 
-
 """
     NoRunoff <: AbstractRunoffModel
 A concrete type of soil runoff model; the 
@@ -58,12 +56,12 @@ struct NoRunoff <: AbstractRunoffModel
 end
 
 """
-    update_runoff!(p, runoff::NoRunoff, input, _...)
+    update_infiltration_water_flux!(p, runoff::NoRunoff, input, _...)
 
 Updates the runoff variables in the cache `p.soil` in place
 in the case of NoRunoff: sets infiltration = precipitation.
 """
-function update_runoff!(p, runoff::NoRunoff, input, _...)
+function update_infiltration_water_flux!(p, runoff::NoRunoff, input, _...)
     p.soil.infiltration .= input
 end
 
@@ -106,7 +104,7 @@ function surface_infiltration(f_ic::FT, input::FT, is_saturated::FT) where {FT}
 end
 
 """
-    update_runoff!(
+    update_infiltration_water_flux!(
         p,
         runoff::SurfaceRunoff,
         input,
@@ -115,7 +113,7 @@ end
         model::AbstractSoilModel,
 )
 
-The update_runoff! function for the SurfaceRunoff model.
+The update_infiltration_water_flux! function for the SurfaceRunoff model.
 
 Updates the runoff model variables in place in `p.soil` for the SurfaceRunoff 
 parameterization:
@@ -123,7 +121,7 @@ p.soil.R_s
 p.soil.is_saturated
 p.soil.infiltration
 """
-function update_runoff!(
+function update_infiltration_water_flux!(
     p,
     runoff::SurfaceRunoff,
     input,
@@ -137,7 +135,6 @@ function update_runoff!(
     FT = eltype(ϑ_l)
     θ_i = model_agnostic_volumetric_ice_content(Y, FT)
     @. p.soil.is_saturated = is_saturated(ϑ_l + θ_i, model.parameters.ν)
-    surface_space = model.domain.space.surface
     is_saturated_sfc =
         ClimaLand.Domains.top_center_to_surface(p.soil.is_saturated) # a view
 
@@ -165,7 +162,7 @@ use in global climate models".
 
 This is currently treated implicitly (evaluated at the next value of
 ϑ_l) but not included in the Jacobian approximation. This is because
-`update_runoff` is called as part of the implicit tendency.
+`update_infiltration_water_flux` is called as part of the implicit tendency.
 
 $(DocStringExtensions.FIELDS)
 """
@@ -210,7 +207,7 @@ end
 
 
 """
-    update_runoff!(p, runoff::TOPMODELRunoff, input, Y,t, model::AbstractSoilModel)
+    update_infiltration_water_flux!(p, runoff::TOPMODELRunoff, input, Y,t, model::AbstractSoilModel)
 
 Updates the runoff model variables in place in `p.soil` for the TOPMODELRunoff
 parameterization:
@@ -219,7 +216,7 @@ p.soil.R_ss
 p.soil.h∇
 p.soil.infiltration
 """
-function update_runoff!(
+function update_infiltration_water_flux!(
     p,
     runoff::TOPMODELRunoff,
     input,

--- a/src/standalone/Soil/Soil.jl
+++ b/src/standalone/Soil/Soil.jl
@@ -56,6 +56,7 @@ for interactions between components.
 =#
 
 using ClimaLand
+using LazyBroadcast: lazy
 using DocStringExtensions
 using LinearAlgebra
 using ClimaCore

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -250,7 +250,13 @@ for FT in (Float32, Float64)
 
             expected_water_flux = @. FT(precip(t)) .+ conditions.vapor_flux_liq
             @test computed_water_flux == expected_water_flux
-            expected_energy_flux = @. R_n_copy + conditions.lhf + conditions.shf
+            expected_energy_flux = @. R_n_copy +
+               conditions.lhf +
+               conditions.shf +
+               FT(precip(t)) * Soil.volumetric_internal_energy_liq(
+                   FT(T_atmos(t)),
+                   earth_param_set,
+               )
             @test computed_energy_flux == expected_energy_flux
 
             # Test soil resistances for liquid water


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This adds an energy flux at the top of the soil domain associated with precipitation and snowmelt. 

One important change to highlight is that prior, we computed the runoff and infiltration using `influx = precip + evap`, and the boundary condition was `bc = infiltration`. However, the energy of the vapor flux is already accounted for in the LHF. This complicates finding the energy of the infiltration, since it could in principle also be due to condensation and therefore already accounted for in the LHF. so, this PR considers a liquid influx only when computing infiltration and runoff, so that the `bc = infiltration + vapor flux`, and the energy bc includes `energy of infiltration + LHF`.

For context, we have four different models that this change is affecting:
soil alone (`src/standalone/Soil/boundary_conditions.jl`)
soil + snow (`src/integrated/soil_snow_model.jl`)
soil+ canopy (`src/integrated/soil_canopy_model.jl`)
soil+canopy+snow. (`src/integrated/land.jl`)
## To-do
[X] Rebase after #1176  is merged

A future PR will
- update the liquid infiltration computation to use @lazy and remove corresponding variables from the cache

We can also consider removing duplicate code in `soil_boundary_fluxes!`, since the computations with snow (snow+soil, or snow_soil+canopy) are identical, and since the computations without snow (soil+canopy, soil alone) are nearly identical. On the other hand, these may differ in the future if the presence of a canopy changes the boundary flux computation (eg. interception of rain or snow in the canopy)


## Content


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clhttps://github.com/CliMA/ClimaLand.jl/pull/1164/filesima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
