### PR TITLE
Kd/plots and offset

### DIFF
--- a/docs/src/tutorials/integrated/snowy_land_fluxnet_tutorial.jl
+++ b/docs/src/tutorials/integrated/snowy_land_fluxnet_tutorial.jl
@@ -103,6 +103,8 @@ diagnostics = ClimaLand.default_diagnostics(
 );
 
 # Choose how often we want to update the forcing.
+# Choosing a frequency > the data frequency results in linear
+# interpolation in time to the intermediate times.
 data_dt = Second(FluxnetSimulations.get_data_dt(site_ID));
 updateat = Array(start_date:data_dt:stop_date);
 

--- a/docs/src/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/src/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -65,26 +65,25 @@ import ClimaLand.LandSimVis as LandSimVis
 const FT = Float32;
 earth_param_set = LP.LandParameters(FT);
 
-# First provide some information about the site:
-# Timezone (offset from UTC in hrs)
-time_offset = 7
-start_date = DateTime(2010) + Hour(time_offset)
-
-# Select a time range to perform time stepping over, and a dt. As usual,
-# the timestep depends on the problem you are solving, the accuracy of the
-# solution required, and the timestepping algorithm you are using.
-N_days = 364
-stop_date = start_date + Day(N_days)
-dt = 225.0
+# We will use prescribed atmospheric and radiative forcing from the
+# US-MOz tower.
+site_ID = "US-MOz";
+site_ID_val = FluxnetSimulations.replace_hyphen(site_ID);
+# Get the latitude and longitude in degrees, as well as the
+# time offset in hours of local time from UTC
+(; time_offset, lat, long) =
+    FluxnetSimulations.get_location(FT, Val(site_ID_val));
+# Get the height of the sensors in m
+(; atmos_h) = FluxnetSimulations.get_fluxtower_height(FT, Val(site_ID_val));
+# Set a start and stop date of the simulation in UTC, as well as
+# a timestep in seconds
+start_date = DateTime("2010-05-01", "yyyy-mm-dd")
+stop_date = DateTime("2010-09-01", "yyyy-mm-dd")
+dt = 450.0
 
 # Site latitude and longitude
 lat = FT(38.7441) # degree
 long = FT(-92.2000) # degree
-
-# Height of the sensor at the site
-atmos_h = FT(32)
-# Site ID
-site_ID = "US-MOz";
 
 # # Setup the Canopy Model
 
@@ -102,8 +101,6 @@ site_ID = "US-MOz";
 # the [`domain`](https://clima.github.io/ClimaLand.jl/stable/APIs/shared_utilities/#Domains)
 # would change.
 domain = Point(; z_sfc = FT(0.0), longlat = (long, lat));
-
-
 
 # We will be using prescribed atmospheric and radiative drivers from the
 # US-MOz tower, which we read in here. We are using prescribed

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -302,13 +302,12 @@ diags = ClimaLand.default_diagnostics(
     start_date;
     output_writer = output_writer,
     output_vars,
-    average_period = :hourly,
+    average_period = :halfhourly,
 )
 
 ## How often we want to update the drivers
 ## defined in the simulatons file
-data_dt = Float64(FluxnetSimulations.get_data_dt(site_ID))
-updateat = Array(start_date:Second(data_dt):stop_date)
+updateat = Array(start_date:Second(dt):stop_date)
 simulation = LandSimulation(
     start_date,
     stop_date,

--- a/experiments/integrated/fluxnet/ozark_pmodel.jl
+++ b/experiments/integrated/fluxnet/ozark_pmodel.jl
@@ -246,12 +246,11 @@ diags = ClimaLand.default_diagnostics(
     start_date;
     output_writer = ClimaDiagnostics.Writers.DictWriter(),
     output_vars,
-    average_period = :hourly,
+    average_period = :halfhourly,
 );
 
 ## How often we want to update the drivers.
-data_dt = Second(FluxnetSimulations.get_data_dt(site_ID))
-updateat = Array(start_date:data_dt:stop_date)
+updateat = Array(start_date:Second(dt):stop_date)
 pmodel_cb = ClimaLand.make_PModel_callback(FT, start_date, dt, land.canopy)
 simulation = LandSimulation(
     start_date,

--- a/experiments/integrated/fluxnet/ozark_soilsnow.jl
+++ b/experiments/integrated/fluxnet/ozark_soilsnow.jl
@@ -186,6 +186,7 @@ simulation = LandSimulation(
     set_ic! = set_ic!,
     updateat,
     solver_kwargs = (; saveat = saveat),
+    diagnostics = nothing,
 )
 sol = solve!(simulation)
 

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -270,13 +270,11 @@ diags = ClimaLand.default_diagnostics(
     start_date;
     output_writer = ClimaDiagnostics.Writers.DictWriter(),
     output_vars,
-    average_period = :hourly,
+    average_period = :halfhourly,
 );
 
 ## How often we want to update the drivers.
-data_dt = Second(FluxnetSimulations.get_data_dt(site_ID))
-updateat = Array(start_date:data_dt:stop_date)
-
+updateat = Array(start_date:Second(dt):stop_date)
 simulation = LandSimulation(
     start_date,
     stop_date,

--- a/experiments/standalone/Vegetation/no_vegetation.jl
+++ b/experiments/standalone/Vegetation/no_vegetation.jl
@@ -29,7 +29,7 @@ long = FT(-92.2000) # degree
 land_domain = Point(; z_sfc = FT(0.0), longlat = (long, lat))
 atmos_h = FT(32)
 site_ID = "US-MOz"
-start_date = DateTime(2010) + Hour(time_offset)
+start_date = DateTime(2010, 1, 2)
 N_days = 10
 stop_date = start_date + Day(N_days)
 dt = 225.0;

--- a/experiments/standalone/Vegetation/varying_lai.jl
+++ b/experiments/standalone/Vegetation/varying_lai.jl
@@ -28,7 +28,7 @@ long = FT(-92.2000) # degree
 land_domain = Point(; z_sfc = FT(0.0), longlat = (long, lat))
 atmos_h = FT(32)
 site_ID = "US-MOz"
-start_date = DateTime(2010) + Hour(time_offset)
+start_date = DateTime(2010, 1, 2)
 N_days = 364
 stop_date = start_date + Day(N_days)
 dt = 225.0;

--- a/experiments/standalone/Vegetation/varying_lai_with_stem.jl
+++ b/experiments/standalone/Vegetation/varying_lai_with_stem.jl
@@ -28,7 +28,7 @@ long = FT(-92.2000) # degree
 land_domain = Point(; z_sfc = FT(0.0), longlat = (long, lat))
 atmos_h = FT(32)
 site_ID = "US-MOz"
-start_date = DateTime(2010) + Hour(time_offset)
+start_date = DateTime(2010, 1, 2)
 N_days = 60
 stop_date = start_date + Day(N_days)
 dt = FT(225);

--- a/ext/land_sim_vis/plotting_utils.jl
+++ b/ext/land_sim_vis/plotting_utils.jl
@@ -189,7 +189,7 @@ function LandSimVis.check_conservation(
     end
     titles =
         ["Global mean energy per area", "Global mean water volume per area"]
-    name = ["energy", "water"]
+    quantity_names = ["energy", "water"]
     errors = [energy_error, water_volume_error]
     typical_value =
         [@sprintf("%1.2le", mean_energy), @sprintf("%1.2le", mean_water_volume)]
@@ -204,7 +204,7 @@ function LandSimVis.check_conservation(
         )
         CairoMakie.lines!(ax, times ./ 24 ./ 3600 ./ 365, errors[i])
         CairoMakie.save(
-            joinpath(savedir, "$(names[i])_$(plot_stem_name).pdf"),
+            joinpath(savedir, "$(quantity_names[i])_$(plot_stem_name).pdf"),
             fig_cycle,
         )
     end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
In our fluxnet plotting, we make plots comparing climaland diagnostics (saved hourly, with a timestamp at the end of the averaging hour) with half hourly data (output at the start of the averaging window). this leads to a relative phase shift between the two diurnal cycles. To be directly comparable to fluxnet we need to save diagnostics at 30 minute intervals, and return the comparison data at the end of the averaging window (TIMESTAMP_END).

This PR addresses that and fixes a typo in our conservation plots (this only affects soil global runs right now). 

@nefrathenrici @juliasloan25 



## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
