### PR TITLE
Use global MODIS LAI for all simulations; remove `modis_lai_fluxnet_sites` artifact

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -185,10 +185,3 @@ git-tree-sha1 = "c35ba0e899040cb8153226ab751f69100f475d39"
     [[mizoguchi_soil_freezing_data.download]]
     sha256 = "0027cc080ba45ba33dc790b176ec2854353ce7dce4eae4bef72963b0dd944e0b"
     url = "https://caltech.box.com/shared/static/tn1bnqjmegyetw5kzd2ixq5pbnb05s3u.gz"
-
-[modis_lai_fluxnet_sites]
-git-tree-sha1 = "cdcc1708832654d2209d267e01a3893c4b25c085"
-
-    [[modis_lai_fluxnet_sites.download]]
-    sha256 = "c74780775d98b56eed74222377604272658f59686d4d7881c7b815b6c230080b"
-    url = "https://caltech.box.com/shared/static/g6vubma6vcxulb9fl0pvzq6v0oto4iu3.gz"

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ ClimaLand.jl Release Notes
 
 main
 -------
+- Use global MODIS LAI for all simulations; remove `modis_lai_fluxnet_sites` artifact PR[#1282](https://github.com/CliMA/ClimaLand.jl/pull/1282)
 - Use ClimaUtilities v0.1.25 to read in spatial data to a point using lat/lon PR[#1279](https://github.com/CliMA/ClimaLand.jl/pull/1279)
 - Add data handling tools to FluxnetSimulationsExt and use throughout docs and experiments PR[#1238](https://github.com/CliMA/ClimaLand.jl/pull/1238)
 - Add convenience constructors for CanopyModel and integrated models PR[#1255](https://github.com/CliMA/ClimaLand.jl/pull/1255)

--- a/experiments/benchmarks/snowy_land.jl
+++ b/experiments/benchmarks/snowy_land.jl
@@ -203,9 +203,10 @@ function setup_prob(t0, tf, Δt; outdir = outdir, nelements = (101, 15))
     photosynthesis_args =
         (; parameters = Canopy.FarquharParameters(FT, is_c3; Vcmax25 = Vcmax25))
     # Set up plant hydraulics
-    modis_lai_ncdata_path = ClimaLand.Artifacts.modis_lai_single_year_path(;
+    modis_lai_ncdata_path = ClimaLand.Artifacts.modis_lai_multiyear_paths(;
         context = nothing,
-        year = Dates.year(Second(t0) + start_date),
+        start_date = start_date + Second(t0),
+        end_date = start_date + Second(t0) + Second(tf),
     )
     LAIfunction = ClimaLand.prescribed_lai_modis(
         modis_lai_ncdata_path,

--- a/experiments/calibration/forward_model_land.jl
+++ b/experiments/calibration/forward_model_land.jl
@@ -216,8 +216,11 @@ function setup_prob(
         #sc = sc,
     ))
     # Set up plant hydraulics
-    modis_lai_ncdata_path =
-        ClimaLand.Artifacts.find_modis_year_paths(date(t0), date(tf); context)
+    modis_lai_ncdata_path = ClimaLand.Artifacts.modis_lai_multiyear_paths(
+        date(t0),
+        date(tf);
+        context,
+    )
     LAIfunction = ClimaLand.prescribed_lai_modis(
         modis_lai_ncdata_path,
         surface_space,

--- a/experiments/integrated/fluxnet/US-Var/US-Var_parameters.jl
+++ b/experiments/integrated/fluxnet/US-Var/US-Var_parameters.jl
@@ -5,7 +5,7 @@ fluxtower site."""
 ## Ma, S., Baldocchi, D. D., Xu, L., Hehn, T. (2007)
 ## Inter-Annual Variability In Carbon Dioxide Exchange Of An
 ## Oak/Grass Savanna And Open Grassland In California, Agricultural
-## And Forest Meteorology, 147(3-4), 157-171. https://doi.org/10.1016/j.agrformet.2007.07.008 
+## And Forest Meteorology, 147(3-4), 157-171. https://doi.org/10.1016/j.agrformet.2007.07.008
 ## CLM 5.0 Tech Note: https://www2.cesm.ucar.edu/models/cesm2/land/CLM50_Tech_Note.pdf
 # Bonan, G. Climate change and terrestrial ecosystem modeling. Cambridge University Press, 2019.
 

--- a/experiments/integrated/fluxnet/fluxnet_domain.jl
+++ b/experiments/integrated/fluxnet/fluxnet_domain.jl
@@ -1,5 +1,5 @@
 """This file sets up the domain to run Clima Land on a fluxtower site, using both
-the generic parameters set in this file as well as the site-specific parameters 
+the generic parameters set in this file as well as the site-specific parameters
 given in the {site-ID}_simulation.jl file in each site directory."""
 
 # Domain setup
@@ -8,7 +8,3 @@ h_canopy = h_stem + h_leaf
 compartment_midpoints =
     n_stem > 0 ? [h_stem / 2, h_stem + h_leaf / 2] : [h_leaf / 2]
 compartment_surfaces = n_stem > 0 ? [zmax, h_stem, h_canopy] : [zmax, h_leaf]
-
-land_domain =
-    Column(; zlim = (zmin, zmax), nelements = nelements, dz_tuple = dz_tuple)
-canopy_domain = ClimaLand.Domains.obtain_surface_domain(land_domain)

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -60,6 +60,14 @@ include(
     ),
 )
 
+land_domain = Column(;
+    zlim = (zmin, zmax),
+    nelements = nelements,
+    dz_tuple = dz_tuple,
+    longlat = (long, lat),
+)
+canopy_domain = ClimaLand.Domains.obtain_surface_domain(land_domain)
+
 # This reads in the data from the flux tower site and creates
 # the atmospheric and radiative driver structs for the model
 include(
@@ -80,8 +88,25 @@ include(
     earth_param_set,
     FT,
 )
-(; LAI, maxLAI) =
-    FluxnetSimulationsExt.prescribed_LAI_fluxnet(site_ID, start_date)
+
+# Read in LAI from MODIS data
+surface_space = land_domain.space.surface
+modis_lai_ncdata_path = ClimaLand.Artifacts.modis_lai_multiyear_paths(;
+    context = ClimaComms.context(surface_space),
+    start_date = start_date + Second(t0),
+    end_date = start_date + Second(t0) + Second(tf),
+)
+LAI = ClimaLand.prescribed_lai_modis(
+    modis_lai_ncdata_path,
+    surface_space,
+    start_date,
+)
+# Get the maximum LAI at this site over the first year of the simulation
+maxLAI = FluxnetSimulationsExt.get_maxLAI_at_site(
+    modis_lai_ncdata_path[1],
+    lat,
+    long,
+);
 RAI = maxLAI * f_root_to_shoot
 capacity = plant_ν * maxLAI * h_leaf * FT(1000)
 

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -105,9 +105,10 @@ conductance_args = (; parameters = Canopy.MedlynConductanceParameters(FT; g1))
 photosynthesis_args =
     (; parameters = Canopy.FarquharParameters(FT, is_c3; Vcmax25 = Vcmax25))
 # Set up plant hydraulics
-modis_lai_ncdata_path = ClimaLand.Artifacts.modis_lai_single_year_path(;
+modis_lai_ncdata_path = ClimaLand.Artifacts.modis_lai_multiyear_paths(;
     context = nothing,
-    year = Dates.year(Second(t0) + start_date),
+    start_date = start_date + Second(t0),
+    end_date = start_date + Second(t0) + Second(tf),
 )
 LAIfunction = ClimaLand.prescribed_lai_modis(
     modis_lai_ncdata_path,

--- a/experiments/integrated/performance/conservation/ozark_conservation.jl
+++ b/experiments/integrated/performance/conservation/ozark_conservation.jl
@@ -1,6 +1,8 @@
 import SciMLBase
 import ClimaTimeSteppers as CTS
 using ClimaCore
+import ClimaComms
+ClimaComms.@import_required_backends
 using CairoMakie
 using Statistics
 using Dates
@@ -35,8 +37,6 @@ for float_type in (Float32, Float64)
         ),
     )
 
-    # Use smaller `tf` for Float32 simulation
-    tf = (FT == Float64) ? t0 + 3600 * 24 * 10 : t0 + 2 * dt
     saveat = Array(t0:dt:tf)
     sv = (;
         t = Array{Float64}(undef, length(saveat)),

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -181,9 +181,10 @@ function setup_model(FT, context, start_date, Δt, domain, earth_param_set)
     photosynthesis_args =
         (; parameters = Canopy.FarquharParameters(FT, is_c3; Vcmax25 = Vcmax25))
     # Set up plant hydraulics
-    modis_lai_ncdata_path = ClimaLand.Artifacts.modis_lai_single_year_path(;
+    modis_lai_ncdata_path = ClimaLand.Artifacts.modis_lai_multiyear_paths(;
         context = context,
-        year = Dates.year(start_date),
+        start_date = start_date + Second(t0),
+        end_date = start_date + Second(t0) + Second(tf),
     )
     LAIfunction = ClimaLand.prescribed_lai_modis(
         modis_lai_ncdata_path,

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -198,15 +198,16 @@ function setup_model(FT, start_date, stop_date, Δt, domain, earth_param_set)
         (; parameters = Canopy.FarquharParameters(FT, is_c3; Vcmax25 = Vcmax25))
     # Set up plant hydraulics
     if LONGER_RUN
-        modis_lai_ncdata_path = ClimaLand.Artifacts.find_modis_year_paths(
+        modis_lai_ncdata_path = ClimaLand.Artifacts.modis_lai_multiyear_paths(
             start_date,
             stop_date;
             context,
         )
     else
-        modis_lai_ncdata_path = ClimaLand.Artifacts.modis_lai_single_year_path(;
+        modis_lai_ncdata_path = ClimaLand.Artifacts.modis_lai_multiyear_paths(;
             context = nothing,
-            year = Dates.year(start_date),
+            start_date = start_date + Second(t0),
+            end_date = start_date + Second(t0) + Second(tf),
         )
     end
     LAIfunction = ClimaLand.prescribed_lai_modis(

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -1687,7 +1687,7 @@ function prescribed_lai_modis(
     modis_lai_ncdata_path,
     surface_space,
     start_date;
-    time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
+    time_interpolation_method = LinearInterpolation(),
     regridder_type = :InterpolationsRegridder,
 )
     return TimeVaryingInput(

--- a/test/integrated/full_land_utils.jl
+++ b/test/integrated/full_land_utils.jl
@@ -21,15 +21,15 @@ import ClimaLand
                                                                    DateTime(2008),
                                                                    earth_param_set,
                                                                    FT),
-                       LAI = ClimaLand.prescribed_lai_modis(ClimaLand.Artifacts.modis_lai_forcing_data_path(DateTime(2008); context),
+                       LAI = ClimaLand.prescribed_lai_modis(ClimaLand.Artifacts.modis_lai_single_year_path(DateTime(2008); context),
                                                             domain.space.surface,
                                                             DateTime(2008))
                            )
 
 An helper function for creating a land model corresponding to a global simulation of the snow, soil, and canopy models.
 
-While not explicitly an outer constructor, this creates and returns `LandModel` struct. This is meant as a helper for setting up a standard 
-global land model easily, and is useful for testing. Note that the user can construct any land model they 
+While not explicitly an outer constructor, this creates and returns `LandModel` struct. This is meant as a helper for setting up a standard
+global land model easily, and is useful for testing. Note that the user can construct any land model they
 wish by using the default (inner) constructor method for `LandModel`, or using the alternate outer constructor method defined in src/integrated/land.jl.
 
 Over time, all scalar parameters will be moved to ClimaParameters, so that only a single parameter set `earth_param_set` is passed.
@@ -258,7 +258,7 @@ its values (where binary_mask == 1) equal to  `val`. Note that
 this is meant to be used with the full land model (canopy,
 snow, soil, soilco2).
 
-Useful for checking if land model functions are updating the 
+Useful for checking if land model functions are updating the
 values over the ocean.
 """
 function check_ocean_values_p(p, binary_mask; val = 0.0)
@@ -319,7 +319,7 @@ its values (where binary_mask == 1) equal to  `val`. Note that
 this is meant to be used with the full land model (canopy,
 snow, soil, soilco2).
 
-Useful for checking if land model functions are updating the 
+Useful for checking if land model functions are updating the
 values over the ocean.
 """
 function check_ocean_values_Y(Y, binary_mask; val = 0.0)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
We've been using 2 different MODIS LAI artifacts: one global map for global runs, and one dataset for 4 fluxnet sites to use for site-level simulations. After #1279, we have the ability to read in spatial maps to Point/Column spaces, so we can use the global map for global and site-level runs.

This PR switches all site-level (fluxnet) runs to use the global map, and removes the site-specific LAI artifact.

Closes #1224

## Content
- [x] rename `find_modis_year_paths` -> `modis_lai_multiyear_paths`
- [x] use `modis_lai_multiyear_paths` instead of `modis_lai_single_year_path` (if we have multiple years of data we may as well use it since this artifact isn't too large). Single year artifact still exists and is tested
- [x] `modis_lai_multiyear_paths` only includes an extra year of data if the end date is in December, instead of always including an extra year of data
- [x] in `modis_lai_multiyear_paths`, remove `PeriodicCalendar` extrapolation from `LinearInterpolation`. Since the data spans multiple years, we get uneven time intervals (e.g. between last date of one year and first date of the next year) so we can't use `PeriodicCalendar` with it
- [x] rename `final_date` -> `end_date` in src/Artifacts.toml for consistency
- [x] always pass `longlat` to domain for fluxnet simulations (this required some restructuring of drivers)

## LAI values at the start of the simulation
| site ID | site-level LAI artifact (main) | global LAI artifact (this PR) |
| :------ | :--------------------------: | --------------------------: |
| US-MOz | 0.320855   | 0.343325  |
| US-Ha1 | 0.594469 | 0.532508  |
| US-Var | .0962558  | 1.0596 |
| US-NR1 | 0.488428 | 0.40729  |

Note that the values from the global LAI artifact are identical whether we have `use_lowres_clm` true or false.

## Changes in results
For most variables output from the 4 fluxnet sites, the R-squared value compared to data remained the same (variables are LHF, SHF, LWU, SWU, GPP, ET). RMSD values mostly decreased (suggesting better agreement with data) but RMSD changes range from 2.3% increase (Ha1 GPP) to 20% decrease (Ozark GPP). Overall it seems like this change slightly improves results, but does not have a strong effect.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
