### PR TITLE
NaNs over the ocean

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ ClimaLand.jl Release Notes
 
 main
 -------
+- Output NaNs in diagnostics where the ocean is PR[#1200](https://github.com/CliMA/ClimaLand.jl/pull/1200)
 - ![breaking change][badge-💥breaking] Make soil albedo parameterization modular
 PR[#1184](https://github.com/CliMA/ClimaLand.jl/pull/1184)
 - Use new spun up initial conditions from 19 year run PR[#1196](https://github.com/CliMA/ClimaLand.jl/pull/1196)

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -338,7 +338,6 @@ short_names_1D = [
     "msf", # β
     "shf", # SHF
     "lhf", # LHF
-    "ghf", # G
     "rn", # Rn
 ]
 short_names_2D = [
@@ -354,7 +353,7 @@ hourly_diag_name_2D = short_names_2D .* "_1h_average"
 # diagnostic_as_vectors()[2] is a vector of a variable,
 # whereas diagnostic_as_vectors()[1] is a vector or time associated with that variable.
 # We index to only extract the period post-spinup.
-SIF, AR, g_stomata, GPP, canopy_T, SW_u, LW_u, ER, ET, β, SHF, LHF, G, Rn = [
+SIF, AR, g_stomata, GPP, canopy_T, SW_u, LW_u, ER, ET, β, SHF, LHF, Rn = [
     ClimaLand.Diagnostics.diagnostic_as_vectors(d_writer, diag_name)[2][(N_spinup_days * 24):end]
     for diag_name in hourly_diag_name
 ]

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -307,7 +307,6 @@ short_names_1D = [
     "msf", # β
     "shf", # SHF
     "lhf", # LHF
-    "ghf", # G
     "rn", # Rn
     "swe",
 ]
@@ -324,11 +323,10 @@ hourly_diag_name_2D = short_names_2D .* "_1h_average"
 # diagnostic_as_vectors()[2] is a vector of a variable,
 # whereas diagnostic_as_vectors()[1] is a vector or time associated with that variable.
 # We index to only extract the period post-spinup.
-SIF, AR, g_stomata, GPP, canopy_T, SW_u, LW_u, ER, ET, β, SHF, LHF, G, Rn, SWE =
-    [
-        ClimaLand.Diagnostics.diagnostic_as_vectors(d_writer, diag_name)[2][(N_spinup_days * 24):end]
-        for diag_name in hourly_diag_name
-    ]
+SIF, AR, g_stomata, GPP, canopy_T, SW_u, LW_u, ER, ET, β, SHF, LHF, Rn, SWE = [
+    ClimaLand.Diagnostics.diagnostic_as_vectors(d_writer, diag_name)[2][(N_spinup_days * 24):end]
+    for diag_name in hourly_diag_name
+]
 
 swc, soil_T, si = [
     ClimaLand.Diagnostics.diagnostic_as_vectors(

--- a/src/diagnostics/Diagnostics.jl
+++ b/src/diagnostics/Diagnostics.jl
@@ -29,6 +29,7 @@ import ClimaDiagnostics.Schedules:
 import ClimaDiagnostics
 import ClimaDiagnostics.Writers: HDF5Writer, NetCDFWriter, DictWriter
 
+import ClimaCore.Fields: zeros, field_values
 import ClimaCore.Operators: column_integral_definite!
 
 include("diagnostic.jl")

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -170,7 +170,6 @@ function default_diagnostics(
             "rn",
             "lhf",
             "shf",
-            "ghf",
             "salb",
         ]
     elseif output_vars == :short
@@ -338,7 +337,6 @@ function default_diagnostics(
             "rn",
             "lhf",
             "shf",
-            "ghf",
             "iwc",
             "snowc",
         ]

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -813,17 +813,6 @@ function define_diagnostics!(land_model)
             compute_subsurface_runoff!(out, Y, p, t, land_model),
     )
 
-    # Ground heat flux
-    add_diagnostic_variable!(
-        short_name = "ghf",
-        long_name = "Ground Heat Flux",
-        standard_name = "ground_heat_flux",
-        units = "W m^-2",
-        comments = "Transfer of heat between the surface and deeper soil layers.",
-        compute! = (out, Y, p, t) ->
-            compute_ground_heat_flux!(out, Y, p, t, land_model),
-    )
-
     ## Stored in Y (prognostic or state variables) ##
 
     # Canopy temperature


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Set ocean values to NaNs in diagnostics. Note that they are still zero in the fields themselves, during the simulation, but set to NaN in diagnostics.

Note that: I had a different PR trying to set NaNs over the ocean when we created the fields themselves (everything in Y, p), but this led to a lot of changes. If we think this is a preferable for any reason compared with having ocean values be zero (in the simulations only), I will resurrect that PR. But this is a quick way to improve our comparisons with data on coastlines

I checked that the nc files created are NaN over the ocean.
The plots created in the soil long run look identical to prior to this change: https://buildkite.com/clima/climaland-long-runs/builds/4052 (I accidentally canceled this when I pushed, before the snowy run finished)
## To-do


## Content
Update diagnostics to have NaNs over the ocean.
Remove GHF which was not computed correctly