### PR TITLE
New soil IC function + bug fix in surface soil moisture used in surface fluxes

### DIFF
--- a/src/simulations/Simulations.jl
+++ b/src/simulations/Simulations.jl
@@ -7,8 +7,10 @@ using Dates
 import ClimaUtilities.TimeManager: ITime, date
 import ClimaDiagnostics
 using ClimaLand
+import ..Parameters as LP
 import ClimaLand.Domains: SphericalShell, HybridBox, SphericalSurface
 export step!, solve!, LandSimulation
+using NCDatasets
 include("initial_conditions.jl")
 
 import ..Diagnostics: close_output_writers

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -1161,6 +1161,11 @@ function soil_compute_turbulent_fluxes_at_a_point(
     γT_ref::FT,
     earth_param_set::P,
 ) where {FT <: AbstractFloat, P}
+    # Limit these to physical values
+    # In particular, the linear interpolation to get θ_l_sfc
+    # may not respect the residual fraction limit
+    θ_l_sfc = max(θ_l_sfc, θ_r_sfc + sqrt(eps(FT)))
+    θ_i_sfc = max(θ_i_sfc, FT(0))
     # Parameters
     surface_flux_params = LP.surface_fluxes_parameters(earth_param_set)
     thermo_params = LP.thermodynamic_parameters(earth_param_set)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
- Add function which sets the soil initial conditions from a netcdf file with total water content and soil temperature.
- Fixes bug where the linearly interpolated soil moisture is below the residual fraction.
- Makes minor changes to other functions to clip values more consistently: this is primarily because in the function `effective_saturation` we clip values of nu_eff and theta_l, but some functions both call `effective_saturation` and use nu_eff and theta_l directly, and we werent clipping consistently.
- Removes comments about keeping S_l \in (0,1]. this is not true.

I tested this on clima using an initial condition from @costachris from ERA5 with soil temp and total water, and when forced with 2008 ERA5 data, it produced no NaNs in the first 8 weeks (I stopped after that).

I changed the IC by calling, in experiments/long_runs/soil.jl:
```
ic_path = "/net/sampo/data1/cchristo/clima/WeatherQuest/processing/data/era5_land_processed_20250701_1200.nc"
set_ic!(Y, p, t, model) =
    ClimaLand.Simulations.set_soil_initial_conditions_from_temperature_and_total_water!(
        Y,
        domain.space.subsurface,
        ic_path,
        model,
    )
```
and passing `set_ic!` as a kwarg to the `LandSimulation` constructor

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
