### PR TITLE
Add AbstractSoilMoistureStressModel, 3 methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ ClimaLand.jl Release Notes
 main
 -------
 
+- Add moisture stress component to the canopy model PR[#1387](https://github.com/CliMA/ClimaLand.jl/pull/1387)
+
 v0.20.1
 -------
 - Add C4 plant support to PModel PR[#1356](https://github.com/CliMA/ClimaLand.jl/pull/1356)

--- a/docs/src/APIs/canopy/Photosynthesis.md
+++ b/docs/src/APIs/canopy/Photosynthesis.md
@@ -31,7 +31,6 @@ ClimaLand.Canopy.light_assimilation_farquhar
 ClimaLand.Canopy.max_electron_transport_farquhar
 ClimaLand.Canopy.electron_transport_farquhar
 ClimaLand.Canopy.net_photosynthesis
-ClimaLand.Canopy.moisture_stress
 ClimaLand.Canopy.dark_respiration_farquhar
 ClimaLand.Canopy.MM_Kc
 ClimaLand.Canopy.MM_Ko

--- a/docs/src/APIs/canopy/soil_moisture_stress.md
+++ b/docs/src/APIs/canopy/soil_moisture_stress.md
@@ -1,0 +1,25 @@
+# Soil moisture stress
+
+```@meta
+CurrentModule = ClimaLand.Canopy
+```
+
+## Models and Parameters
+
+```@docs
+ClimaLand.Canopy.TuzetMoistureStressParameters
+ClimaLand.Canopy.TuzetMoistureStressModel
+ClimaLand.Canopy.TuzetMoistureStressModel{FT}()
+ClimaLand.Canopy.TuzetMoistureStressModel{FT}(toml_dict::CP.ParamDict)
+ClimaLand.Canopy.PiecewiseMoistureStressModel
+ClimaLand.Canopy.PiecewiseMoistureStressModel{FT}()
+Climaland.Canopy.PiecewiseMoistureStressModel{FT}(toml_dict::CP.ParamDict)
+ClimaLand.Canopy.NoMoistureStressModel
+```
+
+## Methods
+
+```@docs
+ClimaLand.Canopy.update_soil_moisture_stress!
+ClimaLand.Canopy.update_piecewise_soil_moisture_stress!
+```

--- a/docs/src/tutorials/calibration/obs_site_level_calibration.jl
+++ b/docs/src/tutorials/calibration/obs_site_level_calibration.jl
@@ -238,7 +238,7 @@ function G(Vcmax25, g1)
                 simulation.start_date,
                 simulation.start_date + Day(20),
                 stop_date,
-            )
+            ),
         )
     return observation
 end;

--- a/docs/src/tutorials/calibration/perfect_model_site_level_calibration.jl
+++ b/docs/src/tutorials/calibration/perfect_model_site_level_calibration.jl
@@ -206,7 +206,7 @@ function G(Vcmax25)
                 lhf,
                 simulation.start_date,
                 simulation.start_date + Day(20),
-            )
+            ),
         )
     return observation
 end

--- a/experiments/integrated/fluxnet/ozark_pmodel.jl
+++ b/experiments/integrated/fluxnet/ozark_pmodel.jl
@@ -180,6 +180,13 @@ conductance = PModelConductance{FT}()
 is_c3 = FT(1)
 photosynthesis = PModel{FT}(surface_domain; is_c3)
 
+# Set up soil moisture stress using soil retention parameters
+soil_moisture_stress = PiecewiseMoistureStressModel{FT}(
+    land_domain,
+    toml_dict;
+    soil_params = retention_parameters,
+)
+
 # Set up plant hydraulics
 # Read in LAI from MODIS data
 surface_space = land_domain.space.surface;
@@ -223,6 +230,7 @@ canopy = Canopy.CanopyModel{FT}(
     radiative_transfer,
     photosynthesis,
     conductance,
+    soil_moisture_stress,
     hydraulics,
     energy,
 )
@@ -266,7 +274,8 @@ simulation = LandSimulation(
     set_ic!,
     updateat,
     diagnostics = diags,
-);
+)
+
 @time solve!(simulation)
 
 comparison_data = FluxnetSimulations.get_comparison_data(site_ID, time_offset)

--- a/experiments/integrated/performance/conservation/ozark_conservation.jl
+++ b/experiments/integrated/performance/conservation/ozark_conservation.jl
@@ -86,7 +86,7 @@ for float_type in (Float32, Float64)
             [parent(sv.saveval[k].drivers.T)[1] for k in 1:length(sv.t)]
         @assert mean(
             abs.(
-                cos.(radiation.θs.(sv.t, radiation.start_date)) .- cache_cosθs
+                cos.(radiation.θs.(sv.t, radiation.start_date)) .- cache_cosθs,
             ),
         ) < eps(FT)
         T_mutable = Vector{FT}(undef, 1)
@@ -201,7 +201,7 @@ for float_type in (Float32, Float64)
             eps(FT) .+
             abs.(
                 (soil_mass_change_actual - soil_mass_change_exp) ./
-                soil_mass_change_exp
+                soil_mass_change_exp,
             ),
             label = "Soil Water Balance",
         )
@@ -211,7 +211,7 @@ for float_type in (Float32, Float64)
             eps(FT) .+
             abs.(
                 (canopy_mass_change_actual - canopy_mass_change_exp) ./
-                canopy_mass_change_exp
+                canopy_mass_change_exp,
             ),
             label = "Canopy Water Balance",
         )
@@ -272,7 +272,7 @@ for float_type in (Float32, Float64)
             eps(FT) .+
             abs.(
                 (soil_energy_change_actual - soil_energy_change_exp) ./
-                soil_energy_change_exp
+                soil_energy_change_exp,
             ),
             label = "Soil Energy Balance",
         )

--- a/experiments/standalone/Vegetation/no_vegetation.jl
+++ b/experiments/standalone/Vegetation/no_vegetation.jl
@@ -76,11 +76,6 @@ canopy = ClimaLand.Canopy.CanopyModel{FT}(
     hydraulics,
 )
 
-
-
-
-
-
 ψ_leaf_0 = FT(-2e5 / 9800)
 (; retention_model, ν, S_s) = canopy.hydraulics.parameters;
 S_l_ini = inverse_water_retention_curve(retention_model, ψ_leaf_0, ν, S_s)

--- a/ext/land_sim_vis/leaderboard/leaderboard.jl
+++ b/ext/land_sim_vis/leaderboard/leaderboard.jl
@@ -205,7 +205,7 @@ function compute_monthly_leaderboard(
         months =
             Dates.month.(
                 Dates.DateTime(sim_var.attributes["start_date"]) .+
-                Dates.Second.(times)
+                Dates.Second.(times),
             )
         months_split, sim_vec_split, rmse_vec_split, bias_vec_split =
             partition_by_val(12, months, sim_vec, rmse_vec, bias_vec)

--- a/ext/neural_snow/DataTools.jl
+++ b/ext/neural_snow/DataTools.jl
@@ -761,7 +761,7 @@ function serreze_qc(input::DataFrame, id::Int, state::AbstractString)
     data[!, :tmax] = maxmin[!, :tmax]
     flags =
         ismissing.(
-            data[1:(end - 1), [:SWE, :precip, :air_temp_avg, :tmin, :tmax]]
+            data[1:(end - 1), [:SWE, :precip, :air_temp_avg, :tmin, :tmax]],
         )
     flags[!, :date] = data[1:(end - 1), :date]
 

--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -410,7 +410,8 @@ import .Canopy:
     ground_albedo_PAR,
     ground_albedo_NIR,
     canopy_radiant_energy_fluxes!,
-    root_energy_flux_per_ground_area!
+    root_energy_flux_per_ground_area!,
+    update_piecewise_soil_moisture_stress!
 ### Concrete types of AbstractLandModels
 ### and associated methods
 include("integrated/soil_energy_hydrology_biogeochemistry.jl")

--- a/src/diagnostics/Diagnostics.jl
+++ b/src/diagnostics/Diagnostics.jl
@@ -24,7 +24,6 @@ import ..Canopy:
     get_Rd_leaf,
     MedlynConductanceModel,
     PModelConductance,
-    moisture_stress,
     canopy_temperature
 import ..Domains:
     top_center_to_surface, AbstractDomain, SphericalShell, HybridBox

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -181,7 +181,7 @@ function default_diagnostics(
         diagnostics = get_short_diagnostics(model)
     else
         @assert typeof(output_vars) <: Vector{String}
-        @assert all([var ∈ possible_diags for var in output_vars])
+        @assert all([var in possible_diags for var in output_vars])
         diagnostics = output_vars
     end
 
@@ -250,7 +250,7 @@ function default_diagnostics(
         diagnostics = possible_diags
     else
         @assert typeof(output_vars) <: Vector{String}
-        @assert all([var ∈ possible_diags for var in output_vars])
+        @assert all([var in possible_diags for var in output_vars])
         diagnostics = output_vars
     end
 

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -115,7 +115,14 @@ function compute_stomatal_conductance!(
 end
 
 function compute_stomatal_conductance!(out, Y, p, t, land_model::CanopyModel)
-    compute_stomatal_conductance!(out, Y, p, t, land_model, canopy.conductance)
+    compute_stomatal_conductance!(
+        out,
+        Y,
+        p,
+        t,
+        land_model,
+        land_model.conductance,
+    )
 end
 
 function compute_stomatal_conductance!(
@@ -273,61 +280,6 @@ function compute_leaf_water_potential!(out, Y, p, t, land_model::CanopyModel)
     end
 end
 
-function compute_moisture_stress_factor!(
-    out,
-    Y,
-    p,
-    t,
-    land_model::Union{SoilCanopyModel, LandModel},
-)
-    canopy = land_model.canopy
-    hydraulics = canopy.hydraulics
-    n_stem = hydraulics.n_stem
-    n_leaf = hydraulics.n_leaf
-    n = n_stem + n_leaf
-
-    earth_param_set = canopy.parameters.earth_param_set
-    grav = LP.grav(earth_param_set)
-    ρ_l = LP.ρ_cloud_liq(earth_param_set)
-    (; sc, pc) = canopy.photosynthesis.parameters
-    ψ = p.canopy.hydraulics.ψ
-    if isnothing(out)
-        out = zeros(land_model.canopy.domain.space.surface) # Allocates
-        fill!(field_values(out), NaN)
-        @. out = moisture_stress(ψ.:($$n) * ρ_l * grav, sc, pc)
-        return out
-    else
-        @. out = moisture_stress(ψ.:($$n) * ρ_l * grav, sc, pc)
-    end
-end
-function compute_moisture_stress_factor!(
-    out,
-    Y,
-    p,
-    t,
-    land_model::Union{CanopyModel},
-)
-    canopy = land_model
-    hydraulics = canopy.hydraulics
-    n_stem = hydraulics.n_stem
-    n_leaf = hydraulics.n_leaf
-    n = n_stem + n_leaf
-
-    earth_param_set = canopy.parameters.earth_param_set
-    grav = LP.grav(earth_param_set)
-    ρ_l = LP.ρ_cloud_liq(earth_param_set)
-    (; sc, pc) = canopy.photosynthesis.parameters
-    ψ = p.canopy.hydraulics.ψ
-    if isnothing(out)
-        out = zeros(land_model.canopy.domain.space.surface) # Allocates
-        fill!(field_values(out), NaN)
-        @. out = moisture_stress(ψ.:($$n) * ρ_l * grav, sc, pc)
-        return out
-    else
-        @. out = moisture_stress(ψ.:($$n) * ρ_l * grav, sc, pc)
-    end
-end
-
 # @diagnostic_compute "flux_per_ground_area" Union{SoilCanopyModel, LandModel} p.canopy.hydraulics.fa # return a Tuple
 @diagnostic_compute "root_flux_per_ground_area" Union{
     SoilCanopyModel,
@@ -339,6 +291,13 @@ end
     LandModel,
     CanopyModel,
 } p.canopy.hydraulics.area_index.leaf
+
+# Canopy - Soil moisture stress
+@diagnostic_compute "moisture_stress_factor" Union{
+    SoilCanopyModel,
+    LandModel,
+    CanopyModel,
+} p.canopy.soil_moisture_stress.βm
 
 # Canopy - Hydraulics
 @diagnostic_compute "root_area_index" Union{

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -77,6 +77,19 @@ struct LandModel{
         @assert soil.parameters.earth_param_set ==
                 snow.parameters.earth_param_set
 
+        # Check that soil moisture stress parameters are consistent between canopy and soil
+        if canopy.soil_moisture_stress isa PiecewiseMoistureStressModel
+            # Note that these functions allocate. These checks should not occur except on initialization.
+            check_land_equality(
+                canopy.soil_moisture_stress.θ_high,
+                soil.parameters.ν,
+            )
+            check_land_equality(
+                canopy.soil_moisture_stress.θ_low,
+                soil.parameters.θ_r,
+            )
+        end
+
         # LandModel-specific checks
         # Runoff and sublimation are also automatically included in the soil model
         @assert RootExtraction{FT}() in soil.sources
@@ -89,8 +102,6 @@ struct LandModel{
         return new{FT, MM, SM, VM, SnM}(soilco2, soil, canopy, snow)
     end
 end
-
-
 
 """
     LandModel{FT}(;
@@ -185,6 +196,9 @@ function LandModel{FT}(;
     end
 
     canopy = Canopy.CanopyModel{FT}(;
+        soil_moisture_stress = canopy_component_types.soil_moisture_stress(
+            canopy_component_args.soil_moisture_stress...,
+        ),
         autotrophic_respiration = canopy_component_types.autotrophic_respiration(
             canopy_component_args.autotrophic_respiration...,
         ),

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -71,6 +71,18 @@ struct SoilCanopyModel{
         @assert canopy_bc.ground isa PrognosticGroundConditions{FT}
         @assert soilco2.drivers.met isa Soil.Biogeochemistry.PrognosticMet
 
+        if canopy.soil_moisture_stress isa PiecewiseMoistureStressModel
+            # Note that these functions allocate. These checks should not occur except on initialization.
+            check_land_equality(
+                canopy.soil_moisture_stress.θ_high,
+                soil.parameters.ν,
+            )
+            check_land_equality(
+                canopy.soil_moisture_stress.θ_low,
+                soil.parameters.θ_r,
+            )
+        end
+
         return new{FT, MM, SM, VM}(soilco2, soil, canopy)
     end
 end
@@ -228,6 +240,9 @@ function SoilCanopyModel{FT}(;
     end
 
     canopy = Canopy.CanopyModel{FT}(;
+        soil_moisture_stress = canopy_component_types.soil_moisture_stress(
+            canopy_component_args.soil_moisture_stress...,
+        ),
         autotrophic_respiration = canopy_component_types.autotrophic_respiration(
             canopy_component_args.autotrophic_respiration...,
         ),

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -297,7 +297,7 @@ function default_zenith_angle(
             Insolation.helper_instantaneous_zenith_angle(
                 current_datetime,
                 insol_params,
-            )
+            ),
         )
     # Reduces allocations by throwing away unwanted values
     zenith_only = (args...) -> Insolation.instantaneous_zenith_angle(args...)[1]

--- a/src/shared_utilities/utils.jl
+++ b/src/shared_utilities/utils.jl
@@ -14,6 +14,46 @@ import ClimaUtilities.TimeManager: ITime, date
 export FTfromY, call_count_nans_state
 
 """
+    check_land_equality(field1, field2)
+
+Check that two fields are equal for masked domains;
+this assumes that the underlying space of field1 is the same
+as for field2, and this specific test is only required if
+the two fields have masked spaces, where the masked values
+are uninitialized. In this case, the masked values may be
+anything and a standard equality field1 == field2 will fail.
+
+This allocates two fields equal in size to field1/field2.
+"""
+function check_land_equality(
+    field1::ClimaCore.Fields.Field,
+    field2::ClimaCore.Fields.Field,
+)
+    tmp1 = ClimaCore.Fields.zeros(axes(field1)) # inherits the mask
+    tmp2 = ClimaCore.Fields.zeros(axes(field2)) # inherits the mask
+    FT = eltype(tmp1)
+    fill!(ClimaCore.Fields.field_values(tmp1), FT(0)) # fills all values to 0
+    fill!(ClimaCore.Fields.field_values(tmp2), FT(0)) # fills all values to 0
+    tmp1 .= field1 # only sets unmasked values/mask aware operation
+    tmp2 .= field2 # only sets unmasked values/mask aware operation
+    @assert tmp1 == tmp2 # checks all values
+end
+
+"""
+    check_land_equality(f1::Union{FT, Vector{FT}}, f2::Union{FT, Vector{FT}}) 
+        where {FT <: AbstractFloat}
+
+Check that two floats or vectors of floats are equal.
+"""
+function check_land_equality(
+    f1::Union{FT, Vector{FT}},
+    f2::Union{FT, Vector{FT}},
+) where {FT <: AbstractFloat}
+    @assert f1 == f2 # checks all values
+end
+
+
+"""
      heaviside(x::FT)::FT where {FT}
 
 Computes the heaviside function H(x) = 1 (x ≥0), 0 (x < 0)

--- a/src/standalone/Vegetation/autotrophic_respiration.jl
+++ b/src/standalone/Vegetation/autotrophic_respiration.jl
@@ -6,7 +6,7 @@ abstract type AbstractAutotrophicRespirationModel{FT} <:
 """
     AutotrophicRespirationParameters{FT<:AbstractFloat}
 
-The required parameters for the autrophic respiration model, which is based 
+The required parameters for the autrophic respiration model, which is based
 off of the JULES model.
 Clark, D. B., et al. "The Joint UK Land Environment Simulator (JULES), model description–Part 2: carbon fluxes and vegetation dynamics." Geoscientific Model Development 4.3 (2011): 701-722.
 $(DocStringExtensions.FIELDS)
@@ -29,7 +29,7 @@ end
 Base.eltype(::AutotrophicRespirationParameters{FT}) where {FT} = FT
 
 """
-    AutotrophicRespirationModel{FT, ARP <: AutotrophicRespirationParameters{FT},} <: AbstractAutotrophicRespirationModel{FT} 
+    AutotrophicRespirationModel{FT, ARP <: AutotrophicRespirationParameters{FT},} <: AbstractAutotrophicRespirationModel{FT}
 
 The JULES autotrophic respiration model.
 
@@ -65,7 +65,7 @@ ClimaLand.auxiliary_domain_names(::AutotrophicRespirationModel) = (:surface,)
 Computes the autotrophic respiration rate  (mol co2 m^-2 s^-1) as the sum of the plant maintenance
 and growth respirations, according to the JULES model.
 
-Clark, D. B., et al. "The Joint UK Land Environment Simulator (JULES), model 
+Clark, D. B., et al. "The Joint UK Land Environment Simulator (JULES), model
 description–Part 2: carbon fluxes and vegetation dynamics." Geoscientific Model Development 4.3 (2011): 701-722.
 """
 function update_autotrophic_respiration!(
@@ -87,10 +87,9 @@ function update_autotrophic_respiration!(
     earth_param_set = canopy.parameters.earth_param_set
     grav = LP.grav(earth_param_set)
     ρ_l = LP.ρ_cloud_liq(earth_param_set)
-    (; sc, pc) = canopy.photosynthesis.parameters
     (; G_Function, Ω) = canopy.radiative_transfer.parameters
     cosθs = p.drivers.cosθs
-    β = @. lazy(moisture_stress(ψ.:($$i_end) * ρ_l * grav, sc, pc))
+    β = p.canopy.soil_moisture_stress.βm
     Vcmax25_leaf = get_Vcmax25_leaf(p, canopy.photosynthesis)
     Rd_leaf = get_Rd_leaf(p, canopy.photosynthesis)
     An_leaf = get_An_leaf(p, canopy.photosynthesis)

--- a/src/standalone/Vegetation/canopy_parameterizations.jl
+++ b/src/standalone/Vegetation/canopy_parameterizations.jl
@@ -1,28 +1,13 @@
 using ..ClimaLand.Canopy
-export moisture_stress,
+export canopy_sw_rt_beer_lambert, # Radiative transfer
+    canopy_sw_rt_two_stream,
+    extinction_coeff,
+    compute_G,
     # Conductance
     medlyn_term,
     medlyn_conductance,
     penman_monteith,
     quadratic_soil_moisture_stress
-
-"""
-    moisture_stress(pl::FT,
-                    sc::FT,
-                    pc::FT) where {FT}
-
-Computes the moisture stress factor (`β`), which is unitless,
- as a function of
-a constant (`sc`, 1/Pa), a reference pressure (`pc`, Pa), and
-the leaf water pressure (`pl`, Pa) .
-
-See Eqn 12.57 of G. Bonan's textbook,
-Climate Change and Terrestrial Ecosystem Modeling (2019).
-"""
-function moisture_stress(pl::FT, sc::FT, pc::FT) where {FT}
-    β = min(FT(1), (1 + exp(sc * pc)) / (1 + exp(sc * (pc - pl))))
-    return β
-end
 
 """
     conductance_molar_flux_to_m_per_s(gs::FT, T::FT, R::FT, P::FT) where {FT}

--- a/src/standalone/Vegetation/photosynthesis_farquhar.jl
+++ b/src/standalone/Vegetation/photosynthesis_farquhar.jl
@@ -76,7 +76,7 @@ Base.eltype(::FarquharParameters{FT}) where {FT} = FT
    FarquharModel{FT, FP <: FarquharParameters{FT}}
 
 A photosynthesis model taking leaf-level Vcmax25 and multiple other
-constants and predicting dark respiration at the leaf level, net 
+constants and predicting dark respiration at the leaf level, net
 photosynthesis at the leaf level, and GPP at the canopy level.
 
 The Farquhar model computes photosynthetic rates using leaf-level
@@ -281,7 +281,7 @@ end
         canopy
 )
 
-Computes the net leaf-level photosynthesis rate `An` (mol CO2/m^2/s) for the Farquhar 
+Computes the net leaf-level photosynthesis rate `An` (mol CO2/m^2/s) for the Farquhar
 model, along with the dark leaf-level respiration `Rd` (mol CO2/m^2/s), and
 canopy level gross photosynthesis (mol CO2/m^2/s).
 """
@@ -344,7 +344,7 @@ function update_photosynthesis!(p, Y, model::FarquharModel, canopy)
     area_index = p.canopy.hydraulics.area_index
     LAI = area_index.leaf
 
-    β = @. lazy(moisture_stress(ψ.:($$i_end) * ρ_l * grav, sc, pc))
+    β = p.canopy.soil_moisture_stress.βm
     medlyn_factor = @. lazy(medlyn_term(g1, T_air, P_air, q_air, thermo_params))
 
     @. Rd = dark_respiration_farquhar(

--- a/src/standalone/Vegetation/soil_moisture_stress.jl
+++ b/src/standalone/Vegetation/soil_moisture_stress.jl
@@ -1,0 +1,216 @@
+export TuzetMoistureStressModel,
+    NoMoistureStressModel,
+    PiecewiseMoistureStressModel,
+    compute_piecewise_moisture_stress,
+    compute_tuzet_moisture_stress,
+    update_piecewise_soil_moisture_stress!
+
+# define an abstract type for all soil moisture stress models
+abstract type AbstractSoilMoistureStressModel{FT} <: AbstractCanopyComponent{FT} end
+
+"""
+    TuzetMoistureStressModel{FT} <: AbstractSoilMoistureStressModel{FT}
+
+An implementation of the Tuzet moisture stress function.
+
+βm = min(1, (1 + exp(sc * pc)) / (1 + exp(sc * (pc - p_leaf)))), where sc and pc
+are stored in the parameter struct.
+
+TUZET, A., PERRIER, A. and LEUNING, R. (2003), A coupled model of stomatal conductance,
+    photosynthesis and transpiration. Plant, Cell & Environment, 26: 1097-1116.
+    https://doi.org/10.1046/j.1365-3040.2003.01035.x
+
+Duursma, R. A., and Medlyn, B. E. (2012). MAESPA: A model to study interactions between
+water limitation, environmental drivers and vegetation function at tree and stand levels,
+with an example application to [CO2] ! drought interactions.
+Geoscientific Model Development, 5, 919–940.
+"""
+Base.@kwdef struct TuzetMoistureStressModel{FT} <:
+                   AbstractSoilMoistureStressModel{FT}
+    "Sensitivity to low water pressure, in the moisture stress factor, (Pa^{-1})"
+    sc::FT
+    "Reference water pressure for the moisture stress factor (Pa)"
+    pc::FT
+end
+
+ClimaLand.name(model::AbstractSoilMoistureStressModel) = :soil_moisture_stress
+ClimaLand.auxiliary_vars(model::TuzetMoistureStressModel) = (:βm,)
+ClimaLand.auxiliary_types(model::TuzetMoistureStressModel{FT}) where {FT} =
+    (FT,)
+ClimaLand.auxiliary_domain_names(::TuzetMoistureStressModel) = (:surface,)
+
+
+"""
+    compute_tuzet_moisture_stress(
+        p_leaf::FT,
+        pc::FT,
+        sc::FT
+    ) where {FT}
+
+This pointwise function computes the soil moisture stress factor using the leaf water potential (Pa) and two
+parameters `sc` (sensitivity to low water potential, Pa^-1) and `pc` (reference water potential, Pa).
+"""
+function compute_tuzet_moisture_stress(p_leaf::FT, pc::FT, sc::FT) where {FT}
+    β = min(FT(1), (1 + exp(sc * pc)) / (1 + exp(sc * (pc - p_leaf))))
+    return β
+end
+
+"""
+    update_soil_moisture_stress!(
+        p,
+        Y,
+        model::TuzetMoistureStressModel,
+        canopy,
+    )
+
+Computes and updates in place the soil moisture stress for the Tuzet formulation.
+"""
+function update_soil_moisture_stress!(
+    p,
+    Y,
+    model::TuzetMoistureStressModel,
+    canopy,
+)
+    # unpack constants
+    earth_param_set = canopy.parameters.earth_param_set
+    grav = LP.grav(earth_param_set)
+    ρ_water = LP.ρ_cloud_liq(earth_param_set)
+    n_stem = canopy.hydraulics.n_stem
+    n_leaf = canopy.hydraulics.n_leaf
+    i_end = n_stem + n_leaf
+
+    ψ = p.canopy.hydraulics.ψ
+    p_leaf = @. lazy(ψ.:($$i_end) * ρ_water * grav) # converts head to hydrostatic pressure
+    (; sc, pc) = model
+    # Compute the moisture stress factor
+    @. p.canopy.soil_moisture_stress.βm =
+        compute_tuzet_moisture_stress(p_leaf, pc, sc)
+end
+
+"""
+    struct NoMoistureStressModel{FT} <: AbstractSoilMoistureStressModel{FT} end
+
+A constructor for NoMoistureStressModel, which sets βm = 1.0 always.
+"""
+struct NoMoistureStressModel{FT} <: AbstractSoilMoistureStressModel{FT} end
+
+Base.eltype(::NoMoistureStressModel{FT}) where {FT} = FT
+
+ClimaLand.auxiliary_vars(model::NoMoistureStressModel) = (:βm,)
+ClimaLand.auxiliary_types(model::NoMoistureStressModel{FT}) where {FT} = (FT,)
+ClimaLand.auxiliary_domain_names(::NoMoistureStressModel) = (:surface,)
+
+function update_soil_moisture_stress!(
+    p,
+    Y,
+    model::NoMoistureStressModel,
+    canopy,
+)
+    @. p.canopy.soil_moisture_stress.βm = 1
+end
+
+"""
+    PiecewiseMoistureStressModel{FT,  F <: Union{FT, ClimaCore.Fields.Field}}
+    <: AbstractSoilMoistureStressModel{FT}
+
+An implementation of a piecewise moisture stress model, taking the form
+
+βm(z) = min(1, [(θ(z)-θ_low)/(θ_high - θ_low)]^c), where θ_high,
+θ_low, and c are parameters, and θ(z) is the soil moisture at z.
+
+The parameters should fall within
+the following ranges:
+- θ_high>θ_low should be in (θ_r, ν) where ν is the porosity of the soil
+- c should be positive
+
+See Egea et al. (2011) for details.
+Citation: https://doi.org/10.1016/j.agrformet.2011.05.019
+"""
+struct PiecewiseMoistureStressModel{
+    FT,
+    F <: Union{FT, ClimaCore.Fields.Field},
+} <: AbstractSoilMoistureStressModel{FT}
+    """Field capacity volumetric water content or porosity (m^3 / m^3) - or porosity"""
+    θ_high::F
+    """Wilting point volumetric water content or residual water fraction(m^3 / m^3) - or residual water"""
+    θ_low::F
+    """Curvature parameter (unitless)"""
+    c::FT
+
+end
+
+function PiecewiseMoistureStressModel{FT}(;
+    θ_high,
+    θ_low,
+    c::FT,
+) where {FT <: AbstractFloat}
+    return PiecewiseMoistureStressModel{FT, typeof(θ_high)}(θ_high, θ_low, c)
+end
+
+ClimaLand.auxiliary_vars(model::PiecewiseMoistureStressModel) = (:βm,)
+ClimaLand.auxiliary_types(model::PiecewiseMoistureStressModel{FT}) where {FT} =
+    (FT,)
+ClimaLand.auxiliary_domain_names(::PiecewiseMoistureStressModel) = (:surface,)
+
+"""
+    compute_piecewise_moisture_stress(
+        θ_high::FT,
+        θ_low::FT,
+        c::FT,
+        θ::FT,
+    ) where {FT}
+
+This function computes at a point the soil moisture stress factor using the volumetric water content θ (m^3/m^3)
+and four parameters: `θ_high` (field capacity, m^3/m^3), `θ_low` (wilting point, m^3/m^3), `c` (curvature parameter,
+unitless). See  Egea et al. (2011).
+
+Citation: https://doi.org/10.1016/j.agrformet.2011.05.019
+"""
+function compute_piecewise_moisture_stress(
+    θ_high::FT,
+    θ_low::FT,
+    c::FT,
+    θ::FT,
+) where {FT}
+    # avoid taking e.g. sqrt of negative numbers for rational c
+    arg = max((θ - θ_low) / (θ_high - θ_low), FT(0))
+    return min(FT(1), arg^c)
+end
+
+"""
+    update_soil_moisture_stress!(
+        p,
+        Y,
+        model::PiecewiseMoistureStressModel,
+        canopy,
+    )
+
+This updates the soil moisture stress factor according to the piecewise soil moisture stress model.
+"""
+function update_soil_moisture_stress!(
+    p,
+    Y,
+    model::PiecewiseMoistureStressModel,
+    canopy,
+)
+    ground = canopy.boundary_conditions.ground
+    update_piecewise_soil_moisture_stress!(ground, p, Y, model, canopy)
+end
+
+"""
+    update_piecewise_soil_moisture_stress!(ground::PrescribedGroundConditions, p, Y, model, canopy)
+
+Updates the soil moisture stress using the piecewise model for Prescribed
+GroundConditions (p.drivers.θ prescribed).
+"""
+function update_piecewise_soil_moisture_stress!(
+    ground::PrescribedGroundConditions,
+    p,
+    Y,
+    model,
+    canopy,
+)
+    @error(
+        "You cannot use the PiecewiseSoilMoistureStress model with a prescribed soil yet."
+    )
+end

--- a/test/integrated/soil_canopy_lsm.jl
+++ b/test/integrated/soil_canopy_lsm.jl
@@ -125,6 +125,7 @@ for FT in (Float32, Float64)
             conductance = Canopy.MedlynConductanceModel{FT},
             hydraulics = Canopy.PlantHydraulicsModel{FT},
             energy = Canopy.BigLeafEnergyModel{FT},
+            soil_moisture_stress = Canopy.NoMoistureStressModel{FT},
         )
         autotrophic_respiration_args =
             (; parameters = Canopy.AutotrophicRespirationParameters(FT))
@@ -167,6 +168,7 @@ for FT in (Float32, Float64)
             compartment_surfaces = [FT(0.0), FT(0.0)],
         )
         energy_args = (parameters = Canopy.BigLeafEnergyParameters{FT}(FT(0)),)
+        soil_moisture_stress_args = (;)
         canopy_component_args = (;
             autotrophic_respiration = autotrophic_respiration_args,
             radiative_transfer = radiative_transfer_args,
@@ -174,6 +176,7 @@ for FT in (Float32, Float64)
             conductance = conductance_args,
             hydraulics = plant_hydraulics_args,
             energy = energy_args,
+            soil_moisture_stress = soil_moisture_stress_args,
         )
         shared_params =
             Canopy.SharedCanopyParameters{FT, typeof(earth_param_set)}(

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -134,7 +134,7 @@ for FT in (Float32, Float64)
                         FT(0.0),
                         params.ρc_ds,
                         params.earth_param_set,
-                    )
+                    ),
                 )
             Y.soil.ρe_int .=
                 Soil.volumetric_internal_energy.(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,6 +102,9 @@ end
 @safetestset "Canopy module tests" begin
     include("standalone/Vegetation/canopy_model.jl")
 end
+@safetestset "Canopy module tests" begin
+    include("standalone/Vegetation/test_soil_moisture_stress.jl")
+end
 @safetestset "Canopy PlantHydraulics tests" begin
     include("standalone/Vegetation/plant_hydraulics_test.jl")
 end

--- a/test/standalone/Bucket/snow_bucket_tests.jl
+++ b/test/standalone/Bucket/snow_bucket_tests.jl
@@ -124,8 +124,8 @@ for FT in (Float32, Float64)
         @test p.bucket.α_sfc ==
               FT.(
             α_bareground_func.(
-                ClimaCore.Fields.coordinate_field(surface_space)
-            )
+                ClimaCore.Fields.coordinate_field(surface_space),
+            ),
         )
         # Test that evaporation is zero
         @test all(parent(p.bucket.turbulent_fluxes.vapor_flux) .== FT(0.0))

--- a/test/standalone/Soil/conservation.jl
+++ b/test/standalone/Soil/conservation.jl
@@ -139,7 +139,7 @@ for FT in (Float32, Float64)
                     dY.soil.∫F_vol_liq_water_dt .- (
                         ClimaCore.Fields.zeros(domain.space.surface) .+
                         FT(((cmax - cmin) * -1e-5))
-                    )
+                    ),
                 ),
             ) < sqrt(eps(FT))
             imp_tendency! = make_imp_tendency(soil)
@@ -234,7 +234,7 @@ for FT in (Float32, Float64)
                     dY.soil.∫F_vol_liq_water_dt .- (
                         ClimaCore.Fields.zeros(domain.space.surface) .+
                         FT(((cmax - cmin) * -1e-5))
-                    )
+                    ),
                 ),
             ) < sqrt(eps(FT)) * abs(FT(((cmax - cmin) * -1e-5)))
             imp_tendency! = make_imp_tendency(soil)

--- a/test/standalone/SurfaceWater/pond_test.jl
+++ b/test/standalone/SurfaceWater/pond_test.jl
@@ -52,7 +52,7 @@ for FT in (Float32, Float64)
             if t % 40 == 0
                 @test abs.(
                     FT(expected_pond_height(t)) .-
-                    Array(parent(Y.surface_water.η))[1]
+                    Array(parent(Y.surface_water.η))[1],
                 ) < eps(FT)
             end
         end

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -51,6 +51,7 @@ import ClimaParams
         )
         for (g1, Vcmax25, is_c3, rooting_depth, α_PAR_leaf, α_NIR_leaf, ld) in
             zipped_params
+
             AR_params = AutotrophicRespirationParameters(FT)
             G_Function = ConstantGFunction.(ld)
             RTparams =
@@ -177,7 +178,7 @@ import ClimaParams
                             step = Δz,
                             stop = Δz * (n_stem + n_leaf),
                         ),
-                    )
+                    ),
                 )
 
             soil_driver = PrescribedGroundConditions{FT}()
@@ -196,6 +197,7 @@ import ClimaParams
                 photosynthesis = photosynthesis_model,
                 conductance = stomatal_model,
                 hydraulics = plant_hydraulics,
+                soil_moisture_stress = Canopy.NoMoistureStressModel{FT}(),
                 boundary_conditions = Canopy.AtmosDrivenCanopyBC(
                     atmos,
                     radiation,
@@ -235,6 +237,7 @@ import ClimaParams
                 :autotrophic_respiration,
                 :energy,
                 :sif,
+                :soil_moisture_stress,
                 :turbulent_fluxes,
             )
             for component in ClimaLand.Canopy.canopy_components(canopy)
@@ -479,7 +482,7 @@ end
                         step = Δz,
                         stop = Δz * (n_stem + n_leaf),
                     ),
-                )
+                ),
             )
 
         plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
@@ -580,6 +583,7 @@ end
         )
         for (g1, Vcmax25, is_c3, rooting_depth, α_PAR_leaf, α_NIR_leaf, ld) in
             zipped_params
+
             G_Function = ConstantGFunction.(ld)
             RTparams =
                 BeerLambertParameters(FT; α_PAR_leaf, α_NIR_leaf, G_Function)
@@ -705,7 +709,7 @@ end
                             step = Δz,
                             stop = Δz * (n_stem + n_leaf),
                         ),
-                    )
+                    ),
                 )
 
             soil_driver = PrescribedGroundConditions{FT}()
@@ -730,6 +734,7 @@ end
                 autotrophic_respiration = autotrophic_respiration_model,
                 energy = energy_model,
                 hydraulics = plant_hydraulics,
+                soil_moisture_stress = Canopy.NoMoistureStressModel{FT}(),
                 boundary_conditions = Canopy.AtmosDrivenCanopyBC(
                     atmos,
                     radiation,
@@ -948,7 +953,7 @@ end
                         step = Δz,
                         stop = Δz * (n_stem + n_leaf),
                     ),
-                )
+                ),
             )
 
         soil_driver = PrescribedGroundConditions{FT}()
@@ -972,6 +977,7 @@ end
             autotrophic_respiration = autotrophic_respiration_model,
             energy = energy_model,
             hydraulics = plant_hydraulics,
+            soil_moisture_stress = Canopy.NoMoistureStressModel{FT}(),
             boundary_conditions = Canopy.AtmosDrivenCanopyBC(
                 atmos,
                 radiation,
@@ -1088,7 +1094,7 @@ end
         ∂Ṫ∂T = Array(parent(jac_value)) .+ 1
         @test (abs.(
             Array(parent((dY_2.canopy.energy.T .- dY.canopy.energy.T) ./ ΔT)) -
-            ∂Ṫ∂T
+            ∂Ṫ∂T,
         ) / ∂Ṫ∂T)[1] < 0.25 # Error propagates here from ∂LHF∂T
     end
 end
@@ -1141,6 +1147,7 @@ end
             τ_NIR_leaf,
             χl,
         ) in zipped_params
+
             BeerLambertparams = BeerLambertParameters(FT)
             # TwoStreamModel parameters
             G_Function = CLMGFunction.(χl)
@@ -1281,7 +1288,7 @@ end
                             step = Δz,
                             stop = Δz * (n_stem + n_leaf),
                         ),
-                    )
+                    ),
                 )
 
             soil_driver = PrescribedGroundConditions{FT}()
@@ -1305,6 +1312,7 @@ end
                     conductance = stomatal_model,
                     autotrophic_respiration = autotrophic_respiration_model,
                     energy = energy_model,
+                    soil_moisture_stress = Canopy.NoMoistureStressModel{FT}(),
                     hydraulics = plant_hydraulics,
                     boundary_conditions = Canopy.AtmosDrivenCanopyBC(
                         atmos,
@@ -1381,6 +1389,8 @@ end
             joinpath(pkgdir(ClimaLand), "toml", "default_parameters.toml"),
         )
         hydraulics = Canopy.PlantHydraulicsModel{FT}(domain, LAI, toml_dict)
+        soil_moisture_stress = Canopy.TuzetMoistureStressModel{FT}(toml_dict)
+
         energy = Canopy.BigLeafEnergyModel{FT}()
         sif = Canopy.Lee2015SIFModel{FT}()
 
@@ -1403,6 +1413,7 @@ end
                 radiative_transfer,
                 photosynthesis,
                 conductance,
+                soil_moisture_stress,
                 hydraulics,
                 energy,
                 sif,
@@ -1425,6 +1436,7 @@ end
             @test canopy.conductance == conductance
             @test canopy.hydraulics == hydraulics
             @test canopy.energy == energy
+            @test canopy.soil_moisture_stress == soil_moisture_stress
             @test canopy.sif == sif
             @test canopy.boundary_conditions == boundary_conditions
             @test canopy.parameters == parameters
@@ -1459,6 +1471,7 @@ end
                 :autotrophic_respiration,
                 :energy,
                 :sif,
+                :soil_moisture_stress,
                 :turbulent_fluxes,
             )
             for component in ClimaLand.Canopy.canopy_components(canopy)
@@ -1535,6 +1548,7 @@ end
             :autotrophic_respiration,
             :energy,
             :sif,
+            :soil_moisture_stress,
             :turbulent_fluxes,
         )
         for component in ClimaLand.Canopy.canopy_components(canopy)

--- a/test/standalone/Vegetation/conservation.jl
+++ b/test/standalone/Vegetation/conservation.jl
@@ -9,29 +9,38 @@ import ClimaParams as CP
 using ClimaLand
 using ClimaLand.Canopy
 using ClimaLand.Canopy.PlantHydraulics
-using ClimaLand.Domains: Column, HybridBox
+using ClimaLand.Domains: Point, Plane
 
 import ClimaLand
 import ClimaLand.Parameters as LP
 
 for FT in (Float32, Float64)
-    cmax = FT(0)
-    cmin = FT(-2)
+    # Domain information
+    cmax = FT(10)
+    cmin = FT(0)
     nelems = 10
-    col = Column(; zlim = (cmin, cmax), nelements = nelems)
-    box = ClimaLand.Domains.HybridBox(;
+    longlat = (FT(-118.14), FT(34.15))
+    pt = Point(; z_sfc = FT(0), longlat)
+    plane = Plane(;
         xlim = (cmin, cmax),
         ylim = (cmin, cmax),
-        zlim = (cmin, cmax),
-        nelements = (nelems, nelems, nelems),
+        nelements = (nelems, nelems),
+        longlat,
     )
+    domains = [pt, plane]
 
-    domains = [col, box]
-    t0 = 0.0
+    # Parameters
+    default_params_filepath =
+        joinpath(pkgdir(ClimaLand), "toml", "default_parameters.toml")
+    toml_dict = LP.create_toml_dict(FT, default_params_filepath)
     earth_param_set = LP.LandParameters(FT)
+
+    # Time information
+    t0 = 0.0
     start_date = DateTime(2005)
     Δt = FT(180.0)
-    "Radiation"
+
+    # Radiation forcing
     SW_d = TimeVaryingInput((t) -> eltype(t)(20.0))
     LW_d = TimeVaryingInput((t) -> eltype(t)(20.0))
     zenith_angle =
@@ -43,7 +52,7 @@ for FT in (Float32, Float64)
             longitude = FT(-120.0),
         )
 
-    rad = PrescribedRadiativeFluxes(
+    radiation = PrescribedRadiativeFluxes(
         FT,
         SW_d,
         LW_d,
@@ -51,7 +60,7 @@ for FT in (Float32, Float64)
         θs = zenith_angle,
         earth_param_set = earth_param_set,
     )
-    "Atmos"
+    # Atmos forcing
     precip = TimeVaryingInput((t) -> eltype(t)(0)) # no precipitation
     T_atmos = TimeVaryingInput((t) -> eltype(t)(290.0))
     u_atmos = TimeVaryingInput((t) -> eltype(t)(2.0))
@@ -69,109 +78,44 @@ for FT in (Float32, Float64)
         h_atmos,
         earth_param_set,
     )
+    # Ground forcing
+    ground = PrescribedGroundConditions{FT}()
 
-    ld = FT(0.5)
-    α_PAR_leaf = FT(0.2)
-    α_NIR_leaf = α_PAR_leaf
-    is_c3 = FT(1.0)
-    Vcmax25 = FT(5e-6)
-    g1 = FT(120)
-    G_Function = ConstantGFunction(ld)
-    RTparams = BeerLambertParameters(FT; α_PAR_leaf, α_NIR_leaf, G_Function)
-    photosynthesis_params = FarquharParameters(FT, is_c3; Vcmax25)
-    stomatal_g_params = MedlynConductanceParameters(FT; g1)
-    stomatal_model = MedlynConductanceModel{FT}(stomatal_g_params)
-    photosynthesis_model = FarquharModel{FT}(photosynthesis_params)
-    rt_model = BeerLambertModel{FT}(RTparams)
-    energy_model = BigLeafEnergyModel{FT}(BigLeafEnergyParameters{FT}())
-    thermo_params = LP.thermodynamic_parameters(earth_param_set)
-    LAI = FT(8.0) # m2 [leaf] m-2 [ground]
-    z_0m = FT(0.1) # m, Roughness length for momentum - value from tall forest ChatGPT
-    z_0b = FT(0.1) # m, Roughness length for scalars - value from tall forest ChatGPT
-    h_int = FT(30.0) # m, "where measurements would be taken at a typical flux tower of a 20m canopy"
-    shared_params = SharedCanopyParameters{FT, typeof(earth_param_set)}(
-        z_0m,
-        z_0b,
-        earth_param_set,
-    )
-    autotrophic_parameters = AutotrophicRespirationParameters(FT)
-    autotrophic_respiration_model =
-        AutotrophicRespirationModel{FT}(autotrophic_parameters)
+    # Hydraulics model
+    LAI_value = FT(8)
+    LAI = TimeVaryingInput(t -> LAI_value) # m2 [leaf] m-2 [ground]
     RAI = FT(1)
     SAI = FT(1)
-    lai_fun = t -> LAI
-    ai_parameterization = PlantHydraulics.PrescribedSiteAreaIndex{FT}(
-        TimeVaryingInput(lai_fun),
-        SAI,
-        RAI,
-    )
-    K_sat_plant = FT(1.8e-8) # m/s
-    ψ63 = FT(-4 / 0.0098) # / MPa to m, Holtzman's original parameter value
-    Weibull_param = FT(4) # unitless, Holtzman's original c param value
-    a = FT(0.05 * 0.0098) # Holtzman's original parameter for the bulk modulus of elasticity
-    plant_ν = FT(0.7) # m3/m3
-    plant_S_s = FT(1e-2 * 0.0098) # m3/m3/MPa to m3/m3/m
-    conductivity_model =
-        PlantHydraulics.Weibull{FT}(K_sat_plant, ψ63, Weibull_param)
-    retention_model = PlantHydraulics.LinearRetentionCurve{FT}(a)
-    rooting_depth = FT(0.5)
-    param_set = PlantHydraulics.PlantHydraulicsParameters(;
-        ai_parameterization = ai_parameterization,
-        ν = plant_ν,
-        S_s = plant_S_s,
-        rooting_depth = rooting_depth,
-        conductivity_model = conductivity_model,
-        retention_model = retention_model,
-    )
-    Δz = FT(1.0) # height of compartments
+    ai_parameterization =
+        PlantHydraulics.PrescribedSiteAreaIndex{FT}(LAI, SAI, RAI)
     n_stem = Int64(2) # number of stem elements
     n_leaf = Int64(1) # number of leaf elements
-    compartment_centers =
-        FT.(
-            Vector(
-                range(
-                    start = Δz / 2,
-                    step = Δz,
-                    stop = Δz * (n_stem + n_leaf) - (Δz / 2),
-                ),
-            ),
-        )
-    compartment_faces =
-        FT.(
-            Vector(
-                range(start = 0.0, step = Δz, stop = Δz * (n_stem + n_leaf)),
-            )
-        )
+    h_stem = h_leaf = FT(1)
 
-    soil_driver = PrescribedGroundConditions{FT}()
-
-    plant_hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(;
-        parameters = param_set,
-        n_stem = n_stem,
-        n_leaf = n_leaf,
-        compartment_surfaces = compartment_faces,
-        compartment_midpoints = compartment_centers,
-    )
     @testset "Canopy model total energy and water, FT = $FT" begin
         for domain in domains
-            canopy = ClimaLand.Canopy.CanopyModel{FT}(;
-                parameters = shared_params,
-                domain = ClimaLand.Domains.obtain_surface_domain(domain),
-                radiative_transfer = rt_model,
-                photosynthesis = photosynthesis_model,
-                conductance = stomatal_model,
-                autotrophic_respiration = autotrophic_respiration_model,
-                energy = energy_model,
-                hydraulics = plant_hydraulics,
-                boundary_conditions = Canopy.AtmosDrivenCanopyBC(
-                    atmos,
-                    rad,
-                    soil_driver,
-                ),
+            hydraulics = PlantHydraulics.PlantHydraulicsModel{FT}(
+                domain,
+                LAI,
+                toml_dict;
+                n_stem,
+                n_leaf,
+                h_stem,
+                h_leaf,
+                SAI,
+                RAI,
+                ai_parameterization,
+            )
+            canopy = ClimaLand.Canopy.CanopyModel{FT}(
+                domain,
+                (; radiation, atmos, ground),
+                LAI,
+                toml_dict;
+                hydraulics,
             )
 
             Y, p, cds = initialize(canopy)
-            ϑ0 = plant_ν / 2
+            ϑ0 = canopy.hydraulics.parameters.ν / 2
             Temp0 = FT(290.5)
 
             Y.canopy.hydraulics.ϑ_l.:1 .= ϑ0
@@ -185,7 +129,7 @@ for FT in (Float32, Float64)
             ClimaLand.total_energy_per_area!(total_energy, canopy, Y, p, t0)
             @test all(
                 parent(total_energy) .≈
-                (LAI + SAI) * canopy.energy.parameters.ac_canopy * Temp0,
+                (LAI_value + SAI) * canopy.energy.parameters.ac_canopy * Temp0,
             )
 
             total_water = ClimaCore.Fields.zeros(domain.space.surface)
@@ -198,7 +142,7 @@ for FT in (Float32, Float64)
             )
             @test all(
                 parent(total_water) .≈
-                (LAI * n_leaf * Δz * ϑ0 + SAI * n_stem * Δz * ϑ0),
+                (LAI_value * n_leaf * h_leaf * ϑ0 + SAI * n_stem * h_stem * ϑ0),
             )
         end
     end

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -265,6 +265,7 @@ for FT in (Float32, Float64)
                     photosynthesis = photosynthesis_model,
                     conductance = stomatal_model,
                     hydraulics = plant_hydraulics,
+                    soil_moisture_stress = Canopy.NoMoistureStressModel{FT}(),
                     boundary_conditions = Canopy.AtmosDrivenCanopyBC(
                         atmos,
                         radiation,
@@ -516,6 +517,7 @@ for FT in (Float32, Float64)
             photosynthesis = photosynthesis_model,
             conductance = stomatal_model,
             hydraulics = plant_hydraulics,
+            soil_moisture_stress = Canopy.NoMoistureStressModel{FT}(),
             boundary_conditions = Canopy.AtmosDrivenCanopyBC(
                 atmos,
                 radiation,
@@ -533,6 +535,7 @@ for FT in (Float32, Float64)
         end
         set_initial_cache! = make_set_initial_cache(model)
         set_initial_cache!(p, Y, FT(0.0))
+        @test all(parent(p.canopy.soil_moisture_stress.βm) .≈ FT(1))
         @test all(parent(p.canopy.hydraulics.fa) .≈ FT(0.0))
         @test all(parent(p.canopy.hydraulics.fa_roots) .≈ FT(0.0))
         @test all(parent(p.canopy.turbulent_fluxes.transpiration) .≈ FT(0.0))

--- a/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
+++ b/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
@@ -151,10 +151,10 @@ for FT in (Float32, Float64)
                 Γstar,
             )
         @test all(@.(Aj == J * (ci - Γstar) / (4 * (ci + 2 * Γstar))))
-        β = moisture_stress(
+        β = compute_tuzet_moisture_stress(
             p_l,
-            photosynthesisparams.sc,
             photosynthesisparams.pc,
+            photosynthesisparams.sc,
         )
         @test β ==
               (1 + exp(photosynthesisparams.sc * photosynthesisparams.pc)) / (

--- a/test/standalone/Vegetation/test_pmodel.jl
+++ b/test/standalone/Vegetation/test_pmodel.jl
@@ -1,8 +1,8 @@
 """
 # P-Model Regression Tests
 
-This module tests the ClimaLand P-Model implementation against reference outputs 
-from the R-based P-Model package. The P-Model predicts photosynthetic carbon 
+This module tests the ClimaLand P-Model implementation against reference outputs
+from the R-based P-Model package. The P-Model predicts photosynthetic carbon
 assimilation and related variables based on environmental conditions.
 
 ## Test Structure
@@ -48,7 +48,7 @@ using Dates
 """
     percent_difference(a, b)
 
-Calculate the percentage difference between `a` and `b` (reference). 
+Calculate the percentage difference between `a` and `b` (reference).
 """
 function percent_difference(a, b)
     return abs(a - b) / abs(b) * 100
@@ -92,8 +92,6 @@ function PModelParameters(inputs::Dict{String, Any}, FT)
         ϕa1_c4,
         ϕa2_c4,
         α = FT(0),
-        sc = FT(0),
-        pc = FT(0),
     )
 end
 
@@ -204,10 +202,10 @@ end
 
                     if haskey(outputs, key_symbol)
                         r_out = ref_outputs_typed[key]
-                        # convert gpp to kg/m^2/s   
+                        # convert gpp to kg/m^2/s
                         r_out = key == "gpp" ? r_out / FT(1000.0) : r_out
 
-                        # convert gs to mol/m^2/s 
+                        # convert gs to mol/m^2/s
                         r_out = key == "gs" ? r_out * P_air : r_out
 
                         j_out = getproperty(outputs, key_symbol)
@@ -283,8 +281,6 @@ end
             ϕa1_c4 = FT(0.022 * 0.087),
             ϕa2_c4 = FT(-0.00034 * 0.087),
             α = FT(0),
-            sc = FT(2e-6),
-            pc = FT(-2e6),
         )
         is_c3 = FT(1)
         constants = PModelConstants{FT}()
@@ -321,7 +317,7 @@ end
                 ca,
                 βm,
                 APAR,
-                FT(1.0), # force update 
+                FT(1.0), # force update
             )
             @test isapprox(
                 outputs_from_EMA.ξ_opt,

--- a/test/standalone/Vegetation/test_soil_moisture_stress.jl
+++ b/test/standalone/Vegetation/test_soil_moisture_stress.jl
@@ -1,0 +1,106 @@
+using Test
+using ClimaLand
+import ClimaComms
+ClimaComms.@import_required_backends
+using ClimaLand.Canopy
+using ClimaLand.Soil
+using ClimaLand.Canopy.PlantHydraulics
+using DelimitedFiles
+using ClimaLand.Domains: Point
+import ClimaLand.Parameters as LP
+import ClimaParams
+import Insolation
+using Dates
+
+for FT in (Float32, Float64)
+    default_params_filepath =
+        joinpath(pkgdir(ClimaLand), "toml", "default_parameters.toml")
+    toml_dict = LP.create_toml_dict(FT, default_params_filepath)
+    soil_moisture_stress_models = (
+        TuzetMoistureStressModel{FT}(; sc = FT(0.01), pc = FT(-0.5e6)),
+        NoMoistureStressModel{FT}(),
+    )
+    soil_moisture_stress_names = ("Tuzet", "No Stress")
+
+    lat = FT(38.7441)
+    long = FT(-92.2000)
+    domain = Point(; z_sfc = FT(0.0), longlat = (long, lat))
+    earth_param_set = LP.LandParameters(FT)
+
+    # dummy forcing
+    atmos, radiation = prescribed_analytic_forcing(FT; h_atmos = FT(1))
+    ground = PrescribedGroundConditions{FT}()
+    LAI = TimeVaryingInput(t -> FT(1))
+    forcing = (; atmos, radiation, ground)
+
+    for (sms_model, name) in
+        zip(soil_moisture_stress_models, soil_moisture_stress_names)
+        canopy = Canopy.CanopyModel{FT}(
+            domain,
+            forcing,
+            LAI,
+            toml_dict;
+            soil_moisture_stress = sms_model,
+        )
+        @testset "Initialize canopy with type $name for float type $FT" begin
+            Y, p, coords = initialize(canopy)
+
+            @test all(parent(p.canopy.soil_moisture_stress.βm) .≈ FT(0.0))
+            # # set initial conditions
+            Y.canopy.hydraulics.ϑ_l.:1 .= canopy.hydraulics.parameters.ν
+            p.canopy.hydraulics.ψ.:1 .= NaN
+            p.canopy.hydraulics.fa.:1 .= NaN
+            set_initial_cache! = make_set_initial_cache(canopy)
+            set_initial_cache!(p, Y, FT(0.0))
+
+            @test all(parent(p.canopy.soil_moisture_stress.βm) .≈ FT(1.0))
+
+            # Repeat with different IC
+            p.canopy.soil_moisture_stress.βm .= 0
+            Y.canopy.hydraulics.ϑ_l.:1 .= canopy.hydraulics.parameters.ν / 2
+            p.canopy.hydraulics.ψ.:1 .= NaN
+            p.canopy.hydraulics.fa.:1 .= NaN
+            set_initial_cache! = make_set_initial_cache(canopy)
+            set_initial_cache!(p, Y, FT(0.0))
+            grav = LP.grav(earth_param_set)
+            ρ_water = LP.ρ_cloud_liq(earth_param_set)
+            if canopy.soil_moisture_stress isa TuzetMoistureStressModel
+                p_leaf = @. p.canopy.hydraulics.ψ.:1 * ρ_water * grav
+                @test all(
+                    parent(p.canopy.soil_moisture_stress.βm) .≈ parent(
+                        compute_tuzet_moisture_stress.(
+                            p_leaf,
+                            canopy.soil_moisture_stress.pc,
+                            canopy.soil_moisture_stress.sc,
+                        ),
+                    ),
+                )
+            else
+                @test all(parent(p.canopy.soil_moisture_stress.βm) .≈ FT(1.0))
+            end
+        end
+    end
+
+    @testset "Test correctness for piecewise soil moisture stress for float type $FT" begin
+        # construct piecewise moisture stress parameters from hydrology
+
+        ν = FT(0.5)
+        θ_r = FT(0.1)
+        sms = PiecewiseMoistureStressModel{FT}(
+            domain,
+            toml_dict;
+            soil_params = (; ν, θ_r),
+        )
+        @test θ_r == sms.θ_low
+        @test ν == sms.θ_high
+        βm_expected = FT(0.5)
+        βm_computed = compute_piecewise_moisture_stress(
+            sms.θ_high,
+            sms.θ_low,
+            sms.c,
+            θ_r + (ν - θ_r) / 2,
+        )
+        @test βm_computed ≈ βm_expected
+    end
+
+end

--- a/toml/default_parameters.toml
+++ b/toml/default_parameters.toml
@@ -1,3 +1,21 @@
+# Moisture stress models
+[moisture_stress_c]
+value = 1.0
+type = "float"
+description = "unitless"
+tag = "SoilMoistureStress"
+
+[moisture_stress_sc]
+value = 5.0e-6
+type = "float"
+description = "1/Pa"
+tag = "SoilMoistureStress"
+
+[moisture_stress_pc]
+value = -2.0e6
+type = "float"
+description = "Pa"
+tag = "SoilMoistureStress"
 # TOPMODELRunoff model
 
 [f_over]


### PR DESCRIPTION
closes #1382 

This commits adds a portion of Yuchen Li PR #1330, a new Canopy component: AbstractSoilMoistureStressModel, with 3 methods: the existing one (Tuzet) which was previously in PlantHydraulics, a Piecewise method using dry to wet soil moisture, and no moisture stress.

Long run: https://buildkite.com/clima/climaland-long-runs/builds/4212

Snowy land is unchanged, Snowy land + pmodel was changed to use new moisture stress. it looks worse overall compared to what we have in main (ILAMB ET and GPP, ERA5 LHF and SHF): GPP dropped by 2x, ET dropped but by much less.

Will revert change to use this is pmodel until we can calibrate it.
Moisture stress now like 0.3 instead of 0.7