### PR TITLE
clip air volumetric fraction

### DIFF
--- a/src/standalone/Soil/Biogeochemistry/co2_parameterizations.jl
+++ b/src/standalone/Soil/Biogeochemistry/co2_parameterizations.jl
@@ -23,7 +23,7 @@ function microbe_source(
         params
     R = FT(LP.gas_constant(earth_param_set))
     Vmax = α_sx * exp(-Ea_sx / (R * T_soil)) # Maximum potential rate of respiration
-    Sx = p_sx * Csom * D_liq * θ_l^3 # All soluble substrate, kgC m⁻³
+    Sx = p_sx * Csom * D_liq * max(θ_l, FT(0))^3 # All soluble substrate, kgC m⁻³
     MM_sx = Sx / (kM_sx + Sx) # Availability of substrate factor, 0-1
     O2 = D_oa * O2_a * (max((ν - θ_l), 0)^(FT(4 / 3))) # Oxygen concentration
     MM_o2 = O2 / (kM_o2 + O2) # Oxygen limitation factor, 0-1
@@ -42,7 +42,7 @@ which is related to the total soil porosity (`ν`) and
 volumetric soil water content (`θ_w = θ_l+θ_i`).
 """
 function volumetric_air_content(θ_w::FT, ν::FT) where {FT}
-    θ_a = ν - θ_w
+    θ_a = max(ν - θ_w, FT(0))
     return θ_a
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Prevent domain errors on CPU by clipping the arguments of soil co2 functions which are exponentiated to a fractional power.

Clip an argument which is raised to a cubic power to prevent the result from being negative.

This does not solve the problems of non-physical soil CO2 variables, but does prevent them from breaking runs on CPU due to the domain error


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
