### PR TITLE
Tr/use land simulation struct

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.9"
+julia_version = "1.10.10"
 manifest_format = "2.0"
 project_hash = "0e313427333375504d76ddc31cd582bee13918ac"
 
@@ -2186,7 +2186,7 @@ version = "3.2.4+0"
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
-version = "0.8.1+4"
+version = "0.8.5+0"
 
 [[deps.OpenMPI_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML", "Zlib_jll"]

--- a/experiments/calibration/model_interface.jl
+++ b/experiments/calibration/model_interface.jl
@@ -359,7 +359,7 @@ function ClimaCalibrate.forward_model(iteration, member)
         calibrate_param_dict,
     )
 
-    simulation = LandSimulation(FT, start_date, stop_date, Δt, model; outdir)
+    simulation = LandSimulation(start_date, stop_date, Δt, model; outdir)
     @info "Run: Global Soil-Canopy-Snow Model"
     @info "Resolution: $nelements"
     @info "Timestep: $Δt s"

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -19,6 +19,7 @@ using ClimaLand.Soil
 using ClimaLand.Soil.Biogeochemistry
 using ClimaLand.Canopy
 using ClimaLand.Canopy.PlantHydraulics
+import ClimaLand.Simulations: LandSimulation, solve!
 import ClimaLand
 import ClimaLand.Parameters as LP
 using ClimaDiagnostics
@@ -105,12 +106,13 @@ canopy_domain = ClimaLand.Domains.obtain_surface_domain(land_domain)
 prognostic_land_components = (:canopy, :soil, :soilco2)
 
 # Set up the timestepping information for the simulation
-t0 = Float64(0)
 dt = Float64(450) # 7.5 minutes
 N_spinup_days = 15
 N_days = N_spinup_days + 340
-tf = Float64(t0 + N_days * 3600 * 24)
-t_spinup = Float64(t0 + N_spinup_days * 3600 * 24)
+N_seconds = Float64(N_days * 3600 * 24)
+start_date = DateTime(2010) + Hour(time_offset)
+end_date = start_date + Day(N_days)
+
 
 timestepper = CTS.ARS111();
 ode_algo = CTS.IMEXAlgorithm(
@@ -164,7 +166,7 @@ pft_pcts = [
 ac_canopy = ac_canopy * 3
 # This reads in the data from the flux tower site and creates
 # the atmospheric and radiative driver structs for the model
-start_date = DateTime(2010) + Hour(time_offset)
+
 (; atmos, radiation) = FluxnetSimulations.prescribed_forcing_fluxnet(
     site_ID,
     lat,
@@ -244,8 +246,8 @@ photosynthesis = FarquharModel{FT}(canopy_domain; photosynthesis_parameters)
 # Read in LAI from MODIS data
 surface_space = land_domain.space.surface;
 modis_lai_ncdata_path = ClimaLand.Artifacts.modis_lai_multiyear_paths(
-    start_date = start_date + Second(t0),
-    end_date = start_date + Second(t0) + Second(tf);
+    start_date = start_date,
+    end_date = end_date;
     context = ClimaComms.context(surface_space),
 );
 LAI = ClimaLand.prescribed_lai_modis(
@@ -297,16 +299,17 @@ canopy = Canopy.CanopyModel{FT}(
 # Integrated plant hydraulics and soil model
 land = SoilCanopyModel{FT}(soilco2, soil, canopy)
 
-Y, p, cds = initialize(land)
-exp_tendency! = make_exp_tendency(land)
-imp_tendency! = make_imp_tendency(land);
-jacobian! = make_jacobian(land);
-jac_kwargs =
-    (; jac_prototype = ClimaLand.FieldMatrixWithSolver(Y), Wfact = jacobian!);
 
-FluxnetSimulations.set_fluxnet_ic!(Y, site_ID, start_date, time_offset, land)
-set_initial_cache! = make_set_initial_cache(land)
-set_initial_cache!(p, Y, t0);
+
+
+
+set_ic!(Y, _, _, model) = FluxnetSimulations.set_fluxnet_ic!(
+    Y,
+    site_ID,
+    start_date,
+    time_offset,
+    model,
+)
 
 # Callbacks
 output_writer = ClimaDiagnostics.Writers.DictWriter()
@@ -337,33 +340,20 @@ diags = ClimaLand.default_diagnostics(
     average_period = :hourly,
 )
 
-diagnostic_handler =
-    ClimaDiagnostics.DiagnosticsHandler(diags, Y, p, t0, dt = dt);
-
-diag_cb = ClimaDiagnostics.DiagnosticsCallback(diagnostic_handler);
-
-## How often we want to update the drivers. Note that this uses the defined `t0` and `tf`
+## How often we want to update the drivers
 ## defined in the simulatons file
 data_dt = Float64(FluxnetSimulations.get_data_dt(site_ID))
-updateat = Array(t0:data_dt:tf)
-model_drivers = ClimaLand.get_drivers(land)
-updatefunc = ClimaLand.make_update_drivers(model_drivers)
-driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
-cb = SciMLBase.CallbackSet(driver_cb, diag_cb)
-
-
-prob = SciMLBase.ODEProblem(
-    CTS.ClimaODEFunction(
-        T_exp! = exp_tendency!,
-        T_imp! = SciMLBase.ODEFunction(imp_tendency!; jac_kwargs...),
-        dss! = ClimaLand.dss!,
-    ),
-    Y,
-    (t0, tf),
-    p,
-);
-
-sol = SciMLBase.solve(prob, ode_algo; dt = dt, callback = cb);
+updateat = Array(start_date:Second(data_dt):end_date)
+simulation = LandSimulation(
+    start_date,
+    end_date,
+    dt,
+    land;
+    set_ic! = set_ic!,
+    updateat,
+    diagnostics = diags,
+)
+sol = solve!(simulation)
 
 ClimaLand.Diagnostics.close_output_writers(diags)
 comparison_data = FluxnetSimulations.get_comparison_data(site_ID, time_offset)

--- a/experiments/integrated/fluxnet/ozark_soilsnow.jl
+++ b/experiments/integrated/fluxnet/ozark_soilsnow.jl
@@ -18,6 +18,7 @@ using ClimaLand.Domains: Column
 using ClimaLand.Soil
 using ClimaLand.Snow
 import ClimaLand
+import ClimaLand.Simulations: LandSimulation, solve!
 import ClimaLand.Parameters as LP
 import ClimaParams
 
@@ -95,14 +96,13 @@ compartment_surfaces = n_stem > 0 ? [zmax, h_stem, h_canopy] : [zmax, h_leaf]
 domain = Column(; zlim = (zmin, zmax), nelements = nelements, dz_tuple)
 
 # Set up the timestepping information for the simulation
-t0 = FT(1800)
-N_days = 360
-dt = FT(900)
-tf = t0 + FT(3600 * 24 * N_days)
-
-# This reads in the data from the flux tower site and creates
-# the atmospheric and radiative driver structs for the model
 start_date = DateTime(2010) + Hour(time_offset)
+N_days = 360
+end_date = start_date + Day(N_days)
+dt = FT(900)
+
+# Height of sensor on flux tower
+atmos_h = FT(32)
 forcing = FluxnetSimulations.prescribed_forcing_fluxnet(
     site_ID,
     lat,
@@ -159,61 +159,39 @@ snow_model = Snow.SnowModel(
 
 # Construct the land model
 land = ClimaLand.SoilSnowModel{FT}(; snow = snow_model, soil = soil_model)
-Y, p, cds = initialize(land)
-exp_tendency! = make_exp_tendency(land)
-imp_tendency! = make_imp_tendency(land)
-jacobian! = ClimaLand.make_jacobian(land);
-jac_kwargs =
-    (; jac_prototype = ClimaLand.FieldMatrixWithSolver(Y), Wfact = jacobian!);
-set_initial_cache! = make_set_initial_cache(land)
 
 # Initial conditions
-FluxnetSimulations.set_fluxnet_ic!(Y, site_ID, start_date, time_offset, land)
-set_initial_cache!(p, Y, t0)
+set_ic!(Y, p, _, model) = FluxnetSimulations.set_fluxnet_ic!(
+    Y,
+    site_ID,
+    start_date,
+    time_offset,
+    model,
+)
 
-saveat = Array(t0:dt:tf)
+saveat = Array(start_date:Second(dt):end_date)
 sv = (;
-    t = Array{Float64}(undef, length(saveat)),
+    t = Array{DateTime}(undef, length(saveat)),
     saveval = Array{NamedTuple}(undef, length(saveat)),
 )
 saving_cb = ClimaLand.NonInterpSavingCallback(sv, saveat)
 
 updateat = deepcopy(saveat)
-model_drivers = ClimaLand.get_drivers(land)
-updatefunc = ClimaLand.make_update_drivers(model_drivers)
-driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
-cb = SciMLBase.CallbackSet(driver_cb, saving_cb)
-# TIME STEPPING
-timestepper = CTS.ARS111();
-ode_algo = CTS.IMEXAlgorithm(
-    timestepper,
-    CTS.NewtonsMethod(
-        max_iters = 3,
-        update_j = CTS.UpdateEvery(CTS.NewNewtonIteration),
-    ),
-);
 
-# Problem definition and callbacks
-prob = SciMLBase.ODEProblem(
-    CTS.ClimaODEFunction(
-        T_exp! = exp_tendency!,
-        T_imp! = SciMLBase.ODEFunction(imp_tendency!; jac_kwargs...),
-        dss! = ClimaLand.dss!,
-    ),
-    Y,
-    (t0, tf),
-    p,
-);
-sol = SciMLBase.solve(
-    prob,
-    ode_algo;
-    callback = cb,
-    dt = dt,
-    saveat = collect(t0:dt:tf),
-);
+simulation = LandSimulation(
+    start_date,
+    end_date,
+    dt,
+    land;
+    user_callbacks = (saving_cb,),
+    set_ic! = set_ic!,
+    updateat,
+    solver_kwargs = (; saveat = saveat),
+)
+sol = solve!(simulation)
 
 # Plotting
-daily = sol.t ./ 3600 ./ 24
+daily = FT.(sol.t) ./ 3600 ./ 24
 savedir =
     joinpath(climaland_dir, "experiments/integrated/fluxnet/ozark_soilsnow")
 mkpath(savedir)
@@ -227,7 +205,7 @@ ax1 = Axis(fig[2, 2], ylabel = "SWC", xlabel = "Days")
 lines!(
     ax1,
     daily,
-    [parent(sol.u[k].soil.ϑ_l)[end - 2] for k in 1:1:length(sol.t)],
+    [parent(sol.u[k].soil.ϑ_l)[end - 2] for k in 1:1:length(FT.(sol.t))],
     label = "10cm",
 )
 lines!(
@@ -235,7 +213,7 @@ lines!(
     daily,
     [
         parent(sol.u[k].soil.θ_i .+ sol.u[k].soil.ϑ_l)[end - 2] for
-        k in 1:1:length(sol.t)
+        k in 1:1:length(FT.(sol.t))
     ],
     label = "10cm, liq+ice",
 )
@@ -259,22 +237,23 @@ lines!(
 )
 axislegend(ax2, position = :rb)
 ax3 = Axis(fig[2, 1], ylabel = "SWE (m)", xlabel = "Days")
-lines!(ax3, daily, [parent(sol.u[k].snow.S)[1] for k in 1:1:length(sol.t)])
+lines!(ax3, daily, [parent(sol.u[k].snow.S)[1] for k in 1:1:length(FT.(sol.t))])
 
 # Temp
+sv_times = Dates.value.(Second.(sv.t .- sv.t[1]))
 ax4 = Axis(fig[1, 1], ylabel = "T (K)")
 hidexdecorations!(ax4, ticks = false)
 lines!(
     ax4,
-    sv.t ./ 24 ./ 3600,
-    [parent(sv.saveval[k].soil.T)[end - 2] for k in 1:1:length(sv.t)],
+    sv_times ./ 24 ./ 3600,
+    [parent(sv.saveval[k].soil.T)[end - 2] for k in 1:1:length(sv_times)],
     label = "Model 10 cm",
 )
 
 lines!(
     ax4,
-    sv.t ./ 24 ./ 3600,
-    [parent(sv.saveval[k].snow.T)[1] for k in 1:1:length(sv.t)],
+    sv_times ./ 24 ./ 3600,
+    [parent(sv.saveval[k].snow.T)[1] for k in 1:1:length(sv_times)],
     label = "Snow",
 )
 lines!(
@@ -355,9 +334,9 @@ end
                 compute_atmos_energy_fluxes(sv.saveval[k]) .-
                 compute_energy_of_runoff(sv.saveval[k]) .-
                 sv.saveval[k].soil.bottom_bc.heat,
-            )[end] for k in 1:1:(length(sv.t) - 1)
+            )[end] for k in 1:1:(length(sv_times) - 1)
         ],
-    ) * (sv.t[2] - sv.t[1])
+    ) * (sv_times[2] - sv_times[1])
 E_measured = [
     sum(sol.u[k].soil.ρe_int) + parent(sol.u[k].snow.U)[end] for
     k in 1:1:length(sv.t)
@@ -369,13 +348,13 @@ E_measured = [
                 compute_atmos_water_vol_fluxes(sv.saveval[k]) .-
                 compute_runoff(sv.saveval[k]) .-
                 sv.saveval[k].soil.bottom_bc.water,
-            )[end] for k in 1:1:(length(sv.t) - 1)
+            )[end] for k in 1:1:(length(sv_times) - 1)
         ],
-    ) * (sv.t[2] - sv.t[1])
+    ) * (sv_times[2] - sv_times[1])
 W_measured = [
     sum(sol.u[k].soil.ϑ_l) +
     sum(sol.u[k].soil.θ_i) * _ρ_i / _ρ_l +
-    parent(sol.u[k].snow.S)[end] for k in 1:1:length(sv.t)
+    parent(sol.u[k].snow.S)[end] for k in 1:1:length(sv_times)
 ]
 lines!(
     ax1,

--- a/experiments/long_runs/bucket.jl
+++ b/experiments/long_runs/bucket.jl
@@ -138,7 +138,6 @@ timestepper = CTS.ExplicitAlgorithm(timestepper)
 
 # Create the simulation
 simulation = LandSimulation(
-    FT,
     start_date,
     stop_date,
     Δt,

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -163,7 +163,7 @@ domain = ClimaLand.Domains.HybridBox(;
 )
 params = LP.LandParameters(FT)
 model = setup_model(FT, context, start_date, Δt, domain, params)
-simulation = LandSimulation(FT, start_date, stop_date, Δt, model; outdir)
+simulation = LandSimulation(start_date, stop_date, Δt, model; outdir)
 ClimaLand.Simulations.solve!(simulation)
 
 LandSimVis.make_heatmaps(simulation; savedir = root_path, date = stop_date)

--- a/experiments/long_runs/low_res_snowy_land.jl
+++ b/experiments/long_runs/low_res_snowy_land.jl
@@ -172,7 +172,7 @@ user_callbacks = (
     ClimaLand.ReportCallback(10000),
 )
 simulation =
-    LandSimulation(FT, start_date, stop_date, Δt, model; user_callbacks, outdir)
+    LandSimulation(start_date, stop_date, Δt, model; user_callbacks, outdir)
 @info "Run: Global Soil-Canopy-Snow Model"
 @info "Resolution: $nelements"
 @info "Timestep: $Δt s"

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -189,7 +189,7 @@ domain = ClimaLand.Domains.global_domain(
 )
 params = LP.LandParameters(FT)
 model = setup_model(FT, start_date, stop_date, Δt, domain, params)
-simulation = LandSimulation(FT, start_date, stop_date, Δt, model; outdir)
+simulation = LandSimulation(start_date, stop_date, Δt, model; outdir)
 @info "Run: Global Soil-Canopy-Snow Model"
 @info "Resolution: $nelements"
 @info "Timestep: $Δt s"

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -93,7 +93,7 @@ diagnostics = ClimaLand.default_diagnostics(
     conservation_period = Day(10),
 )
 simulation =
-    LandSimulation(FT, start_date, stop_date, Δt, model; outdir, diagnostics)
+    LandSimulation(start_date, stop_date, Δt, model; outdir, diagnostics)
 
 @info "Run: Global Soil Model"
 @info "Resolution: $nelements"

--- a/experiments/standalone/Vegetation/no_vegetation.jl
+++ b/experiments/standalone/Vegetation/no_vegetation.jl
@@ -17,6 +17,7 @@ using ClimaLand.Canopy.PlantHydraulics
 import ClimaLand
 import ClimaLand.Parameters as LP
 import ClimaUtilities.OutputPathGenerator: generate_output_path
+import ClimaLand.Simulations: LandSimulation, solve!
 using DelimitedFiles
 import ClimaLand.FluxnetSimulations as FluxnetSimulations
 
@@ -30,6 +31,9 @@ land_domain = Point(; z_sfc = FT(0.0), longlat = (long, lat))
 atmos_h = FT(32)
 site_ID = "US-MOz"
 start_date = DateTime(2010) + Hour(time_offset)
+N_days = 10
+end_date = start_date + Day(N_days)
+dt = 225.0;
 
 # Prescribed forcing from Fluxnet data
 (; atmos, radiation) = FluxnetSimulations.prescribed_forcing_fluxnet(
@@ -50,65 +54,49 @@ ground = PrescribedGroundConditions{FT}(;
 forcing = (; atmos, radiation, ground);
 
 function fakeLAIfunction(t)
-    if t < 30 * 24 * 3600
+    if FT(t) < 30 * 24 * 3600
         0.0
-    elseif t < (364 - 30) * 24 * 3600.0
-        max(2.0 * sin(2 * π / (730 * 24 * 3600) * (t - 30 * 24 * 3600)), 0)
+    elseif FT(t) < (364 - 30) * 24 * 3600.0
+        max(2.0 * sin(2 * π / (730 * 24 * 3600) * (FT(t) - 30 * 24 * 3600)), 0)
     else
         0.0
     end
 end
-LAI = TimeVaryingInput(fakeLAIfunction)
 
-# Set up plant hydraulics with no vegetation
+LAI = TimeVaryingInput(fakeLAIfunction)
 SAI = RAI = FT(0)
 hydraulics = PlantHydraulicsModel{FT}(land_domain, LAI; SAI, RAI);
-
-# Construct a CanopyModel with default parameters
 canopy = ClimaLand.Canopy.CanopyModel{FT}(
     land_domain,
     forcing,
     LAI,
     earth_param_set;
     hydraulics,
-);
+)
 
-Y, p, coords = ClimaLand.initialize(canopy)
-exp_tendency! = make_exp_tendency(canopy);
-imp_tendency! = make_imp_tendency(canopy)
-jacobian! = make_jacobian(canopy);
-jac_kwargs =
-    (; jac_prototype = ClimaLand.FieldMatrixWithSolver(Y), Wfact = jacobian!);
+
+
+
+
 
 ψ_leaf_0 = FT(-2e5 / 9800)
 (; retention_model, ν, S_s) = canopy.hydraulics.parameters;
 S_l_ini = inverse_water_retention_curve(retention_model, ψ_leaf_0, ν, S_s)
 
-Y.canopy.hydraulics.ϑ_l.:1 .= augmented_liquid_fraction.(ν, S_l_ini)
-
-t0 = 0.0
-N_days = 10
-tf = t0 + 3600 * 24 * N_days
-dt = 225.0;
-
-evaluate!(Y.canopy.energy.T, atmos.T, t0)
-set_initial_cache! = make_set_initial_cache(canopy)
-set_initial_cache!(p, Y, t0);
-
+function set_ic!(Y, p, t0, model)
+    Y.canopy.hydraulics.ϑ_l.:1 .= augmented_liquid_fraction.(ν, S_l_ini)
+    evaluate!(Y.canopy.energy.T, atmos.T, t0)
+end
 
 n = 16
-saveat = Array(t0:(n * dt):tf)
+saveat = Array(start_date:Second(n * dt):end_date)
 sv = (;
-    t = Array{Float64}(undef, length(saveat)),
+    t = Array{DateTime}(undef, length(saveat)),
     saveval = Array{NamedTuple}(undef, length(saveat)),
 )
 saving_cb = ClimaLand.NonInterpSavingCallback(sv, saveat);
 
-updateat = Array(t0:1800:tf)
-drivers = ClimaLand.get_drivers(canopy)
-updatefunc = ClimaLand.make_update_drivers(drivers)
-driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
-cb = SciMLBase.CallbackSet(driver_cb, saving_cb);
+updateat = Array(start_date:Second(1800):end_date)
 
 # Set up timestepper
 timestepper = CTS.ARS111();
@@ -120,18 +108,18 @@ ode_algo = CTS.IMEXAlgorithm(
     ),
 );
 
-prob = SciMLBase.ODEProblem(
-    CTS.ClimaODEFunction(
-        T_exp! = exp_tendency!,
-        T_imp! = SciMLBase.ODEFunction(imp_tendency!; jac_kwargs...),
-        dss! = ClimaLand.dss!,
-    ),
-    Y,
-    (t0, tf),
-    p,
-);
-
-sol = SciMLBase.solve(prob, ode_algo; dt = dt, callback = cb, saveat = saveat);
+simulation = LandSimulation(
+    start_date,
+    end_date,
+    dt,
+    canopy;
+    set_ic! = set_ic!,
+    user_callbacks = (saving_cb,),
+    updateat = updateat,
+    solver_kwargs = (; saveat = deepcopy(saveat)),
+    timestepper = ode_algo,
+)
+sol = solve!(simulation)
 
 savedir =
     generate_output_path("experiments/standalone/Vegetation/no_vegetation");
@@ -173,33 +161,34 @@ Tr = [
     parent(sv.saveval[k].canopy.turbulent_fluxes.transpiration)[1] for
     k in 1:length(sol.t)
 ]
+times = FT.(sol.t) ./ 24 ./ 3600
 fig = Figure()
 ax = Axis(fig[1, 1], xlabel = "Time (days)", ylabel = "Temperature (K)")
-lines!(ax, sol.t ./ 24 ./ 3600, T, label = "Canopy")
-lines!(ax, sol.t ./ 24 ./ 3600, T_atmos, label = "Atmos")
+lines!(ax, times, T, label = "Canopy")
+lines!(ax, times, T_atmos, label = "Atmos")
 axislegend(ax)
 ax = Axis(fig[2, 1], xlabel = "Time (days)", ylabel = "Volumetric Water")
-lines!(ax, sol.t ./ 24 ./ 3600, ϑ, label = "Canopy")
+lines!(ax, times, ϑ, label = "Canopy")
 axislegend(ax)
 ax = Axis(fig[3, 1], xlabel = "Time (days)", ylabel = "LAI")
-lines!(ax, sol.t ./ 24 ./ 3600, fakeLAIfunction.(sol.t), label = "Canopy")
+lines!(ax, times, fakeLAIfunction.(sol.t), label = "Canopy")
 axislegend(ax)
 save(joinpath(savedir, "no_veg_state.png"), fig)
 fig2 = Figure()
 ax = Axis(fig2[1, 1], xlabel = "Time (days)", ylabel = "Energy Fluxes")
-lines!(ax, sol.t ./ 24 ./ 3600, SW_n, label = "SW")
-lines!(ax, sol.t ./ 24 ./ 3600, LW_n, label = "LW")
-lines!(ax, sol.t ./ 24 ./ 3600, SHF, label = "SHF")
-lines!(ax, sol.t ./ 24 ./ 3600, LHF, label = "LHF")
-lines!(ax, sol.t ./ 24 ./ 3600, RE, label = "RE")
+lines!(ax, times, SW_n, label = "SW")
+lines!(ax, times, LW_n, label = "LW")
+lines!(ax, times, SHF, label = "SHF")
+lines!(ax, times, LHF, label = "LHF")
+lines!(ax, times, RE, label = "RE")
 axislegend(ax)
 ax = Axis(fig2[2, 1], xlabel = "Time (days)", ylabel = "Water Fluxes")
-lines!(ax, sol.t ./ 24 ./ 3600, Tr, label = "Transpiration")
-lines!(ax, sol.t ./ 24 ./ 3600, R, label = "R")
+lines!(ax, times, Tr, label = "Transpiration")
+lines!(ax, times, R, label = "R")
 
 axislegend(ax)
 ax = Axis(fig2[3, 1], xlabel = "Time (days)", ylabel = "Carbon Fluxes")
-lines!(ax, sol.t ./ 24 ./ 3600, GPP, label = "GPP")
-lines!(ax, sol.t ./ 24 ./ 3600, resp, label = "Respiration")
+lines!(ax, times, GPP, label = "GPP")
+lines!(ax, times, resp, label = "Respiration")
 axislegend(ax)
 save(joinpath(savedir, "no_veg_fluxes.png"), fig2)

--- a/experiments/standalone/Vegetation/varying_lai.jl
+++ b/experiments/standalone/Vegetation/varying_lai.jl
@@ -16,6 +16,7 @@ using ClimaLand.Canopy
 using ClimaLand.Canopy.PlantHydraulics
 import ClimaLand
 import ClimaLand.Parameters as LP
+import ClimaLand.Simulations: LandSimulation, solve!
 using DelimitedFiles
 import ClimaLand.FluxnetSimulations as FluxnetSimulations
 import ClimaUtilities.OutputPathGenerator: generate_output_path
@@ -29,6 +30,9 @@ land_domain = Point(; z_sfc = FT(0.0), longlat = (long, lat))
 atmos_h = FT(32)
 site_ID = "US-MOz"
 start_date = DateTime(2010) + Hour(time_offset)
+N_days = 364
+end_date = start_date + Day(N_days)
+dt = 225.0;
 (; atmos, radiation) = FluxnetSimulations.prescribed_forcing_fluxnet(
     site_ID,
     lat,
@@ -47,10 +51,10 @@ ground = PrescribedGroundConditions{FT}(;
 forcing = (; atmos, radiation, ground);
 
 function fakeLAIfunction(t)
-    if t < 30 * 24 * 3600
+    if FT(t) < 30 * 24 * 3600
         0.0
-    elseif t < (364 - 30) * 24 * 3600.0
-        max(2.0 * sin(2 * π / (730 * 24 * 3600) * (t - 30 * 24 * 3600)), 0)
+    elseif FT(t) < (364 - 30) * 24 * 3600.0
+        max(2.0 * sin(2 * π / (730 * 24 * 3600) * (FT(t) - 30 * 24 * 3600)), 0)
     else
         0.0
     end
@@ -73,41 +77,26 @@ canopy = ClimaLand.Canopy.CanopyModel{FT}(
     hydraulics,
 );
 
-Y, p, coords = ClimaLand.initialize(canopy)
-exp_tendency! = make_exp_tendency(canopy);
-imp_tendency! = make_imp_tendency(canopy)
-jacobian! = make_jacobian(canopy);
-jac_kwargs =
-    (; jac_prototype = ClimaLand.FieldMatrixWithSolver(Y), Wfact = jacobian!);
-
 
 (; retention_model, ν, S_s) = canopy.hydraulics.parameters;
 ψ_leaf_0 = FT(-2e5 / 9800)
 S_l_ini = inverse_water_retention_curve(retention_model, ψ_leaf_0, ν, S_s)
-Y.canopy.hydraulics.ϑ_l.:1 .= augmented_liquid_fraction.(ν, S_l_ini)
 
-t0 = 0.0
-N_days = 364
-tf = t0 + 3600 * 24 * N_days
-dt = 225.0;
-evaluate!(Y.canopy.energy.T, atmos.T, t0)
-set_initial_cache! = make_set_initial_cache(canopy)
-set_initial_cache!(p, Y, t0);
+function set_ic!(Y, p, t0, model)
+    Y.canopy.hydraulics.ϑ_l.:1 .= augmented_liquid_fraction.(ν, S_l_ini)
+    evaluate!(Y.canopy.energy.T, atmos.T, t0)
+end
 
 
 n = 16
-saveat = Array(t0:(n * dt):tf)
+saveat = Array(start_date:Second(n * dt):end_date)
 sv = (;
-    t = Array{Float64}(undef, length(saveat)),
+    t = Array{DateTime}(undef, length(saveat)),
     saveval = Array{NamedTuple}(undef, length(saveat)),
 )
 saving_cb = ClimaLand.NonInterpSavingCallback(sv, saveat);
-
-updateat = Array(t0:1800:tf)
+updateat = Array(start_date:Second(1800):end_date)
 drivers = ClimaLand.get_drivers(canopy)
-updatefunc = ClimaLand.make_update_drivers(drivers)
-driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
-cb = SciMLBase.CallbackSet(driver_cb, saving_cb);
 
 # Set up timestepper
 timestepper = CTS.ARS111();
@@ -119,18 +108,18 @@ ode_algo = CTS.IMEXAlgorithm(
     ),
 );
 
-prob = SciMLBase.ODEProblem(
-    CTS.ClimaODEFunction(
-        T_exp! = exp_tendency!,
-        T_imp! = SciMLBase.ODEFunction(imp_tendency!; jac_kwargs...),
-        dss! = ClimaLand.dss!,
-    ),
-    Y,
-    (t0, tf),
-    p,
-);
-
-sol = SciMLBase.solve(prob, ode_algo; dt = dt, callback = cb, saveat = saveat);
+simulation = LandSimulation(
+    start_date,
+    end_date,
+    dt,
+    canopy;
+    set_ic! = set_ic!,
+    user_callbacks = (saving_cb,),
+    updateat = updateat,
+    solver_kwargs = (; saveat = deepcopy(saveat)),
+    timestepper = ode_algo,
+)
+sol = solve!(simulation)
 
 savedir = generate_output_path("experiments/standalone/Vegetation/varying_lai");
 T = [parent(sol.u[k].canopy.energy.T)[1] for k in 1:length(sol.t)]
@@ -171,33 +160,34 @@ Tr = [
     parent(sv.saveval[k].canopy.turbulent_fluxes.transpiration)[1] for
     k in 1:length(sol.t)
 ]
+times = float.(sol.t) ./ 24 ./ 3600
 fig = Figure()
 ax = Axis(fig[1, 1], xlabel = "Time (days)", ylabel = "Temperature (K)")
-lines!(ax, sol.t ./ 24 ./ 3600, T, label = "Canopy")
-lines!(ax, sol.t ./ 24 ./ 3600, T_atmos, label = "Atmos")
+lines!(ax, times, T, label = "Canopy")
+lines!(ax, times, T_atmos, label = "Atmos")
 axislegend(ax)
 ax = Axis(fig[2, 1], xlabel = "Time (days)", ylabel = "Volumetric Water")
-lines!(ax, sol.t ./ 24 ./ 3600, ϑ, label = "Canopy")
+lines!(ax, times, ϑ, label = "Canopy")
 axislegend(ax)
 ax = Axis(fig[3, 1], xlabel = "Time (days)", ylabel = "LAI")
-lines!(ax, sol.t ./ 24 ./ 3600, fakeLAIfunction.(sol.t), label = "Canopy")
+lines!(ax, times, fakeLAIfunction.(sol.t), label = "Canopy")
 axislegend(ax)
 save(joinpath(savedir, "varying_lai_state.png"), fig)
 fig2 = Figure()
 ax = Axis(fig2[1, 1], xlabel = "Time (days)", ylabel = "Energy Fluxes")
-lines!(ax, sol.t ./ 24 ./ 3600, SW_n, label = "SW_n")
-lines!(ax, sol.t ./ 24 ./ 3600, LW_n, label = "LW_n")
-lines!(ax, sol.t ./ 24 ./ 3600, SHF, label = "SHF")
-lines!(ax, sol.t ./ 24 ./ 3600, LHF, label = "LHF")
-lines!(ax, sol.t ./ 24 ./ 3600, RE, label = "RE")
+lines!(ax, times, SW_n, label = "SW_n")
+lines!(ax, times, LW_n, label = "LW_n")
+lines!(ax, times, SHF, label = "SHF")
+lines!(ax, times, LHF, label = "LHF")
+lines!(ax, times, RE, label = "RE")
 axislegend(ax)
 ax = Axis(fig2[2, 1], xlabel = "Time (days)", ylabel = "Water Fluxes")
-lines!(ax, sol.t ./ 24 ./ 3600, Tr, label = "Transpiration")
-lines!(ax, sol.t ./ 24 ./ 3600, R, label = "R")
+lines!(ax, times, Tr, label = "Transpiration")
+lines!(ax, times, R, label = "R")
 
 axislegend(ax)
 ax = Axis(fig2[3, 1], xlabel = "Time (days)", ylabel = "Carbon Fluxes")
-lines!(ax, sol.t ./ 24 ./ 3600, GPP, label = "GPP")
-lines!(ax, sol.t ./ 24 ./ 3600, resp, label = "Respiration")
+lines!(ax, times, GPP, label = "GPP")
+lines!(ax, times, resp, label = "Respiration")
 axislegend(ax)
 save(joinpath(savedir, "varying_lai_fluxes.png"), fig2)

--- a/ext/LandSimulationVisualizationExt.jl
+++ b/ext/LandSimulationVisualizationExt.jl
@@ -6,6 +6,7 @@ import ClimaAnalysis
 import ClimaAnalysis.Visualize as viz
 using CairoMakie
 import GeoMakie
+import ClimaUtilities.TimeManager: ITime
 using Dates
 import NCDatasets
 using ClimaLand

--- a/ext/land_sim_vis/plotting_utils.jl
+++ b/ext/land_sim_vis/plotting_utils.jl
@@ -369,7 +369,7 @@ function LandSimVis.make_diurnal_timeseries(
                     dn,
                 )
             save_Δt = model_time[2] - model_time[1] # in seconds
-            model_dates = Second.(model_time) .+ start_date
+            model_dates = Second.(float.(model_time)) .+ start_date
             spinup_idx = findfirst(spinup_date .<= model_dates)
             hour_of_day, model_diurnal_cycle = compute_diurnal_cycle(
                 model_dates[spinup_idx:end],
@@ -486,7 +486,7 @@ function LandSimVis.make_timeseries(
                     dn,
                 )
             save_Δt = model_time[2] - model_time[1] # in seconds
-            model_dates = Second.(model_time) .+ start_date
+            model_dates = Second.(float.(model_time)) .+ start_date
             spinup_idx = findfirst(spinup_date .<= model_dates)
             hour_of_day, model_diurnal_cycle = compute_diurnal_cycle(
                 model_dates[spinup_idx:end],

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -83,7 +83,7 @@ function era5_land_forcing_data2008_path(; context = nothing, lowres = false)
             return hires_path
         catch
             @warn(
-                "High resolution ERA5 forcing not available locally; downloading and using low resolution data instead."
+                "High resolution ERA5 forcing not available locally; using low resolution data instead."
             )
             return lowres_path
         end

--- a/src/diagnostics/Diagnostics.jl
+++ b/src/diagnostics/Diagnostics.jl
@@ -18,7 +18,7 @@ import ..Soil: EnergyHydrology
 import ..Canopy: medlyn_conductance, medlyn_term, moisture_stress
 import ..Domains:
     top_center_to_surface, AbstractDomain, SphericalShell, HybridBox
-
+import ClimaLand
 import ..heaviside
 
 import ClimaDiagnostics:
@@ -32,6 +32,7 @@ import ClimaDiagnostics.Writers: HDF5Writer, NetCDFWriter, DictWriter
 
 import ClimaCore.Fields: zeros, field_values
 import ClimaCore.Operators: column_integral_definite!
+import ClimaUtilities.TimeManager: ITime, date
 
 export close_output_writers
 

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -49,6 +49,23 @@ end
 
 include("standard_diagnostic_frequencies.jl")
 
+# The default diagnostics currently require a start date because they use Dates.Period.
+default_diagnostics(
+    model::ClimaLand.AbstractModel,
+    start_date::Union{Nothing, ITime{<:Any, <:Any, Nothing}},
+    outdir,
+) = []
+
+function default_diagnostics(model::ClimaLand.AbstractModel, start_date, outdir)
+    # a starting date is required for default diagnostics
+    domain = ClimaLand.get_domain(model)
+    default_diagnostic_domain =
+        haskey(domain.space, :subsurface) ? domain.space.subsurface :
+        domain.space.surface
+    output_writer = NetCDFWriter(default_diagnostic_domain, outdir; start_date)
+    return default_diagnostics(model, start_date; output_writer)
+end
+
 # Bucket
 function default_diagnostics(
     land_model::BucketModel{FT},
@@ -401,3 +418,11 @@ function default_diagnostics(
         )
     end
 end
+
+# fallback method if no default diagnostics are defined
+default_diagnostics(
+    land_model::ClimaLand.AbstractModel,
+    start_date;
+    output_writer,
+    average_period = nothing,
+) = []

--- a/src/shared_utilities/Domains.jl
+++ b/src/shared_utilities/Domains.jl
@@ -1213,7 +1213,16 @@ function landsea_mask(
     return binary_mask
 end
 
-function landsea_mask(domain::Domains.AbstractDomain; kwargs...)
+# Points and Columns do not have a horizontal dim, so a horizontal mask cannot be applied
+landsea_mask(domain::Union{Point, Column}; kwargs...) = nothing
+
+function landsea_mask(
+    domain::Union{SphericalShell, SphericalSurface, HybridBox, Plane};
+    kwargs...,
+)
+    # HybridBox and Plane domains might not have longlat, which is needed for the mask
+    (hasproperty(domain, :longlat) && isnothing(domain.longlat)) &&
+        return nothing
     # average_horizontal_resolution_degrees returns a tuple with the resolution
     # along the two directions, so we take the minimum
     resolution_degrees = minimum(average_horizontal_resolution_degrees(domain))

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -534,9 +534,11 @@ function ClimaLand.make_compute_jacobian(model::EnergyHydrology{FT}) where {FT}
             @. p.soil.full_bidiag_matrix_scratch +=
                 MatrixFields.LowerDiagonalMatrixRow(p.soil.topBC_scratch)
         end
-
+        # dtγ can be an ITime or a float
         @. ∂ϑres∂ϑ =
-            -dtγ * (divf2c_matrix() ⋅ p.soil.full_bidiag_matrix_scratch) - (I,)
+            FT(-1) *
+            float(dtγ) *
+            (divf2c_matrix() ⋅ p.soil.full_bidiag_matrix_scratch) - (I,)
 
         # Now create the flux term for ∂ρe∂ϑ using bidiag_matrix_scratch
         # This overwrites full_bidiag_matrix_scratch
@@ -550,7 +552,9 @@ function ClimaLand.make_compute_jacobian(model::EnergyHydrology{FT}) where {FT}
                 ),
             ) ⋅ p.soil.bidiag_matrix_scratch
         @. ∂ρeres∂ϑ =
-            -dtγ * (divf2c_matrix() ⋅ p.soil.full_bidiag_matrix_scratch) - (I,)
+            FT(-1) *
+            float(dtγ) *
+            (divf2c_matrix() ⋅ p.soil.full_bidiag_matrix_scratch) - (I,)
 
         # Now overwrite bidiag_matrix_scratch and full_bidiag scratch for the ρe ρe bidiagonal
         @. p.soil.bidiag_matrix_scratch =
@@ -566,7 +570,9 @@ function ClimaLand.make_compute_jacobian(model::EnergyHydrology{FT}) where {FT}
             MatrixFields.DiagonalMatrixRow(interpc2f_op(-p.soil.κ)) ⋅
             p.soil.bidiag_matrix_scratch
         @. ∂ρeres∂ρe =
-            -dtγ * (divf2c_matrix() ⋅ p.soil.full_bidiag_matrix_scratch) - (I,)
+            FT(-1) *
+            float(dtγ) *
+            (divf2c_matrix() ⋅ p.soil.full_bidiag_matrix_scratch) - (I,)
     end
     return compute_jacobian!
 end

--- a/src/standalone/Soil/rre.jl
+++ b/src/standalone/Soil/rre.jl
@@ -438,7 +438,9 @@ function ClimaLand.make_compute_jacobian(model::RichardsModel{FT}) where {FT}
         end
         # Compute divergence matrix
         @. ∂ϑres∂ϑ =
-            -dtγ * (divf2c_matrix() ⋅ p.soil.full_bidiag_matrix_scratch) - (I,)
+            FT(-1) *
+            float(dtγ) *
+            (divf2c_matrix() ⋅ p.soil.full_bidiag_matrix_scratch) - (I,)
 
 
     end

--- a/src/standalone/Vegetation/canopy_energy.jl
+++ b/src/standalone/Vegetation/canopy_energy.jl
@@ -190,7 +190,7 @@ function ClimaLand.make_compute_jacobian(
             Y.canopy.energy.T - _T_freeze,
         )# use atmos air pressure as approximation for surface air pressure
         @. ∂Tres∂T =
-            dtγ * MatrixFields.DiagonalMatrixRow(
+            float(dtγ) * MatrixFields.DiagonalMatrixRow(
                 (∂LW_n∂Tc - ∂SHF∂Tc - ∂LHF∂qc * ∂qc∂Tc) /
                 (ac_canopy * max(area_index.leaf + area_index.stem, eps(FT))),
             ) - (I,)
@@ -241,7 +241,7 @@ end
 A function which updates `surface_field` in place with the value of
 the big leaf model's energy.
 
-Note that this assumes that there is at most a single canopy and stem 
+Note that this assumes that there is at most a single canopy and stem
 component, and that the area index for them refers to the integrated
 area index (in height) - not the value per layer.
 """


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Closes #1190 

This PR makes all experiments and docs use the `LandSimulation` struct. This also means that all changed simulations will use ITime internally. 


## Content
Add `LandSimulation` constructors that handle ITime conversion.

Make callbacks work with `ITime`

Add kwargs to `LandSimulation`

Drop `FT` as argument to `LandSimulation`

If an experiment/simulation has a start_date anywhere, use start and end date instead of t0 and tf. This makes it so that each simulation only has one notion of time.

TODO:

Some of the output plots do not match because the callback saving order is modified. Fix this before merging. Examples are ozark_soilsnow and snowmip.

#1309 clean up the `set_ic!` functions
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
