### PR TITLE
Use distributed when making docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,4 +26,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia --color=yes --project=docs/ docs/make.jl
+        run: julia --color=yes --project=docs/ --procs=4 docs/make.jl

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,7 @@ push!(LOAD_PATH, joinpath(@__DIR__, ".."))
 using Distributed
 @everywhere using Documenter
 @everywhere using Literate
-using ClimaLand
+@everywhere using ClimaLand
 include("pages_helper.jl")
 include("list_tutorials.jl")
 


### PR DESCRIPTION
closes #1335 - This PR starts the documentation with four processes and use distributed to make the documentation.