### PR TITLE
bring benchmarks up to date

### DIFF
--- a/experiments/benchmarks/bucket.jl
+++ b/experiments/benchmarks/bucket.jl
@@ -257,7 +257,7 @@ if profiler == "flamegraph"
     end
 
     if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaland-benchmark"
-        PREVIOUS_BEST_TIME = 0.533
+        PREVIOUS_BEST_TIME = 0.333
         if average_timing_s > PREVIOUS_BEST_TIME + std_timing_s
             @info "Possible performance regression, previous average time was $(PREVIOUS_BEST_TIME)"
         elseif average_timing_s < PREVIOUS_BEST_TIME - std_timing_s

--- a/experiments/benchmarks/snowy_land.jl
+++ b/experiments/benchmarks/snowy_land.jl
@@ -76,7 +76,7 @@ outdir = "snowy_land_benchmark_$(device_suffix)"
 
 function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     earth_param_set = LP.LandParameters(FT)
-    domain = ClimaLand.Model.Setup.global_domain(FT; nelements = nelements)
+    domain = ClimaLand.ModelSetup.global_domain(FT; nelements = nelements)
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
All benchmarks run with up-to-date timing:https://buildkite.com/clima/climaland-benchmark/builds/3253


Fixes a typo and updates the bucket benchmark time