### PR TITLE
fix land zenith computation

### DIFF
--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -292,11 +292,14 @@ function default_zenith_angle(
     else
         start_date + Dates.Second(round(t))
     end
+    # This is hardcoded because it is not currently in ClimaParams.
+    # Please see https://github.com/CliMA/Insolation.jl/issues/41
+    date0 = DateTime("2000-01-01T11:58:56.816")
     d, δ, η_UTC =
         FT.(
             Insolation.helper_instantaneous_zenith_angle(
                 current_datetime,
-                start_date,
+                date0,
                 insol_params,
             )
         )


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
@szy21 has found a bug in our land zenith angle computation. 
Mean anomaly uses t0:
https://clima.github.io/Insolation.jl/dev/ZenithAngleEquations/#Mean-Anomaly
e.g. here:
https://github.com/CliMA/Insolation.jl/blob/990e3521d377fa12260416a059d5492b1e1e3d1e/src/ZenithAngleCalc.jl#L65-L72
which is used here:
https://github.com/CliMA/Insolation.jl/blob/990e3521d377fa12260416a059d5492b1e1e3d1e/src/ZenithAngleCalc.jl#L142-L157


In our code, we were passing start_date, which will lead to errors if start_date is ne Jan 1

@imreddyTeja Zhaoyi and I think this makes sense based on what is in Insolations.jl; this is the only place where we define the zenith angle, right?
## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
