### PR TITLE
add model callbacks

### DIFF
--- a/docs/src/standalone/pages/vegetation/photosynthesis/pmodel.md
+++ b/docs/src/standalone/pages/vegetation/photosynthesis/pmodel.md
@@ -2,17 +2,8 @@ The P-model is model for photosynthesis and stomatal conductance that extends th
 ## Usage in ClimaLand
 The P-model differs from other canopy component models in two main ways: 
 1) The P-model encompasses *both* a photosynthesis model *and* a stomatal conductance model. Therefore, `PModel` must be used for photosynthesis iff `PModelConductance` is used for stomatal conductance. 
-2) The P-model requires an extra callback `PModelCallback` which checks if it is local noon every model timestep and updates the optimal parameters according to local noon (see Implementation for scientific background). When you are constructing a simulation via `SciMLBase`, this callback can be constructed like so:
+2) The P-model requires an extra callback `PModelCallback` which checks if it is local noon every model timestep and updates the optimal parameters according to local noon (see Implementation for scientific background). When you are constructing a simulation via `LandSimulation`, this callback will be constructed and added to your simulation automatically.
 
-```julia
-# make the callback 
-pmodel_cb = ClimaLand.make_PModel_callback(FT, start_date, t0, dt, canopy)
-
-# add this callback to the CallbackSet with driver, diag
-cb = SciMLBase.CallbackSet(driver_cb, diag_cb, pmodel_cb);
-```
-
-**To be implemented**: when using the P-model within a LandSimulation, automatically detect this and use the P-model callback. 
 ## Theory 
 The first assumption, which we'll call the "cost minimization principle", can be mathematically written as follows. We define a cost which is dependent on the transpiration $E$, maximum rate of Rubisco limited photosynthesis $V_{c\max}$, normalized to the rate of assimilation $A$:
 ```math

--- a/experiments/integrated/fluxnet/ozark_pmodel.jl
+++ b/experiments/integrated/fluxnet/ozark_pmodel.jl
@@ -255,13 +255,12 @@ diags = ClimaLand.default_diagnostics(
 
 ## How often we want to update the drivers.
 updateat = Array(start_date:Second(dt):stop_date)
-pmodel_cb = ClimaLand.make_PModel_callback(FT, start_date, dt, land.canopy)
 simulation = LandSimulation(
     start_date,
     stop_date,
     dt,
     land;
-    user_callbacks = (pmodel_cb,),
+    user_callbacks = (),
     set_ic!,
     updateat,
     diagnostics = diags,

--- a/experiments/long_runs/snowy_land_pmodel.jl
+++ b/experiments/long_runs/snowy_land_pmodel.jl
@@ -173,20 +173,7 @@ default_params_filepath =
     joinpath(pkgdir(ClimaLand), "toml", "default_parameters.toml")
 toml_dict = LP.create_toml_dict(FT, default_params_filepath)
 model = setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
-
-# Construct the PModel callback
-pmodel_cb = ClimaLand.make_PModel_callback(FT, start_date, Δt, model.canopy)
-nancheck_cb = ClimaLand.NaNCheckCallback(
-    Dates.Month(6),
-    start_date,
-    ITime(Δt, epoch = start_date),
-    mask = ClimaLand.Domains.landsea_mask(ClimaLand.get_domain(model)),
-)
-report_cb = ClimaLand.ReportCallback(1000)
-user_callbacks = (pmodel_cb, nancheck_cb, report_cb)
-
-simulation =
-    LandSimulation(start_date, stop_date, Δt, model; outdir, user_callbacks)
+simulation = LandSimulation(start_date, stop_date, Δt, model; outdir)
 @info "Run: Global Soil-Canopy-Snow Model"
 @info "Resolution: $nelements"
 @info "Timestep: $Δt s"

--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -21,6 +21,7 @@ import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
 
 import NCDatasets # Needed to load the ClimaUtilities.*VaryingInput
 using .Domains
+
 include("shared_utilities/checkpoints.jl")
 include("shared_utilities/utils.jl")
 include("shared_utilities/models.jl")
@@ -426,6 +427,28 @@ import .Diagnostics: default_diagnostics
 
 # Simulations
 include(joinpath("simulations", "Simulations.jl"))
+
+"""
+     get_model_callbacks(model::AbstractLandModel{FT};
+                         kwargs...
+                         ) where {FT}
+
+Creates the tuple of model callbacks for any AbstractLandModel
+by calling `get_model_callbacks` on each component model.
+
+Do *not* rely on the callbacks being in a particular order based on
+component order.
+"""
+function get_model_callbacks(model::AbstractLandModel{FT}; kwargs...) where {FT}
+    components = land_components(model)
+    callbacks = ()
+    callback_list = map(components) do (component)
+        submodel = getproperty(model, component)
+        cb = get_model_callbacks(submodel; kwargs...)
+        callbacks = (callbacks..., cb...)
+    end
+    return callbacks
+end
 
 # Extensions
 include(joinpath("ext", "LandSimVis.jl"))

--- a/src/shared_utilities/models.jl
+++ b/src/shared_utilities/models.jl
@@ -21,6 +21,7 @@ export AbstractModel,
     make_update_cache,
     add_drivers_to_cache,
     get_drivers,
+    get_model_callbacks,
     name,
     total_liq_water_vol_per_area!,
     total_energy_per_area!
@@ -508,4 +509,19 @@ per unit ground area for the `model`, computed from `Y`, `p`, and `t`.
 """
 function total_energy_per_area!(cache, model::AbstractModel, Y, p, t)
     cache .= 0
+end
+
+"""
+    get_model_callbacks(model::AbstractModel; kwargs...)
+
+Returns the a tuple of required callbacks for the model, not including the
+forcing callbacks for radiation and atmospheric state, which are handled
+separately.
+
+These are used in the LandSimulation struct; model callbacks are evaluated
+after the user_callbacks (optional), forcing callbacks (required), but
+prior to the diagnostic callbacks (optional).
+"""
+function get_model_callbacks(model::ClimaLand.AbstractModel; kwargs...)
+    return ()
 end

--- a/src/simulations/Simulations.jl
+++ b/src/simulations/Simulations.jl
@@ -203,7 +203,9 @@ function LandSimulation(
     updateat =
         updateat isa AbstractVector ? updateat : [promote(t0:updateat:tf...)...]
     driver_cb = ClimaLand.DriverUpdateCallback(updateat, updatefunc)
-    required_callbacks = (driver_cb,) # TBD: can we update each step?
+    model_callbacks = ClimaLand.get_model_callbacks(model; start_date, Δt)# everything else you need should be in the model!
+
+    required_callbacks = (driver_cb, model_callbacks...) # TBD: can we update each step?
 
     diagnostics = isnothing(diagnostics) ? () : diagnostics
     diagnostic_handler =
@@ -403,5 +405,4 @@ convert_updates(t0::ITime, update_time::Dates.Period) =
     promote(t0, ITime(Dates.value(convert(Dates.Second, update_time));))[2]
 convert_updates(t0::ITime, update_time::AbstractFloat) =
     promote(t0, ITime(update_time, epoch = t0.epoch))[2]
-
 end#module

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -31,6 +31,7 @@ import ClimaLand:
     make_compute_imp_tendency,
     make_compute_jacobian,
     get_drivers,
+    get_model_callbacks,
     total_liq_water_vol_per_area!,
     total_energy_per_area!,
     FrequencyBasedCallback
@@ -1214,6 +1215,23 @@ However, for other photosynthesis models this is not needed, so do nothing by de
 """
 function set_historical_cache!(p, Y0, m::AbstractPhotosynthesisModel, canopy)
     return nothing
+end
+
+"""
+     get_model_callbacks(model::CanopyModel{FT}; start_date, Δt) where {FT}
+
+Creates the tuple of model callbacks for a CanopyModel
+by calling `get_model_callbacks` on each component model.
+"""
+function get_model_callbacks(model::CanopyModel{FT}; start_date, Δt) where {FT}
+    components = canopy_components(model)
+    callbacks = ()
+    callback_list = map(components) do (component)
+        submodel = getproperty(model, component)
+        cb = get_model_callbacks(submodel, model; start_date, Δt)
+        callbacks = (callbacks..., cb...)
+    end
+    return callbacks
 end
 
 end

--- a/src/standalone/Vegetation/component_models.jl
+++ b/src/standalone/Vegetation/component_models.jl
@@ -183,3 +183,16 @@ order of operations must be enforced by the developer who writes the `update_aux
 function.
 """
 function set_canopy_prescribed_field!(component::AbstractCanopyComponent, p, t) end
+
+"""
+    get_model_callbacks(component::AbstractCanopyComponent, canopy; kwargs...)
+
+Creates an empty tuple as a default set of model callbacks for canopy component models.
+"""
+function get_model_callbacks(
+    component::AbstractCanopyComponent,
+    canopy;
+    kwargs...,
+)
+    return ()
+end

--- a/src/standalone/Vegetation/pmodel.jl
+++ b/src/standalone/Vegetation/pmodel.jl
@@ -1478,3 +1478,22 @@ function inst_temp_scaling_rd(T_canopy::FT, To::FT, aRd::FT, bRd::FT) where {FT}
         bRd * ((T_canopy - FT(273.15))^2 - (To - FT(273.15))^2),
     )
 end
+
+"""
+    get_model_callbacks(component::AbstractCanopyComponent, canopy; kwargs...)
+
+Creates the pmodel callback and returns it as a single element tuple of model callbacks;
+we add the callback for the photosynthesis component,
+and not for the conductance component(PModelConductance).
+
+Note that the Δt passed here is an ITime because it is the Δt used in the simulation.
+"""
+function get_model_callbacks(
+    component::PModel{FT},
+    canopy;
+    start_date,
+    Δt,
+) where {FT}
+    pmodel_cb = make_PModel_callback(FT, start_date, float(Δt), canopy)
+    return (pmodel_cb,)
+end

--- a/test/integrated/lsms.jl
+++ b/test/integrated/lsms.jl
@@ -17,7 +17,8 @@ import ClimaLand:
     make_update_boundary_fluxes,
     make_update_aux,
     make_set_initial_cache,
-    land_components
+    land_components,
+    get_model_callbacks
 using ClimaLand
 
 
@@ -41,6 +42,7 @@ using ClimaLand
         ClimaLand.auxiliary_vars(::DummyModel1{FT}) = (:b,)
         ClimaLand.auxiliary_types(::DummyModel1{FT}) = (FT,)
         ClimaLand.auxiliary_domain_names(::DummyModel1{FT}) = (:surface,)
+        ClimaLand.get_model_callbacks(::DummyModel1) = (:foo,)# this should be a callback, but we are just testing that is is added correctly
         ClimaLand.name(::DummyModel2{FT}) = :m2
         ClimaLand.prognostic_vars(::DummyModel2{FT}) = (:c, :d)
         ClimaLand.prognostic_types(::DummyModel2{FT}) = (FT, FT)
@@ -85,6 +87,8 @@ using ClimaLand
         m1 = DummyModel1{FT}(d)
         m2 = DummyModel2{FT}(d)
         m = DummyModel{FT}(m1, m2)
+        @test get_model_callbacks(m) == (:foo,)
+        @test get_model_callbacks(m2) == ()
         Y, p, cds = ClimaLand.initialize(m)
         @test propertynames(p) == (:i1, :m1, :m2)
         exp_tendency! = make_exp_tendency(m)

--- a/test/standalone/Vegetation/test_pmodel.jl
+++ b/test/standalone/Vegetation/test_pmodel.jl
@@ -252,9 +252,9 @@ end
         photosynthesis = PModel{FT}(),
         conductance = PModelConductance{FT}(),
     )
-
-    @test_nowarn pmodel_callback =
-        make_PModel_callback(FT, start_date, dt, canopy)
+    pmodel_callback = make_PModel_callback(FT, start_date, dt, canopy)
+    @test typeof(get_model_callbacks(canopy; start_date, Δt = dt)[1]) ==
+          typeof(pmodel_callback)
 end
 
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Adds model callbacks by default to the simulation struct; makes it so the user does not need to create/know about the pmodel callback themselves


## To-do


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
