### PR TITLE
Remove 3 vars from canopy cache

### DIFF
--- a/lib/ClimaLandSimulations/src/utilities/climaland_output_dataframe.jl
+++ b/lib/ClimaLandSimulations/src/utilities/climaland_output_dataframe.jl
@@ -45,10 +45,9 @@ function make_output_df(
     output_list = vcat(
         (1, :SW_u),
         (1, :LW_u),
-        (1, :canopy, :conductance, :gs),
+        (1, :canopy, :conductance, :r_stomata_canopy),
         (1, :canopy, :autotrophic_respiration, :Ra),
         (1, :canopy, :photosynthesis, :GPP),
-        (1, :canopy, :hydraulics, :β),
         (1, :canopy, :hydraulics, :area_index, :leaf),
         (1, :canopy, :turbulent_fluxes, :transpiration),
         (1, :canopy, :turbulent_fluxes, :lhf),

--- a/lib/ClimaLandSimulations/src/utilities/makie_plots.jl
+++ b/lib/ClimaLandSimulations/src/utilities/makie_plots.jl
@@ -197,19 +197,11 @@ function timeseries_H2O_fig(
         color = :blue,
     )
 
-    # Moisture stress
-    p_MS = lines!(
-        ax_MS,
-        datetime2unix.(climaland.DateTime),
-        climaland.β,
-        color = :green,
-    ) # not sure about units
-
     # Stomatal conductance
     p_SC = lines!(
         ax_SC,
         datetime2unix.(climaland.DateTime),
-        climaland.gs,
+        climaland.r_stomata_canopy,
         color = :green,
     )
 
@@ -244,7 +236,7 @@ function timeseries_H2O_fig(
                 datetime2unix(climaland.DateTime[1]),
                 datetime2unix(climaland.DateTime[end]),
             ),
-        ) for axes in [ax_H2O, ax_H2O_rain, ax_MS, ax_SC]
+        ) for axes in [ax_H2O, ax_H2O_rain, ax_SC]
     ]
 
     fig

--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -2,7 +2,7 @@ module ClimaLand
 using DocStringExtensions
 
 using ClimaCore
-using LazyBroadcast: @lazy
+using LazyBroadcast: lazy
 import ClimaCore: Fields, Spaces
 
 include("shared_utilities/Parameters.jl")

--- a/src/diagnostics/Diagnostics.jl
+++ b/src/diagnostics/Diagnostics.jl
@@ -14,6 +14,7 @@ import ..LandModel
 
 import ..Soil: EnergyHydrology
 
+import ..Canopy: medlyn_conductance, medlyn_term, moisture_stress
 import ..Domains:
     top_center_to_surface, AbstractDomain, SphericalShell, HybridBox
 

--- a/src/standalone/Snow/Snow.jl
+++ b/src/standalone/Snow/Snow.jl
@@ -3,7 +3,7 @@ module Snow
 using DocStringExtensions
 import ...Parameters as LP
 using ClimaCore
-using LazyBroadcast: @lazy
+using LazyBroadcast: lazy
 using Thermodynamics
 using ClimaLand
 using ClimaLand:

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -498,7 +498,7 @@ function volumetric_energy_flux_falling_snow(atmos, p, parameters)
     _LH_f0 = LP.LH_f0(parameters.earth_param_set)
     _ρ_liq = LP.ρ_cloud_liq(parameters.earth_param_set)
     ρe_snow = -_LH_f0 * _ρ_liq
-    return @lazy @. ρe_snow * p.drivers.P_snow # per unit vol of liquid water
+    return @. lazy(ρe_snow * p.drivers.P_snow) # per unit vol of liquid water
 end
 
 """
@@ -513,8 +513,10 @@ CoupledAtmosphere, and the energy flux of the falling rain is passed in the
 cache `p`.  In that case, this should specify `atmos::PrescribedAtmosphere`.
 """
 function volumetric_energy_flux_falling_rain(atmos, p, parameters)
-    return @lazy @. volumetric_internal_energy_liq(p.drivers.T, parameters) *
-                    p.drivers.P_liq
+    return @. lazy(
+        volumetric_internal_energy_liq(p.drivers.T, parameters) *
+        p.drivers.P_liq,
+    )
 end
 
 

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -287,13 +287,11 @@ prognostic_vars(model::PlantHydraulicsModel) = (:ϑ_l,)
 
 A function which returns the names of the auxiliary
 variables of the `PlantHydraulicsModel`,
-the transpiration stress factor `β` (unitless),
 the water potential `ψ` (m), the volume flux*cross section `fa` (1/s),
 and the volume flux*root cross section in the roots `fa_roots` (1/s),
 where the cross section can be represented by an area index.
 """
-auxiliary_vars(model::PlantHydraulicsModel) =
-    (:β, :ψ, :fa, :fa_roots, :area_index)
+auxiliary_vars(model::PlantHydraulicsModel) = (:ψ, :fa, :fa_roots, :area_index)
 
 """
     ClimaLand.prognostic_types(model::PlantHydraulicsModel{FT}) where {FT}
@@ -310,14 +308,13 @@ ClimaLand.prognostic_domain_names(::PlantHydraulicsModel) = (:surface,)
 Defines the auxiliary types for the PlantHydraulicsModel.
 """
 ClimaLand.auxiliary_types(model::PlantHydraulicsModel{FT}) where {FT} = (
-    FT,
     NTuple{model.n_stem + model.n_leaf, FT},
     NTuple{model.n_stem + model.n_leaf, FT},
     FT,
     NamedTuple{(:root, :stem, :leaf), Tuple{FT, FT, FT}},
 )
 ClimaLand.auxiliary_domain_names(::PlantHydraulicsModel) =
-    (:surface, :surface, :surface, :surface, :surface)
+    (:surface, :surface, :surface, :surface)
 
 function clip(x::FT, threshold::FT) where {FT}
     x > threshold ? x : FT(0)

--- a/src/standalone/Vegetation/stomatalconductance.jl
+++ b/src/standalone/Vegetation/stomatalconductance.jl
@@ -38,9 +38,6 @@ end
 
 ClimaLand.name(model::AbstractStomatalConductanceModel) = :conductance
 
-ClimaLand.auxiliary_vars(model::MedlynConductanceModel) =
-    (:medlyn_term, :gs, :r_stomata_canopy)
-ClimaLand.auxiliary_types(model::MedlynConductanceModel{FT}) where {FT} =
-    (FT, FT, FT)
-ClimaLand.auxiliary_domain_names(::MedlynConductanceModel) =
-    (:surface, :surface, :surface)
+ClimaLand.auxiliary_vars(model::MedlynConductanceModel) = (:r_stomata_canopy,)
+ClimaLand.auxiliary_types(model::MedlynConductanceModel{FT}) where {FT} = (FT,)
+ClimaLand.auxiliary_domain_names(::MedlynConductanceModel) = (:surface,)

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -331,7 +331,7 @@ import ClimaParams
 
             es =
                 Thermodynamics.saturation_vapor_pressure.(
-                    Ref(thermo_params),
+                    thermo_params,
                     FT.(T_atmos(t0)),
                     Ref(Thermodynamics.Liquid()),
                 )
@@ -349,10 +349,26 @@ import ClimaParams
             ga = 1 / r_ae
             γ = FT(66)
             R = FT(LP.gas_constant(earth_param_set))
-            gs = Array(
+            (; g1, g0, Drel) = canopy.conductance.parameters
+            medlyn_factor =
+                medlyn_term.(
+                    g1,
+                    FT.(T_atmos(t0)),
+                    FT.(P_atmos(t0)),
+                    FT.(q_atmos(t0)),
+                    thermo_params,
+                )
+            An = p.canopy.photosynthesis.An
+            gcanopy = Array(
                 parent(
                     ClimaLand.Canopy.upscale_leaf_conductance.(
-                        p.canopy.conductance.gs,
+                        medlyn_conductance.(
+                            g0,
+                            Drel,
+                            medlyn_factor,
+                            An,
+                            FT.(c_atmos(t0)),
+                        ),
                         LAI,
                         FT.(T_atmos(t0)),
                         R,
@@ -371,7 +387,7 @@ import ClimaParams
                 VPD, # vapor pressure deficit (Pa)
                 ga, # Conductivity of air, atmospheric conductance (m s−1)
                 γ, # Psychrometric constant (γ ≈ 66 Pa K−1)
-                gs, # Conductivity of stoma, surface or stomatal conductance (m s−1)
+                gcanopy, # Conductivity of stoma, surface or stomatal conductance (m s−1)
                 Lv, # Volumetric latent heat of vaporization. Energy required per water volume vaporized. (Lv = 2453 MJ m−3)
             )
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Remove medlyn term, beta(moisture stress), and stomatal conductance at the leaf level from the canopy cache.

Use lazy broadcasting to compute in the tendencies, compute on the fly in diagnostics when needed


## To-do



## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
