### PR TITLE
force type specialization in constructors

### DIFF
--- a/docs/src/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/src/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -141,8 +141,7 @@ shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
 
 ψ_soil = FT(0.0)
 T_soil = FT(298.0)
-soil_driver = PrescribedGroundConditions(
-    FT;
+soil_driver = PrescribedGroundConditions{FT}(;
     α_PAR = FT(0.2),
     α_NIR = FT(0.4),
     T = TimeVaryingInput(t -> T_soil),

--- a/experiments/benchmarks/richards.jl
+++ b/experiments/benchmarks/richards.jl
@@ -99,7 +99,7 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
         atmos = ClimaLand.PrescribedPrecipitation{FT, typeof(precip)}(precip),
     )
 
-    model = ClimaLand.Soil.RichardsModel(FT, domain, forcing)
+    model = ClimaLand.Soil.RichardsModel{FT}(domain, forcing)
 
     Y, p, cds = initialize(model)
     z = ClimaCore.Fields.coordinate_field(cds.subsurface).z

--- a/experiments/integrated/fluxnet/snow_soil/simulation.jl
+++ b/experiments/integrated/fluxnet/snow_soil/simulation.jl
@@ -2,7 +2,7 @@
 ## Ma, S., Baldocchi, D. D., Xu, L., Hehn, T. (2007)
 ## Inter-Annual Variability In Carbon Dioxide Exchange Of An
 ## Oak/Grass Savanna And Open Grassland In California, Agricultural
-## And Forest Meteorology, 147(3-4), 157-171. https://doi.org/10.1016/j.agrformet.2007.07.008 
+## And Forest Meteorology, 147(3-4), 157-171. https://doi.org/10.1016/j.agrformet.2007.07.008
 ## CLM 5.0 Tech Note: https://www2.cesm.ucar.edu/models/cesm2/land/CLM50_Tech_Note.pdf
 # Bonan, G. Climate change and terrestrial ecosystem modeling. Cambridge University Press, 2019.
 
@@ -93,8 +93,7 @@ S_s = FT(1e-3)
 z_0m = FT(0.01)
 z_0b = FT(0.001)
 emissivity = FT(0.98)
-soil_model = Soil.EnergyHydrology(
-    FT,
+soil_model = Soil.EnergyHydrology{FT}(
     domain,
     forcing,
     earth_param_set;
@@ -121,7 +120,7 @@ snow_model = Snow.SnowModel(
     density,
 )
 
-land = ClimaLand.SoilSnowModel(; snow = snow_model, soil = soil_model)
+land = ClimaLand.SoilSnowModel{FT}(; snow = snow_model, soil = soil_model)
 Y, p, cds = initialize(land)
 exp_tendency! = make_exp_tendency(land)
 imp_tendency! = make_imp_tendency(land)

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -84,7 +84,7 @@ forcing = ClimaLand.prescribed_forcing_era5(
     max_wind_speed = 25.0,
     time_interpolation_method,
 )
-model = ClimaLand.Soil.EnergyHydrology(FT, domain, forcing, params)
+model = ClimaLand.Soil.EnergyHydrology{FT}(domain, forcing, params)
 diagnostics = ClimaLand.default_diagnostics(
     model,
     start_date;

--- a/experiments/standalone/Vegetation/no_vegetation.jl
+++ b/experiments/standalone/Vegetation/no_vegetation.jl
@@ -54,8 +54,7 @@ shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
     earth_param_set,
 );
 
-soil_driver = PrescribedGroundConditions(
-    FT;
+soil_driver = PrescribedGroundConditions{FT}(;
     α_PAR = FT(0.2),
     α_NIR = FT(0.4),
     ϵ = FT(0.99),

--- a/experiments/standalone/Vegetation/timestep_test.jl
+++ b/experiments/standalone/Vegetation/timestep_test.jl
@@ -93,8 +93,7 @@ shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
     earth_param_set,
 );
 
-soil_driver = PrescribedGroundConditions(
-    FT;
+soil_driver = PrescribedGroundConditions{FT}(;
     α_PAR = FT(0.2),
     α_NIR = FT(0.4),
     ϵ = FT(0.99),

--- a/experiments/standalone/Vegetation/varying_lai.jl
+++ b/experiments/standalone/Vegetation/varying_lai.jl
@@ -54,8 +54,7 @@ shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
     earth_param_set,
 );
 
-soil_driver = PrescribedGroundConditions(
-    FT;
+soil_driver = PrescribedGroundConditions{FT}(;
     α_PAR = FT(0.2),
     α_NIR = FT(0.4),
     ϵ = FT(0.99),

--- a/experiments/standalone/Vegetation/varying_lai_with_stem.jl
+++ b/experiments/standalone/Vegetation/varying_lai_with_stem.jl
@@ -54,8 +54,7 @@ shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
     earth_param_set,
 );
 
-soil_driver = PrescribedGroundConditions(
-    FT;
+soil_driver = PrescribedGroundConditions{FT}(;
     α_PAR = FT(0.2),
     α_NIR = FT(0.4),
     ϵ = FT(0.99),

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -186,7 +186,7 @@ end
 """
    ClimaLand.land_components(land::LandModel)
 
-Returns the components of the `LandModel`. 
+Returns the components of the `LandModel`.
 
 Currently, this method is required in order to preserve an ordering in how
 we update the component models' auxiliary states. The canopy update_aux! step
@@ -383,7 +383,7 @@ function lsm_radiant_energy_fluxes!(
     canopy_radiation::Canopy.AbstractRadiationModel{FT},
     Y,
     t,
-) where {(FT)}
+) where {FT}
     canopy = land.canopy
     canopy_bc = canopy.boundary_conditions
     radiation = canopy_bc.radiation
@@ -535,7 +535,7 @@ end
    compute_liquid_influx(p,
                          model,
                          prognostic_land_components::Val{(:canopy, :snow, :soil, :soilco2)},
-    ) 
+    )
 
 Returns the liquid water volume flux at the surface of the soil; uses
 the same method as the soil+snow integrated model.

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -292,7 +292,7 @@ function lsm_radiant_energy_fluxes!(
     canopy_radiation::Canopy.AbstractRadiationModel{FT},
     Y,
     t,
-) where {(FT)}
+) where {FT}
     canopy = land.canopy
     earth_param_set = canopy.parameters.earth_param_set
     _σ = LP.Stefan(earth_param_set)
@@ -450,7 +450,7 @@ end
    compute_liquid_influx(p,
                          model,
                          prognostic_land_components::Val{(:canopy, :soil, :soilco2)},
-    ) 
+    )
 
 Returns the liquid water volume flux at the surface of the soil; in
  a model without snow as a prognostic variable, the influx is

--- a/src/integrated/soil_snow_model.jl
+++ b/src/integrated/soil_snow_model.jl
@@ -31,7 +31,7 @@ struct SoilSnowModel{
     snow::SnM
     "The soil model to be used"
     soil::SoM
-    function SoilSnowModel(; snow, soil)
+    function SoilSnowModel{FT}(; snow, soil) where {FT <: AbstractFloat}
         prognostic_land_components = (:snow, :soil)
         top_soil_bc = soil.boundary_conditions.top
         snow_bc = snow.boundary_conditions
@@ -46,7 +46,6 @@ struct SoilSnowModel{
 
         @assert soil.parameters.earth_param_set ==
                 snow.parameters.earth_param_set
-        FT = eltype(soil.parameters.earth_param_set)
         new{FT, typeof(snow), typeof(soil)}(snow, soil)
     end
 
@@ -154,7 +153,7 @@ see equation 24 and 25, with k=N, of Best et al, Geosci. Model Dev., 4, 677–69
 
 However, this is for a multi-layer snow model, with
 T_snow and Δz_snow related to the bottom layer.
-We only have a single layer snow model, and using Δz_snow = height of snow leads to a very small flux when the snow is deep. 
+We only have a single layer snow model, and using Δz_snow = height of snow leads to a very small flux when the snow is deep.
 Due to this, we cap Δz_snow at 10 cm.
 """
 function update_soil_snow_ground_heat_flux!(
@@ -321,7 +320,7 @@ end
    compute_liquid_influx(p,
                          model,
                          prognostic_land_components::Val{(:snow, :soil,)},
-    ) 
+    )
 
 Returns the liquid water volume flux at the surface of the soil,
 accounting for snowmelt and rainfall.

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -1096,7 +1096,7 @@ struct PrescribedGroundConditions{
 end
 
 """
-     function PrescribedGroundConditions(FT;
+     function PrescribedGroundConditions{FT}(;
          ψ::TimeVaryingInput,
          T::TimeVaryingInput,
          α_PAR::FT,
@@ -1107,14 +1107,13 @@ end
 An outer constructor for the PrescribedGroundConditions allowing the user to
 specify the ground parameters by keyword arguments.
 """
-function PrescribedGroundConditions(
-    FT;
+function PrescribedGroundConditions{FT}(;
     ψ = TimeVaryingInput((t) -> 0.0),
     T = TimeVaryingInput((t) -> 298.0),
     α_PAR = FT(0.2),
     α_NIR = FT(0.4),
     ϵ = FT(0.99),
-)
+) where {FT <: AbstractFloat}
     return PrescribedGroundConditions{FT, typeof(ψ), typeof(T)}(
         ψ,
         T,
@@ -1472,8 +1471,8 @@ The argument `era5_ncdata_path` is either a list of nc files, each with all of t
 
 ########## WARNING ##########
 
-High wind speed anomalies (10-100x increase and decrease over a period of a several hours) appear in the ERA5 
-reanalysis data. These generate very large surface fluxes (due to wind speeds up to 300 m/s), which lead to instability. The kwarg max_wind_speed, 
+High wind speed anomalies (10-100x increase and decrease over a period of a several hours) appear in the ERA5
+reanalysis data. These generate very large surface fluxes (due to wind speeds up to 300 m/s), which lead to instability. The kwarg max_wind_speed,
 with a value give in m/s,
 is used to clip these if it is not `nothing`.
 See: https://confluence.ecmwf.int/display/CKB/ERA5%3A+large+10m+winds

--- a/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
+++ b/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
@@ -71,7 +71,7 @@ end
 
 
 """
-    SoilCO2ModelParameters(FT; kwargs...)
+    SoilCO2ModelParameters(::Type{FT}; kwargs...)
     SoilCO2ModelParameters(toml_dict; kwargs...)
 
 SoilCO2ModelParameters has two constructors: float-type and toml dict based.

--- a/src/standalone/Soil/Soil.jl
+++ b/src/standalone/Soil/Soil.jl
@@ -194,7 +194,7 @@ using .Biogeochemistry
 # Soil model constructor useful for working with simulations forced by
 # the atmosphere
 """
-    EnergyHydrology(FT, domain, forcing, earth_param_set;
+    EnergyHydrology{FT}(domain, forcing, earth_param_set;
                          prognostic_land_components = (:soil),
                          albedo = CLMTwoBandSoilAlbedo{FT}(; clm_soil_albedo_parameters(domain.space.surface)...),
                          runoff =  Runoff.TOPMODELRunoff{FT}(f_over = FT(3.28),
@@ -208,7 +208,7 @@ using .Biogeochemistry
                          z_0b = LP.get_default_parameter(FT, :soil_scalar_roughness_length),
                          emissivity = LP.get_default_parameter(FT, :soil_bare_soil),
                          additional_sources = (),
-                         )
+                         ) where {FT <: AbstractFloat}
 
 Creates a EnergyHydrology model with the given float type FT, domain, earth_param_set, forcing, and prognostic land components.
 
@@ -225,8 +225,7 @@ component models.
 Roughness lengths and soil emissivity are currently treated as constants; these can be passed in as Floats
 by kwarg; otherwise the default values are used.
 """
-function EnergyHydrology(
-    FT,
+function EnergyHydrology{FT}(
     domain,
     forcing,
     earth_param_set;
@@ -252,7 +251,7 @@ function EnergyHydrology(
     z_0b = LP.get_default_parameter(FT, :soil_scalar_roughness_length),
     emissivity = LP.get_default_parameter(FT, :emissivity_bare_soil),
     additional_sources = (),
-)
+) where {FT <: AbstractFloat}
     # TODO: Move runoff scalar parameters to ClimaParams, possibly use types in retention, composition,
     #  roughness, and emissivity.
     top_bc = AtmosDrivenFluxBC(
@@ -285,7 +284,7 @@ end
 
 
 """
-    RichardsModel(FT, domain, forcing;
+    RichardsModel{FT}(domain, forcing;
                          runoff =  ClimaLand.Soil.Runoff.TOPMODELRunoff{FT}(f_over = FT(3.28),
                                                                             R_sb = FT(1.484e-4 / 1000),
                                                                             f_max = topmodel_fmax(domain.space.surface,FT),
@@ -301,8 +300,7 @@ changed with keyword arguments.
 
 The runoff parameterization is also provided and can be changed via keyword argument.
 """
-function RichardsModel(
-    FT,
+function RichardsModel{FT}(
     domain,
     forcing;
     runoff::Runoff.AbstractRunoffModel = Runoff.TOPMODELRunoff{FT}(
@@ -315,7 +313,7 @@ function RichardsModel(
         FT,
     ),
     S_s = ClimaCore.Fields.zeros(domain.space.subsurface) .+ 1e-3,
-)
+) where {FT}
     # TODO: Move scalar parameters to ClimaParams and obtain from earth_param_set, possibly use types in retention argument.
     top_bc = RichardsAtmosDrivenFluxBC(forcing.atmos, runoff)
     bottom_bc = WaterFluxBC((p, t) -> 0.0)

--- a/src/standalone/Vegetation/optimality_farquhar.jl
+++ b/src/standalone/Vegetation/optimality_farquhar.jl
@@ -85,7 +85,7 @@ ClimaLand.auxiliary_domain_names(::OptimalityFarquharModel) =
     update_photosynthesis!(p, Y, model::OptimalityFarquharModel,canopy)
 
 Computes the net photosynthesis rate `An` (mol CO2/m^2/s)for the Optimality Farquhar model, along with the
-dark respiration `Rd` (mol CO2/m^2/s), the value of `Vcmax25`(mol CO2/m^2/s) , and the gross primary 
+dark respiration `Rd` (mol CO2/m^2/s), the value of `Vcmax25`(mol CO2/m^2/s) , and the gross primary
 productivity `GPP` (mol CO2/m^2/s), and updates them in place.
 """
 function update_photosynthesis!(p, Y, model::OptimalityFarquharModel, canopy)
@@ -194,7 +194,7 @@ Base.broadcastable(m::OptimalityFarquharParameters) = tuple(m)
 
 """
     function OptimalityFarquharParameters(
-        FT,
+        ::Type{FT},
         kwargs...  # For individual parameter overrides
     )
 

--- a/src/standalone/Vegetation/photosynthesis.jl
+++ b/src/standalone/Vegetation/photosynthesis.jl
@@ -276,7 +276,7 @@ include("./optimality_farquhar.jl")
 
 """
     function FarquharParameters(
-        FT,
+        ::Type{FT},
         is_c3::Union{FT, ClimaCore.Fields.Field};
         Vcmax25 = FT(5e-5),
         kwargs...  # For individual parameter overrides

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -344,7 +344,7 @@ function TwoStreamParameters(
 end
 
 """
-    function BeerLambertParameters(FT::AbstractFloat;
+    function BeerLambertParameters(::Type{FT};
         ld = (_) -> 0.5,
         α_PAR_leaf = 0.1,
         α_NIR_leaf = 0.4,

--- a/src/standalone/Vegetation/stomatalconductance.jl
+++ b/src/standalone/Vegetation/stomatalconductance.jl
@@ -76,7 +76,7 @@ end
 # For interfacing with ClimaParams
 
 """
-    function MedlynConductanceParameters(FT::AbstractFloat;
+    function MedlynConductanceParameters(::Type{FT};
         g1 = 790,
         kwargs...
     )

--- a/test/integrated/soil_snow.jl
+++ b/test/integrated/soil_snow.jl
@@ -68,8 +68,7 @@ z_0m = FT(0.001)
 z_0b = z_0m
 prognostic_land_components = (:snow, :soil)
 
-soil = ClimaLand.Soil.EnergyHydrology(
-    FT,
+soil = ClimaLand.Soil.EnergyHydrology{FT}(
     domain,
     forcing,
     earth_param_set;
@@ -92,7 +91,7 @@ snow = ClimaLand.Snow.SnowModel(
     Δt;
     prognostic_land_components,
 )
-land_model = ClimaLand.SoilSnowModel(; snow, soil)
+land_model = ClimaLand.SoilSnowModel{FT}(; snow, soil)
 
 Y, p, coords = ClimaLand.initialize(land_model)
 p_soil_alone = deepcopy(p)

--- a/test/shared_utilities/drivers.jl
+++ b/test/shared_utilities/drivers.jl
@@ -238,7 +238,7 @@ end
 
 @testset "Ground Conditions" begin
     for FT in (Float32, Float64)
-        soil_driver = PrescribedGroundConditions(FT)
+        soil_driver = PrescribedGroundConditions{FT}()
         prognostic_soil_driver = ClimaLand.PrognosticGroundConditions{FT}()
         @test ClimaLand.Canopy.ground_albedo_PAR(
             Val((:canopy,)),

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -180,7 +180,7 @@ import ClimaParams
                     )
                 )
 
-            soil_driver = PrescribedGroundConditions(FT)
+            soil_driver = PrescribedGroundConditions{FT}()
             plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
                 parameters = param_set,
                 n_stem = n_stem,
@@ -708,7 +708,7 @@ end
                     )
                 )
 
-            soil_driver = PrescribedGroundConditions(FT)
+            soil_driver = PrescribedGroundConditions{FT}()
 
             plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
                 parameters = param_set,
@@ -951,7 +951,7 @@ end
                 )
             )
 
-        soil_driver = PrescribedGroundConditions(FT)
+        soil_driver = PrescribedGroundConditions{FT}()
         plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
             parameters = param_set,
             n_stem = n_stem,
@@ -1284,7 +1284,7 @@ end
                     )
                 )
 
-            soil_driver = PrescribedGroundConditions(FT)
+            soil_driver = PrescribedGroundConditions{FT}()
 
             plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
                 parameters = param_set,
@@ -1389,7 +1389,7 @@ end
 
         # Use simple analytic forcing for atmosphere and radiation
         atmos, radiation = prescribed_analytic_forcing(FT)
-        soil_driver = PrescribedGroundConditions(FT)
+        soil_driver = PrescribedGroundConditions{FT}()
         boundary_conditions =
             Canopy.AtmosDrivenCanopyBC(atmos, radiation, soil_driver)
 

--- a/test/standalone/Vegetation/conservation.jl
+++ b/test/standalone/Vegetation/conservation.jl
@@ -143,7 +143,7 @@ for FT in (Float32, Float64)
             )
         )
 
-    soil_driver = PrescribedGroundConditions(FT)
+    soil_driver = PrescribedGroundConditions{FT}()
 
     plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
         parameters = param_set,

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -231,7 +231,7 @@ for FT in (Float32, Float64)
         ψ_soil0 = FT(0.0)
         transpiration = PrescribedTranspiration{FT}(leaf_transpiration)
 
-        soil_driver = PrescribedGroundConditions(FT)
+        soil_driver = PrescribedGroundConditions{FT}()
 
         autotrophic_parameters = AutotrophicRespirationParameters(FT)
         autotrophic_respiration_model =
@@ -494,7 +494,7 @@ for FT in (Float32, Float64)
         )
 
         transpiration = DiagnosticTranspiration{FT}()
-        soil_driver = PrescribedGroundConditions(FT)
+        soil_driver = PrescribedGroundConditions{FT}()
         plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
             parameters = param_set,
             transpiration = transpiration,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
We prefer to write a function with a type parameter over passing the type as a regular function argument because the method with a parametric type will always be specialized by the compiler. When the type is passed as an argument, the compiler will specialize if the type is used within the function body, but not if it's only passed to other functions. See the [relevant section of the Julia manual](https://docs.julialang.org/en/v1/manual/performance-tips/#Be-aware-of-when-Julia-avoids-specializing) for more details.

Because our types are large and complex, and because we often pass FT around without using it within a function (e.g. for constructors), we do want to force specialization and therefore type inference. This PR changes constructors to uniformly take FT as a type parameter.

### Examples
These will specialize:
```julia
# used by model constructors
function f{FT}() where {FT}
end

# used by parameter constructors
function f(::Type{FT}) where {FT}
end
```
but these won't:
```julia
# removed in this PR
function f(FT)
end

function f(::Type)
end
```

## To-do
- [x] PrescribedGroundConditions constructor
- [x] EnergyHydrology constructor
- [x] RichardsModel constructor
