### PR TITLE
Add simple standalone EnergyHydrology, Canopy tutorials

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -117,7 +117,7 @@ steps:
         agents:
           slurm_ntasks_per_node: 4
           slurm_nodes: 1
-          slurm_mem: 16G
+          slurm_mem: 24G
 
       - label: "Canopy Implicit Stepping CPU"
         command: "julia --color=yes --project=.buildkite experiments/standalone/Vegetation/timestep_test.jl"

--- a/README.md
+++ b/README.md
@@ -24,11 +24,10 @@ component) or standalone (single component) modes.  </strong>
 # Introduction
 
 This is the repository of the CliMA land model code. Here are some notable features:
-- ClimaLand has a modular design, models can be run as standalone (e.g., soil moisture only) or integrated (e.g., soil moisture and energy AND canopy AND snow, etc.)
+- ClimaLand has a modular design, models can be run as standalone (e.g., soil moisture/energy only) or integrated (e.g., soil moisture/energy AND canopy AND snow, etc.)
 - ClimaLand can simulate single columns, regional boxes, and global runs
 - ClimaLand is CPU and GPU compatible
-- ClimaLand welcome contributions: please feel free to reach out to us with questions about how to get started, create a branch, and extend our code. For example, a modeler might want to test a new stomatal conductance model.
-- ClimaLand provides APIs and UIs at multiple levels.
+- ClimaLand welcomes contributions! Please feel free to reach out to us with questions about how to get started, create a branch, and extend our code.
 
 ## Installation
 
@@ -40,14 +39,8 @@ julia> using Pkg
 julia> Pkg.add(ClimaLand)
 ```
 
-Which is equivalent to doing
-
-```Julia
-julia> ] # typing the ] key with go into package REPL mode
-pkg> add ClimaLand
-```
-
-You are now ready to use `ClimaLand.jl`. To get started, we recommend reading the [documentation](https://clima.github.io/ClimaLand.jl/dev/).
+You are now ready to use `ClimaLand.jl`.
+To run a simple first simulation, please see our documentation page [Running your first simulation](https://clima.github.io/ClimaLand.jl/stable/getting_started/).
 
 ## Models
 
@@ -55,21 +48,22 @@ In our code base, a "model" define a set of prognostic variables which must be t
 
 <strong> Component Models: </strong>
 
-- RichardsModel <: AbstractSoilModel <: AbstractModel (runnable only in standalone mode)
+- `RichardsModel`: Soil model option; runnable only in standalone mode
 
-- EnergyHydrologyModel <: AbstractSoilModel <: AbstractModel (runnable in standalone mode, or as part of a land model)
+- `EnergyHydrology`: Soil model option; runnable in standalone mode, or as part of an integrated model
 
-- CanopyModel <: AbstractVegetationModel <: AbstractModel  (runnable in standalone mode, or as part of a land model)
+- `CanopyModel`: runnable in standalone mode, or as part of an integrated model
 
-- SnowModel <: AbstractSnowModel <: AbstractModel (runnable in standalone mode, or as part of a land model)
+- `SnowModel`: runnable in standalone mode, or as part of an integrated model
 
 <strong> Combined Models: </strong>
 
-- SoilCanopyModel <: AbstractLandModel <: AbstractModel (an example of a land model, made of individual component models which are solved simultaneously but taking into account interactions between the components)
+- `SoilCanopyModel`: an integrated model made of individual component models `EnergyHydrology` + `CanopyModel`
+- `LandModel`: an integrated model made of individual component models `EnergyHydrology` + `CanopyModel` + `SnowModel` + `SoilCO2Model`
 
 ## Notes
 
-Recommended Julia Version: Stable release v1.11.1. CI tests Julia v1.10 and 1.11.
+Recommended Julia Version: Stable release v1.11.x. CI tests Julia v1.10 and 1.11.
 
 ClimaLand.jl is a different model from the original CliMA Land,
 which aims to utilize remote sensing data through more complex canopy RT

--- a/docs/list_tutorials.jl
+++ b/docs/list_tutorials.jl
@@ -16,6 +16,7 @@ tutorials = [
             "Changing soil parameterizations" => "standalone/Soil/changing_soil_parameterizations.jl",
         ],
         "Canopy" => [
+            "Default Canopy" => "standalone/Canopy/default_canopy.jl",
             "Standalone Canopy" => "standalone/Canopy/canopy_tutorial.jl",
             "Changing canopy parameterizations" => "standalone/Canopy/changing_canopy_parameterizations.jl",
         ],

--- a/docs/src/architectures.md
+++ b/docs/src/architectures.md
@@ -20,7 +20,7 @@ Below, we have descriptions for how to specify the context when trying to run a
 simulation in different setups. There are two ways to do this: internally within a
 script/REPL, or in the terminal via environment variables.
 
-For more detailed information, please see the ClimaComms.jl [documentation](https://clima.github.io/ClimaComms.jl/dev/).
+For more detailed information, please see the ClimaComms.jl [documentation](https://clima.github.io/ClimaComms.jl/stable/).
 
 ## Choosing the architecture within a script/REPL
 

--- a/docs/src/calibration.md
+++ b/docs/src/calibration.md
@@ -43,7 +43,7 @@ EKP.jl is possible, CliMA's preferred approach is using
 optimized for running on compute clusters. `ClimaCalibrate` handles efficient
 job orchestration and abstracts the details of the underlying system, providing
 a simpler user experience. Consult the
-[ClimaCalibrate documentation](https://clima.github.io/ClimaCalibrate.jl/dev/)
+[ClimaCalibrate documentation](https://clima.github.io/ClimaCalibrate.jl/stable/)
 for further information.
 
 ## Calibrate a land model
@@ -98,7 +98,7 @@ target plus or minus the noise at specific space and time, the goal is reached.
 - `TransformUnscented.Unscented` is a method in EKP, that requires `2p + 1`
   ensemble members for each iteration, where `p` is the number of parameters.
   For more information, read the
-  [EKP documentation for that method](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/unscented_kalman_inversion/).
+  [EKP documentation for that method](https://clima.github.io/EnsembleKalmanProcesses.jl/stable/unscented_kalman_inversion/).
 
 - `verbose = true` is a setting that writes information about your calibration
   run to a log file.
@@ -106,12 +106,12 @@ target plus or minus the noise at specific space and time, the goal is reached.
 - `rng` is a set random seed.
 
 - `Scheduler` is a EKP setting for timestepping, please read
-  [EKP schedulers documentation](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/learning_rate_scheduler/).
+  [EKP schedulers documentation](https://clima.github.io/EnsembleKalmanProcesses.jl/stable/learning_rate_scheduler/).
 
 - `ClimaCalibrate.WorkerBackend` defines how to interact with the underlying
   compute system. For other possible backends (for example, `JuliaBackend`,
   `ClimaGPUBackend`, or `DerechoBackend`), see the
-  [backend documentation in ClimaCalibrate](https://clima.github.io/ClimaCalibrate.jl/dev/backends/).
+  [backend documentation in ClimaCalibrate](https://clima.github.io/ClimaCalibrate.jl/stable/backends/).
 
 Each backend is optimized for specific use cases and computing resources. The
 backend system is implemented through Julia's multiple dispatch, so that code
@@ -126,7 +126,7 @@ prior_sc = EKP.constrained_gaussian("sc", 5e-6, 5e-4, 0, Inf);
 prior_pc = EKP.constrained_gaussian("pc", -2e6, 1e6, -Inf, Inf);
 prior = EKP.combine_distributions([prior_sc, prior_pc]);
 ```
-For more documentation about prior distribution, see [this EKP documentation page](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/parameter_distributions/).
+For more documentation about prior distribution, see [this EKP documentation page](https://clima.github.io/EnsembleKalmanProcesses.jl/stable/parameter_distributions/).
 
 - `n_iterations` is the number of times your priors distribution will be
   updated, at each iteration your model is run for  the number of
@@ -323,7 +323,7 @@ For the land calibration, the default optimization method is
 scheduler, you need to go to the `experiments/calibration/run_calibration.jl`
 file and modify it there. For more information about the different optimization
 methods, see
-[EnsembleKalmanProcesses.jl](https://clima.github.io/EnsembleKalmanProcesses.jl/dev/)
+[EnsembleKalmanProcesses.jl](https://clima.github.io/EnsembleKalmanProcesses.jl/stable/)
 for more information.
 
 ### Observation settings
@@ -359,14 +359,14 @@ over a particular year or over multiple years for example.
 
 To change the covariance matrix, you need to go to `generate_observations.jl`
 and modify the covariance matrix that is passed in. See
-[ClimaCalibrate.jl documentation](https://clima.github.io/ClimaCalibrate.jl/dev/api/#Observation-Recipe-Interface)
+[ClimaCalibrate.jl documentation](https://clima.github.io/ClimaCalibrate.jl/stable/api/#Observation-Recipe-Interface)
 for a list of different covariance matrices that can be used.
 
 #### Data pipelines
 
 !!! note "Data preprocessing"
     The data preprocessing uses ClimaAnalysis.jl. See the
-    [ClimaAnalysis.jl documentation](https://clima.github.io/ClimaAnalysis.jl/dev/api/)
+    [ClimaAnalysis.jl documentation](https://clima.github.io/ClimaAnalysis.jl/stable/api/)
     for functions you can use for preprocessing.
 
 To add additional variables or change how a variable is preprocessed, you must

--- a/docs/src/itime.md
+++ b/docs/src/itime.md
@@ -2,9 +2,9 @@
 
 `ITime`, or _integer time_, is a time type used by CliMA simulations to keep
 track of simulation time. For more information, refer to the
-[TimeManager section](https://clima.github.io/ClimaUtilities.jl/dev/timemanager/)
+[TimeManager section](https://clima.github.io/ClimaUtilities.jl/stable/timemanager/)
 in ClimaUtilities and the
-[ITime section](https://clima.github.io/ClimaAtmos.jl/dev/itime/) in ClimaAtmos.
+[ITime section](https://clima.github.io/ClimaAtmos.jl/stable/itime/) in ClimaAtmos.
 
 ### How do I use ITime?
 
@@ -70,7 +70,7 @@ chosen for the `ITime`.
     If no period is provided, then the constructor for `ITime` will assume the
     provided value is in seconds and choose a reasonable value for the period.
     See
-    [TimeManager section](https://clima.github.io/ClimaUtilities.jl/dev/timemanager/)
+    [TimeManager section](https://clima.github.io/ClimaUtilities.jl/stable/timemanager/)
     in ClimaUtilities for more information.
 
 Next, the different types of `dt1`, `dt2`, and `dt3` can lead to problems as

--- a/docs/src/leaderboard/leaderboard.md
+++ b/docs/src/leaderboard/leaderboard.md
@@ -23,7 +23,7 @@ modified to add a new variable to the leaderboard. The dictionaries are `sim_var
 
 To add a variable for the leaderboard, add a key-value pair to the dictionary `sim_var_dict`
 whose key is the short name of the variable and the value is a function that returns a
-[`OutputVar`](https://clima.github.io/ClimaAnalysis.jl/dev/var/). Any preprocessing is done
+[`OutputVar`](https://clima.github.io/ClimaAnalysis.jl/stable/var/). Any preprocessing is done
 in the function which includes unit conversion and shifting the dates.
 
 ```julia

--- a/docs/src/tutorials/calibration/minimal_working_example.jl
+++ b/docs/src/tutorials/calibration/minimal_working_example.jl
@@ -76,7 +76,7 @@ ensemble_kalman_process = EKP.EnsembleKalmanProcess(
 # We are now ready to carry out the inversion. At each iteration, we get the ensemble from the last iteration, apply
 # Ozark_LatentHeatFlux(params) to each ensemble member, and apply the Kalman update to the ensemble.
 
-# Can be multithreaded, see https://clima.github.io/EnsembleKalmanProcesses.jl/dev/parallel_hpc/
+# Can be multithreaded, see https://clima.github.io/EnsembleKalmanProcesses.jl/stable/parallel_hpc/
 ClimaLand_out = []
 for i in 1:N_iterations # This will run the model N_ensemble * N_iterations times
     params_i = EKP.get_ϕ_final(prior, ensemble_kalman_process)

--- a/docs/src/tutorials/integrated/snowy_land_fluxnet_tutorial.jl
+++ b/docs/src/tutorials/integrated/snowy_land_fluxnet_tutorial.jl
@@ -86,7 +86,7 @@ LAI = ClimaLand.prescribed_lai_modis(
 # # Setup the integrated model
 
 # We want to simulate the canopy-soil-snow system together, so the model type
-# [`LandModel`](https://clima.github.io/ClimaLand.jl/dev/APIs/ClimaLand/#Integrated-Land-Model-Types-and-methods)
+# [`LandModel`](https://clima.github.io/ClimaLand.jl/stable/APIs/ClimaLand/#Integrated-Land-Model-Types-and-methods)
 # is chosen. Here we use the highest level model constructor, which uses default parameters,
 # and parameterizations, for the soil, snow, and canopy models.
 

--- a/docs/src/tutorials/integrated/soil_canopy_fluxnet_tutorial.jl
+++ b/docs/src/tutorials/integrated/soil_canopy_fluxnet_tutorial.jl
@@ -91,7 +91,7 @@ LAI = ClimaLand.prescribed_lai_modis(
 # # Setup the integrated model
 
 # We want to simulate the canopy-soil system together, so we pick the  model type
-# [`SoilCanopyModel`](https://clima.github.io/ClimaLand.jl/dev/APIs/ClimaLand/#Integrated-Land-Model-Types-and-methods)
+# [`SoilCanopyModel`](https://clima.github.io/ClimaLand.jl/stable/APIs/ClimaLand/#Integrated-Land-Model-Types-and-methods)
 # Here we use the highest level model constructor, which uses default parameters,
 # and parameterizations, for the soil and canopy models.
 land_model = SoilCanopyModel{FT}(forcing, LAI, earth_param_set, domain);

--- a/docs/src/tutorials/standalone/Bucket/bucket_tutorial.jl
+++ b/docs/src/tutorials/standalone/Bucket/bucket_tutorial.jl
@@ -7,7 +7,7 @@
 # This tutorial explains in brief the core equations and the
 # necessary parameters of the bucket model, and shows how to set up a simulation in standalone
 # mode. More detail for coupled runs can be
-# found in the ClimaCoupler.jl [documentation](https://clima.github.io/ClimaCoupler.jl/dev/) and in the coupled simulation [tutorial](https://clima.github.io/ClimaLand.jl/dev/generated/coupled_bucket/).
+# found in the ClimaCoupler.jl [documentation](https://clima.github.io/ClimaCoupler.jl/stable/) and in the coupled simulation [tutorial](https://clima.github.io/ClimaLand.jl/stable/generated/coupled_bucket/).
 
 # At each coordinate point on the surface, we solve ordinary differential
 # equations for the subsurface water storage

--- a/docs/src/tutorials/standalone/Bucket/coupled_bucket.jl
+++ b/docs/src/tutorials/standalone/Bucket/coupled_bucket.jl
@@ -1,11 +1,11 @@
 # # Setting up a Coupled Simulation
 
 # For more information about the bucket model,
-# please see [the bucket model tutorial](https://clima.github.io/ClimaLand.jl/dev/generated/bucket_tutorial/).
+# please see [the bucket model tutorial](https://clima.github.io/ClimaLand.jl/stable/generated/bucket_tutorial/).
 
 # This tutorial shows how to set up a simulation for a coupled simulation. More detail for coupled runs can be
-# found in the ClimaCoupler.jl [documentation](https://clima.github.io/ClimaCoupler.jl/dev/). In
-# preparation for understanding this tutorial, we recommend also reading the [intro to multi-component models tutorial](https://clima.github.io/ClimaLand.jl/dev/generated/LSM_single_column_tutorial/) as well as being familiar
+# found in the ClimaCoupler.jl [documentation](https://clima.github.io/ClimaCoupler.jl/stable/). In
+# preparation for understanding this tutorial, we recommend also reading the [intro to multi-component models tutorial](https://clima.github.io/ClimaLand.jl/stable/generated/LSM_single_column_tutorial/) as well as being familiar
 # with multiple dispatch programming in Julia.
 
 # # Background
@@ -59,11 +59,11 @@
 # prescribed_radiation = PrescribedRadiativeFluxes{FT}(*driver data passed in here*)
 # ```
 
-# These are stored in the [BucketModel](https://clima.github.io/ClimaLand.jl/dev/APIs/Bucket/#ClimaLand.Bucket.BucketModel) object,
-# along with [BucketParameters](https://clima.github.io/ClimaLand.jl/dev/APIs/Bucket/#ClimaLand.Bucket.BucketParameters).
-# In order to compute turbulent surface fluxes, we call [turbulent_fluxes!](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.turbulent_fluxes!),
+# These are stored in the [BucketModel](https://clima.github.io/ClimaLand.jl/stable/APIs/Bucket/#ClimaLand.Bucket.BucketModel) object,
+# along with [BucketParameters](https://clima.github.io/ClimaLand.jl/stable/APIs/Bucket/#ClimaLand.Bucket.BucketParameters).
+# In order to compute turbulent surface fluxes, we call [turbulent_fluxes!](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.turbulent_fluxes!),
 # with arguments including `prescribed_atmos`. Since this argument is of the type `PrescribedAtmosphere`, the method of `turbulent_fluxes` which is executed is one which computes the turbulent surface fluxes
-# using MOST. We have a similar function for [net_radiation](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.net_radiation) and which computes the net radiation based on the prescribed downwelling radiative fluxes, stored in an argument
+# using MOST. We have a similar function for [net_radiation](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.net_radiation) and which computes the net radiation based on the prescribed downwelling radiative fluxes, stored in an argument
 # `prescribed_radiation`, which is of type `PrescribedRadiation`.
 
 # In the coupled case, we want different behavior. We have defined new _coupled_ types to
@@ -110,9 +110,9 @@
 # (or extracted them from another model) and modified `p`!
 
 # # Surface air density
-# Within the right hand side/ODE function calls for the bucket model, we need both the 
+# Within the right hand side/ODE function calls for the bucket model, we need both the
 # surface air density (for computing specific humidity at the surface). In standalone runs,
-# we call the function [`surface_air_density`](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.surface_air_density),
+# we call the function [`surface_air_density`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.surface_air_density),
 # When the `atmos` type is `PrescribedAtmosphere`, this function uses the atmospheric state and surface
 # temperature to estimate the surface air density assuming an ideal gas and hydrostatic balance
 # and by extrapolating from the air density at the lowest level of the atmosphere.

--- a/docs/src/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/src/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -2,7 +2,7 @@
 
 # This tutorial shows how to instantiate and run a simulation of the
 # canopy biophysics model in ClimaLand. A
-# [`CanopyModel`](https://clima.github.io/ClimaLand.jl/dev/APIs/canopy/Canopy/#Canopy-Model-Structs)
+# [`CanopyModel`](https://clima.github.io/ClimaLand.jl/stable/APIs/canopy/Canopy/#Canopy-Model-Structs)
 # including all component
 # models is initialized, then an example simulation is run. The initial conditions,
 # atmospheric and radiative flux conditions, and canopy properties are set up
@@ -90,7 +90,7 @@ site_ID = "US-MOz";
 
 # We want to simulate a vegetative canopy in standalone mode, without coupling
 # the canopy to atmospheric or soil physics models, so we choose a
-# [`CanopyModel`](https://clima.github.io/ClimaLand.jl/dev/APIs/canopy/Canopy/#Canopy-Model-Structs).
+# [`CanopyModel`](https://clima.github.io/ClimaLand.jl/stable/APIs/canopy/Canopy/#Canopy-Model-Structs).
 # Here we will use the default parameterizations and parameters for ease of setting up
 # the model, but these can be overridden by constructing and passing canopy
 # components to the `CanopyModel` constructor. This will be explored in a later tutorial.
@@ -99,7 +99,7 @@ site_ID = "US-MOz";
 # by some of the component models. Here we are performing a 1-dimensional
 # simulation in a `Point` domain and will use
 # single stem and leaf compartments, but for 2D simulations, the parameters of
-# the [`domain`](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#Domains)
+# the [`domain`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#Domains)
 # would change.
 domain = Point(; z_sfc = FT(0.0), longlat = (long, lat));
 

--- a/docs/src/tutorials/standalone/Canopy/default_canopy.jl
+++ b/docs/src/tutorials/standalone/Canopy/default_canopy.jl
@@ -1,0 +1,132 @@
+# # Default Canopy Model Tutorial
+# Now that we've run a simple default soil model simulation in [Getting Started](@ref getting_started.md),
+# let's try doing the same with the canopy model.
+
+# This tutorial sets up our CanopyModel on a column domain.
+# The model prognoses canopy temperature and liquid water content,
+# and diagnoses many more variables.
+# Here you'll see that the setup for different models is very similar,
+# and we'll highlight the changes between them.
+
+# Note: we use SI units unless otherwise specified.
+# See our [Physical Units](https://clima.github.io/ClimaLand.jl/stable/physical_units/) documentation for more information.
+
+# First import the Julia packages we'll need.
+import ClimaParams as CP
+using ClimaUtilities: TimeVaryingInput
+using ClimaLand
+using ClimaLand.Domains
+using ClimaLand.Canopy
+import ClimaLand.Simulations: LandSimulation, solve!
+import ClimaLand.Parameters as LP
+using Dates
+import ClimaDiagnostics
+using CairoMakie, ClimaAnalysis, GeoMakie, Printf, StatsBase
+import ClimaLand.LandSimVis as LandSimVis
+
+# Choose a floating point precision, and get the parameter set,
+# which holds constants used across CliMA models.
+FT = Float32
+earth_param_set = LP.LandParameters(FT);
+
+# We will run this simulation on a point domain at a lat/lon location
+# near Pasadena, California.
+# This is different from the soil example, which ran on a column, because the
+# soil model has depth and the canopy model does not.
+longlat = FT.((34.1, -118.1))
+domain = Domains.Point(; z_sfc = FT(0.0), longlat);
+surface_space = domain.space.surface;
+
+# We choose the initial and final simulation times as DatesTimes, and a timestep in seconds.
+start_date = DateTime(2008);
+end_date = start_date + Second(60 * 60 * 72);
+dt = 1000.0;
+
+# Whereas the soil model takes in 2 forcing objects (atmosphere and radiation),
+# the canopy takes in 3 (atmosphere, radiation, and ground). Here we read in the
+# first two from ERA5 data, and specify that the following ground conditions will
+# be prescribed: emissivity, albedo, temperature, and soil moisture.
+# We also set up a constant leaf area index (LAI); for an example reading LAI from
+# MODIS data, please see the [canopy_tutorial.jl tutorial](https://clima.github.io/ClimaLand.jl/stable/generated/standalone/Canopy/canopy_tutorial/).
+# This differs from the soil example because we have the extra inputs of the ground conditions and LAI.
+era5_ncdata_path =
+    ClimaLand.Artifacts.era5_land_forcing_data2008_path(; lowres = true);
+atmos, radiation = ClimaLand.prescribed_forcing_era5(
+    era5_ncdata_path,
+    surface_space,
+    start_date,
+    earth_param_set,
+    FT,
+);
+ground = PrescribedGroundConditions{FT}();
+LAI = TimeVaryingInput((t) -> FT(1.0));
+
+# Now, we can create the canopy model.
+# This constructor uses default parameters and parameterizations,
+# but these can also be overwritten, which we'll demonstrate in later tutorials.
+# Of course, this model construction differs from the soil example because we're
+# using a different model type, but the approach remains the same.
+model = Canopy.CanopyModel{FT}(
+    domain,
+    (; atmos, radiation, ground),
+    LAI,
+    earth_param_set,
+);
+
+# Define a function to set initial conditions for the prognostic variables.
+# Since these are specific to the model physics, the contents here differ from
+# the soil example, but the function structure remains the same.
+# The variables initialized here are described in the Model Equations section
+# of the documentation.
+function set_ic!(Y, p, t0, model)
+    ψ_leaf_0 = FT(-2e5 / 9800)
+    (; retention_model, ν, S_s) = model.hydraulics.parameters
+    S_l_ini = Canopy.PlantHydraulics.inverse_water_retention_curve(
+        retention_model,
+        ψ_leaf_0,
+        ν,
+        S_s,
+    )
+    Y.canopy.hydraulics.ϑ_l.:1 .=
+        Canopy.PlantHydraulics.augmented_liquid_fraction.(ν, S_l_ini)
+    evaluate!(Y.canopy.energy.T, atmos.T, t0)
+end
+
+# Since we'll want to make some plots, let's set up an object to save the
+# model output periodically, as we did for the soil tutorial.
+diag_writer = ClimaDiagnostics.Writers.DictWriter();
+diagnostics = ClimaLand.Diagnostics.default_diagnostics(
+    model,
+    start_date;
+    output_vars = ["ct", "trans"],
+    output_writer = diag_writer,
+    average_period = :hourly,
+);
+
+# Now construct the `LandSimulation` object, which contains the model
+# and additional timestepping information. This is identical to the soil example.
+simulation = LandSimulation(
+    start_date,
+    end_date,
+    dt,
+    model;
+    set_ic!,
+    user_callbacks = (),
+    diagnostics,
+);
+
+# Now we can run the simulation!
+solve!(simulation);
+
+# Let's plot some results, for example diurnally averaged canopy temperature and transpiration over time:
+LandSimVis.make_diurnal_timeseries(
+    simulation;
+    short_names = ["ct", "trans"],
+    plot_stem_name = "default_canopy",
+);
+# ![](ct_default_canopy.png)
+# ![](trans_default_canopy.png)
+
+# Atmospheric forcing data citation:
+# Hersbach, Hans, et al. "The ERA5 global reanalysis."
+# Quarterly journal of the royal meteorological society 146.730 (2020): 1999-2049.

--- a/docs/src/tutorials/standalone/Soil/richards_equation.jl
+++ b/docs/src/tutorials/standalone/Soil/richards_equation.jl
@@ -185,7 +185,7 @@ p.soil |> propertynames
 
 
 # Note that the variables are nested into `Y` and `p` in a hierarchical way.
-# Since we have the vectors (composed of [ClimaCore Fields](https://clima.github.io/ClimaCore.jl/dev/api/#ClimaCore.Fields.Field) handy, we can now set them to the desired initial
+# Since we have the vectors (composed of [ClimaCore Fields](https://clima.github.io/ClimaCore.jl/stable/api/#ClimaCore.Fields.Field) handy, we can now set them to the desired initial
 # conditions.
 sol = solve!(simulation);
 
@@ -218,6 +218,7 @@ plot(
     legend = :bottomleft,
     title = "Equilibrium test",
 );
+plot!(1e-3 .+ ϑ_l[1], z, label = "porosity");
 plot!(ϑ_l[end], z, label = string("t = ", string(t[end]), "days"));
 function hydrostatic_equilibrium(z, z_interface)
     ν = 0.495
@@ -232,8 +233,6 @@ function hydrostatic_equilibrium(z, z_interface)
     end
 end
 plot!(hydrostatic_equilibrium.(z, -0.56), z, label = "equilibrium solution");
-
-plot!(1e-3 .+ ϑ_l[1], z, label = "porosity");
 
 # Save the output:
 savefig("equilibrium_test_ϑ_l.png");

--- a/docs/src/tutorials/standalone/Soil/soil_energy_hydrology.jl
+++ b/docs/src/tutorials/standalone/Soil/soil_energy_hydrology.jl
@@ -101,14 +101,14 @@ earth_param_set = LP.LandParameters(FT);
 
 # # Create the model
 # Set the values of other parameters required by the model:
-ν = FT(0.395)
+ν = FT(0.395);
 # Soil solids
 # are the components of soil besides water, ice, gases, and air.
 # We specify the soil component fractions, relative to all soil solids.
 # These do not sum to unity; the remainder is ν_ss_minerals (=0.08, in this case).
-ν_ss_quartz = FT(0.92)
-ν_ss_om = FT(0.0)
-ν_ss_gravel = FT(0.0)
+ν_ss_quartz = FT(0.92);
+ν_ss_om = FT(0.0);
+ν_ss_gravel = FT(0.0);
 # Other parameters include the hydraulic conductivity at saturation, the specific
 # storage, and the van Genuchten parameters for sand.
 # We recommend Chapter 8 of Bonan (2019) for finding parameters
@@ -271,13 +271,27 @@ t = parent(FT.(sol.t))
 ϑ_l = [parent(sol.u[k].soil.ϑ_l) for k in 1:length(t)]
 T = [parent(saved_values.saveval[k].soil.T) for k in 1:length(t)];
 # Let's look at the initial and final times:
-plot(ϑ_l[1], z, xlabel = "ϑ_l", ylabel = "z (m)", label = "t = 0d")
+plot(
+    ϑ_l[1],
+    z,
+    xlabel = "ϑ_l",
+    ylabel = "z (m)",
+    label = "t = 0d",
+    title = "Moisture Equilibration from t = 0d to t = 3d",
+)
 plot!(ϑ_l[4], z, label = "t = 1.5d")
 plot!(ϑ_l[end], z, label = "t = 3d")
 savefig("eq_moisture_plot.png");
 # ![](eq_moisture_plot.png)
 
-plot(T[1], z, xlabel = "T (K)", ylabel = "z (m)", label = "t = 0d")
+plot(
+    T[1],
+    z,
+    xlabel = "T (K)",
+    ylabel = "z (m)",
+    label = "t = 0d",
+    title = "Temperature Equilibration from t = 0d to t = 3d",
+)
 plot!(T[4], z, xlabel = "T (K)", ylabel = "z (m)", label = "t = 1.5d")
 plot!(T[end], z, xlabel = "T (K)", ylabel = "z (m)", label = "t = 3d")
 savefig("eq_temperature_plot.png");

--- a/docs/src/tutorials/standalone/Usage/LSM_single_column_tutorial.jl
+++ b/docs/src/tutorials/standalone/Usage/LSM_single_column_tutorial.jl
@@ -1,5 +1,5 @@
 # The `AbstractModel`
-# [tutorial](https://clima.github.io/ClimaLand.jl/dev/generated/model_tutorial)
+# [tutorial](https://clima.github.io/ClimaLand.jl/stable/generated/model_tutorial)
 # describes how a user can run
 # simulations of a physical system governed by differential equations.
 # In this framework, the user must define a model type for their problem,
@@ -136,7 +136,7 @@ soil_ode! = make_exp_tendency(soil);
 # functions, given the model, and evaluates them before computing
 # the tendency, so we do not need to define that for the soil model.
 
-# Note also that we have defined methods `make_compute_exp_tendency`, 
+# Note also that we have defined methods `make_compute_exp_tendency`,
 # `make_update_aux`, and `make_update_boundary_fluxes`, which only take
 # the `model` as argument, and which return
 # the functions `compute_exp_tendency!`, `update_aux!`, and `update_boundary_fluxes!`.

--- a/docs/src/tutorials/standalone/Usage/domain_tutorial.jl
+++ b/docs/src/tutorials/standalone/Usage/domain_tutorial.jl
@@ -48,19 +48,19 @@ discretization is tied to a set of basis functions you wish to use to represent 
 variable as a function of space. The nodal points - the locations in space where the variable
 is solved for - are arranged in `space` in a manner which depends on these basis functions.
 Note that these spaces are only mathematically needed when your variables satisfy PDEs[^1],
-but that they still exist when your variables do not, because we are using the same 
+but that they still exist when your variables do not, because we are using the same
 underlying infrastructure in both cases.
 
 
 ## Domain types
 All ClimaLand domains are subtypes of abstract type
-[`ClimaLand.Domains.AbstractDomain`](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.Domains.AbstractDomain).
+[`ClimaLand.Domains.AbstractDomain`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.Domains.AbstractDomain).
 A variety of concrete domain types are supported:
 
-- 0D: [`Domains.Point`](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.Domains.Point)
-- 1D: [`Domains.Column`](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.Domains.Column)
-- 2D: [`Domains.Plane`](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.Domains.Plane), [`Domains.SphericalSurface`](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.Domains.SphericalSurface)
-- 3D: [`Domains.HybridBox`](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.Domains.HybridBox), [`Domains.SphericalShell`](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.Domains.SphericalShell).
+- 0D: [`Domains.Point`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.Domains.Point)
+- 1D: [`Domains.Column`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.Domains.Column)
+- 2D: [`Domains.Plane`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.Domains.Plane), [`Domains.SphericalSurface`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.Domains.SphericalSurface)
+- 3D: [`Domains.HybridBox`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.Domains.HybridBox), [`Domains.SphericalShell`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.Domains.SphericalShell).
 
 As discussed above, our modeling requires that variables of a model can be defined on different subsets of the domain. Because of that, we define the concept of a surface domain, and a subsurface domain. Not all domains have a surface and subsurface; some only have surface domains, as shown in the Table below.
 
@@ -74,7 +74,7 @@ As discussed above, our modeling requires that variables of a model can be defin
 
 There is a single key method which take a ClimaLand domain as an argument.
 
-- [` coordinates(domain)`](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.Domains.coordinates): under the hood, this function  uses
+- [` coordinates(domain)`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.Domains.coordinates): under the hood, this function  uses
 the NamedTuple of function spaces (domain.space) to create the coordinate field for the surface and subsurface domains (as applicable), stored in a NamedTuple.
 Depending on the domain, the returned coordinate field will have elements of different names and types. For example,
 the SphericalShell domain has subsurface coordinates of latitude, longitude, and depth, while the surface coordinates
@@ -98,28 +98,28 @@ make sense to use. A single layer snow model does not require vertical resolutio
 that make sense to use are a Point, Plane, or SphericalSurface.
 
 When a developer first defines a model, they need to specify the symbols used for the prognostic variables,
-via [`prognostic_vars`](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.prognostic_vars),
+via [`prognostic_vars`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.prognostic_vars),
 and
 the types of those variables,
- via [`prognostic_types`](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.prognostic_types).
+ via [`prognostic_types`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.prognostic_types).
 
-They additionally need to define which subset of the domain the variables are defined on, using 
-[`prognostic_domain_names`](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.prognostic_domain_names).
+They additionally need to define which subset of the domain the variables are defined on, using
+[`prognostic_domain_names`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.prognostic_domain_names).
 
-The [`initialize`](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.initialize)
+The [`initialize`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.initialize)
 function (which calls both
-[`initialize_prognostic`](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.initialize_prognostic)
- and [`initialize_auxiliary`](https://clima.github.io/ClimaLand.jl/dev/APIs/shared_utilities/#ClimaLand.initialize_auxiliary))
+[`initialize_prognostic`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.initialize_prognostic)
+ and [`initialize_auxiliary`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#ClimaLand.initialize_auxiliary))
 creates the prognostic state vector `Y` (a ClimaCore.Fields.FieldVector). Each field (ClimaCore.Fields.Field) stored within
 the field vector corresponds to a prognostic variable (identified with the symbol specified). If the prognostic type for that variable
 is a float, the field will be a field of float values (a scalar field)[^4].
 
-How do domains tie into this? The field of a prognostic variable corresponds in a 1-1 fashion with the coordinate field of the subset of the domain associated with that variable via `prognostic_domain_name`.  For example, the bucket model has a vertically resolved temperature `T`, but the bucket water content 
-`W` is not vertically resolved. If your domain is a Column, the subsurface coordinates may be [-4.5,-3.5,-2.5,-1.5, -0.5], and 
-the surface coordinate would be [-0.0]. Your prognostic variable field for `T` will be [T[-4.5], T[-3.5]; T[-2.5], T[-1.5], T[-0.5]], and for `W`  it will be [W[0.0],]. Your variable always has the same spatial resolution as the associated subset of the domain. 
+How do domains tie into this? The field of a prognostic variable corresponds in a 1-1 fashion with the coordinate field of the subset of the domain associated with that variable via `prognostic_domain_name`.  For example, the bucket model has a vertically resolved temperature `T`, but the bucket water content
+`W` is not vertically resolved. If your domain is a Column, the subsurface coordinates may be [-4.5,-3.5,-2.5,-1.5, -0.5], and
+the surface coordinate would be [-0.0]. Your prognostic variable field for `T` will be [T[-4.5], T[-3.5]; T[-2.5], T[-1.5], T[-0.5]], and for `W`  it will be [W[0.0],]. Your variable always has the same spatial resolution as the associated subset of the domain.
 
 This functionality is not required for every standalone component model. For example, a single layer snow model
-will only have variables on the surface of the domain (which in this case, would be the entire Point, Plane, or 
+will only have variables on the surface of the domain (which in this case, would be the entire Point, Plane, or
 SphericalShell domain). The user still must define the prognostic_domain_names method. This functionality is required
 for most multi-component models.
 

--- a/ext/land_sim_vis/plotting_utils.jl
+++ b/ext/land_sim_vis/plotting_utils.jl
@@ -18,9 +18,9 @@ Generates png files called in the provided savedir;
 these images are global maps for the provided short_names variables
 contained in the provided savedir folder (see ClimaAnalysis documentation),
 at the date provided. Plots are saved under the name
-short_name_date_plot_stem_name.png. 
+short_name_date_plot_stem_name.png.
 Variables with multiple levels are plotted at each level
-in levels, with the level appended to the plot name; 
+in levels, with the level appended to the plot name;
 if levels is nothing, the surface is plotted by default.
 
 The plotting defaults are set for global plots with an ocean mask.
@@ -126,9 +126,9 @@ Generates two png files assessing water and energy conservation in
 savedir/water_plot_stem_name.png
 savedir/energy_plot_stem_name.png
 
-The resulting png files contain a time series of the global mean 
-(area-weighted) energy or water volume error, in units of 
-`J/m^2` and `m`. Only continents are included in the global average. 
+The resulting png files contain a time series of the global mean
+(area-weighted) energy or water volume error, in units of
+`J/m^2` and `m`. Only continents are included in the global average.
 """
 function LandSimVis.check_conservation(
     savedir,
@@ -199,7 +199,7 @@ function LandSimVis.check_conservation(
         ax = Axis(
             fig_cycle[1, 1],
             xlabel = "Years",
-            ylabel = "Global Mean Conservation Error $(units[i])",
+            ylabel = "Global Mean Conservation Error [$(units[i])]",
             title = "$(titles[i]), typical value = $(typical_value[i]) $(units[i])",
         )
         CairoMakie.lines!(ax, times ./ 24 ./ 3600 ./ 365, errors[i])
@@ -222,7 +222,7 @@ end
 Generates multiple png files called short_name_plot_stem_name.png in the provided savedir,
 one for each short_name in the Vector provided `short_names`.
 These images contain the timeseries for the global mean of the provided short_names variables
-contained in the provided savedir folder (see ClimaAnalysis documentation). 
+contained in the provided savedir folder (see ClimaAnalysis documentation).
 """
 function make_ocean_masked_annual_timeseries(
     savedir,
@@ -309,11 +309,11 @@ end
 
 Converts an ITime to a date using the epoch
 of the Itime, the counter, and the period (unit)
-of the counter. 
+of the counter.
 
 Although the epoch can be different from the start_date,
 we usually think of the simulation time as relative to the start_date,
-and so we warn here if that is not the case 
+and so we warn here if that is not the case
 """
 function time_to_date(t::ITime, start_date)
     start_date != t.epoch &&
@@ -336,13 +336,13 @@ average diurnal cycle for the diagnostics; the files
 is saved under short_name_plot_stem_name.png in the directory `savedir`.
 
 The `start_date` is used to convert from timestamps of seconds since
-the start date (in diagnostics) to dates; only values observed or 
+the start date (in diagnostics) to dates; only values observed or
 simulated after the `spinup_date` are included.
 
 To include a comparison to data, a NamedTuple `comparison_data`
 may optionally be passed. This should include the timeseries of the
 data labeled with the same variable name as the diagnostics use. For example:
-comparison_data = (; UTC_datetime, gpp = [....], shf = [....]) will 
+comparison_data = (; UTC_datetime, gpp = [....], shf = [....]) will
 result in the timeseries of gpp vs UTC_datetime and shf vs UTC_datetime
 being plotted, provided that those diagnostics were recorded during the simulation.
 """
@@ -376,7 +376,7 @@ function LandSimVis.make_diurnal_timeseries(
         ax = CairoMakie.Axis(
             fig[1, 1],
             xlabel = "Hour of day (UTC)",
-            ylabel = "$sn $(unit)",
+            ylabel = "$sn [$(unit)]",
         )
         CairoMakie.lines!(
             ax,
@@ -446,13 +446,13 @@ timeseries for the diagnostics; the files
 is saved under short_name_plot_stem_name.png in the directory `savedir`.
 
 The `start_date` is used to convert from timestamps of seconds since
-the start date (in diagnostics) to dates; only values observed or 
+the start date (in diagnostics) to dates; only values observed or
 simulated after the `spinup_date` are included.
 
 To include a comparison to data, a NamedTuple `comparison_data`
 may optionally be passed. This should include the timeseries of the
 data labeled with the same variable name as the diagnostics use. For example:
-comparison_data = (; UTC_datetime, gpp = [....], shf = [....]) will 
+comparison_data = (; UTC_datetime, gpp = [....], shf = [....]) will
 result in the timeseries of gpp vs UTC_datetime and shf vs UTC_datetime
 being plotted, provided that those diagnostics were recorded during the simulation.
 """
@@ -486,7 +486,7 @@ function LandSimVis.make_timeseries(
         ax = CairoMakie.Axis(
             fig[1, 1],
             xlabel = "Date (UTC)",
-            ylabel = "$sn $(unit)",
+            ylabel = "$sn [$(unit)]",
         )
         CairoMakie.lines!(
             ax,

--- a/src/standalone/Soil/Soil.jl
+++ b/src/standalone/Soil/Soil.jl
@@ -308,6 +308,7 @@ end
                          )
 
 Creates a RichardsModel model with the given float type FT, domain, earth_param_set and forcing.
+Here, `forcing` should be a `NamedTuple` containing a field `atmos` with the atmospheric forcing.
 
 Default spatially varying parameters (for retention curve parameters and specific storativity) are provided but can be
 changed with keyword arguments.


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Adds 2 simple simulations using default model constructors for EnergyHydrology and CanopyModel. These will be used as the basic demo tutorials for the MC3 meeting (in colab notebooks).

The simple soil simulation doesn't make plots so it can be as simple as possible. The canopy simulation does, and it looks like this:
[diurnal_timeseries.pdf](https://github.com/user-attachments/files/21778786/diurnal_timeseries.pdf)

## Content
- [x] add simple soil simulation in Getting Started page
- [x] add simple canopy tutorial
- [x] update README (taken from #1311)
- [x] link to stable docs instead of dev - this is more consistent with using our packages as "libraries", as outside users will want to do


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
