### PR TITLE
add constructors for CanopyModel + integrated models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ ClimaLand.jl Release Notes
 
 main
 -------
+- Add convenience constructors for CanopyModel and integrated models PR[#1255](https://github.com/CliMA/ClimaLand.jl/pull/1255)
 - Rename LandSimulationVisualization to LandSimulationVisualizationExt; add template for FluxnetSimulationsExt PR[#1259](https://github.com/CliMA/ClimaLand.jl/pull/1259)
 - Remove root_depths from the PrescribeGroundConditions struct, and treat these ground ``drivers" consistently with how we handle atmospheric forcing PR[#1199](https://github.com/CliMA/ClimaLand.jl/pull/1240)
 - Add constructors with default values for Canopy components PR[#1233](https://github.com/CliMA/ClimaLand.jl/pull/1233)

--- a/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
+++ b/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
@@ -134,21 +134,29 @@ end
 
 """
 SoilCO2Model{FT}(;
-        parameters::SoilCO2ModelParameters{FT},
         domain::ClimaLand.AbstractDomain,
-        boundary_conditions::NamedTuple,
-        sources::Tuple,
         drivers::DT,
+        parameters = SoilCO2ModelParameters(FT),
+        boundary_conditions::BC = (
+            top = AtmosCO2StateBC(),
+            bottom = SoilCO2FluxBC((p, t) -> 0.0) # no flux
+        ),
+        sources::Tuple = (MicrobeProduction{FT}(),),
     ) where {FT, BC, DT}
 
 A constructor for `SoilCO2Model`.
+Defaults are provided for the parameters, boundary conditions, and sources.
+These can be overridden by providing the appropriate keyword arguments.
 """
 function SoilCO2Model{FT}(;
-    parameters::SoilCO2ModelParameters{FT},
     domain::ClimaLand.AbstractDomain,
-    boundary_conditions::BC,
-    sources::Tuple,
     drivers::DT,
+    parameters::SoilCO2ModelParameters{FT} = SoilCO2ModelParameters(FT),
+    boundary_conditions::BC = (
+        top = AtmosCO2StateBC(),
+        bottom = SoilCO2FluxBC((p, t) -> 0.0), # no flux
+    ),
+    sources::Tuple = (MicrobeProduction{FT}(),),
 ) where {FT, BC, DT}
     args = (parameters, domain, boundary_conditions, sources, drivers)
     SoilCO2Model{FT, typeof.(args)...}(args...)

--- a/src/standalone/Soil/Soil.jl
+++ b/src/standalone/Soil/Soil.jl
@@ -246,7 +246,7 @@ function EnergyHydrology{FT}(
         domain.space.subsurface,
         FT,
     ),
-    S_s = ClimaCore.Fields.zeros(domain.space.subsurface) .+ 1e-3,
+    S_s = ClimaCore.Fields.zeros(domain.space.subsurface) .+ FT(1e-3),
     z_0m = LP.get_default_parameter(FT, :soil_momentum_roughness_length),
     z_0b = LP.get_default_parameter(FT, :soil_scalar_roughness_length),
     emissivity = LP.get_default_parameter(FT, :emissivity_bare_soil),


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Use the recently-added canopy component convenience constructors (see #1233) to add clean higher-level constructors. 

CanopyModel constructor should be analogous to the current EnergyHydrology constructor, but it's a little different because of the canopy component nested structure
The integrated model constructors are analogous to #1220

Closes #1250

## To-do
- [x] CanopyModel constructor
- [x] SoilCO2Model constructor
- [x] SoilCanopyModel constructor
- [x] LandModel constructor

## Questions
- do we want runoff in soil model for integrated models?
- before we passed `forcing` into PlantHydraulicsModel and expected it to be a NamedTuple containing `LAI`. In the integrated models we have `forcing` as a NT containing atmos, radiation, and ground (for canopy). In this PR I renamed the hydraulics forcing to just LAI (no longer a NT)

## Notes
- soil, canopy store atmosphere in boundary_conditions but snow stores it in drivers
- kind of confusing that we have both `PrognosticGroundConditions` and `PrognosticSoilConditions`


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
