### PR TITLE
increase h_atmos of prescribed analytic forcing

### DIFF
--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -1475,7 +1475,7 @@ and the earth_param_set.
 
 The argument `era5_ncdata_path` is either a list of nc files, each with all of the variables required, but with different time intervals in the different files, or else it is a single file with all the variables.
 
-The ClimaLand default is to use nearest neighbor interpolation, but 
+The ClimaLand default is to use nearest neighbor interpolation, but
 linear interpolation is supported
 by passing interpolation_method = Interpolations.Linear().
 
@@ -1663,7 +1663,7 @@ LAI cover data in a netcdf file, the surface_space, the start date, and the eart
 
 This currently one works when a single file is passed for both the era5 lai and era5 lai cover data.
 
-The ClimaLand default is to use nearest neighbor interpolation, but 
+The ClimaLand default is to use nearest neighbor interpolation, but
 linear interpolation is supported
 by passing interpolation_method = Interpolations.Linear().
 """
@@ -1711,7 +1711,7 @@ A helper function which constructure the TimeVaryingInput object for Lead Area
 Index from a file path pointint to the MODIS LAI data in a netcdf file, the
 surface_space, the start date, and the earth_param_set.
 
-The ClimaLand default is to use nearest neighbor interpolation, but 
+The ClimaLand default is to use nearest neighbor interpolation, but
 linear interpolation is supported
 by passing interpolation_method = Interpolations.Linear().
 """
@@ -1778,7 +1778,7 @@ function prescribed_analytic_forcing(
     T_atmos = (t) -> 280.0,
     u_atmos = (t) -> 1.0,
     q_atmos = (t) -> 0.0, # no atmos water
-    h_atmos = FT(1e-8),
+    h_atmos = FT(1), # m
     P_atmos = (t) -> 101325,
     atmos = PrescribedAtmosphere(
         TimeVaryingInput(precip),

--- a/src/simulations/Simulations.jl
+++ b/src/simulations/Simulations.jl
@@ -142,6 +142,17 @@ function LandSimulation(
     updateat = [promote(t0:(ITime(3600 * 3)):tf...)...],
     solver_kwargs = (;),
 )
+    # Enforce `h_atmos >= h_canopy` for models with canopy
+    if hasproperty(model, :canopy)
+        h_atmos = model.canopy.boundary_conditions.atmos.h
+        h_canopy = model.canopy.hydraulics.compartment_surfaces[end]
+        @assert h_atmos >= h_canopy "Atmospheric height must be greater than or equal to canopy height"
+    elseif model isa ClimaLand.Canopy.CanopyModel
+        h_atmos = model.boundary_conditions.atmos.h
+        h_canopy = model.hydraulics.compartment_surfaces[end]
+        @assert h_atmos >= h_canopy "Atmospheric height must be greater than or equal to canopy height"
+    end
+
     start_date = isnothing(t0.epoch) ? nothing : date(t0)
 
     if !isnothing(diagnostics) &&
@@ -232,7 +243,7 @@ end
         kwargs...,
     )
 
-A convenience constructor for `LandSimulation` that converts `t0`, `tf`, `Δt` into `ITime`(s), setting the epoch of the ITime to nothing. 
+A convenience constructor for `LandSimulation` that converts `t0`, `tf`, `Δt` into `ITime`(s), setting the epoch of the ITime to nothing.
 If the `kwargs` contain `updateat`, it will
 convert the update times to `ITime`(s) as well. The same applies to `saveat` in `solver_kwargs`.
 

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -60,7 +60,8 @@ for FT in (Float32, Float64)
 
         @testset "Zero flux tendency, FT = $FT" begin
             # Radiation
-            bucket_atmos, bucket_rad = ClimaLand.prescribed_analytic_forcing(FT)
+            bucket_atmos, bucket_rad =
+                ClimaLand.prescribed_analytic_forcing(FT; h_atmos = FT(1e-8))
             τc = FT(1.0)
             bucket_parameters =
                 BucketModelParameters(FT; albedo, z_0m, z_0b, τc)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Increase from 1e-8 to 1 m, to avoid `h_atmos < h_canopy` for SF calculations. Adds an assertion in the `LandSimulation` constructor that `h_atmos >= h_canopy`.

closes #1333
