### PR TITLE
restructuring domain + site parameters for Fluxnet simulation into a module

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -43,17 +43,18 @@ git-tree-sha1 = "136f1db3ed969614fb589c5250545a3ed1e8aaab"
     url = "https://caltech.box.com/shared/static/of1admpndmikoumtgk5j3yvt92v71awk.gz"
 
 ["clm_data_0.9x1.25"]
-git-tree-sha1 = "283c62220fca8c4afe36a62348d3e9a159af2ee9"
+git-tree-sha1 = "38488be5dd476890deb6fbd2b26e3e1cee2d449e"
 
     [["clm_data_0.9x1.25".download]]
-    sha256 = "88d5899a729de800017a74bd8a7278582c2c55c0d8730a529bae384425d70e4e"
-    url = "https://caltech.box.com/shared/static/mxs3l1c1dppjwy81assk8w8ofn9d70pu.gz"
+    sha256 = "cb5ead78868243879261d26cbb42d665bfd98135ebbebc052487d4d13ebf3a98"
+    url = "https://caltech.box.com/shared/static/6ms2qzyiekorksewmfyie6mbonlq5ctp.gz"
 ["clm_data_0.125x0.125"]
-git-tree-sha1 = "6284ddefbc7937d9c1fb68fa731ff3f00b68e917"
+git-tree-sha1 = "b8816f0af2c6d182111a156c3b8eed2ed83efea7"
 
     [["clm_data_0.125x0.125".download]]
-    sha256 = "8d2a61baad53346515f4a66c4342f8aafce37ca9520020c17f99cc4f4aa98b15"
-    url = "https://caltech.box.com/shared/static/uteaw1l6fg7wmwhb3ey1c0jq4r8vg0ts.gz"
+    sha256 = "993b5b97b6ec22ec484db4e523b65a231d736ead8b5e0759ad3abd00050bb58c"
+    url = "https://caltech.box.com/shared/static/fx9138ysguyg4g65l4tvibbk16er0nqo.gz"
+
 [era5_land_forcing_data2008]
 git-tree-sha1 = "93d2e93f491e77cb8fba2a1b8b3946f38bde469e"
 [era5_land_forcing_data2008_lowres]
@@ -185,3 +186,6 @@ git-tree-sha1 = "c35ba0e899040cb8153226ab751f69100f475d39"
     [[mizoguchi_soil_freezing_data.download]]
     sha256 = "0027cc080ba45ba33dc790b176ec2854353ce7dce4eae4bef72963b0dd944e0b"
     url = "https://caltech.box.com/shared/static/tn1bnqjmegyetw5kzd2ixq5pbnb05s3u.gz"
+
+[fluxnet2015]
+git-tree-sha1 = "94d6eb8e3bc5fc361a43597ab4fb6941bdbe2850"

--- a/ext/FluxnetSimulationsExt.jl
+++ b/ext/FluxnetSimulationsExt.jl
@@ -6,12 +6,15 @@ import ClimaUtilities.TimeManager: ITime, date
 using Thermodynamics
 using Dates
 using DelimitedFiles
-using DocStringExtensions
 using Insolation
 import ClimaLand.Parameters as LP
 using ClimaLand
 using ClimaLand.Canopy
 using ClimaLand.PlantHydraulics
+using ClimaLand.Domains
+using ClimaCore
+
+using NCDatasets
 export prescribed_forcing_fluxnet,
     make_set_fluxnet_initial_conditions,
     get_comparison_data,
@@ -19,7 +22,11 @@ export prescribed_forcing_fluxnet,
     get_data_dt,
     replace_hyphen,
     get_parameters,
-    get_domain_info
+    get_domain_info,
+    get_location
+
+# Get the metadata for the fluxnet sites.
+include("fluxnet_simulations/get_fluxnet_metadata.jl")
 
 # Include site-specific configurations, as well as the default generic site.
 include("fluxnet_simulations/generic_site.jl")

--- a/ext/fluxnet_simulations/generic_site.jl
+++ b/ext/fluxnet_simulations/generic_site.jl
@@ -2,7 +2,168 @@
 #        MODULE FUNCTIONS         #
 ###################################
 
-# TODO
+"""
+    get_domain_info(FT; dz_bottom = FT(1.5), dz_top = FT(0.1),
+        nelements = 20, zmin = FT(-10),  zmax = FT(0))
+
+Gets and returns primary domain information for a generic Fluxnet site, using
+default values corresponding to a 10m deep soil column with 20 layers, with
+a resolution of 10 cm at the top of the domain and 1.5m at the bottom of the domain.
+"""
+function FluxnetSimulations.get_domain_info(
+    FT;
+    dz_bottom = FT(1.5),
+    dz_top = FT(0.1),
+    nelements = 20,
+    zmin = FT(-10),
+    zmax = FT(0),
+)
+
+    dz_tuple = (dz_bottom, dz_top)
+
+    return (; dz_tuple, nelements, zmin, zmax)
+end
+
+function FluxnetSimulations.get_location(
+    site_ID::String;
+    site_info = FluxnetSimulationsExt.get_site_info(site_ID),
+    lat = site_info[:lat],
+    long = site_info[:long],
+    time_offset = site_info[:time_offset],
+)
+    atmos_h = site_info[:atmospheric_sensor_height][1] # take the first height as default
+    return (; time_offset, lat, long, atmos_h)
+end
+
+"""
+    get_parameters(FT, site_ID, domain, pft::Pft; kwargs...)
+
+Gets parameters for a generic Fluxnet site based on PFT (plant functional type),
+supplemented with additional autofilled values from US-MOz (Missouri Ozark) site.
+
+Data sources:
+
+Hydraulics parameters:
+    - Holtzman, Nataniel, et al. 2023, https://doi.org/10.1029/2023WR035481
+"""
+function FluxnetSimulations.get_parameters(
+    FT,
+    site_ID,
+    domain,
+    pft::Pft = ClimaLand.Canopy.clm_dominant_pft(domain.space.surface),
+    ;
+    soil_params_gupta = ClimaLand.Soil.soil_vangenuchten_parameters(
+        domain.space.subsurface,
+        FT,
+    ),
+    soil_params_grids = ClimaLand.Soil.soil_composition_parameters(
+        domain.space.subsurface,
+        FT,
+    ),
+    soil_ν = soil_params_gupta[:ν],
+    soil_K_sat = soil_params_gupta[:K_sat],
+    soil_S_s = FT(1e-2),
+    soil_hydrology_cm = soil_params_gupta[:hydrology_cm],
+    θ_r = soil_params_gupta[:θ_r],
+    ν_ss_quartz = soil_params_grids[:ν_ss_quartz],
+    ν_ss_om = soil_params_grids[:ν_ss_om],
+    ν_ss_gravel = soil_params_grids[:ν_ss_gravel],
+    z_0m_soil = FT(0.01),
+    z_0b_soil = FT(0.01),
+    soil_ϵ = FT(0.98),
+    soil_albedo = ClimaLand.Soil.CLMTwoBandSoilAlbedo{FT}(;
+        ClimaLand.Soil.clm_soil_albedo_parameters(domain.space.surface)...,
+    ),
+    Ω = pft.parameters.Ω,
+    χl = pft.parameters.χl,
+    G_Function = CLMGFunction(χl),
+    α_PAR_leaf = pft.parameters.α_PAR_leaf,
+    λ_γ_PAR = FT(5e-7),
+    α_NIR_leaf = pft.parameters.α_NIR_leaf,
+    τ_PAR_leaf = pft.parameters.τ_PAR_leaf,
+    τ_NIR_leaf = pft.parameters.τ_NIR_leaf,
+    ϵ_canopy = pft.parameters.ϵ_canopy,
+    ac_canopy = pft.parameters.ac_canopy,
+    g1 = pft.parameters.g1,
+    Drel = FT(1.6),
+    g0 = ClimaCore.Fields.field2array(
+        ClimaLand.Canopy.clm_medlyn_g0(domain.space.surface),
+    )[1],
+    Vcmax25 = pft.parameters.Vcmax25,
+    pc = FT(-2.0e6),
+    sc = FT(5e-6),
+    SAI = FT(0),
+    f_root_to_shoot = pft.parameters.f_root_to_shoot,
+    K_sat_plant = pft.parameters.K_sat_plant,
+    ψ63 = pft.parameters.ψ63,
+    Weibull_param = FT(4),
+    a = FT(0.1 * 0.0098),
+    conductivity_model = PlantHydraulics.Weibull{FT}(
+        K_sat_plant,
+        ψ63,
+        Weibull_param,
+    ),
+    retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a),
+    plant_ν = pft.parameters.plant_ν,
+    plant_S_s = FT(1e-2 * 0.0098),
+    rooting_depth = pft.parameters.rooting_depth,
+    n_stem = Int64(0),
+    n_leaf = Int64(1),
+    h_leaf = ClimaCore.Fields.field2array(
+        ClimaLand.Canopy.clm_z_top(domain.space.surface),
+    )[1],
+    h_canopy = FluxnetSimulationsExt.get_canopy_height(site_ID),
+    h_stem = h_canopy - h_leaf,
+    z0_m = FT(0.13) * h_canopy,
+    z0_b = FT(0.1) * z0_m,
+)
+    return (;
+        soil_ν,
+        soil_K_sat,
+        soil_S_s,
+        soil_hydrology_cm,
+        θ_r,
+        ν_ss_quartz,
+        ν_ss_om,
+        ν_ss_gravel,
+        z_0m_soil,
+        z_0b_soil,
+        soil_ϵ,
+        soil_albedo,
+        Ω,
+        χl,
+        G_Function,
+        α_PAR_leaf,
+        λ_γ_PAR,
+        τ_PAR_leaf,
+        α_NIR_leaf,
+        τ_NIR_leaf,
+        ϵ_canopy,
+        ac_canopy,
+        g1,
+        Drel,
+        g0,
+        Vcmax25,
+        SAI,
+        f_root_to_shoot,
+        K_sat_plant,
+        ψ63,
+        Weibull_param,
+        a,
+        conductivity_model,
+        retention_model,
+        plant_ν,
+        plant_S_s,
+        rooting_depth,
+        n_stem,
+        n_leaf,
+        h_leaf,
+        h_stem,
+        h_canopy,
+        z0_m,
+        z0_b,
+    )
+end
 
 ###################################
 #            UTILITIES            #

--- a/ext/fluxnet_simulations/get_fluxnet_metadata.jl
+++ b/ext/fluxnet_simulations/get_fluxnet_metadata.jl
@@ -1,0 +1,121 @@
+using DelimitedFiles
+using ClimaLand
+
+function parse_array_field(field)
+    if field == "" || field == "NaN"
+        return Float64[]
+    elseif field isa Float64
+        return isnan(field) ? Float64[] : [field]
+    else
+        return parse.(Float64, split(String(field), ";"))
+    end
+end
+
+
+"""
+    get_site_info(site_ID)
+
+This function retrieves the site information from an artifact for a given fluxnet site ID.
+    
+Returns a Float64-valued namedtuple containing: 
+- `lat`: Latitude of the site (deg)
+- `long`: Longitude of the site (deg)
+- `time_offset`: Time offset from UTC (hours). Note that the ClimaLand convention is for
+    UTC = local_time + time_offset.
+- `atmospheric_sensor_height` (Vector): Heights of atmospheric sensors (m)
+"""
+function get_site_info(site_ID; fluxnet2015_metadata_path = nothing)
+    if fluxnet2015_metadata_path === nothing
+        # Use the default path from ClimaLand.Artifacts
+        fluxnet2015_data_path = ClimaLand.Artifacts.fluxnet2015_data_path()
+        fluxnet2015_metadata_path =
+            joinpath(fluxnet2015_data_path, "metadata_DD_clean.csv")
+    end
+    raw = readdlm(fluxnet2015_metadata_path, ',', Any)
+    header = raw[1, :]
+    data = raw[2:end, :]
+
+    # Find the row matching site_ID
+    row_idx = findfirst(row -> row[1] == site_ID, eachrow(data))
+    if isnothing(row_idx)
+        error("Site ID $site_ID not found in metadata.")
+    end
+
+    site_metadata = data[row_idx, :]
+
+    varnames =
+        ["latitude", "longitude", "utc_offset", "atmospheric_sensor_heights"]
+    column_name_map = Dict(
+        varname => findfirst(header[:] .== varname) for varname in varnames
+    )
+
+    nan_if_empty(x) =
+        (x isa String && isempty(x)) ? NaN :
+        (x isa AbstractFloat && isnan(x)) ? NaN : x
+
+    for (varname, column) in column_name_map
+        field = site_metadata[column]
+        if field == "" || (field isa AbstractFloat && isnan(field))
+            @warn "Field $(varname) is missing for site $site_ID"
+        end
+    end
+
+    return (;
+        lat = nan_if_empty(site_metadata[column_name_map["latitude"]]),
+        long = nan_if_empty(site_metadata[column_name_map["longitude"]]),
+        time_offset = -1 * nan_if_empty(
+            site_metadata[column_name_map["utc_offset"]],
+        ),
+        atmospheric_sensor_height = parse_array_field(
+            site_metadata[column_name_map["atmospheric_sensor_heights"]],
+        ),
+    )
+end
+
+
+"""
+    get_canopy_height(site_ID)
+
+This function retrieves a canopy height from an artifact for a given fluxnet site ID.
+    
+Returns a Float64-valued namedtuple containing: 
+- `canopy_height`: Canopy height of the site (m)
+"""
+function get_canopy_height(site_ID; fluxnet2015_metadata_path = nothing)
+    if fluxnet2015_metadata_path === nothing
+        # Use the default path from ClimaLand.Artifacts
+        fluxnet2015_data_path = ClimaLand.Artifacts.fluxnet2015_data_path()
+        fluxnet2015_metadata_path =
+            joinpath(fluxnet2015_data_path, "metadata_DD_clean.csv")
+    end
+
+    raw = readdlm(fluxnet2015_metadata_path, ',', Any)
+    header = raw[1, :]
+    data = raw[2:end, :]
+
+    site_info = get_site_info(site_ID; fluxnet2015_metadata_path)
+
+    # Find the row matching site_ID
+    row_idx = findfirst(row -> row[1] == site_ID, eachrow(data))
+    if isnothing(row_idx)
+        error("Site ID $site_ID not found in metadata.")
+    end
+
+    site_metadata = data[row_idx, :]
+
+    varname = "canopy_height"
+
+    col_idx = findfirst(header[:] .== varname)
+
+    nan_if_empty(x) =
+        (x isa String && isempty(x)) ? NaN :
+        (x isa AbstractFloat && isnan(x)) ? NaN : x
+
+    canopy_height = site_metadata[col_idx]
+    if canopy_height == "" ||
+       (canopy_height isa AbstractFloat && isnan(canopy_height))
+        @warn "Field $(varname) is missing for site $site_ID"
+    end
+
+    return nan_if_empty(canopy_height)
+end

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -277,6 +277,10 @@ function experiment_fluxnet_data_path(site_ID; context = nothing)
     return data_path
 end
 
+function fluxnet2015_data_path(; context = nothing)
+    return @clima_artifact("fluxnet2015", context)
+end
+
 """
     esm_snowmip_data_path(; context = nothing)
 

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -52,7 +52,6 @@ using Dates
 include("./autotrophic_respiration.jl")
 include("./spatially_varying_parameters.jl")
 
-
 ########################################################
 # Convenience constructors for Canopy model components
 ########################################################

--- a/src/standalone/Vegetation/spatially_varying_parameters.jl
+++ b/src/standalone/Vegetation/spatially_varying_parameters.jl
@@ -289,3 +289,159 @@ function clm_medlyn_g1(
     )
     return g1
 end
+
+"""
+    clm_medlyn_g0(
+        surface_space;
+        regridder_type = :InterpolationsRegridder,
+        extrapolation_bc = (
+            Interpolations.Periodic(),
+            Interpolations.Flat(),
+            Interpolations.Flat(),
+        ),
+        lowres=use_lowres_clm(surface_space),
+    )
+
+Reads spatially varying g0 for the canopy, from a NetCDF file
+based on CLM data, and regrids it to the grid defined by the
+`surface_space` of the Clima simulation. Returns a NamedTuple of ClimaCore
+Fields.
+
+The values correspond to the value of the dominant PFT at each point.
+
+The NetCDF files are stored in ClimaArtifacts and more detail on their origin
+is provided there. The keyword arguments `regridder_type` and `extrapolation_bc`
+affect the regridding by (1) changing how we interpolate to ClimaCore points which
+are not in the data, and (2) changing how extrapolate to points beyond the range of the
+data. The keyword argument lowres is a flag that determines if the 0.9x1.25 or 0.125x0.125
+resolution CLM data artifact is used. If the lowres flag is not provided, the clm artifact
+with the closest resolution to the surface_space is used.
+"""
+function clm_medlyn_g0(
+    surface_space;
+    regridder_type = :InterpolationsRegridder,
+    extrapolation_bc = (
+        Interpolations.Periodic(),
+        Interpolations.Flat(),
+        Interpolations.Flat(),
+    ),
+    lowres = use_lowres_clm(surface_space),
+)
+    context = ClimaComms.context(surface_space)
+    clm_artifact_path = Artifacts.clm_data_folder_path(; context, lowres)
+
+    g0 = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "medlynintercept",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    return g0
+end
+
+"""
+    clm_medlyn_g0(
+        surface_space;
+        regridder_type = :InterpolationsRegridder,
+        extrapolation_bc = (
+            Interpolations.Periodic(),
+            Interpolations.Flat(),
+            Interpolations.Flat(),
+        ),
+        lowres=use_lowres_clm(surface_space),
+    )
+
+Reads spatially varying z_top (h_leaf) for the canopy, from a NetCDF file
+based on CLM data, and regrids it to the grid defined by the
+`surface_space` of the Clima simulation. Returns a NamedTuple of ClimaCore
+Fields.
+
+The values correspond to the value of the dominant PFT at each point.
+
+The NetCDF files are stored in ClimaArtifacts and more detail on their origin
+is provided there. The keyword arguments `regridder_type` and `extrapolation_bc`
+affect the regridding by (1) changing how we interpolate to ClimaCore points which
+are not in the data, and (2) changing how extrapolate to points beyond the range of the
+data. The keyword argument lowres is a flag that determines if the 0.9x1.25 or 0.125x0.125
+resolution CLM data artifact is used. If the lowres flag is not provided, the clm artifact
+with the closest resolution to the surface_space is used.
+"""
+function clm_z_top(
+    surface_space;
+    regridder_type = :InterpolationsRegridder,
+    extrapolation_bc = (
+        Interpolations.Periodic(),
+        Interpolations.Flat(),
+        Interpolations.Flat(),
+    ),
+    lowres = use_lowres_clm(surface_space),
+)
+    context = ClimaComms.context(surface_space)
+    clm_artifact_path = Artifacts.clm_data_folder_path(; context, lowres)
+
+    z_top = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "z_top",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+    return z_top
+end
+
+"""
+    clm_dominant_pft(
+        surface_space;
+        regridder_type = :InterpolationsRegridder,
+        extrapolation_bc = (
+            Interpolations.Periodic(),
+            Interpolations.Flat(),
+            Interpolations.Flat(),
+        ),
+        interpolation_method = Interpolations.Constant(),
+        lowres = use_lowres_clm(surface_space),
+    )
+
+Reads spatially varying dominant PFT, from a NetCDF file
+based on CLM data, and regrids it to the grid defined by the
+`surface_space` of the Clima simulation. Returns a Pft() object.
+
+The values correspond to the value of the dominant PFT at each point.
+
+The NetCDF files are stored in ClimaArtifacts and more detail on their origin
+is provided there. The keyword arguments `regridder_type` and `extrapolation_bc`
+affect the regridding by (1) changing how we interpolate to ClimaCore points which
+are not in the data, and (2) changing how extrapolate to points beyond the range of the
+data. The keyword argument lowres is a flag that determines if the 0.9x1.25 or 0.125x0.125
+resolution CLM data artifact is used. If the lowres flag is not provided, the clm artifact
+with the closest resolution to the surface_space is used.
+"""
+function clm_dominant_pft(
+    surface_space;
+    regridder_type = :InterpolationsRegridder,
+    extrapolation_bc = (
+        Interpolations.Periodic(),
+        Interpolations.Flat(),
+        Interpolations.Flat(),
+    ),
+    interpolation_method = Interpolations.Constant(),
+    lowres = use_lowres_clm(surface_space),
+)
+    context = ClimaComms.context(surface_space)
+    clm_artifact_path = Artifacts.clm_data_folder_path(; context, lowres)
+
+    dominant_pft_idx = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "dominant_PFT_map.nc"),
+        "dominant_PFT",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc,),
+    )
+
+    dominant_pft_idx =
+        trunc(Int64, ClimaCore.Fields.field2array(dominant_pft_idx)[1])
+
+    dominant_pft = ClimaLand.default_pfts[dominant_pft_idx]
+    return dominant_pft
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- [x] remove lingering syntax + style issues
- [x] make a test file and test each site's parameters
- [x] move into /ext


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Created site-specific ```get_domain_info``` and ```get_parameters``` functions for US-Ha1, US-MOz, US-NR1, and US-Var
- Created generic ```get``` functions for undefined sites (currently using US-MOz info)


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
