### PR TITLE
update label for snowy land longer run

### DIFF
--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -59,7 +59,7 @@ steps:
         artifact_paths: "california_longrun_gpu/*pdf"
         agents:
           slurm_gpus: 1
-          slurm_time: 00:30:00
+          slurm_time: 01:00:00
         env:
           CLIMACOMMS_DEVICE: "CUDA"
 
@@ -86,7 +86,7 @@ steps:
   - group: "Longer runs of Global Land Models"
     if: build.env("LONGER_RUN") != null
     steps:
-      - label: "Snowy Land, 10 years"
+      - label: "Snowy Land, 19 years"
         command:
           - julia --color=yes --project=.buildkite experiments/long_runs/snowy_land.jl
         artifact_paths:
@@ -99,7 +99,7 @@ steps:
           CLIMACOMMS_DEVICE: "CUDA"
           LONGER_RUN: ""
 
-      - label: "Soil, 10 years"
+      - label: "Soil, 20 years"
         command:
           - julia --color=yes --project=.buildkite experiments/long_runs/soil.jl
         artifact_paths: "soil_longrun_gpu/*pdf"

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -151,7 +151,7 @@ end
 
 function setup_simulation(; greet = false)
     # If not LONGER_RUN, run for 2 years; note that the forcing from 2008 is repeated.
-    # If LONGER run, run for 10 years, with the correct forcing each year.
+    # If LONGER run, run for 20 years, with the correct forcing each year.
     start_date = LONGER_RUN ? DateTime(2000) : DateTime(2008)
     stop_date = LONGER_RUN ? DateTime(2020) : DateTime(2010)
     Δt = 450.0


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The snowy land `LONGER RUN` was recently changed to run for 19 years instead of 10 years, but we didn't update the label in the buildkite pipeline. It's updated here.
