### PR TITLE
enable plotting comparison between simulations

### DIFF
--- a/ext/LandSimulationVisualizationExt.jl
+++ b/ext/LandSimulationVisualizationExt.jl
@@ -22,7 +22,7 @@ include("land_sim_vis/leaderboard/leaderboard.jl")
 
 
 Uses the diagnostic output of the `sim` to create leaderboard plots, comparing the output of the simulation to the ``observations"
-from ERA5 or ILAMB. 
+from ERA5 or ILAMB.
 """
 function LandSimVis.make_leaderboard_plots(
     sim::ClimaLand.Simulations.LandSimulation;
@@ -302,8 +302,8 @@ plots are saved in `savedir` with their short_name and the plot_stem_name
 combined to created the output file name: short_name_plot_stem_name.png,
 after spinup is removed.
 
-The comparison data can optionally be provided as a NamedTuple; the data must 
-be labeled with a key equal to the same name as in `short_names`, 
+The comparison data can optionally be provided as a NamedTuple; the data must
+be labeled with a key equal to the same name as in `short_names`,
 or no comparison will be plotted. The value at each key is the timeseries of
 the variable. The timestamp of each is passed as another key `UTC_datetime`,
 with values equal to the time at which the observations where made.
@@ -318,6 +318,7 @@ function LandSimVis.make_diurnal_timeseries(
     savedir = ".",
     short_names = nothing,
     plot_stem_name = "diurnal_timeseries",
+    diagnostics2 = nothing,
     comparison_data = nothing,
     spinup_date = sim.start_date,
 )
@@ -329,6 +330,7 @@ function LandSimVis.make_diurnal_timeseries(
         plot_stem_name,
         savedir,
         short_names,
+        diagnostics2,
         comparison_data,
         spinup_date,
     )
@@ -340,6 +342,7 @@ function LandSimVis.make_diurnal_timeseries(
     start_date;
     plot_stem_name = "diurnal_timeseries",
     savedir = ".",
+    diagnostics2 = nothing,
     short_names = nothing,
     comparison_data = nothing,
     spinup_date = start_date,
@@ -354,6 +357,7 @@ function LandSimVis.make_diurnal_timeseries(
     plot_stem_name = "diurnal_timeseries",
     savedir = ".",
     short_names = nothing,
+    diagnostics2 = nothing,
     comparison_data = nothing,
     spinup_date = start_date,
 )
@@ -365,11 +369,18 @@ function LandSimVis.make_diurnal_timeseries(
         short_names = avail_short_names
     end
     diag_ids = [findfirst(sn .== avail_short_names) for sn in short_names]
+
+    if !isnothing(diagnostics2)
+        diagnostics2_ids = diagnostics2[diag_ids]
+    else
+        diagnostics2_ids = nothing
+    end
     LandSimVis.make_diurnal_timeseries(
         savedir,
         diagnostics[diag_ids], # To be consistent with global/regional runs, this should be a directory with the saved diagnostics.
         start_date;
         plot_stem_name,
+        diagnostics2 = diagnostics2_ids,
         comparison_data,
         spinup_date,
     )
@@ -392,8 +403,8 @@ plots are saved in `savedir` with their short_name and the plot_stem_name
 combined to created the output file name: short_name_plot_stem_name.png,
 after spinup is removed.
 
-The comparison data can optionally be provided as a NamedTuple; the data must 
-be labeled with a key equal to the same name as in `short_names`, 
+The comparison data can optionally be provided as a NamedTuple; the data must
+be labeled with a key equal to the same name as in `short_names`,
 or no comparison will be plotted. The value at each key is the timeseries of
 the variable. The timestamp of each is passed as another key `UTC_datetime`,
 with values equal to the time at which the observations where made.

--- a/ext/land_sim_vis/plotting_utils.jl
+++ b/ext/land_sim_vis/plotting_utils.jl
@@ -351,6 +351,7 @@ function LandSimVis.make_diurnal_timeseries(
     diagnostics,
     start_date;
     plot_stem_name = "diurnal_timeseries",
+    diagnostics2 = nothing,
     comparison_data = nothing,
     spinup_date = start_date,
 )
@@ -385,6 +386,26 @@ function LandSimVis.make_diurnal_timeseries(
             label = "Model",
             color = "blue",
         )
+        # Plot diagnostics from the second model, if provided
+        if !(isnothing(diagnostics2))
+            model_time, model_output2 =
+                ClimaLand.Diagnostics.diagnostic_as_vectors(
+                    diagnostics2[1].output_writer,
+                    dn,
+                )
+            hour_of_day, model_diurnal_cycle2 = compute_diurnal_cycle(
+                model_dates[spinup_idx:end],
+                model_output2[spinup_idx:end],
+            )
+            CairoMakie.lines!(
+                ax,
+                hour_of_day,
+                model_diurnal_cycle2,
+                label = "Model 2",
+                color = "red",
+            )
+        end
+
         if ~(comparison_data isa Nothing) &&
            (Symbol(sn) ∈ propertynames(comparison_data))
             data = getproperty(comparison_data, Symbol(sn))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Adds a keyword arg `diagnostics2` to enable comparing model output between two simulations.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
