### PR TITLE
Bugs in canopy/leaf level quantities

### DIFF
--- a/src/diagnostics/Diagnostics.jl
+++ b/src/diagnostics/Diagnostics.jl
@@ -21,7 +21,7 @@ import ..Canopy:
     CanopyModel,
     medlyn_conductance,
     medlyn_term,
-    gs_h2o_pmodel,
+    gcanopy_h2o_pmodel,
     get_Vcmax25,
     MedlynConductanceModel,
     PModelConductance,

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -260,7 +260,6 @@ function get_possible_diagnostics(model::CanopyModel{FT}) where {FT}
         "rai",
         "sai",
         "gpp",
-        "an",
         "rd",
         "vcmax25",
         "nir",

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -206,7 +206,7 @@ function define_diagnostics!(land_model)
     # Autotrophic respiration
     add_diagnostic_variable!(
         short_name = "ra",
-        long_name = "Autotrophic Respiration",
+        long_name = "Canopy level autotrophic Respiration",
         standard_name = "autotrophic_respiration",
         units = "mol CO2 m^-2 s^-1",
         comments = "The canopy autotrophic respiration, the sum of leaves, stems and roots respiration.",
@@ -214,7 +214,7 @@ function define_diagnostics!(land_model)
             compute_autotrophic_respiration!(out, Y, p, t, land_model),
     )
 
-    ### Canopy - Conductance
+    ### Canopy - conductance
     # Stomatal conductance
     add_diagnostic_variable!(
         short_name = "gs",
@@ -349,20 +349,8 @@ function define_diagnostics!(land_model)
         long_name = "Gross Primary Productivity",
         standard_name = "gross_primary_productivity",
         units = "mol CO2 m^-2 s^-1",
-        comments = "Net photosynthesis (carbon assimilation) of the canopy. This is equivalent to leaf net assimilation scaled to the canopy level.",
         compute! = (out, Y, p, t) ->
-            compute_photosynthesis_net_canopy!(out, Y, p, t, land_model),
-    )
-
-    # Leaf net photosynthesis
-    add_diagnostic_variable!(
-        short_name = "an",
-        long_name = "Leaf Net Photosynthesis",
-        standard_name = "leaf_net_photosynthesis",
-        units = "mol CO2 m^-2 s^-1",
-        comments = "Net photosynthesis (carbon assimilation) of a leaf, computed for example by the Farquhar model.",
-        compute! = (out, Y, p, t) ->
-            compute_photosynthesis_net_leaf!(out, Y, p, t, land_model),
+            compute_gross_primary_productivity!(out, Y, p, t, land_model),
     )
 
     # Leaf respiration
@@ -373,17 +361,18 @@ function define_diagnostics!(land_model)
         units = "mol CO2 m^-2 s^-1",
         comments = "Leaf respiration, called dark respiration because usually measured in the abscence of radiation.",
         compute! = (out, Y, p, t) ->
-            compute_respiration_leaf!(out, Y, p, t, land_model),
+            compute_dark_respiration_leaf!(out, Y, p, t, land_model),
     )
 
     # Vcmax25
     add_diagnostic_variable!(
         short_name = "vcmax25",
-        long_name = "Vcmax25",
-        standard_name = "vcmax25",
+        long_name = "Vcmax25 at leaf level",
+        standard_name = "vcmax25_leaf",
         units = "mol CO2 m^-2 s^-1",
         comments = "The parameter vcmax at 25 degree celsius. Important for the Farquhar model of leaf photosynthesis.",
-        compute! = (out, Y, p, t) -> compute_vcmax25!(out, Y, p, t, land_model),
+        compute! = (out, Y, p, t) ->
+            compute_vcmax25_leaf!(out, Y, p, t, land_model),
     )
 
     ### Canopy - Radiative Transfer

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -922,7 +922,6 @@ function ClimaLand.make_update_aux(
         set_canopy_prescribed_field!(canopy.hydraulics, p, t)
 
         # Shortcut names
-        An = p.canopy.photosynthesis.An
         ψ = p.canopy.hydraulics.ψ
         ϑ_l = Y.canopy.hydraulics.ϑ_l
         fa = p.canopy.hydraulics.fa

--- a/src/standalone/Vegetation/canopy_parameterizations.jl
+++ b/src/standalone/Vegetation/canopy_parameterizations.jl
@@ -15,7 +15,6 @@ export canopy_sw_rt_beer_lambert, # Radiative transfer
     net_photosynthesis,
     moisture_stress,
     dark_respiration,
-    compute_GPP,
     MM_Kc,
     MM_Ko,
     compute_Vcmax,
@@ -820,22 +819,6 @@ function c3_dark_respiration(
 end
 
 """
-    compute_GPP(An::FT,
-             K::FT,
-             LAI::FT,
-             Ω::FT) where {FT}
-
-Computes the total canopy photosynthesis (`GPP`) as a function of
-the total net carbon assimilation (`An`), the extinction coefficient (`K`),
-leaf area index (`LAI`) and the clumping index (`Ω`).
-"""
-function compute_GPP(An::FT, K::FT, LAI::FT, Ω::FT) where {FT}
-    GPP = An * (1 - exp(-K * LAI * Ω)) / (K * Ω)
-    return GPP
-end
-
-
-"""
     upscale_leaf_conductance(gs::FT, LAI::FT, T::FT, R::FT, P::FT) where {FT}
 
 This currently takes a leaf conductance (moles per leaf area per second)
@@ -852,7 +835,7 @@ function upscale_leaf_conductance(
 ) where {FT}
     # TODO: Check what CLM does, and check if we can use the same function
     #  for GPP from An, and make more general.
-    canopy_conductance = gs * LAI * (R * T) / P # convert to m s-1
+    canopy_conductance = gs * (R * T) / P # convert to m s-1
     return canopy_conductance
 end
 

--- a/src/standalone/Vegetation/optimality_farquhar.jl
+++ b/src/standalone/Vegetation/optimality_farquhar.jl
@@ -143,10 +143,9 @@ function update_photosynthesis!(p, Y, model::OptimalityFarquharModel, canopy)
     medlyn_factor = @. lazy(medlyn_term(g1, T_air, P_air, q_air, thermo_params))
     Γstar = @. lazy(co2_compensation(Γstar25, ΔHΓstar, T, To, R))
     ci = @. lazy(intercellular_co2(c_co2_air, Γstar, medlyn_factor))# may change?
-    APAR_leaf_moles = @. lazy(compute_APAR_leaf_moles(f_abs_par, par_d, λ_γ_PAR, c, planck_h, N_a, LAI))
     rates = @. lazy(
         optimality_max_photosynthetic_rates(
-            APAR_leaf_moles,
+            f_abs * par_d / energy_per_mole_photon_par,
             θj,
             ϕ,
             oi,
@@ -161,7 +160,7 @@ function update_photosynthesis!(p, Y, model::OptimalityFarquharModel, canopy)
     Vcmax = rates.:2
     J = @. lazy(
         electron_transport(
-            APAR_leaf_moles,
+            f_abs * par_d / energy_per_mole_photon_par,
             Jmax,
             θj,
             ϕ,
@@ -184,8 +183,8 @@ function update_photosynthesis!(p, Y, model::OptimalityFarquharModel, canopy)
     @. Jmax25 = Jmax / arrhenius_function(T_canopy, To, R, ΔHJmax)
     @. Rd = dark_respiration(is_c3, Vcmax25, β, T_canopy, R, To, fC3, ΔHRd)
     @. An = net_photosynthesis(Ac, Aj, Rd, β)
-    # Compute GPP
-    @. GPP = GPP_from_leaf_level_An(An, extinction_coeff(G_Function, cosθs), LAI, Ω)
+    # Compute GPP: TODO - move to diagnostics only
+    @. GPP = compute_GPP(An, extinction_coeff(G_Function, cosθs), LAI, Ω)
 end
 
 get_Vcmax25(p, m::OptimalityFarquharModel) = p.canopy.photosynthesis.Vcmax25
@@ -207,11 +206,9 @@ function get_electron_transport(Y, p, canopy, m::OptimalityFarquharModel)
     c = LP.light_speed(earth_param_set)
     planck_h = LP.planck_constant(earth_param_set)
     N_a = LP.avogadro_constant(earth_param_set)
-    area_index = p.canopy.hydraulics.area_index
-    LAI = area_index.leaf
-    APAR_leaf_moles = @. lazy(compute_APAR_leaf_moles(f_abs_par, par_d, λ_γ_PAR, c, planck_h, N_a, LAI))
+    APAR = @. lazy(compute_APAR(f_abs_par, par_d, λ_γ_PAR, c, planck_h, N_a))
     Jmax = get_Jmax(Y, p, canopy, m)
-    return @. lazy(electron_transport(APAR_leaf_moles, Jmax, θj, ϕ))
+    return @. lazy(electron_transport(APAR, Jmax, θj, ϕ))
 end
 
 Base.broadcastable(m::OptimalityFarquharParameters) = tuple(m)

--- a/src/standalone/Vegetation/photosynthesis.jl
+++ b/src/standalone/Vegetation/photosynthesis.jl
@@ -17,7 +17,7 @@ Base.@kwdef struct FarquharParameters{
     MECH <: Union{FT, ClimaCore.Fields.Field},
     VC <: Union{FT, ClimaCore.Fields.Field},
 }
-    "Vcmax at 25 °C (mol CO2/m^2/s)"
+    "Vcmax at 25 °C (mol CO2/m^2/s; per leaf area)"
     Vcmax25::VC
     "Γstar at 25 °C (mol/mol)"
     Γstar25::FT
@@ -93,15 +93,13 @@ ClimaLand.auxiliary_domain_names(::FarquharModel) =
     (:surface, :surface, :surface)
 
 
-function photosynthesis_at_a_point_Farquhar(
+function gross_leaf_photosynthesis_at_a_point_Farquhar(
     T,
-    β,
-    Rd,
     APAR_leaf_moles,
     c_co2,
     medlyn_factor,
     R,
-    Vcmax25,
+    Vcmax25_leaf,
     is_c3,
     Γstar25,
     ΔHJmax,
@@ -127,17 +125,28 @@ function photosynthesis_at_a_point_Farquhar(
     s6,
     E,
 )
-    Jmax = max_electron_transport(Vcmax25, ΔHJmax, T, To, R)
+    Jmax = max_electron_transport(Vcmax25_leaf, ΔHJmax, T, To, R)
     J = electron_transport(APAR_leaf_moles, Jmax, θj, ϕ)
-    Vcmax =
-        compute_Vcmax(is_c3, Vcmax25, T, R, To, ΔHVcmax, Q10, s1, s2, s3, s4)
+    Vcmax_leaf = compute_Vcmax(
+        is_c3,
+        Vcmax25_leaf,
+        T,
+        R,
+        To,
+        ΔHVcmax,
+        Q10,
+        s1,
+        s2,
+        s3,
+        s4,
+    )
     Γstar = co2_compensation(Γstar25, ΔHΓstar, T, To, R)
     ci = intercellular_co2(c_co2, Γstar, medlyn_factor)
     Aj = light_assimilation(is_c3, J, ci, Γstar, APAR_leaf_moles, E)
     Kc = MM_Kc(Kc25, ΔHkc, T, To, R)
     Ko = MM_Ko(Ko25, ΔHko, T, To, R)
-    Ac = rubisco_assimilation(is_c3, Vcmax, ci, Γstar, Kc, Ko, oi)
-    return net_photosynthesis(Ac, Aj, Rd, β)
+    Ac = rubisco_assimilation(is_c3, Vcmax_leaf, ci, Γstar, Kc, Ko, oi)
+    return gross_photosynthesis(Ac, Aj)
 end
 
 """
@@ -149,7 +158,8 @@ end
 )
 
 Computes the net leaf photosynthesis rate `An` (mol CO2/m^2/s) for the Farquhar model, along with the
-dark respiration `Rd` (mol CO2/m^2/s) and gross primary productivity `GPP` (mol CO2/m^2/s), and updates them in place.
+dark respiration `Rd` (mol CO2/m^2/s) and gross primary productivity `GPP` (mol CO2/m^2/s), 
+and updates them in place.
 """
 function update_photosynthesis!(p, Y, model::FarquharModel, canopy)
     (;
@@ -201,7 +211,6 @@ function update_photosynthesis!(p, Y, model::FarquharModel, canopy)
     R = LP.gas_constant(earth_param_set)
     thermo_params = earth_param_set.thermo_params
     (; G_Function, λ_γ_PAR, Ω) = canopy.radiative_transfer.parameters
-    energy_per_mole_photon_par = planck_h * c / λ_γ_PAR * N_a
     (; sc, pc) = canopy.photosynthesis.parameters
     (; g1,) = canopy.conductance.parameters
     n_stem = canopy.hydraulics.n_stem
@@ -213,7 +222,7 @@ function update_photosynthesis!(p, Y, model::FarquharModel, canopy)
 
     β = @. lazy(moisture_stress(ψ.:($$i_end) * ρ_l * grav, sc, pc))
     medlyn_factor = @. lazy(medlyn_term(g1, T_air, P_air, q_air, thermo_params))
-    
+
     @. Rd = dark_respiration(
         is_c3,
         Vcmax25,
@@ -228,58 +237,145 @@ function update_photosynthesis!(p, Y, model::FarquharModel, canopy)
         s6,
         fC4,
     )
-    # TO DO: refactor to pass parameter struct, not the parameters individually
-    APAR_leaf_moles = @. lazy(compute_APAR_leaf_moles(f_abs, par_d, λ_γ_PAR, lightspeed, planck_h, N_a, LAI))
-    @. An = photosynthesis_at_a_point_Farquhar(
-        T_canopy,
-        β,
-        Rd,
-        APAR_leaf_moles,
-        c_co2_air,
-        medlyn_factor,
-        R,
-        Vcmax25,
-        is_c3,
-        Γstar25,
-        ΔHJmax,
-        ΔHVcmax,
-        ΔHΓstar,
-        fC3,
-        fC4,
-        ΔHRd,
-        To,
-        θj,
-        ϕ,
-        oi,
-        Kc25,
-        Ko25,
-        ΔHkc,
-        ΔHko,
-        Q10,
-        s1,
-        s2,
-        s3,
-        s4,
-        s5,
-        s6,
-        E,
+    APAR_leaf_moles = @. lazy(
+        compute_APAR_leaf_moles(
+            f_abs,
+            par_d,
+            λ_γ_PAR,
+            lightspeed,
+            planck_h,
+            N_a,
+            LAI,
+        ),
     )
-    # Compute GPP: scale from leaf level An to canopy level GPP
-    @. GPP = GPP_from_leaf_level_An(An, extinction_coeff(G_Function, cosθs), LAI, Ω)
+    A_leaf = @. lazy(
+        gross_leaf_photosynthesis_at_a_point_Farquhar(
+            T_canopy,
+            APAR_leaf_moles,
+            c_co2_air,
+            medlyn_factor,
+            R,
+            Vcmax25,
+            is_c3,
+            Γstar25,
+            ΔHJmax,
+            ΔHVcmax,
+            ΔHΓstar,
+            fC3,
+            fC4,
+            ΔHRd,
+            To,
+            θj,
+            ϕ,
+            oi,
+            Kc25,
+            Ko25,
+            ΔHkc,
+            ΔHko,
+            Q10,
+            s1,
+            s2,
+            s3,
+            s4,
+            s5,
+            s6,
+            E,
+        ),
+    )
+    # Compute net from gross
+    # See Table 11.5 of G. Bonan's textbook, Climate Change and Terrestrial Ecosystem Modeling (2019).
+    @. An = max(0, β * A_leaf - Rd)
+    # Compute GPP: scale from leaf level A to canopy level GPP
+    @. GPP = GPP_from_leaf_level_An(
+        A_leaf * β,
+        extinction_coeff(G_Function, cosθs),
+        LAI,
+        Ω,
+    )
 
 end
+
 Base.broadcastable(m::FarquharParameters) = tuple(m)
 
-get_Vcmax25(p, m::FarquharModel) = m.parameters.Vcmax25
-
-function get_Jmax(Y, p, canopy, m::FarquharModel)
+get_Vcmax25_leaf(p, m::FarquharModel) = m.parameters.Vcmax25
+get_Rd_leaf(p, m::FarquharModel) = p.canopy.photosynthesis.Rd
+get_An_leaf(p, m::FarquharModel) = p.canopy.photosynthesis.An
+function get_Jmax_leaf(Y, p, canopy, m::FarquharModel)
     T_canopy = canopy_temperature(canopy.energy, canopy, Y, p)
+    earth_param_set = canopy.parameters.earth_param_set
     (; Vcmax25, ΔHJmax, To) = m.parameters
     R = LP.gas_constant(canopy.parameters.earth_param_set)
-    return @. lazy(max_electron_transport(Vcmax25, ΔHJmax, T_canopy, To, R))
+    Jmax_leaf =
+        @. lazy(max_electron_transport(Vcmax25, ΔHJmax, T_canopy, To, R))
+    return Jmax_leaf
 end
 
-function get_electron_transport(Y, p, canopy, m::FarquharModel)
+
+function get_J_over_Jmax(Y, p, canopy, m::FarquharModel)
+    J = get_J_leaf(Y, p, canopy, m)
+    Jmax = get_Jmax_leaf(Y, p, canopy, m)
+    FT = eltype(p.canopy.photosynthesis.An)
+    return @. lazy(J / max(Jmax, sqrt(eps(FT))))
+end
+"""
+    max_electron_transport(Vcmax::FT) where {FT}
+
+Computes the maximum potential rate of electron transport (`Jmax`),
+in units of mol/m^2/s,
+as a function of Vcmax at 25 °C (`Vcmax25`),
+a constant (`ΔHJmax`), a standard temperature (`To`),
+the unversal gas constant (`R`), and the temperature (`T`);
+used in the Farquhar model.
+
+See Table 11.5 of G. Bonan's textbook,
+Climate Change and Terrestrial Ecosystem Modeling (2019).
+"""
+function max_electron_transport(
+    Vcmax25::FT,
+    ΔHJmax::FT,
+    T::FT,
+    To::FT,
+    R::FT,
+) where {FT}
+    Jmax25 = Vcmax25 * FT(exp(1))
+    Jmax = Jmax25 * arrhenius_function(T, To, R, ΔHJmax)
+    return Jmax
+end
+
+
+"""
+    electron_transport(APAR_leaf_moles::FT,
+                       Jmax::FT,
+                       θj::FT,
+                       ϕ::FT) where {FT}
+
+Computes the rate of electron transport (`J`),
+in units of mol/m^2/s, as a function of
+the maximum potential rate of electron transport (`Jmax`),
+absorbed photosynthetically active radiation (`APAR_leaf_moles`),
+an empirical "curvature parameter" (`θj`; Bonan Eqn 11.21)
+and the quantum yield of photosystem II (`ϕ`);
+used in the Farquhar model.
+
+See Ch 11, G. Bonan's textbook, Climate Change and Terrestrial Ecosystem Modeling (2019).
+"""
+function electron_transport(
+    APAR_leaf_moles::FT,
+    Jmax::FT,
+    θj::FT,
+    ϕ::FT,
+) where {FT}
+    # Light utilization of APAR (leaf level)
+    IPSII = ϕ * APAR_leaf_moles / 2
+    # This is a solution to a quadratic equation
+    # θj *J^2 - (IPSII+Jmax)*J+IPSII*Jmax = 0, Equation 11.21
+    J =
+        (IPSII + Jmax - sqrt((IPSII + Jmax)^2 - 4 * θj * IPSII * Jmax)) /
+        (2 * θj)
+    return J
+end
+
+function get_J_leaf(Y, p, canopy, m::FarquharModel)
     T_canopy = canopy_temperature(canopy.energy, canopy, Y, p)
     earth_param_set = canopy.parameters.earth_param_set
     f_abs_par = p.canopy.radiative_transfer.par.abs
@@ -290,11 +386,21 @@ function get_electron_transport(Y, p, canopy, m::FarquharModel)
     N_a = LP.avogadro_constant(earth_param_set)
     area_index = p.canopy.hydraulics.area_index
     LAI = area_index.leaf
-    APAR_leaf_moles = @. lazy(compute_APAR_leaf_moles(f_abs_par, par_d, λ_γ_PAR, c, planck_h, N_a, LAI))
+    APAR_leaf_moles = @. lazy(
+        compute_APAR_leaf_moles(
+            f_abs_par,
+            par_d,
+            λ_γ_PAR,
+            c,
+            planck_h,
+            N_a,
+            LAI,
+        ),
+    )
 
-    Jmax = get_Jmax(Y, p, canopy, m)
+    Jmax_leaf = get_Jmax_leaf(Y, p, canopy, m)
     (; θj, ϕ) = m.parameters
-    return @. lazy(electron_transport(APAR_leaf_moles, Jmax, θj, ϕ))
+    return @. lazy(electron_transport(APAR_leaf_moles, Jmax_leaf, θj, ϕ))
 end
 
 include("./optimality_farquhar.jl")

--- a/src/standalone/Vegetation/photosynthesis.jl
+++ b/src/standalone/Vegetation/photosynthesis.jl
@@ -263,8 +263,8 @@ function update_photosynthesis!(p, Y, model::FarquharModel, canopy)
         s6,
         E,
     )
-    # Compute GPP: TODO - move to diagnostics only
-    @. GPP = compute_GPP(An, extinction_coeff(G_Function, cosθs), LAI, Ω)
+    # Compute GPP: remove if this stays the same
+    @. GPP = An
 
 end
 Base.broadcastable(m::FarquharParameters) = tuple(m)

--- a/src/standalone/Vegetation/pmodel.jl
+++ b/src/standalone/Vegetation/pmodel.jl
@@ -55,9 +55,9 @@ $(DocStringExtensions.FIELDS)
 Base.@kwdef struct PModelConstants{FT}
     """Gas constant (J mol^-1 K^-1)"""
     R::FT
-    """Michaelis-Menten parameter for carboxylation at 25°C (μmol mol^-1)"""
+    """Michaelis-Menten parameter for carboxylation at 25°C (Pa)"""
     Kc25::FT
-    """Michaelis-Menten parameter for oxygenation at 25°C (μmol mol^-1)"""
+    """Michaelis-Menten parameter for oxygenation at 25°C (Pa)"""
     Ko25::FT
     """Reference temperature equal to 25˚C (K)"""
     To::FT
@@ -121,12 +121,12 @@ Creates a `PModelConstants` object with default values for the P-model constants
 See Stocker et al. (2020) Table A2 and references within for more information.
 """
 function PModelConstants{FT}(;
-    Kc25 = FT(39.97), # Pa (see note on line 38 above)
-    Ko25 = FT(27480), # Pa (see note on line 38 above)
+    Kc25 = FT(39.97),
+    Ko25 = FT(27480),
     ΔHkc = FT(79430),
     ΔHko = FT(36380),
     ΔHΓstar = FT(37830),
-    Γstar25 = FT(4.332), # Pa (see note on line 38 above)
+    Γstar25 = FT(4.332),
     Ha_Vcmax = FT(71513),
     Hd_Vcmax = FT(200000),
     aS_Vcmax = FT(668.39),
@@ -928,7 +928,7 @@ function update_photosynthesis!(p, Y, model::PModel, canopy)
         Vcmax # canopy level
 
     @. GPP = gross_photosynthesis(
-        c3_rubisco_assimilation(Vcmax, ci, Γstar, Kmm),
+        c3_rubisco_assimilation_pmodel(Vcmax, ci, Γstar, Kmm),
         c3_light_assimilation(J, ci, Γstar),
     )
 

--- a/src/standalone/Vegetation/solar_induced_fluorescence.jl
+++ b/src/standalone/Vegetation/solar_induced_fluorescence.jl
@@ -24,9 +24,9 @@ $(DocStringExtensions.FIELDS)
     kn_p2::FT = FT(0.5944)
     "Rate coefficient for photochemical quenching"
     kp::FT = FT(4.0)
-    "Slope of line relating leaf-level fluorescence to spectrometer-observed fluorescence as a function of Vcmax 25. Lee et al 2015."
+    "Slope of line relating leaf-level fluorescence to spectrometer-observed fluorescence as a function of leaf level Vcmax 25. Lee et al 2015."
     kappa_p1::FT = FT(0.045)
-    "Intercept of line relating leaf-level fluorescence to spectrometer-observed fluorescence as a function of Vcmax 25.  Lee et al 2015."
+    "Intercept of line relating leaf-level fluorescence to spectrometer-observed fluorescence as a function of leaf level Vcmax 25.  Lee et al 2015."
     kappa_p2::FT = FT(7.85)
 end
 
@@ -53,8 +53,8 @@ ClimaLand.auxiliary_domain_names(::Lee2015SIFModel) = (:surface,)
 """
     update_SIF!(p, Y, sif_model::Lee2015SIFModel, canopy)
 
-Updates observed SIF at 755 nm in W/m^2. Note that Tc is in Kelvin, and photo
-synthetic rates are in mol/m^2/s, and APAR is in PPFD.
+Computes and updates observed SIF at 755 nm in W/m^2.
+
 Lee et al, 2015. Global Change Biology 21, 3469-3477, doi:10.1111/gcb.12948
 """
 function update_SIF!(p, Y, sif_model::Lee2015SIFModel, canopy)
@@ -68,23 +68,21 @@ function update_SIF!(p, Y, sif_model::Lee2015SIFModel, canopy)
     c = LP.light_speed(earth_param_set)
     planck_h = LP.planck_constant(earth_param_set)
     N_a = LP.avogadro_constant(earth_param_set)
-    APAR = @. lazy(compute_APAR(f_abs_par, par_d, λ_γ_PAR, c, planck_h, N_a))
-
+    APAR_canopy_moles = @. lazy(
+        compute_APAR_canopy_moles(f_abs_par, par_d, λ_γ_PAR, c, planck_h, N_a),
+    )
     # Get max photosynthesis rates
     T_canopy = canopy_temperature(canopy.energy, canopy, Y, p)
-    Vcmax25 = get_Vcmax25(p, canopy.photosynthesis)
-    Jmax = get_Jmax(Y, p, canopy, canopy.photosynthesis)
-    J = get_electron_transport(Y, p, canopy, canopy.photosynthesis)
-
+    Vcmax25_leaf = get_Vcmax25_leaf(p, canopy.photosynthesis)
+    J_over_Jmax = get_J_over_Jmax(Y, p, canopy, canopy.photosynthesis) # lazy
     T_freeze = LP.T_freeze(earth_param_set)
     sif_parameters = sif_model.parameters
 
     @. SIF = compute_SIF_at_a_point(
-        APAR,
+        APAR_canopy_moles,
         T_canopy,
-        Vcmax25,
-        Jmax,
-        J,
+        Vcmax25_leaf,
+        J_over_Jmax,
         T_freeze,
         sif_parameters,
     )
@@ -95,41 +93,38 @@ Base.broadcastable(m::SIFParameters) = tuple(m)
 
 """
     compute_SIF_at_a_point(
-        APAR::FT,
+        APAR_canopy_moles::FT,
         Tc::FT,
-        Vcmax25::FT,
-        Jmax::FT,
-        J::FT,
+        Vcmax25_leaf::FT,
+        J_over_Jmax::FT,
         T_freeze::FT,
         sif_parameters::SIFParameters{FT},
     ) where {FT}
     
 Computes the Solar Induced Fluorescence (SIF) at 755 nm in W/m^2 using the Lee et al. 2015 model.
-This takes as parameters `APAR` (absorbed photosynthetically active radiation, mol/m^2/s), `Tc`
-(canopy temperature, K), `Vcmax25` (maximum carboxylation rate at 25 °C, mol/m^2/s), `Jmax`
-(electron transport rate, mol/m^2/s), `J` (electron transport rate, mol/m^2/s), `T_freeze` 
+This takes as parameters canopy `APAR` (absorbed photosynthetically active radiation, mol/m^2/s), `Tc`
+(canopy temperature, K), `Vcmax25` at the leaf level (maximum carboxylation rate at 25 °C, mol/m^2/s), the ratio
+`J_over_Jmax`,  `T_freeze` 
 (freezing temperature, K), `sif_parameters` (SIF parameters). 
 """
 function compute_SIF_at_a_point(
-    APAR::FT,
+    APAR_canopy_moles::FT,
     Tc::FT,
-    Vcmax25::FT,
-    Jmax::FT,
-    J::FT,
+    Vcmax25_leaf::FT,
+    J_over_Jmax::FT,
     T_freeze::FT,
     sif_parameters::SIFParameters{FT},
 ) where {FT}
     (; kf, kd_p1, kd_p2, min_kd, kn_p1, kn_p2, kp, kappa_p1, kappa_p2) =
         sif_parameters
     kd = max(kd_p1 * (Tc - T_freeze) + kd_p2, min_kd)
-    x = 1 - J / max(Jmax, eps(FT))
+    x = 1 - J_over_Jmax
     kn = (kn_p1 * x - kn_p2) * x
     ϕp0 = kp / max(kf + kp + kn, eps(FT))
-    ϕp = J / max(Jmax, eps(FT)) * ϕp0
+    ϕp = J_over_Jmax * ϕp0
     ϕf = kf / max(kf + kd + kn, eps(FT)) * (1 - ϕp)
-    κ = kappa_p1 * Vcmax25 * FT(1e6) + kappa_p2 # formula expects Vcmax25 in μmol/m^2/s
-    F = APAR * ϕf
+    κ = kappa_p1 * Vcmax25_leaf * FT(1e6) + kappa_p2 # formula expects Vcmax25 in μmol/m^2/s
+    F = APAR_canopy_moles * ϕf
     SIF_755 = F / max(κ, eps(FT))
-
     return SIF_755
 end

--- a/src/standalone/Vegetation/stomatalconductance.jl
+++ b/src/standalone/Vegetation/stomatalconductance.jl
@@ -166,8 +166,8 @@ function update_canopy_conductance!(p, Y, model::PModelConductance, canopy)
     @. p.canopy.conductance.r_stomata_canopy =
         1 / (
             upscale_leaf_conductance(
-                gs_h2o_pmodel(χ, c_co2_air, An, Drel), # leaf level conductance in mol H2O Pa^-1
-                LAI,
+                gs_h2o_pmodel(χ, c_co2_air, An, Drel), # canopy level conductance in mol H2O Pa^-1
+                FT(0), # LAI = 0 since already canopy level
                 T_air,
                 R,
                 P_air,

--- a/src/standalone/Vegetation/stomatalconductance.jl
+++ b/src/standalone/Vegetation/stomatalconductance.jl
@@ -165,9 +165,8 @@ function update_canopy_conductance!(p, Y, model::PModelConductance, canopy)
     χ = @. lazy(ci / (c_co2_air * P_air))       # ratio of intercellular to ambient CO2 concentration, unitless
     @. p.canopy.conductance.r_stomata_canopy =
         1 / (
-            upscale_leaf_conductance(
-                gs_h2o_pmodel(χ, c_co2_air, An, Drel), # canopy level conductance in mol H2O Pa^-1
-                FT(0), # LAI = 0 since already canopy level
+            molar_conductance_to_m_per_s(
+                gcanopy_h2o_pmodel(χ, c_co2_air, An, Drel), # canopy level conductance in mol H2O Pa^-1
                 T_air,
                 R,
                 P_air,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
- Farquhar works entirely in leaf level fluxes, and therefore (1) GPP needs to be upscaled to canopy level from An, and (2) stomatal conductance needs to be upscaled to canopy level with LAI. The Vcmax, Jmax, Rd, etc are all leaf level. However, we pass in APAR at the canopy level, not leaf level
- Pmodel: works entirely in canopy level: uses APAR_canopy, predicts GPP = An. Therefore, conductance computed from An is already leaf level. Jmax,Vcmac, Rd are all canopy level. We pass in the correct APAR, but upscale GPP and conductance when we dont need to.
- Downstream autotrophic respiration and SIF use quantities computed by the photosynthesis models and we need to be consistent with which values are leaf or canopy level
- Diagnostics also need to be consistent between the two (e.g. cannot return Vcmax25 canopy in one case, and leaf level in the other case).

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
Diagnostics: GPP (canopy gross photosynthesis), vcmax25_leaf, rd_leaf now clearly labeled. I removed An since this not used anywhere currently.
Bug fix: GPP is gross, not net: we should not subtract Rd from it. This is consistent with pmodel papers and Bonan's book
Bug fix: Farquhar works entirely with leaf level, medlyn conductance uses An at leaf level
Bug fix: Pmodel works entirely with canopy level: no need to upscale to get GPP from A or when computing conductance of the canopy
Helper functions to get Vcmax25, Jmax, etc of leaves from the pmodel - make it clear what is canopy vs leaf in downstream SIF and autotrophic respiration


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
