### PR TITLE
Increase simulation end time to encompass a full season

### DIFF
--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -336,8 +336,11 @@ end
 function setup_simulation(; greet = false)
     # If not LONGER_RUN, run for 2 years; note that the forcing from 2008 is repeated.
     # If LONGER run, run for 10 years, with the correct forcing each year.
-    start_date = LONGER_RUN ? DateTime(2004) : DateTime(2008)
-    stop_date = LONGER_RUN ? DateTime(2014) : DateTime(2010)
+    # Note that since the Northern hemisphere's winter season is defined as DJF,
+    # we simulate from and until the beginning of
+    # March so that a full season is included in seasonal metrics.
+    start_date = LONGER_RUN ? DateTime("2014-03-01") : DateTime("2008-03-01")
+    stop_date = LONGER_RUN ? DateTime("2014-03-01") : DateTime("2010-03-01")
     Δt = 450.0
     nelements = (101, 15)
     if greet

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -339,7 +339,7 @@ function setup_simulation(; greet = false)
     # Note that since the Northern hemisphere's winter season is defined as DJF,
     # we simulate from and until the beginning of
     # March so that a full season is included in seasonal metrics.
-    start_date = LONGER_RUN ? DateTime("2014-03-01") : DateTime("2008-03-01")
+    start_date = LONGER_RUN ? DateTime("2004-03-01") : DateTime("2008-03-01")
     stop_date = LONGER_RUN ? DateTime("2014-03-01") : DateTime("2010-03-01")
     Δt = 450.0
     nelements = (101, 15)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Our long run simulations for the snowy land model use seasonal metrics to assess performance. However, they start and end on January 1. This means that the first full season is MAM (not DJF). Because of this, the last DJF season of the last year is incorrect, because it is missing January and February.

This extends the simulation time to March 1 of the year following the last year.
see : https://buildkite.com/clima/climaland-long-runs/builds/4031 for the plots I am referring to. (ERA rmse bias plots, e..g)

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
