### PR TITLE
dispatch on abstract canopy types

### DIFF
--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -879,9 +879,9 @@ end
 """
      ClimaLand.make_update_aux(canopy::CanopyModel{FT,
                                                   <:AutotrophicRespirationModel,
-                                                  <:Union{BeerLambertModel, TwoStreamModel},
-                                                  <:FarquharModel,
-                                                  <:MedlynConductanceModel,
+                                                  <:AbstractRadiationModel,
+                                                  <:AbstractPhotosynthesisModel,
+                                                  <:AbstractStomatalConductanceModel,
                                                   <:PlantHydraulicsModel,},
                               ) where {FT}
 
@@ -903,9 +903,9 @@ function ClimaLand.make_update_aux(
     canopy::CanopyModel{
         FT,
         <:AutotrophicRespirationModel,
-        <:Union{BeerLambertModel, TwoStreamModel},
-        <:Union{FarquharModel, PModel},
-        <:Union{MedlynConductanceModel, PModelConductance},
+        <:AbstractRadiationModel,
+        <:AbstractPhotosynthesisModel,
+        <:AbstractStomatalConductanceModel,
         <:PlantHydraulicsModel,
         <:AbstractCanopyEnergyModel,
     },
@@ -1043,11 +1043,11 @@ function make_compute_exp_tendency(
     canopy::CanopyModel{
         FT,
         <:AutotrophicRespirationModel,
-        <:Union{BeerLambertModel, TwoStreamModel},
-        <:Union{FarquharModel, PModel},
-        <:Union{MedlynConductanceModel, PModelConductance},
+        <:AbstractRadiationModel,
+        <:AbstractPhotosynthesisModel,
+        <:AbstractStomatalConductanceModel,
         <:PlantHydraulicsModel,
-        <:Union{PrescribedCanopyTempModel, BigLeafEnergyModel},
+        <:AbstractCanopyEnergyModel,
     },
 ) where {FT}
     components = canopy_components(canopy)
@@ -1073,11 +1073,11 @@ function make_compute_imp_tendency(
     canopy::CanopyModel{
         FT,
         <:AutotrophicRespirationModel,
-        <:Union{BeerLambertModel, TwoStreamModel},
-        <:Union{FarquharModel, PModel},
-        <:Union{MedlynConductanceModel, PModelConductance},
+        <:AbstractRadiationModel,
+        <:AbstractPhotosynthesisModel,
+        <:AbstractStomatalConductanceModel,
         <:PlantHydraulicsModel,
-        <:Union{PrescribedCanopyTempModel, BigLeafEnergyModel},
+        <:AbstractCanopyEnergyModel,
     },
 ) where {FT}
     components = canopy_components(canopy)
@@ -1103,11 +1103,11 @@ function ClimaLand.make_compute_jacobian(
     canopy::CanopyModel{
         FT,
         <:AutotrophicRespirationModel,
-        <:Union{BeerLambertModel, TwoStreamModel},
-        <:Union{FarquharModel, PModel},
-        <:Union{MedlynConductanceModel, PModelConductance},
+        <:AbstractRadiationModel,
+        <:AbstractPhotosynthesisModel,
+        <:AbstractStomatalConductanceModel,
         <:PlantHydraulicsModel,
-        <:Union{PrescribedCanopyTempModel, BigLeafEnergyModel},
+        <:AbstractCanopyEnergyModel,
     },
 ) where {FT}
     components = canopy_components(canopy)

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -157,11 +157,11 @@ end
                             canopy::CanopyModel{
                                 FT,
                                 <:AutotrophicRespirationModel,
-                                <:Union{BeerLambertModel, TwoStreamModel},
-                                <:Union{FarquharModel, PModel},
-                                <:Union{MedlynConductanceModel, PModelConductance},
+                                <:AbstractRadiationModel,
+                                <:AbstractPhotosynthesisModel,
+                                <:AbstractStomatalConductanceModel,
                                 <:PlantHydraulicsModel,
-                                <:Union{PrescribedCanopyTempModel,BigLeafEnergyModel}
+                                <:AbstractCanopyEnergyModel}
                             },
                             Y::ClimaCore.Fields.FieldVector,
                             t,
@@ -183,11 +183,11 @@ function canopy_boundary_fluxes!(
     canopy::CanopyModel{
         FT,
         <:AutotrophicRespirationModel,
-        <:Union{BeerLambertModel, TwoStreamModel},
-        <:Union{FarquharModel, PModel},
-        <:Union{MedlynConductanceModel, PModelConductance},
+        <:AbstractRadiationModel,
+        <:AbstractPhotosynthesisModel,
+        <:AbstractStomatalConductanceModel,
         <:PlantHydraulicsModel,
-        <:Union{PrescribedCanopyTempModel, BigLeafEnergyModel},
+        <:AbstractCanopyEnergyModel,
     },
     Y::ClimaCore.Fields.FieldVector,
     t,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Previously, we used Unions of component model types to dispatch on. This PR makes the small cleanup change of instead using abstract types for dispatch.

closes #1327