### PR TITLE
change start and end dates for "longer runs"

### DIFF
--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -335,12 +335,12 @@ end
 
 function setup_simulation(; greet = false)
     # If not LONGER_RUN, run for 2 years; note that the forcing from 2008 is repeated.
-    # If LONGER run, run for 10 years, with the correct forcing each year.
+    # If LONGER run, run for 19 years, with the correct forcing each year.
     # Note that since the Northern hemisphere's winter season is defined as DJF,
     # we simulate from and until the beginning of
     # March so that a full season is included in seasonal metrics.
     start_date = LONGER_RUN ? DateTime("2000-03-01") : DateTime("2008-03-01")
-    stop_date = LONGER_RUN ? DateTime("2020-03-01") : DateTime("2010-03-01")
+    stop_date = LONGER_RUN ? DateTime("2019-03-01") : DateTime("2010-03-01")
     Δt = 450.0
     nelements = (101, 15)
     if greet

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -339,8 +339,8 @@ function setup_simulation(; greet = false)
     # Note that since the Northern hemisphere's winter season is defined as DJF,
     # we simulate from and until the beginning of
     # March so that a full season is included in seasonal metrics.
-    start_date = LONGER_RUN ? DateTime("2004-03-01") : DateTime("2008-03-01")
-    stop_date = LONGER_RUN ? DateTime("2014-03-01") : DateTime("2010-03-01")
+    start_date = LONGER_RUN ? DateTime("2000-03-01") : DateTime("2008-03-01")
+    stop_date = LONGER_RUN ? DateTime("2020-03-01") : DateTime("2010-03-01")
     Δt = 450.0
     nelements = (101, 15)
     if greet

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -152,8 +152,8 @@ end
 function setup_simulation(; greet = false)
     # If not LONGER_RUN, run for 2 years; note that the forcing from 2008 is repeated.
     # If LONGER run, run for 10 years, with the correct forcing each year.
-    start_date = LONGER_RUN ? DateTime(2004) : DateTime(2008)
-    stop_date = LONGER_RUN ? DateTime(2014) : DateTime(2010)
+    start_date = LONGER_RUN ? DateTime(2000) : DateTime(2008)
+    stop_date = LONGER_RUN ? DateTime(2020) : DateTime(2010)
     Δt = 450.0
     nelements = (101, 15)
     if greet


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Now that 10 year runs are stable, we'd like to extend our longer runs and see how things go. 
@ph-kev any reason not to use the years 2000-2019? (observations or forcing data not available? It looks like MODIS is 2000-2020, but I believe we try and grab an extra year of data so I truncated the sim at 2019 instead. Seems like we should be fine on the ERA5 front)


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
