### PR TITLE
remove broken image links in docs

### DIFF
--- a/docs/src/standalone/pages/soil/biogeochemistry/DAMM_model.md
+++ b/docs/src/standalone/pages/soil/biogeochemistry/DAMM_model.md
@@ -1,14 +1,8 @@
 # Microbial respiration
 This section describes multiple models of soil organic decomposition
-by microbes, implemented in ClimaLand. 
+by microbes, implemented in ClimaLand.
 
 ## Dual Arrhenius Michaelis-Menten
-
-```@raw html
-<iframe src="https://clima.westus3.cloudapp.azure.com/jsserve/Rh"
-   style="height:1500px;width:100%;">
-</iframe>
-```
 
 The Dual Arrhenius and Michaelis-Menten (DAMM) kinetics model in ClimaLand.jl follows Davidson et al. 2012. DAMM models heterotrophic respiration ($Rh$) as a function of soil temperature ($T_s$) and soil moisture ($\theta$).
 
@@ -82,7 +76,7 @@ To sum up, the model has the following parameters:
 | Volumetric fraction of $O_2$ in the soil air content  | $O_{2_a}$   | - | 0.005--0.5 |
 | Fraction of soil carbon that is considered soluble | $p_{s_x}$ | - | 0.005--0.5 |
 | Soil organic C | $C_{som}$  | kg C $m^{-3}$ | 1.0--10.0 |
-  
+
 | Constants | Symbol | Unit | Value |
 | :---         |     :---:      |    :---:      |     :---:   |
 | Air-filled porosity at soil water potential of -100 cm H₂O (~ 10 Pa) | $O_{a100}$ | - | 0.1816 |

--- a/docs/src/standalone/pages/vegetation/photosynthesis/farquhar_model.md
+++ b/docs/src/standalone/pages/vegetation/photosynthesis/farquhar_model.md
@@ -5,22 +5,7 @@ The biochemical processes within a leaf determine the rate of photosynthesis, pa
 
 The net assimilation by a leaf (An) is calculated based on the biochemistry of C3 and C4 photosynthesis
 to determine potential (unstressed by water availability) leaf-level photosynthesis. This is calculated in terms of two potentially-limiting rates:
-
-An vs. air Temperature (T, °C) and Photosynthetically Active Radiation (PAR, μmol m⁻² s⁻¹)
-
-```@raw html
-<iframe src="https://clima.westus3.cloudapp.azure.com/jsserve/leaf_An"
-   style="height:1200px;width:90%;">
-</iframe>
-```
-
-An vs. air Temperature (T, °C) and intra-cellular CO2 (ci, ppm)
-
-```@raw html
-<iframe src="https://clima.westus3.cloudapp.azure.com/jsserve/leaf_An_ci"
-   style="height:1400px;width:100%;">
-</iframe>
-```
+the Rubisco-limited rate and light-limited rate.
 
 ## Rubisco limited rate
 
@@ -57,7 +42,7 @@ a_2 =
 \begin{cases}
       J(T, PAR) (c_i - \Gamma^*)/4(c_i + 2  \Gamma^*) & \text{for C3}\\
       J(T, PAR) & \text{for C4}
-\end{cases}       
+\end{cases}
 \end{equation}
 ```
 
@@ -81,7 +66,7 @@ A_n(T, PAR, VPD, c_a) = \text{max}(0, \text{min}(a_1 \beta, a_2) - R_d)
 \end{align}
 ```
 
-where $\beta$ is the moisture stress factor which is related to the mean soil moisture concentration in the root zone and R$_d$ is the leaf dark respiration calculated as 
+where $\beta$ is the moisture stress factor which is related to the mean soil moisture concentration in the root zone and R$_d$ is the leaf dark respiration calculated as
 ```math
 \begin{align}
     R_{d,25}(\psi_l) &= f V_{cmax,25}\beta(\psi_l), \nonumber \\
@@ -89,8 +74,8 @@ where $\beta$ is the moisture stress factor which is related to the mean soil mo
 \end{align}
 ```
 
-where $f = 0.015$ is a constant, $\Delta H_{R_d}$ is the energy of activation for $R_d$, and finally 
-Vcmax is calculated as 
+where $f = 0.015$ is a constant, $\Delta H_{R_d}$ is the energy of activation for $R_d$, and finally
+Vcmax is calculated as
 ```math
 \begin{equation}
 V_{cmax}(T) = V_{cmax,25} \exp\left(\Delta H_{Vcmax}\frac{T - T_o}{T_o R T}\right)\\
@@ -119,7 +104,7 @@ We need to supply the following parameters and “drivers"
 - ``K_{c,25}`` and $K_{o,25}$, $V_{cmax, 25}$, $\Gamma^*_{25},\phi$, $\theta_j$, $o_i$, $s_c$, $\psi_c$
 - ``\psi_l``, to compute $\beta$
 - Temperature $T$, $PAR$, $c_a$, VPD, $\theta_s$.
- 
+
 | Output | Symbol | Unit | Range |
 | :---         |     :---:      |    :---:      |     :---:   |
 | Total net carbon assimilation | $A_n$   | μmol CO$_2$ m$^{-2}$ s$^{-1}$  | 0--25 |
@@ -135,7 +120,7 @@ We need to supply the following parameters and “drivers"
 | Leaf Area Index   | LAI   | m² m⁻² | 1--10 |
 | $CO_2$ concentration | $c_a$   | ppm | 300e--500 |
 | Vapor pressure deficit | VPD | kPa  | 1-10 |
-  
+
 | Constants | Symbol | Unit | Value |
 | :---         |     :---:      |    :---:      |     :---:   |
 | Zenith angle | $θ_s$  | rad | 0.6 |

--- a/docs/src/standalone/pages/vegetation/radiative_transfer/beer_model.md
+++ b/docs/src/standalone/pages/vegetation/radiative_transfer/beer_model.md
@@ -1,6 +1,6 @@
 # Radiative transfer scheme
-This section describes multiple models of radiative transfer 
-through the vegetation canopy, implemented in ClimaLand. 
+This section describes multiple models of radiative transfer
+through the vegetation canopy, implemented in ClimaLand.
 
 ## Beer's law
 Plants utilize Photosynthetically Active Radiation (PAR) for the process of photosynthesis, during which they convert light energy into chemical energy, fueling the synthesis of sugars and other organic compounds. PAR refers to the portion of the electromagnetic spectrum that is essential for photosynthesis in plants. PAR includes wavelengths ranging from approximately 400 to 700 nanometers and corresponds to the visible light spectrum. The unit used to measure PAR is called micromoles per square meter per second (μmol/m²/s), representing the number of photons within the PAR range that strike a square meter of a surface per second.
@@ -45,15 +45,7 @@ The model has the following parameters:
 | Extinction coefficient  | $K$   | - | 0.0--1.0 |
 | Clumping index | $Ω$  | -  | 0.0--1.0 |
 | Zenith angle | $θ_s$  | rad | 0--π |
-  
+
 | Constants | Symbol | Unit | Value |
 | :---         |     :---:      |    :---:      |     :---:   |
 | Leaf angle distribution | $l_d$ | - | 0.5 |
-
-### Interactive APAR(PAR, LAI, $ρ_{leaf}$, $K$, $Ω$)
-
-```@raw html
-<iframe src="https://clima.westus3.cloudapp.azure.com/jsserve/beer_APAR"
-   style="height:1400px;width:100%;">
-</iframe>
-```


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Some of our docs weren't rendering correctly - they would give an error and then not display the rest of the page (see below). This was due to trying to include some images using html. These images weren't included in our recent paper, and I think the documentation is complete without them, so I just removed them.


## Screenshot of docs error
<img width="926" height="501" alt="Screenshot 2025-07-25 at 11 55 47 AM" src="https://github.com/user-attachments/assets/e4487f4d-b012-444b-a85a-bcf7ec319c1d" />
