### PR TITLE
clip VPD

### DIFF
--- a/src/standalone/Vegetation/canopy_parameterizations.jl
+++ b/src/standalone/Vegetation/canopy_parameterizations.jl
@@ -946,6 +946,13 @@ where `VPD` is the vapor pressure deficit in the atmosphere
 (Pa), and `g_1` is a constant with units of `sqrt(Pa)`.
 
 `thermo_params` is the Thermodynamics.jl parameter set.
+
+Note that in supersaturated conditions the vapor pressure deficit will be negative,
+which leads to an imaginary Medlyn term `m`. Clipping to zero is not an option, because
+this leads to divison by zero. An alternative is to compute the inverse of this quantity
+and stomatal resistance instead of conductance.
+
+Since g1 ~ O(100) √Pa, a floor of VPD = 1e-2 Pa yields g1/√VPD ~ 1000.
 """
 function medlyn_term(
     g1::FT,
@@ -954,7 +961,10 @@ function medlyn_term(
     q_air::FT,
     thermo_params,
 ) where {FT}
-    VPD = ClimaLand.vapor_pressure_deficit(T_air, P_air, q_air, thermo_params)
+    VPD = max(
+        ClimaLand.vapor_pressure_deficit(T_air, P_air, q_air, thermo_params),
+        FT(1e-2),
+    )
     return 1 + g1 / sqrt(VPD)
 end
 

--- a/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
+++ b/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
@@ -140,7 +140,7 @@ for FT in (Float32, Float64)
 
         m_t = medlyn_term(stomatal_g_params.g1, T, P, q, thermo_params)
 
-        @test m_t == 1 + stomatal_g_params.g1 / sqrt(VPD)
+        @test m_t == 1 + stomatal_g_params.g1 / sqrt(max(FT(1e-2), VPD))
         ci = intercellular_co2(ca, Γstar, m_t)
         @test ci == ca * (1 - 1 / m_t)
         @test intercellular_co2(ca, FT(1), m_t) == FT(1)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The medlyn term is = 1+g1/sqrt(VPD). When VPD is zero or positive, this errors. As suggested by @trontrytel, we could compute the inverse of this, and then compute the stomatal resistance, but all of our names everywhere are "conductance" so this would be a somewhat big change to make. For now, I clipped VPD to be > 1e-2 Pa. This is 1000x smaller than g1 which seems reasonable. This leads to a conductance which is very large (i.e., a very small stomatal resistance).


## To-do
upgrade thermodynamics compat once the release happens


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
