### PR TITLE
Creating function to be able to run run_fluxnet for any fluxnet site with generic parameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 SurfaceFluxes = "49b00bb7-8bd4-4f2b-b78c-51cd0450215f"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 

--- a/experiments/integrated/fluxnet/any_run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/any_run_fluxnet.jl
@@ -9,6 +9,7 @@ using Dates
 using Insolation
 using StatsBase
 
+using DelimitedFiles
 using ClimaLand
 using ClimaLand.Domains: Column
 using ClimaLand.Snow
@@ -28,14 +29,12 @@ climaland_dir = pkgdir(ClimaLand)
 include(joinpath(climaland_dir, "experiments/integrated/fluxnet/data_tools.jl"))
 include(joinpath(climaland_dir, "experiments/integrated/fluxnet/plot_utils.jl"))
 
-# Read in the site to be run from the command line
-#if length(ARGS) < 1
-#    error("Must provide site ID on command line")
-#end
-#
-site_ID = "US-MOz"
+include(joinpath(pkgdir(ClimaLand),"experiments/integrated/fluxnet/path_to_data_file.jl"))
+site_ID = "US-Ha1"
+data_path = get_path(site_ID)
 params = Dict("g1" => 1.0, "Vcmax25" => 1.0)
 
+driver_data = readdlm(data_path, ',')
 
 function zenith_angle(
         t,
@@ -68,19 +67,13 @@ function zenith_angle(
       )
 end
 
-# Currently, site_ID can only be "US-MOz", "US-Var", "US-Ha1", "US-NR1"
-# But we want ALL fluxnet sites
-# to do: change the included files to read meta data, all same config otherwise
-# (same parameters, same domains, same resolution, etc.)
-# data files will be read directly from caltech hpc filepath
-
 function run_single_site(params, site_ID) # e.g., run_single_site(params, "US-MOz")
 
     # Read all site-specific domain parameters from the simulation file for the site
     include(
             joinpath(
                      climaland_dir,
-                     "experiments/integrated/fluxnet/$site_ID/$(site_ID)_simulation.jl",
+                     "experiments/integrated/fluxnet/any_site/any_simulation.jl",
                     ),
            )
 
@@ -92,7 +85,7 @@ function run_single_site(params, site_ID) # e.g., run_single_site(params, "US-MO
     include(
             joinpath(
                      climaland_dir,
-                     "experiments/integrated/fluxnet/$site_ID/$(site_ID)_parameters.jl",
+                     "experiments/integrated/fluxnet/any_site/any_parameters.jl",
                     ),
            )
 
@@ -132,13 +125,6 @@ function run_single_site(params, site_ID) # e.g., run_single_site(params, "US-MO
                                              NIR_albedo = soil_α_NIR,
                                             );
 
-<<<<<<< HEAD
-# Soil microbes model
-soilco2_type = Soil.Biogeochemistry.SoilCO2Model{FT}
-soilco2_ps = Soil.Biogeochemistry.SoilCO2ModelParameters(FT)
-Csom = ClimaLand.PrescribedSoilOrganicCarbon{FT}(TimeVaryingInput((t) -> 5))
-soilco2_args = (; domain = soil_domain, parameters = soilco2_ps)
-=======
     soil_args = (domain = soil_domain, parameters = soil_ps)
     soil_model_type = Soil.EnergyHydrology{FT}
 
@@ -155,7 +141,6 @@ soilco2_args = (; domain = soil_domain, parameters = soilco2_ps)
     soilco2_sources = (MicrobeProduction{FT}(),)
 
     soilco2_boundary_conditions = (; top = soilco2_top_bc, bottom = soilco2_bot_bc)
->>>>>>> ec7314fbe (fluxnet function)
 
     soilco2_args = (;
                     boundary_conditions = soilco2_boundary_conditions,

--- a/experiments/integrated/fluxnet/any_site/any_parameters.jl
+++ b/experiments/integrated/fluxnet/any_site/any_parameters.jl
@@ -1,0 +1,69 @@
+"""Site-specific model parameters for running Clima Land on the Harvard Forest
+fluxtower site."""
+
+# Timezone (offset from UTC in hrs)
+time_offset = 5
+
+# Site latitude and longitude
+lat = FT(42.5378) # degree
+long = FT(-72.1715) # degree
+
+# Height of sensor
+atmos_h = FT(30)
+# https://atmos.seas.harvard.edu/research-harvard_forest-instrumentation
+
+# Soil parameters
+soil_ν = FT(0.5) # m3/m3
+soil_K_sat = FT(4e-7) # m/s, matches Natan
+soil_S_s = FT(1e-3) # 1/m, guess
+soil_vg_n = FT(2.05) # unitless
+soil_vg_α = FT(0.04) # inverse meters
+θ_r = FT(0.067) # m3/m3, from Wang et al. 2021 https://doi.org/10.5194/gmd-14-6741-2021
+
+# Soil makeup
+ν_ss_quartz = FT(0.1)
+ν_ss_om = FT(0.1)
+ν_ss_gravel = FT(0.0);
+z_0m_soil = FT(0.01)
+z_0b_soil = FT(0.001)
+soil_ϵ = FT(0.98)
+soil_α_PAR = FT(0.2)
+soil_α_NIR = FT(0.2)
+
+# TwoStreamModel parameters
+Ω = FT(0.69)
+ld = FT(0.5)
+G_Function = ConstantGFunction(ld)
+α_PAR_leaf = FT(0.1)
+λ_γ_PAR = FT(5e-7)
+τ_PAR_leaf = FT(0.05)
+α_NIR_leaf = FT(0.45)
+τ_NIR_leaf = FT(0.25)
+ϵ_canopy = FT(0.97)
+
+# Energy Balance model
+ac_canopy = FT(2.5e3)
+
+# Conductance Model
+g1 = FT(141) # Wang et al: 141 sqrt(Pa) for Medlyn model; Natan used 300.
+Drel = FT(1.6)
+g0 = FT(1e-4)
+
+#Photosynthesis model
+Vcmax25 = FT(9e-5) # from Yujie's paper 4.5e-5 , Natan used 9e-5
+
+# Plant Hydraulics and general plant parameters
+SAI = FT(1.0) # m2/m2 or: estimated from Wang et al, FT(0.00242) ?
+f_root_to_shoot = FT(3.5)
+K_sat_plant = 5e-9 # m/s # seems much too small?
+ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value is -4 MPa
+Weibull_param = FT(4) # unitless, Holtzman's original c param value
+a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
+conductivity_model =
+    PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
+retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
+plant_ν = FT(2.46e-4)
+plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
+rooting_depth = FT(0.5) # from Natan
+z0_m = FT(0.13) * h_canopy
+z0_b = FT(0.1) * z0_m

--- a/experiments/integrated/fluxnet/any_site/any_simulation.jl
+++ b/experiments/integrated/fluxnet/any_site/any_simulation.jl
@@ -1,0 +1,26 @@
+"""This file contains simulation variables for running Clima Land on the US-Ha1
+fluxtower site. This includes both the domain variables and timestepping 
+variables for running the simulation."""
+
+# DOMAIN SETUP:
+
+# Column dimensions - separation of layers at the top and bottom of the column:
+dz_bottom = FT(1.5)
+dz_top = FT(0.025)
+dz_tuple = (dz_bottom, dz_top)
+nelements = 20
+zmin = FT(-10)
+zmax = FT(0)
+# Stem and leaf compartments and their heights:
+n_stem = Int64(1)
+n_leaf = Int64(1)
+h_leaf = FT(12) # m
+h_stem = FT(14) # m
+
+# TIME STEPPING:
+
+# Starting time:
+t0 = Float64(0)
+
+# Time step size:
+dt = Float64(450)

--- a/experiments/integrated/fluxnet/met_drivers_FLUXNET.jl
+++ b/experiments/integrated/fluxnet/met_drivers_FLUXNET.jl
@@ -12,15 +12,105 @@ import ClimaComms
 
 context = ClimaComms.context()
 
+import SciMLBase
+import ClimaTimeSteppers as CTS
+import ClimaComms
+ClimaComms.@import_required_backends
+using ClimaCore
+import ClimaParams as CP
+using Statistics
+using Dates
+using Insolation
+using StatsBase
+
+using ClimaLand
+using ClimaLand.Domains: Column
+using ClimaLand.Snow
+using ClimaLand.Soil
+using ClimaLand.Soil.Biogeochemistry
+using ClimaLand.Canopy
+using ClimaLand.Canopy.PlantHydraulics
+import ClimaLand
+import ClimaLand.Parameters as LP
+import ClimaUtilities.OutputPathGenerator: generate_output_path
+using ClimaDiagnostics
+using ClimaUtilities
+const FT = Float64
+earth_param_set = LP.LandParameters(FT)
+climaland_dir = pkgdir(ClimaLand)
+
+include(joinpath(climaland_dir, "experiments/integrated/fluxnet/data_tools.jl"))
+include(joinpath(climaland_dir, "experiments/integrated/fluxnet/plot_utils.jl"))
+
+# Read in the site to be run from the command line
+#if length(ARGS) < 1
+#    error("Must provide site ID on command line")
+#end
+#
+site_ID = "US-MOz"
+params = Dict("g1" => 1.0, "Vcmax25" => 1.0)
+
+
+# function zenith_angle(
+#         t,
+#         start_date;
+#         latitude = lat,
+#         longitude = long,
+#         insol_params::Insolation.Parameters.InsolationParameters{FT} = earth_param_set.insol_params,
+#     ) where {FT}
+#     # This should be time in UTC
+#     current_datetime = start_date + Dates.Second(round(t))
+
+#     # Orbital Data uses Float64, so we need to convert to our sim FT
+#     d, δ, η_UTC =
+#     FT.(
+#         Insolation.helper_instantaneous_zenith_angle(
+#                                                      current_datetime,
+#                                                      start_date,
+#                                                      insol_params,
+#                                                     )
+#        )
+
+#     FT(
+#        Insolation.instantaneous_zenith_angle(
+#                                              d,
+#                                              δ,
+#                                              η_UTC,
+#                                              longitude,
+#                                              latitude,
+#                                             )[1],
+#       )
+# end
+
+# include(
+#     joinpath(pkgdir(ClimaLand), "experiments/integrated/fluxnet/any_site/any_simulation.jl"),
+# )
+
+# include(
+#     joinpath(pkgdir(ClimaLand), "experiments/integrated/fluxnet/fluxnet_domain.jl"),
+# )
+
+# include(
+#     joinpath(pkgdir(ClimaLand), "experiments/integrated/fluxnet/any_site/any_parameters.jl"),
+# )
+
+# include(
+#     joinpath(pkgdir(ClimaLand), "experiments/integrated/fluxnet/fluxnet_simulation.jl"),
+# )
+
 # Methods for reading in the LAI data from MODIS data
 include(
     joinpath(pkgdir(ClimaLand), "experiments/integrated/fluxnet/pull_MODIS.jl"),
 )
 
-data_path = ClimaLand.Artifacts.experiment_fluxnet_data_path(site_ID)
+include(joinpath(pkgdir(ClimaLand),"experiments/integrated/fluxnet/path_to_data_file.jl"))
+site_ID = "US-Ha1"
+data_path = get_path(site_ID)
+#data_path = ClimaLand.Artifacts.experiment_fluxnet_data_path(site_ID)
 driver_data = readdlm(data_path, ',')
 
 LOCAL_DATETIME = DateTime.(format.(driver_data[2:end, 1]), "yyyymmddHHMM")
+time_offset = 5 # temporary testing
 UTC_DATETIME = LOCAL_DATETIME .+ Dates.Hour(time_offset)
 DATA_DT = Second(LOCAL_DATETIME[2] - LOCAL_DATETIME[1]).value # seconds
 

--- a/experiments/integrated/fluxnet/path_to_data_file.jl
+++ b/experiments/integrated/fluxnet/path_to_data_file.jl
@@ -1,0 +1,15 @@
+function get_path(site_ID)
+    directories = readdir("/groups/esm/ClimaArtifacts/artifacts/fluxnet2015/")
+
+    for directory in directories
+        if occursin(site_ID, directory)
+            parts = split(directory, r"FULLSET_", limit=2)
+
+            parts[1] *= "FULLSET"
+            ret_str = "/groups/esm/ClimaArtifacts/artifacts/fluxnet2015/" * directory * "/" * parts[1] * "_MM_" * parts[2] * ".csv"
+            println(ret_str)
+            return ret_str
+        end
+    end
+
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Added function to allow run_fluxnet.jl to be extrapolated for a fixed set of params and any fluxnet site (stored in any_run_fluxnet.jl). Was tested with US-Ha1 to confirm that it is working.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- [ ] Make sure "iterating over empty list" bug is fixed (possibly fixed once rebased to origin)
- [ ] Rebase onto main

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Implemented function to get data files using site ID
- Confirmed met_drivers_FLUXNET.jl worked with generic fluxnet sites


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
