### PR TITLE
fix three bugs: one in canopy, one in run fluxnet, one in fluxnet data

### DIFF
--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -58,7 +58,6 @@ site_ID_val = FluxnetSimulations.replace_hyphen(site_ID)
     soil_α_NIR,
     Ω,
     χl,
-    G_Function,
     α_PAR_leaf,
     λ_γ_PAR,
     τ_PAR_leaf,

--- a/experiments/integrated/fluxnet/ozark_soilsnow.jl
+++ b/experiments/integrated/fluxnet/ozark_soilsnow.jl
@@ -55,7 +55,6 @@ site_ID_val = FluxnetSimulations.replace_hyphen(site_ID)
     soil_α_NIR,
     Ω,
     χl,
-    G_Function,
     α_PAR_leaf,
     λ_γ_PAR,
     τ_PAR_leaf,

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -58,7 +58,6 @@ site_ID_val = FluxnetSimulations.replace_hyphen(site_ID)
     soil_α_NIR,
     Ω,
     χl,
-    G_Function,
     α_PAR_leaf,
     λ_γ_PAR,
     τ_PAR_leaf,

--- a/ext/fluxnet_simulations/data_processing.jl
+++ b/ext/fluxnet_simulations/data_processing.jl
@@ -186,8 +186,8 @@ function FluxnetSimulations.get_comparison_data(
         v = data[:, idx]
         missing_mask = var_missing.(v; val)
         not_missing_mask = .~missing_mask
-        n_missing = sum(not_missing_mask)
-        if n_missing <= length(v) # some data are present
+        n_missing = sum(missing_mask)
+        if n_missing < length(v) # some data are present
             v[missing_mask] .= sum(v[not_missing_mask]) / sum(not_missing_mask)
             return (; Symbol(climaland_shortname) => preprocess_func.(v))
         else

--- a/src/standalone/Vegetation/canopy_parameterizations.jl
+++ b/src/standalone/Vegetation/canopy_parameterizations.jl
@@ -59,13 +59,16 @@ end
 
 Returns the leaf angle distribution value for CLM G function as a function of the
 cosine of the solar zenith angle and the leaf orientation index.
-See section 3.1 of https://www2.cesm.ucar.edu/models/cesm2/land/CLM50_Tech_Note.pdf
+See section 3.1 of https://www2.cesm.ucar.edu/models/cesm2/land/CLM50_Tech_Note.pdf.
+
+Note that the zenith angle is defined ∈ [0,2π), so to prevent a negative value
+of G when the sun is below the horizon, we clip cosθs >= 0
 """
 function compute_G(G::CLMGFunction, cosθs::FT) where {FT}
     χl = G.χl
     ϕ1 = 0.5 - 0.633 * χl - 0.33 * χl^2
     ϕ2 = 0.877 * (1 - 2 * ϕ1)
-    return FT(ϕ1 + ϕ2 * cosθs)
+    return FT(ϕ1 + ϕ2 * max(cosθs, 0))
 end
 
 """

--- a/src/standalone/Vegetation/canopy_parameterizations.jl
+++ b/src/standalone/Vegetation/canopy_parameterizations.jl
@@ -62,7 +62,7 @@ cosine of the solar zenith angle and the leaf orientation index.
 See section 3.1 of https://www2.cesm.ucar.edu/models/cesm2/land/CLM50_Tech_Note.pdf.
 
 Note that the zenith angle is defined ∈ [0,2π), so to prevent a negative value
-of G when the sun is below the horizon, we clip cosθs >= 0
+of G when the sun is below the horizon, we clip cosθs >= 0.
 """
 function compute_G(G::CLMGFunction, cosθs::FT) where {FT}
     χl = G.χl


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR fixes three bugs:
- we now use the CLMGFunction for fluxnet runs (as of #1306), but in the method that computes G with that type, if cos(zenith angle) is negative, G can be negative. This occurs when the sun is below the horizon. This then leads to a value of K which is very large and negative, and this is not correct. K is expected to be positive. Before we used a ConstantGFunction which does not depend on zenith angle so the error did not appear.
- the fluxnet params function returns a constant GFunction and chi_l, and this is confusing. For now, in the fluxnet scripts, I removed G_Function, since we make G_function = CLMGFunction(chi_l) in the script.
- there was a bug in the comparison data which returned all NaNs if the data column was missing, but we want it to return an empty named tuple.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
