### PR TITLE
Add LAI and Tsoil to output diagnostics, fix flux from soil to snow

### DIFF
--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -359,6 +359,8 @@ function default_diagnostics(
             "trans",
             "msf",
             "lwp",
+            "tsoil",
+            "lai",
             "iwc",
             "swd",
             "lwd",

--- a/src/integrated/soil_snow_model.jl
+++ b/src/integrated/soil_snow_model.jl
@@ -200,7 +200,8 @@ see equation 24 and 25, with k=N, of Best et al, Geosci. Model Dev., 4, 677–69
 
 However, this is for a multi-layer snow model, with
 T_snow and Δz_snow related to the bottom layer.
-It's not clear this is ideal when we have a single layer snow model. We can revisit this.
+We only have a single layer snow model, and using Δz_snow = height of snow leads to a very small flux when the snow is deep. 
+Due to this, we cap Δz_snow at 10 cm.
 """
 function update_soil_snow_ground_heat_flux!(
     p,
@@ -215,7 +216,7 @@ function update_soil_snow_ground_heat_flux!(
     κ_soil = ClimaLand.Domains.top_center_to_surface(p.soil.κ)
 
     # Depths
-    Δz_snow = p.snow.z_snow
+    Δz_snow = @. lazy(max(p.snow.z_snow, FT(0.1)))
     Δz_soil = soil_domain.fields.Δz_top
 
     # Temperatures


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
- Adds Tsoil and LAI to our default diagnostics
- Clips dz_snow to be 10 cm or less when computing the heat flux between soil and snow. If dz_snow = height of snow (our current implementation), the flux between soil and snow will be very small if the snow is deep. This will lead to unphysical soil temperatures.

Long run: https://buildkite.com/clima/climaland-long-runs/builds/4048
## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
