### PR TITLE
Fix texture norm and reset means for soil parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ ClimaLand.jl Release Notes
 
 main
 -------
+- Fix texure norm bug (soil composition) PR[#1217](https://github.com/CliMA/ClimaLand.jl/pull/1217)
 - ![breaking change][badge-💥breaking] Remove ModelSetup.jl and split spatial parameter functions up PR[#1211](https://github.com/CliMA/ClimaLand.jl/pull/1211)
 - ![breaking change][badge-💥breaking] Rename all `comms_ctx` to `context` PR[#1207](https://github.com/CliMA/ClimaLand.jl/pull/1207)
 - Output NaNs in diagnostics where the ocean is PR[#1200](https://github.com/CliMA/ClimaLand.jl/pull/1200)

--- a/experiments/benchmarks/snowy_land.jl
+++ b/experiments/benchmarks/snowy_land.jl
@@ -449,7 +449,7 @@ if profiler == "flamegraph"
         @info "Saved allocation flame to $alloc_flame_file"
     end
     if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaland-benchmark"
-        PREVIOUS_BEST_TIME = 0.74
+        PREVIOUS_BEST_TIME = 0.67
         if average_timing_s > PREVIOUS_BEST_TIME + std_timing_s
             @info "Possible performance regression, previous average time was $(PREVIOUS_BEST_TIME)"
         elseif average_timing_s < PREVIOUS_BEST_TIME - std_timing_s

--- a/src/standalone/Soil/spatially_varying_parameters.jl
+++ b/src/standalone/Soil/spatially_varying_parameters.jl
@@ -163,11 +163,17 @@ function soil_vangenuchten_parameters(
         file_reader_kwargs = (; preprocess_func = (data) -> data > 0,),
     )
     # If the parameter mask =  0, set to physical value
+    # (equal to the mean where we have data; the mean of α is in log space)
     # This function in applied in **simulation mask** aware
     # manner.
-    μ = FT(0.27)
+    # That is, we replace values in the simulation, but without data, with the mean
+    # over the data.
+    masked_to_value(field, mask, value) =
+        mask == 1.0 ? field : eltype(field)(value)
+
+    μ = FT(0.33)
     vg_α .= masked_to_value.(vg_α, soil_params_mask, 10.0^μ)
-    μ = FT(1.65)
+    μ = FT(1.74)
     vg_n .= masked_to_value.(vg_n, soil_params_mask, μ)
 
     vg_fields_to_hcm_field(α::FT, n::FT) where {FT} =
@@ -206,13 +212,13 @@ function soil_vangenuchten_parameters(
         regridder_kwargs = (; extrapolation_bc,),
     )
 
-    μ = FT(-6)
+    # Set missing values to the mean. For Ksat, we use the mean in log space.
+    μ = FT(-5.08)
     K_sat .= masked_to_value.(K_sat, soil_params_mask, 10.0^μ)
 
-    μ = FT(0.5)
-    ν .= masked_to_value.(ν, soil_params_mask, μ)
+    ν .= masked_to_value.(ν, soil_params_mask, 0.47)
 
-    θ_r .= masked_to_value.(θ_r, soil_params_mask, 0)
+    θ_r .= masked_to_value.(θ_r, soil_params_mask, 0.09)
 
     return (; ν = ν, hydrology_cm = hydrology_cm, K_sat = K_sat, θ_r = θ_r)
 end
@@ -291,10 +297,11 @@ function soil_composition_parameters(
     # we require that the sum of these be less than 1 and equal to or bigger than zero.
     # The input should satisfy this almost exactly, but the regridded values may not.
     # Values of zero are OK here, so we dont need to apply any masking
-    texture_norm = @. min(ν_ss_gravel + ν_ss_quartz + ν_ss_om, 1)
-    @. ν_ss_gravel = ν_ss_gravel / max(texture_norm, eps(FT))
-    @. ν_ss_om = ν_ss_om / max(texture_norm, eps(FT))
-    @. ν_ss_quartz = ν_ss_quartz / max(texture_norm, eps(FT))
+    # if sum > 1, normalize by sum, else "normalize" by 1 (i.e., do not normalize)
+    texture_norm = @. max(ν_ss_gravel + ν_ss_quartz + ν_ss_om, 1)
+    @. ν_ss_gravel = ν_ss_gravel / texture_norm
+    @. ν_ss_om = ν_ss_om / texture_norm
+    @. ν_ss_quartz = ν_ss_quartz / texture_norm
 
     return (;
         ν_ss_om = ν_ss_om,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The branch used in #1211 was based on a old version of main which did not have an important bug fix in the computation of the soil composition parameters. When I rebased, this was lost(and some NaNs reintroduced!). This PR makes our soil spatial parameters match what we had before.


## To-do
Double check that NaNs are gone again


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
