### PR TITLE
move LAI to canopy directory

### DIFF
--- a/docs/src/tutorials/calibration/obs_site_level_calibration.jl
+++ b/docs/src/tutorials/calibration/obs_site_level_calibration.jl
@@ -108,8 +108,11 @@ forcing = FluxnetSimulations.prescribed_forcing_fluxnet(
 );
 
 # Get Leaf Area Index (LAI) data from MODIS satellite observations.
-LAI =
-    ClimaLand.prescribed_lai_modis(domain.space.surface, start_date, stop_date);
+LAI = ClimaLand.Canopy.prescribed_lai_modis(
+    domain.space.surface,
+    start_date,
+    stop_date,
+);
 
 # ## Model Setup
 # 

--- a/docs/src/tutorials/calibration/perfect_model_site_level_calibration.jl
+++ b/docs/src/tutorials/calibration/perfect_model_site_level_calibration.jl
@@ -110,8 +110,11 @@ forcing = FluxnetSimulations.prescribed_forcing_fluxnet(
 );
 
 # Get Leaf Area Index (LAI) data from MODIS satellite observations.
-LAI =
-    ClimaLand.prescribed_lai_modis(domain.space.surface, start_date, stop_date);
+LAI = ClimaLand.Canopy.prescribed_lai_modis(
+    domain.space.surface,
+    start_date,
+    stop_date,
+);
 
 # ## Model Setup
 # 

--- a/docs/src/tutorials/global/snowy_land.jl
+++ b/docs/src/tutorials/global/snowy_land.jl
@@ -67,8 +67,11 @@ forcing = ClimaLand.prescribed_forcing_era5(
 );
 
 # MODIS LAI is prescribed for the canopy model:
-LAI =
-    ClimaLand.prescribed_lai_modis(domain.space.surface, start_date, stop_date);
+LAI = ClimaLand.Canopy.prescribed_lai_modis(
+    domain.space.surface,
+    start_date,
+    stop_date,
+);
 # Make the model:
 model = ClimaLand.LandModel{FT}(forcing, LAI, toml_dict, domain, Δt);
 simulation = ClimaLand.Simulations.LandSimulation(

--- a/docs/src/tutorials/integrated/changing_snowy_land_parameterizations.jl
+++ b/docs/src/tutorials/integrated/changing_snowy_land_parameterizations.jl
@@ -87,8 +87,11 @@ forcing = FluxnetSimulations.prescribed_forcing_fluxnet(
     FT,
 );
 # LAI for the site - this uses our interface for working with MODIS data.
-LAI =
-    ClimaLand.prescribed_lai_modis(domain.space.surface, start_date, stop_date);
+LAI = ClimaLand.Canopy.prescribed_lai_modis(
+    domain.space.surface,
+    start_date,
+    stop_date,
+);
 
 # # Setup the integrated model
 

--- a/docs/src/tutorials/integrated/fluxnet_data.jl
+++ b/docs/src/tutorials/integrated/fluxnet_data.jl
@@ -117,7 +117,8 @@ domain =
     Column(; zlim = (FT(-3.0), FT(0.0)), nelements = 10, longlat = (long, lat))
 surface_space = domain.space.surface;
 # Get the paths to each year of MODIS data within the start and stop dates.
-LAI = ClimaLand.prescribed_lai_modis(surface_space, start_date, stop_date);
+LAI =
+    ClimaLand.Canopy.prescribed_lai_modis(surface_space, start_date, stop_date);
 
 # Just like with the air temperature, the LAI is an object that we can use
 # to linearly interpolate observed LAI to any simulation time.

--- a/docs/src/tutorials/integrated/snowy_land_fluxnet_tutorial.jl
+++ b/docs/src/tutorials/integrated/snowy_land_fluxnet_tutorial.jl
@@ -79,8 +79,11 @@ forcing = FluxnetSimulations.prescribed_forcing_fluxnet(
     FT,
 );
 # LAI for the site - this uses our interface for working with MODIS data.
-LAI =
-    ClimaLand.prescribed_lai_modis(domain.space.surface, start_date, stop_date);
+LAI = ClimaLand.Canopy.prescribed_lai_modis(
+    domain.space.surface,
+    start_date,
+    stop_date,
+);
 
 # # Setup the integrated model
 

--- a/docs/src/tutorials/integrated/soil_canopy_fluxnet_tutorial.jl
+++ b/docs/src/tutorials/integrated/soil_canopy_fluxnet_tutorial.jl
@@ -83,8 +83,11 @@ forcing = FluxnetSimulations.prescribed_forcing_fluxnet(
     FT,
 );
 # LAI for the site - this uses our interface for working with MODIS data.
-LAI =
-    ClimaLand.prescribed_lai_modis(domain.space.surface, start_date, stop_date);
+LAI = ClimaLand.Canopy.prescribed_lai_modis(
+    domain.space.surface,
+    start_date,
+    stop_date,
+);
 
 # # Setup the integrated model
 

--- a/docs/src/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/src/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -136,7 +136,8 @@ forcing = (; atmos, radiation, ground);
 
 # Now we read in time-varying LAI from a global MODIS dataset.
 surface_space = domain.space.surface;
-LAI = ClimaLand.prescribed_lai_modis(surface_space, start_date, stop_date);
+LAI =
+    ClimaLand.Canopy.prescribed_lai_modis(surface_space, start_date, stop_date);
 # Get the maximum LAI at this site over the first year of the simulation
 maxLAI = FluxnetSimulations.get_maxLAI_at_site(start_date, lat, long);
 

--- a/experiments/benchmarks/snowy_land.jl
+++ b/experiments/benchmarks/snowy_land.jl
@@ -101,7 +101,11 @@ function setup_prob(
     forcing = (; atmos, radiation)
 
     # Read in LAI from MODIS data
-    LAI = ClimaLand.prescribed_lai_modis(surface_space, start_date, stop_date)
+    LAI = ClimaLand.Canopy.prescribed_lai_modis(
+        surface_space,
+        start_date,
+        stop_date,
+    )
 
     # Overwrite some defaults for the canopy model
     # Energy model

--- a/experiments/calibration/model_interface.jl
+++ b/experiments/calibration/model_interface.jl
@@ -86,7 +86,11 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
     forcing = (; atmos, radiation)
 
     # Read in LAI from MODIS data
-    LAI = ClimaLand.prescribed_lai_modis(surface_space, start_date, stop_date)
+    LAI = ClimaLand.Canopy.prescribed_lai_modis(
+        surface_space,
+        start_date,
+        stop_date,
+    )
 
     # Overwrite some defaults for the canopy model
     # Energy model

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -230,7 +230,8 @@ photosynthesis = FarquharModel{FT}(canopy_domain; photosynthesis_parameters)
 # Read in LAI from MODIS data
 surface_space = land_domain.space.surface;
 
-LAI = ClimaLand.prescribed_lai_modis(surface_space, start_date, stop_date)
+LAI =
+    ClimaLand.Canopy.prescribed_lai_modis(surface_space, start_date, stop_date)
 # Get the maximum LAI at this site over the first year of the simulation
 maxLAI = FluxnetSimulations.get_maxLAI_at_site(start_date, lat, long);
 RAI = maxLAI * f_root_to_shoot

--- a/experiments/integrated/fluxnet/ozark_pmodel.jl
+++ b/experiments/integrated/fluxnet/ozark_pmodel.jl
@@ -182,7 +182,8 @@ photosynthesis = PModel{FT}()
 # Set up plant hydraulics
 # Read in LAI from MODIS data
 surface_space = land_domain.space.surface;
-LAI = ClimaLand.prescribed_lai_modis(surface_space, start_date, stop_date)
+LAI =
+    ClimaLand.Canopy.prescribed_lai_modis(surface_space, start_date, stop_date)
 # Get the maximum LAI at this site over the first year of the simulation
 maxLAI = FluxnetSimulations.get_maxLAI_at_site(start_date, lat, long);
 RAI = maxLAI * f_root_to_shoot

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -187,7 +187,8 @@ photosynthesis = FarquharModel{FT}(surface_domain; photosynthesis_parameters)
 # Set up plant hydraulics
 # Read in LAI from MODIS data
 surface_space = land_domain.space.surface;
-LAI = ClimaLand.prescribed_lai_modis(surface_space, start_date, stop_date)
+LAI =
+    ClimaLand.Canopy.prescribed_lai_modis(surface_space, start_date, stop_date)
 # Get the maximum LAI at this site over the first year of the simulation
 maxLAI = FluxnetSimulations.get_maxLAI_at_site(start_date, lat, long);
 RAI = maxLAI * f_root_to_shoot

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -92,7 +92,8 @@ canopy_domain = ClimaLand.obtain_surface_domain(domain)
 canopy_forcing = (; atmos, radiation, ground)
 
 # Set up plant hydraulics
-LAI = ClimaLand.prescribed_lai_modis(surface_space, start_date, stop_date)
+LAI =
+    ClimaLand.Canopy.prescribed_lai_modis(surface_space, start_date, stop_date)
 
 canopy = Canopy.CanopyModel{FT}(
     canopy_domain,

--- a/experiments/integrated/global/global_soil_canopy_pmodel.jl
+++ b/experiments/integrated/global/global_soil_canopy_pmodel.jl
@@ -94,7 +94,8 @@ canopy_domain = ClimaLand.obtain_surface_domain(domain)
 canopy_forcing = (; atmos, radiation, ground)
 
 # Set up plant hydraulics
-LAI = ClimaLand.prescribed_lai_modis(surface_space, start_date, stop_date)
+LAI =
+    ClimaLand.Canopy.prescribed_lai_modis(surface_space, start_date, stop_date)
 
 # Construct the P model manually since it is not a default
 photosynthesis = PModel{FT}()

--- a/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
+++ b/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
@@ -164,7 +164,7 @@ photosynthesis = FarquharModel{FT}(canopy_domain; photosynthesis_parameters)
 # Set up plant hydraulics
 # Read in LAI from MODIS data
 surface_space = land_domain.space.surface
-LAI = ClimaLand.prescribed_lai_modis(
+LAI = ClimaLand.Canopy.prescribed_lai_modis(
     surface_space,
     start_date + Second(t0),
     stop_date + Second(tf),

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -71,7 +71,11 @@ function setup_model(FT, context, start_date, Δt, domain, toml_dict)
     forcing = (; atmos, radiation)
 
     # Read in LAI from MODIS data
-    LAI = ClimaLand.prescribed_lai_modis(surface_space, start_date, stop_date)
+    LAI = ClimaLand.Canopy.prescribed_lai_modis(
+        surface_space,
+        start_date,
+        stop_date,
+    )
 
     # Overwrite some defaults for the canopy model
     # Energy model

--- a/experiments/long_runs/low_res_snowy_land_rh.jl
+++ b/experiments/long_runs/low_res_snowy_land_rh.jl
@@ -72,7 +72,11 @@ function setup_model(FT, start_date, stop_date, Δt, domain, earth_param_set)
     forcing = (; atmos, radiation)
 
     # Read in LAI from MODIS data
-    LAI = ClimaLand.prescribed_lai_modis(surface_space, start_date, stop_date)
+    LAI = ClimaLand.Canopy.prescribed_lai_modis(
+        surface_space,
+        start_date,
+        stop_date,
+    )
 
     # Overwrite some defaults for the canopy model
     # Energy model

--- a/experiments/long_runs/low_res_snowy_land_temp.jl
+++ b/experiments/long_runs/low_res_snowy_land_temp.jl
@@ -72,7 +72,11 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
     forcing = (; atmos, radiation)
 
     # Read in LAI from MODIS data
-    LAI = ClimaLand.prescribed_lai_modis(surface_space, start_date, stop_date)
+    LAI = ClimaLand.Canopy.prescribed_lai_modis(
+        surface_space,
+        start_date,
+        stop_date,
+    )
 
     # Overwrite some defaults for the canopy model
     # Energy model

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -88,7 +88,11 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
     forcing = (; atmos, radiation)
 
     # Read in LAI from MODIS data
-    LAI = ClimaLand.prescribed_lai_modis(surface_space, start_date, stop_date)
+    LAI = ClimaLand.Canopy.prescribed_lai_modis(
+        surface_space,
+        start_date,
+        stop_date,
+    )
 
     # Overwrite some defaults for the canopy model
     # Energy model

--- a/experiments/long_runs/snowy_land_pmodel.jl
+++ b/experiments/long_runs/snowy_land_pmodel.jl
@@ -88,7 +88,11 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
     forcing = (; atmos, radiation)
 
     # Read in LAI from MODIS data
-    LAI = ClimaLand.prescribed_lai_modis(surface_space, start_date, stop_date)
+    LAI = ClimaLand.Canopy.prescribed_lai_modis(
+        surface_space,
+        start_date,
+        stop_date,
+    )
 
     # Overwrite some defaults for the canopy model
     # Energy model

--- a/experiments/standalone/Vegetation/timestep_test.jl
+++ b/experiments/standalone/Vegetation/timestep_test.jl
@@ -97,7 +97,8 @@ forcing = (; atmos, radiation, ground);
 
 # Read in LAI from MODIS data
 surface_space = land_domain.space.surface
-LAI = ClimaLand.prescribed_lai_modis(surface_space, start_date, stop_date)
+LAI =
+    ClimaLand.Canopy.prescribed_lai_modis(surface_space, start_date, stop_date)
 
 # Overwrite energy parameter for stability
 energy = BigLeafEnergyModel{FT}(; ac_canopy = FT(1e3))

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -35,7 +35,6 @@ export AbstractAtmosphericDrivers,
     relative_humidity,
     specific_humidity_from_dewpoint,
     make_update_drivers,
-    prescribed_lai_era5,
     prescribed_forcing_era5,
     prescribed_perturbed_temperature_era5,
     prescribed_perturbed_rh_era5,
@@ -1645,100 +1644,6 @@ function prescribed_forcing_era5(
         frac_diff = frac_diff,
     )
     return (; atmos, radiation)
-end
-
-"""
-     prescribed_lai_era5(era5_lai_ncdata_path,
-                         era5_lai_cover_ncdata_path,
-                         surface_space,
-                         start_date,
-                         earth_param_set;
-                         time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
-                         regridder_type = :InterpolationsRegridder,
-                         interpolation_method = Interpolations.Constant(),)
-
-A helper function which constructs the TimeVaryingInput object for Leaf Area Index, from a
-file path pointing to the ERA5 LAI data in a netcdf file, a file path pointing to the ERA5
-LAI cover data in a netcdf file, the surface_space, the start date, and the earth_param_set.
-
-This currently one works when a single file is passed for both the era5 lai and era5 lai cover data.
-
-The ClimaLand default is to use nearest neighbor interpolation, but
-linear interpolation is supported
-by passing interpolation_method = Interpolations.Linear().
-"""
-function prescribed_lai_era5(
-    era5_lai_ncdata_path,
-    era5_lai_cover_ncdata_path,
-    surface_space,
-    start_date;
-    time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
-    regridder_type = :InterpolationsRegridder,
-    interpolation_method = Interpolations.Constant(),
-)
-    hvc_ds = NCFileReader(era5_lai_cover_ncdata_path, "cvh")
-    lvc_ds = NCFileReader(era5_lai_cover_ncdata_path, "cvl")
-    hv_cover = read(hvc_ds)
-    lv_cover = read(lvc_ds)
-    close(hvc_ds)
-    close(lvc_ds)
-    compose_function = let hv_cover = hv_cover, lv_cover = lv_cover
-        (lai_hv, lai_lv) -> lai_hv .* hv_cover .+ lai_lv .* lv_cover
-    end
-    return TimeVaryingInput(
-        era5_lai_ncdata_path,
-        ["lai_hv", "lai_lv"],
-        surface_space;
-        start_date,
-        regridder_type,
-        regridder_kwargs = (; interpolation_method),
-        method = time_interpolation_method,
-        compose_function = compose_function,
-    )
-end
-
-"""
-     prescribed_lai_modis(surface_space,
-                          start_date
-                          stop_date,
-                          earth_param_set;
-                          time_interpolation_method =
-                                        LinearInterpolation(PeriodicCalendar()))
-                          regridder_type = :InterpolationsRegridder,
-                          interpolation_method = Interpolations.Constant(),
-                          context = ClimaComms.context(surface_space))
-
-A helper function which constructs the TimeVaryingInput object for Leaf Area
-Index using MODIS LAI data; requires the
-surface_space, the start and stop dates, and the earth_param_set.
-
-The ClimaLand default is to use nearest neighbor interpolation, but
-linear interpolation is supported
-by passing interpolation_method = Interpolations.Linear().
-"""
-function prescribed_lai_modis(
-    surface_space,
-    start_date,
-    stop_date;
-    time_interpolation_method = LinearInterpolation(),
-    regridder_type = :InterpolationsRegridder,
-    interpolation_method = Interpolations.Constant(),
-    context = ClimaComms.context(surface_space),
-)
-    modis_lai_ncdata_path = ClimaLand.Artifacts.modis_lai_multiyear_paths(;
-        context,
-        start_date,
-        stop_date,
-    )
-    return TimeVaryingInput(
-        modis_lai_ncdata_path,
-        ["lai"],
-        surface_space;
-        start_date,
-        regridder_type,
-        regridder_kwargs = (; interpolation_method),
-        method = time_interpolation_method,
-    )
 end
 
 """

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -38,6 +38,7 @@ using ClimaLand: PrescribedGroundConditions, AbstractGroundConditions
 using ClimaLand.Domains: Point, Plane, SphericalSurface, get_long
 export SharedCanopyParameters, CanopyModel, set_canopy_prescribed_field!
 include("./component_models.jl")
+include("./biomass.jl")
 include("./PlantHydraulics.jl")
 using .PlantHydraulics
 include("./stomatalconductance.jl")

--- a/src/standalone/Vegetation/biomass.jl
+++ b/src/standalone/Vegetation/biomass.jl
@@ -1,0 +1,104 @@
+import ClimaUtilities.TimeVaryingInputs:
+    TimeVaryingInput, LinearInterpolation, PeriodicCalendar
+import Interpolations: Constant
+import ClimaUtilities.Regridders: InterpolationsRegridder
+import ClimaUtilities.FileReaders: NCFileReader, read
+using DocStringExtensions
+
+export prescribed_lai_era5, prescribed_lai_modis
+
+
+
+"""
+     prescribed_lai_era5(era5_lai_ncdata_path,
+                         era5_lai_cover_ncdata_path,
+                         surface_space,
+                         start_date,
+                         earth_param_set;
+                         time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
+                         regridder_type = :InterpolationsRegridder,
+                         interpolation_method = Interpolations.Constant(),)
+
+A helper function which constructs the TimeVaryingInput object for Leaf Area Index, from a
+file path pointing to the ERA5 LAI data in a netcdf file, a file path pointing to the ERA5
+LAI cover data in a netcdf file, the surface_space, the start date, and the earth_param_set.
+
+This currently one works when a single file is passed for both the era5 lai and era5 lai cover data.
+
+The ClimaLand default is to use nearest neighbor interpolation, but
+linear interpolation is supported
+by passing interpolation_method = Interpolations.Linear().
+"""
+function prescribed_lai_era5(
+    era5_lai_ncdata_path,
+    era5_lai_cover_ncdata_path,
+    surface_space,
+    start_date;
+    time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
+    regridder_type = :InterpolationsRegridder,
+    interpolation_method = Interpolations.Constant(),
+)
+    hvc_ds = NCFileReader(era5_lai_cover_ncdata_path, "cvh")
+    lvc_ds = NCFileReader(era5_lai_cover_ncdata_path, "cvl")
+    hv_cover = read(hvc_ds)
+    lv_cover = read(lvc_ds)
+    close(hvc_ds)
+    close(lvc_ds)
+    compose_function = let hv_cover = hv_cover, lv_cover = lv_cover
+        (lai_hv, lai_lv) -> lai_hv .* hv_cover .+ lai_lv .* lv_cover
+    end
+    return TimeVaryingInput(
+        era5_lai_ncdata_path,
+        ["lai_hv", "lai_lv"],
+        surface_space;
+        start_date,
+        regridder_type,
+        regridder_kwargs = (; interpolation_method),
+        method = time_interpolation_method,
+        compose_function = compose_function,
+    )
+end
+
+"""
+     prescribed_lai_modis(surface_space,
+                          start_date
+                          stop_date,
+                          earth_param_set;
+                          time_interpolation_method =
+                                        LinearInterpolation(PeriodicCalendar()))
+                          regridder_type = :InterpolationsRegridder,
+                          interpolation_method = Interpolations.Constant(),
+                          context = ClimaComms.context(surface_space))
+
+A helper function which constructs the TimeVaryingInput object for Leaf Area
+Index using MODIS LAI data; requires the
+surface_space, the start and stop dates, and the earth_param_set.
+
+The ClimaLand default is to use nearest neighbor interpolation, but
+linear interpolation is supported
+by passing interpolation_method = Interpolations.Linear().
+"""
+function prescribed_lai_modis(
+    surface_space,
+    start_date,
+    stop_date;
+    time_interpolation_method = LinearInterpolation(),
+    regridder_type = :InterpolationsRegridder,
+    interpolation_method = Interpolations.Constant(),
+    context = ClimaComms.context(surface_space),
+)
+    modis_lai_ncdata_path = ClimaLand.Artifacts.modis_lai_multiyear_paths(;
+        context,
+        start_date,
+        stop_date,
+    )
+    return TimeVaryingInput(
+        modis_lai_ncdata_path,
+        ["lai"],
+        surface_space;
+        start_date,
+        regridder_type,
+        regridder_kwargs = (; interpolation_method),
+        method = time_interpolation_method,
+    )
+end

--- a/test/integrated/full_land.jl
+++ b/test/integrated/full_land.jl
@@ -206,8 +206,11 @@ forcing = ClimaLand.prescribed_forcing_era5(
     earth_param_set,
     FT;
 )
-LAI =
-    ClimaLand.prescribed_lai_modis(domain.space.surface, start_date, stop_date);
+LAI = ClimaLand.Canopy.prescribed_lai_modis(
+    domain.space.surface,
+    start_date,
+    stop_date,
+);
 
 land = LandModel{FT}(forcing, LAI, toml_dict, domain, Δt);
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
For clarity, move LAI to the Canopy section of the code, and let "drivers" refer only to external forcing.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
