### PR TITLE
remove two cache variables

### DIFF
--- a/experiments/integrated/fluxnet/snow_soil/simulation.jl
+++ b/experiments/integrated/fluxnet/snow_soil/simulation.jl
@@ -253,11 +253,41 @@ _ρ_i = FT(LP.ρ_cloud_ice(earth_param_set))
 _ρ_l = FT(LP.ρ_cloud_liq(earth_param_set))
 fig = Figure(size = (1600, 1200), fontsize = 26)
 ax1 = Axis(fig[2, 1], ylabel = "ΔEnergy (J/A)", xlabel = "Days")
+function compute_surface_energy_fluxes(p)
+    ρe_flux_falling_snow =
+        Snow.volumetric_energy_flux_falling_snow(atmos, p, land.snow.parameters)
+    ρe_flux_falling_rain =
+        Snow.volumetric_energy_flux_falling_rain(atmos, p, land.snow.parameters)
+
+    return @. (1 - p.snow.snow_cover_fraction) * (
+                  p.soil.turbulent_fluxes.lhf +
+                  p.soil.turbulent_fluxes.shf +
+                  p.soil.R_n
+              ) +
+              p.snow.snow_cover_fraction * (
+                  p.snow.turbulent_fluxes.lhf +
+                  p.snow.turbulent_fluxes.shf +
+                  p.snow.R_n +
+                  ρe_flux_falling_rain
+              ) +
+              ρe_flux_falling_snow
+end
+
+function compute_surface_water_vol_fluxes(p)
+    return @. p.drivers.P_snow +
+              p.drivers.P_liq +
+              (1 - p.snow.snow_cover_fraction) * (
+                  p.soil.turbulent_fluxes.vapor_flux_liq +
+                  p.soil.turbulent_fluxes.vapor_flux_ice
+              ) +
+              p.snow.snow_cover_fraction * p.snow.turbulent_fluxes.vapor_flux
+end
+
 ΔE_expected =
     cumsum(
         -1 .* [
             parent(
-                sv.saveval[k].atmos_energy_flux .-
+                compute_surface_energy_fluxes(sv.saveval[k]) .-
                 sv.saveval[k].soil.bottom_bc.heat,
             )[end] for k in 1:1:(length(sv.t) - 1)
         ],
@@ -270,7 +300,7 @@ E_measured = [
     cumsum(
         -1 .* [
             parent(
-                sv.saveval[k].atmos_water_flux .-
+                compute_surface_water_vol_fluxes(sv.saveval[k]) .-
                 sv.saveval[k].soil.bottom_bc.water .+ sv.saveval[k].soil.R_s,
             )[end] for k in 1:1:(length(sv.t) - 1)
         ],

--- a/test/integrated/soil_snow.jl
+++ b/test/integrated/soil_snow.jl
@@ -95,8 +95,6 @@ p_soil_alone = deepcopy(p)
 for lsm_aux_var in (
     :excess_water_flux,
     :excess_heat_flux,
-    :atmos_energy_flux,
-    :atmos_water_flux,
     :ground_heat_flux,
     :effective_soil_sfc_T,
     :sfc_scratch,
@@ -184,29 +182,6 @@ dY_soil_snow = deepcopy(Y) .* 0
 ClimaLand.source!(dY_soil_snow, src, Y, p, land_model.soil)
 @test all(parent(dY_soil_snow.soil.θ_i) .≈ 0)
 
-# Check conservation
-@test p.atmos_water_flux == @. p.drivers.P_snow +
-         p.drivers.P_liq +
-         (1 - p.snow.snow_cover_fraction) * (
-             p.soil.turbulent_fluxes.vapor_flux_liq +
-             p.soil.turbulent_fluxes.vapor_flux_ice
-         ) +
-         p.snow.snow_cover_fraction * p.snow.turbulent_fluxes.vapor_flux
-
-_LH_f0 = FT(LP.LH_f0(earth_param_set))
-_ρ_liq = FT(LP.ρ_cloud_liq(earth_param_set))
-ρe_falling_snow = -_LH_f0 * _ρ_liq # per unit vol of liquid water
-@test p.atmos_energy_flux == @. (1 - p.snow.snow_cover_fraction) * (
-             p.soil.turbulent_fluxes.lhf +
-             p.soil.turbulent_fluxes.shf +
-             p.soil.R_n
-         ) +
-         p.snow.snow_cover_fraction * (
-             p.snow.turbulent_fluxes.lhf +
-             p.snow.turbulent_fluxes.shf +
-             p.snow.R_n
-         ) +
-         p.drivers.P_snow * ρe_falling_snow
 # Make sure soil boundary flux method also worked
 G = deepcopy(p.ground_heat_flux)
 p_snow_alone = deepcopy(p)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
In our simulations, we have the cache variables "atmos_energy_flux" and "atmos_water_flux". While useful for tracking conservation (see the experiment script and plot in buildkite that this PR changes), we dont need to store them in the cache. we can compute this after the fact from our other variables in `p`.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
