### PR TITLE
use get_default_parameter for canopy parameters

### DIFF
--- a/src/shared_utilities/Parameters.jl
+++ b/src/shared_utilities/Parameters.jl
@@ -121,8 +121,8 @@ end
 """
     get_default_parameter(FT, climaparams_name)
 
-Helper function for accessing and returning the default 
-parameter value (a float of type `FT`) from  the ClimaParams 
+Helper function for accessing and returning the default
+parameter value (a float of type `FT`) from  the ClimaParams
 dictionary. To look up the value, you must use the name
 of the parameter from ClimaParams (`climaparams_name`).
 For example, the following keys in the ClimaParams dictionary map
@@ -140,6 +140,8 @@ to the variables in the parameter structs as noted below:
 
 :canopy_emissivity => :ϵ_canopy (TwoStreamParameters, BeerLambertParameters)
 :min_stomatal_conductance => :g0 (MedlynConductanceParameters)
+:low_water_pressure_sensitivity => :sc (FarquharParameters, OptimalityFarquharParameters)
+:moisture_stress_ref_water_pressure => :pc (FarquharParameters, OptimalityFarquharParameters)
 
 :soil_conductivity => :κ_soil (BucketModelParameters)
 :soil_heat_capacity => :ρc_soil (BucketModelParameters)

--- a/src/standalone/Soil/Soil.jl
+++ b/src/standalone/Soil/Soil.jl
@@ -216,17 +216,14 @@ When running the soil model in standalone mode, `prognostic_land_components = (:
 this should be a list of the component models. This value of this argument must be the same across all components in the land model.
 
 Default spatially varying parameters (for retention curve parameters, composition, and specific storativity) are provided but can be
-changed with keyword arguments. 
+changed with keyword arguments.
 
-The runoff and albedo parameterizations are also provided and can be changed via keyword argument; 
-additional sources may be required in your model if the soil model will be composed with other 
+The runoff and albedo parameterizations are also provided and can be changed via keyword argument;
+additional sources may be required in your model if the soil model will be composed with other
 component models.
 
 Roughness lengths and soil emissivity are currently treated as constants; these can be passed in as Floats
 by kwarg; otherwise the default values are used.
-
-TODO: Move runoff scalar parameters to ClimaParams, possibly use types in retention, composition,
-roughness, and emissivity.
 """
 function EnergyHydrology(
     FT,
@@ -256,6 +253,8 @@ function EnergyHydrology(
     emissivity = LP.get_default_parameter(FT, :emissivity_bare_soil),
     additional_sources = (),
 )
+    # TODO: Move runoff scalar parameters to ClimaParams, possibly use types in retention, composition,
+    #  roughness, and emissivity.
     top_bc = AtmosDrivenFluxBC(
         forcing.atmos,
         forcing.radiation,
@@ -298,11 +297,9 @@ end
 Creates a RichardsModel model with the given float type FT, domain, earth_param_set and forcing.
 
 Default spatially varying parameters (for retention curve parameters and specific storativity) are provided but can be
-changed with keyword arguments. 
+changed with keyword arguments.
 
 The runoff parameterization is also provided and can be changed via keyword argument.
-
-TODO: Move scalar parameters to ClimaParams and obtain from earth_param_set, possibly use types in retention argument.
 """
 function RichardsModel(
     FT,
@@ -319,6 +316,7 @@ function RichardsModel(
     ),
     S_s = ClimaCore.Fields.zeros(domain.space.subsurface) .+ 1e-3,
 )
+    # TODO: Move scalar parameters to ClimaParams and obtain from earth_param_set, possibly use types in retention argument.
     top_bc = RichardsAtmosDrivenFluxBC(forcing.atmos, runoff)
     bottom_bc = WaterFluxBC((p, t) -> 0.0)
     boundary_conditions = (; top = top_bc, bottom = bottom_bc)

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -74,6 +74,7 @@ The following default parameter is used:
 function BigLeafEnergyModel{FT}(;
     ac_canopy::FT = FT(2e3),
 ) where {FT <: AbstractFloat}
+    # TODO: move `ac_canopy` to ClimaParams.jl so we can call `get_default_parameter`.
     parameters = BigLeafEnergyParameters{FT}(ac_canopy)
     return BigLeafEnergyModel{FT, typeof(parameters)}(parameters)
 end
@@ -85,8 +86,8 @@ end
         photosynthesis_parameters = clm_photosynthesis_parameters(
             domain.space.surface,
         ),
-        pc::FT = -2e6,
-        sc::FT = 5e-6,
+        sc::FT = LP.get_default_parameter(FT, :low_water_pressure_sensitivity),
+        pc::FT = LP.get_default_parameter(FT, :moisture_stress_ref_water_pressure),
     ) where {
         FT <: AbstractFloat,
         MECH <: Union{FT, ClimaCore.Fields.Field},
@@ -110,8 +111,8 @@ function FarquharModel{FT}(
     photosynthesis_parameters = clm_photosynthesis_parameters(
         domain.space.surface,
     ),
-    sc::FT = FT(5e-6),
-    pc::FT = FT(-2e6),
+    sc::FT = LP.get_default_parameter(FT, :low_water_pressure_sensitivity),
+    pc::FT = LP.get_default_parameter(FT, :moisture_stress_ref_water_pressure),
 ) where {FT <: AbstractFloat}
     (; is_c3, Vcmax25) = photosynthesis_parameters
     parameters = FarquharParameters(FT, is_c3; Vcmax25, sc, pc)
@@ -194,6 +195,7 @@ function PlantHydraulicsModel{FT}(
     rooting_depth = clm_rooting_depth(domain.space.surface),
     transpiration = PlantHydraulics.DiagnosticTranspiration{FT}(),
 ) where {FT <: AbstractFloat}
+    # TODO: move hydraulics paramters to ClimaParams.jl so we can call `get_default_parameter`.
     @assert n_stem >= 0 "Stem number must be non-negative"
     @assert n_leaf >= 0 "Leaf number must be non-negative"
     @assert h_stem >= 0 "Stem height must be non-negative"
@@ -301,7 +303,7 @@ end
 ## Stomatal conductance models
 """
     MedlynConductanceModel{FT}(;
-        g0::FT = FT(1e-4),
+        g0::FT = LP.get_default_parameter(FT, :min_stomatal_conductance),
         g1 = clm_medlyn_g1(domain.space.surface),
     ) where {FT <: AbstractFloat}
 
@@ -317,8 +319,8 @@ The following default parameter is used:
 """
 function MedlynConductanceModel{FT}(
     domain;
-    g0::FT = FT(1e-4),
     g1 = clm_medlyn_g1(domain.space.surface),
+    g0::FT = LP.get_default_parameter(FT, :min_stomatal_conductance),
 ) where {FT <: AbstractFloat}
     parameters = MedlynConductanceParameters(FT; g0, g1)
     return MedlynConductanceModel{FT, typeof(parameters)}(parameters)

--- a/src/standalone/Vegetation/canopy_parameterizations.jl
+++ b/src/standalone/Vegetation/canopy_parameterizations.jl
@@ -71,7 +71,7 @@ end
 Computes the PAR and NIR fractional absorbances, reflectances, and tranmittances
 for a canopy in the case of the
 Beer-Lambert model. The absorbances are a function of the radiative transfer
-model, as well as the leaf area index, the clumping index, 
+model, as well as the leaf area index, the clumping index,
 the cosine of the zenith angle, the leaf angle distribution,
 the extinction coefficient, and the
 soil albedo in the PAR and NIR bands. Returns a
@@ -116,7 +116,7 @@ end
 Computes the PAR and NIR fractional absorbances, reflectances, and tranmittances
 for a canopy in the case of the
 Two-stream model. The absorbances are a function of the radiative transfer
-model, as well as the leaf area index, the clumping index, 
+model, as well as the leaf area index, the clumping index,
 the cosine of the zenith angle, the leaf angle distribution,
 the extinction coefficient, and the
 soil albedo in the PAR and NIR bands.
@@ -799,9 +799,6 @@ This currently takes a leaf conductance (moles per leaf area per second)
 and (1) converts it to m/s, (2) upscales to the entire canopy, by assuming
 the leaves in the canopy are in parallel and hence multiplying
 by LAI.
-
-TODO: Check what CLM does, and check if we can use the same function
-for GPP from An, and make more general.
 """
 function upscale_leaf_conductance(
     gs::FT,
@@ -810,6 +807,8 @@ function upscale_leaf_conductance(
     R::FT,
     P::FT,
 ) where {FT}
+    # TODO: Check what CLM does, and check if we can use the same function
+    #  for GPP from An, and make more general.
     canopy_conductance = gs * LAI * (R * T) / P # convert to m s-1
     return canopy_conductance
 end
@@ -949,7 +948,7 @@ where `VPD` is the vapor pressure deficit in the atmosphere
 
 Note that in supersaturated conditions the vapor pressure deficit will be negative,
 which leads to an imaginary Medlyn term `m`. Clipping to zero solves this, but this leads
-to division by zero, so we regularize the division by adding a small quantity. 
+to division by zero, so we regularize the division by adding a small quantity.
 
 An alternative to consider in the future is to compute the inverse of this quantity
 and stomatal resistance instead of conductance.


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
In #1233, we added convenience constructors for canopy component models. These constructors provide defaults for many parameters that can easily be overwritten.

However, we forgot to use `get_default_parameter` as the defaults for some parameters that are available via ClimaParams. Note that some parameters are still hardcoded because they aren't in ClimaParams, but eventually we'd like to add them there as well.

