### PR TITLE
Specify `device` consistently for domains

### DIFF
--- a/src/shared_utilities/Domains.jl
+++ b/src/shared_utilities/Domains.jl
@@ -154,7 +154,9 @@ end
     Column(;
         zlim::Tuple{FT, FT},
         nelements::Int,
-        dz_tuple::Union{Tuple{FT, FT}, Nothing} = nothing) where {FT}
+        device = ClimaComms.device(),
+        longlat::Union{Tuple{FT, FT}, Nothing} = nothing,
+        dz_tuple::Union{Tuple{FT, FT}, Nothing} = nothing)
 
 Outer constructor for the 1D `Column` domain.
 
@@ -182,11 +184,11 @@ The latitude and longitude of the returned domain can be accessed as follows:
 function Column(;
     zlim::Tuple{FT, FT},
     nelements::Int,
+    device = ClimaComms.device(),
     longlat::Union{Tuple{FT, FT}, Nothing} = nothing,
     dz_tuple::Union{Tuple{FT, FT}, Nothing} = nothing,
 ) where {FT}
     @assert zlim[1] < zlim[2]
-    device = ClimaComms.device()
     boundary_names = (:bottom, :top)
 
     if isnothing(longlat)
@@ -442,15 +444,15 @@ end
 
 """
     HybridBox(;
-        xlim::Tuple{FT, FT},
-        ylim::Tuple{FT, FT},
-        zlim::Tuple{FT, FT},
-        longlat = nothing,
-        nelements::Tuple{Int, Int, Int},
-        npolynomial::Int,
-        dz_tuple::Union{Tuple{FT, FT}, Nothing} = nothing,
-        periodic = (true, true),
-    ) where {FT}
+    xlim::Tuple{FT, FT},
+    ylim::Tuple{FT, FT},
+    zlim::Tuple{FT, FT},
+    nelements::Tuple{Int, Int, Int},
+    npolynomial::Int = 0,
+    device = ClimaComms.device(),
+    dz_tuple::Union{Tuple{FT, FT}, Nothing} = nothing,
+    longlat = nothing,
+    periodic::Tuple{Bool, Bool} = (true, true))
 
 Constructs the `HybridBox` domain
  with limits `xlim` `ylim` and `zlim
@@ -485,6 +487,7 @@ function HybridBox(;
     zlim::Tuple{FT, FT},
     nelements::Tuple{Int, Int, Int},
     npolynomial::Int = 0,
+    device = ClimaComms.device(),
     dz_tuple::Union{Tuple{FT, FT}, Nothing} = nothing,
     longlat = nothing,
     periodic::Tuple{Bool, Bool} = isnothing(longlat) ? (true, true) :
@@ -516,7 +519,6 @@ function HybridBox(;
             reverse_mode = true,
         )
     end
-    device = ClimaComms.device()
     vert_center_space =
         ClimaCore.Spaces.CenterFiniteDifferenceSpace(device, vertmesh)
 
@@ -642,7 +644,7 @@ function SphericalShell(;
             reverse_mode = true,
         )
     end
-    device = ClimaComms.device()
+    device = ClimaComms.device(context)
     vert_center_space =
         ClimaCore.Spaces.CenterFiniteDifferenceSpace(device, vertmesh)
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Closes #1359 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- For `SphericalShell`, obtains the device from the context.
- For `Column` and `HybridBox`, adds `device` as a keyword argument and updates docstrings.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
