### PR TITLE
Clean up with docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -100,7 +100,7 @@ makedocs(
     pages = pages,
     checkdocs = :exports,
     doctest = true,
-    warnonly = true,
+    warnonly = [:missing_docs, :footnote, :cross_references],
     clean = true,
     modules = [ClimaLand],
 )

--- a/docs/src/APIs/canopy/Photosynthesis.md
+++ b/docs/src/APIs/canopy/Photosynthesis.md
@@ -8,7 +8,7 @@ CurrentModule = ClimaLand.Canopy
 
 ```@docs
 ClimaLand.Canopy.PModel
-ClimaLand.Canopy.PModel()
+ClimaLand.Canopy.PModel{FT}(domain)
 ClimaLand.Canopy.PModelParameters
 ClimaLand.Canopy.PModelConstants
 ClimaLand.Canopy.FarquharModel
@@ -47,7 +47,6 @@ ClimaLand.Canopy.make_PModel_callback
 ClimaLand.Canopy.intrinsic_quantum_yield
 ClimaLand.Canopy.compute_viscosity_ratio
 ClimaLand.Canopy.compute_Kmm
-ClimaLand.Canopy.optimal_co2_ratio_c3
 ClimaLand.Canopy.intercellular_co2_pmodel
 ClimaLand.Canopy.gs_co2_pmodel
 ClimaLand.Canopy.gs_h2o_pmodel

--- a/docs/src/APIs/canopy/soil_moisture_stress.md
+++ b/docs/src/APIs/canopy/soil_moisture_stress.md
@@ -7,13 +7,10 @@ CurrentModule = ClimaLand.Canopy
 ## Models and Parameters
 
 ```@docs
-ClimaLand.Canopy.TuzetMoistureStressParameters
 ClimaLand.Canopy.TuzetMoistureStressModel
-ClimaLand.Canopy.TuzetMoistureStressModel{FT}()
 ClimaLand.Canopy.TuzetMoistureStressModel{FT}(toml_dict::CP.ParamDict)
 ClimaLand.Canopy.PiecewiseMoistureStressModel
-ClimaLand.Canopy.PiecewiseMoistureStressModel{FT}()
-Climaland.Canopy.PiecewiseMoistureStressModel{FT}(toml_dict::CP.ParamDict)
+ClimaLand.Canopy.PiecewiseMoistureStressModel(domain, toml_dict::CP.ParamDict)
 ClimaLand.Canopy.NoMoistureStressModel
 ```
 

--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -236,7 +236,7 @@ land_components(land::AbstractLandModel) = propertynames(land)
         p,
         t,
         sfc_cache,
-)
+    )
 
 A function which computes the total energy per unit area and updates
 `surface_field` in place, for the land model `land`, by calling
@@ -269,7 +269,7 @@ end
         p,
         t,
         sfc_cache,
-)
+    )
 
 A function which computes the total liquid water volume
 per unit area and updates
@@ -362,21 +362,21 @@ end
 
 
 """
-   lsm_aux_vars(m::AbstractLandModel)
+    lsm_aux_vars(m::AbstractLandModel)
 
 Returns the additional aux variable symbols for the model in the form of a tuple.
 """
 lsm_aux_vars(m::AbstractLandModel) = ()
 
 """
-   lsm_aux_types(m::AbstractLandModel)
+    lsm_aux_types(m::AbstractLandModel)
 
 Returns the shared additional aux variable types for the model in the form of a tuple.
 """
 lsm_aux_types(m::AbstractLandModel) = ()
 
 """
-   lsm_aux_domain_names(m::AbstractLandModel)
+    lsm_aux_domain_names(m::AbstractLandModel)
 
 Returns the additional domain symbols in the form of a tuple e.g. :surface or :subsurface.
 

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -350,15 +350,15 @@ function LandModel{FT}(
 end
 
 """
-   ClimaLand.land_components(land::LandModel)
+    ClimaLand.land_components(land::LandModel)
 
 Returns the components of the `LandModel`.
 
-Currently, this method is required in order to preserve an ordering in how
-we update the component models' auxiliary states. The canopy update_aux! step
+Currently, this method is required in order to preserve an ordering in how we
+update the component models' auxiliary states. The canopy `update_aux!` step
 depends on snow and soil albedo, but those are only updated in the snow and soil
-update_aux! steps. So those must occur first (as controlled by the order of the components
-returned by `land_components!`.
+`update_aux!` steps. So those must occur first (as controlled by the order of
+the components returned by `land_components!`.
 
 This needs to be fixed.
 """

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -304,7 +304,7 @@ These include the broadband albedo of the land surface
 `α_sfc`, defined as the ratio of SW_u/SW_d,
 and `T_sfc`, defined as the temperature a blackbody with emissivity
 `ϵ_sfc` would have
-in order to emit the same LW_u as the land surface does. This is called the
+in order to emit the same `LW_u` as the land surface does. This is called the
 [effective temperature](https://en.wikipedia.org/wiki/Effective_temperature) in some fields,
 and is not the same as the skin temperature (defined e.g. Equation 7.13 of  Bonan, 2019, Climate Change and Terrestrial Ecosystem Modeling.  DOI: 10.1017/9781107339217).
 """

--- a/src/integrated/soil_snow_model.jl
+++ b/src/integrated/soil_snow_model.jl
@@ -402,12 +402,12 @@ in ϑ_l, ρe_int but explicitly in θ_i.
 end
 
 """
-     source!(dY::ClimaCore.Fields.FieldVector,
-             src::SoilSublimationwithSnow{FT},
-             Y::ClimaCore.Fields.FieldVector,
-             p::NamedTuple,
-             model
-             )
+    source!(dY::ClimaCore.Fields.FieldVector,
+            src::SoilSublimationwithSnow{FT},
+            Y::ClimaCore.Fields.FieldVector,
+            p::NamedTuple,
+            model
+            )
 
 Updates `dY.soil.θ_i` in place with a term due to sublimation; this only affects
 the surface layer of soil.

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -201,7 +201,7 @@ must be `nothing`, or both must not be `nothing``.
 During the driver update, cosθs is unchanged if `θs` is `nothing`. This behavior differs from
 the `PrescribedRadiativeFluxes` where `cosθs` set to `NaN` if `θs` is `nothing`.
 Otherwise, `θs` recieves the following arguments:
-(time_from_start, `start_date`), and is expected to return zenith angle at the given time.
+(`time_from_start`, `start_date`), and is expected to return zenith angle at the given time.
 $(DocStringExtensions.FIELDS)
 """
 struct CoupledRadiativeFluxes{FT, F <: Union{Function, Nothing}, T} <:
@@ -1460,23 +1460,23 @@ end
                              regridder_type = :InterpolationsRegridder,
                              interpolation_method = Interpolations.Constant(),)
 
-A helper function which constructs the `PrescribedAtmosphere` and `PrescribedRadiativeFluxes`
-from a file path pointing to the ERA5 data in a netcdf file, the surface_space, the start date,
-and the earth_param_set.
+A helper function which constructs the `PrescribedAtmosphere` and
+`PrescribedRadiativeFluxes` from a file path pointing to the ERA5 data in a netcdf file, the
+`surface_space`, the `start_date`, and the `earth_param_set`.
 
 The argument `era5_ncdata_path` is either a list of nc files, each with all of the variables required, but with different time intervals in the different files, or else it is a single file with all the variables.
 
 The ClimaLand default is to use nearest neighbor interpolation, but
 linear interpolation is supported
-by passing interpolation_method = Interpolations.Linear().
+by passing `interpolation_method = Interpolations.Linear()`.
 
-########## WARNING ##########
-
-High wind speed anomalies (10-100x increase and decrease over a period of a several hours) appear in the ERA5
-reanalysis data. These generate very large surface fluxes (due to wind speeds up to 300 m/s), which lead to instability. The kwarg max_wind_speed,
-with a value give in m/s,
-is used to clip these if it is not `nothing`.
-See: https://confluence.ecmwf.int/display/CKB/ERA5%3A+large+10m+winds
+!!! warning "Clipped values"
+    High wind speed anomalies (10-100x increase and decrease over a period of a
+    several hours) appear in the ERA5 reanalysis data. These generate very large
+    surface fluxes (due to wind speeds up to 300 m/s), which lead to
+    instability. The kwarg `max_wind_speed`, with a value give in m/s, is used to
+    clip these if it is not `nothing`. See
+    [here](https://confluence.ecmwf.int/display/CKB/ERA5%3A+large+10m+winds).
 """
 function prescribed_forcing_era5(
     era5_ncdata_path,

--- a/src/shared_utilities/models.jl
+++ b/src/shared_utilities/models.jl
@@ -75,7 +75,7 @@ all models.
 prognostic_vars(m::AbstractModel) = ()
 
 """
-   prognostic_domain_names(m::AbstractModel)
+    prognostic_domain_names(m::AbstractModel)
 
 Returns the domain names for the prognostic variables in the form of a tuple.
 
@@ -116,7 +116,7 @@ Returns the auxiliary variable symbols for the model in the form of a tuple.
 auxiliary_vars(m::AbstractModel) = ()
 
 """
-   auxiliary_domain_names(m::AbstractModel)
+    auxiliary_domain_names(m::AbstractModel)
 
 Returns the domain names for the auxiliary variables in the form of a tuple.
 
@@ -125,16 +125,15 @@ Examples: (:surface, :surface, :subsurface).
 auxiliary_domain_names(m::AbstractModel) = ()
 
 """
-   auxiliary_types(m::AbstractModel{FT}) where {FT}
+    auxiliary_types(m::AbstractModel{FT}) where {FT}
 
 Returns the auxiliary variable types for the model in the form of a tuple.
 
 Types provided must have `ClimaCore.RecursiveApply.rzero(T::DataType)`
-defined. Common examples
- include
-- Float64, Float32 for scalar variables (a scalar value at each
+defined. Common examples include
+- `Float64`, `Float32` for scalar variables (a scalar value at each
 coordinate point)
-- SVector{k,Float64} for a mutable but statically sized array of
+- `SVector{k,Float64}` for a mutable but statically sized array of
  length `k` at each coordinate point.
 - Note that Arrays, MVectors are not isbits and cannot be used.
 

--- a/src/shared_utilities/sources.jl
+++ b/src/shared_utilities/sources.jl
@@ -8,11 +8,11 @@ An abstract type for types of source terms.
 abstract type AbstractSource{FT <: AbstractFloat} end
 
 """
-     source!(dY::ClimaCore.Fields.FieldVector,
-             src::AbstractSource,
-             Y::ClimaCore.Fields.FieldVector,
-             p::NamedTuple
-             )::ClimaCore.Fields.Field
+    source!(dY::ClimaCore.Fields.FieldVector,
+            src::AbstractSource,
+            Y::ClimaCore.Fields.FieldVector,
+            p::NamedTuple
+            )::ClimaCore.Fields.Field
 
 A stub function, which is extended by ClimaLand.
 """

--- a/src/standalone/Bucket/bucket_parameterizations.jl
+++ b/src/standalone/Bucket/bucket_parameterizations.jl
@@ -78,11 +78,11 @@ end
 Computes the beta factor which scales the evaporation/sublimation from the potential
 rate. The beta factor is given by:
 
-β = (x/x_c)^p x < x_c
+β = (x/x\\_c)^p x < x\\_c
     1         otherwise
 
-where x = W and x_c = f_bucket * W_f for the bucket,
-and x = σS and x_c = f_snow *σS_c for snow.
+where x = W and x\\_c = f\\_bucket * W\\_f for the bucket,
+and x = σS and x\\_c = f\\_snow *σS\\_c for snow.
 
 """
 function beta_factor(W::FT, σS::FT, fW_f::FT, fσS_c::FT, p::FT) where {FT}

--- a/src/standalone/Snow/Snow.jl
+++ b/src/standalone/Snow/Snow.jl
@@ -109,11 +109,12 @@ end
 
 Establishes the albedo parameterization where albedo
 depends on the cosine of the zenith angle of the sun, as
-    α = f(x) * [α_0 + Δα*exp(-k*cos(θs))],
 
-where cos θs is the cosine of the zenith angle, α_0, Δα, and k
+``\\alpha = f(x) [\\alpha_0 + \\Delta\\alpha \\cdot \\text{exp}(-k\\cos(\\theta s))]``
+
+where cos θs is the cosine of the zenith angle, α\\_0, Δα, and k
 are free parameters. The factor out front is a function of
-x = ρ_snow/ρ_liq, of the form f(x) = min(1 - β(x-x0), 1). The parameters
+x = ρ\\_snow/ρ\\_liq, of the form f(x) = min(1 - β(x-x0), 1). The parameters
 x0 ∈ [0,1] and β ∈ [0,1] are free. Choose β = 0 to remove this dependence on snow density.
 
 
@@ -174,16 +175,16 @@ Establishes the snow cover parameterization of Wu, Tongwen, and
 Guoxiong Wu. "An empirical formula to compute
 snow cover fraction in GCMs." Advances in Atmospheric Sciences
 21 (2004): 529-535,
-    scf = min(β_scf * z̃ / (z̃ + 1), 1),
+    scf = min(β\\_scf * z̃ / (z̃ + 1), 1),
 
-where z̃ = snow depth per ground area / 0.106 m, and β_scf
-is computed using a resolution dependent formula:
-β_scf = max(β0 - γ(horz_degree_res - 1.5), β_min), where horz_degree_res is the
-horizontal resolution of the simulation, in degrees, and β0, β_min and γ
-are unitless. It is correct to think of β0, β_min, γ, and z0 as the free
-parameters, while horz_degree_res is provided and β_scf is determined.
+where z̃ = snow depth per ground area / 0.106 m, and β\\_scf is computed using a
+resolution dependent formula: β\\_scf = max(β0 - γ(horz\\_degree\\_res - 1.5),
+β\\_min), where horz\\_degree\\_res is the horizontal resolution of the
+simulation, in degrees, and β0, β\\_min and γ are unitless. It is correct to
+think of β0, β\\_min, γ, and z0 as the free parameters, while
+horz\\_degree\\_res is provided and β\\_scf is determined.
 
-β0, β_min, γ, and β_scf must be > 0.
+β0, β\\_min, γ, and β\\_scf must be > 0.
 
 From Wu and Wu et al, β0 ∼ 1.77 and γ ∼ 0.08, over a range of 1.5-4.5∘
 """
@@ -580,14 +581,19 @@ density_prog_names(::AbstractDensityModel) = ()
     auxiliary_vars(::SnowModel)
 
 Returns the auxiliary variable names for the snow model. These
-include the specific humidity at the surface of the snow `(`q_sfc`, unitless),
-the mass fraction in liquid water (`q_l`, unitless),
-the thermal conductivity (`κ`, W/m/K),
-the bulk temperature (`T`, K), the surface temperature (`T_sfc`, K), the snow depth (`z_snow`, m),
-the bulk snow density (`ρ_snow`, kg/m^3)
-the SHF, LHF, and vapor flux (`turbulent_fluxes.shf`, etc),
-the net radiation (`R_n, J/m^2/s)`, the energy flux in liquid water runoff
-(`energy_runoff`, J/m^2/s), the water volume in runoff (`water_runoff`, m/s), and the total energy and water fluxes applied to the snowpack.
+include
+- the specific humidity at the surface of the snow (`q_sfc`, unitless),
+- the mass fraction in liquid water (`q_l`, unitless),
+- the thermal conductivity (`κ`, W/m/K),
+- the bulk temperature (`T`, K),
+- the surface temperature (`T_sfc`, K),
+- the snow depth (`z_snow`, m),
+- the bulk snow density (`ρ_snow`, kg/m^3)
+- the SHF, LHF, and vapor flux (`turbulent_fluxes.shf`, etc),
+- the net radiation (`R_n, J/m^2/s)`,
+- the energy flux in liquid water runoff (`energy_runoff`, J/m^2/s),
+- the water volume in runoff (`water_runoff`, m/s),
+and the total energy and water fluxes applied to the snowpack.
 
 Since the snow can melt completely in one timestep, we clip the water and energy fluxes
 such that SWE cannot become negative and U cannot become unphysical. The
@@ -858,7 +864,7 @@ include("./boundary_fluxes.jl")
         Y,
         p,
         t,
-)
+    )
 
 A function which updates `surface_field` in place with the value for
 the total liquid water volume per unit ground area for the `SnowModel`.
@@ -886,7 +892,7 @@ end
         Y,
         p,
         t,
-)
+    )
 
 A function which updates `surface_field` in place with the value for
 the total energy per unit ground area for the `SnowModel`.

--- a/src/standalone/Snow/boundary_fluxes.jl
+++ b/src/standalone/Snow/boundary_fluxes.jl
@@ -13,7 +13,7 @@ abstract type AbstractSnowBC <: ClimaLand.AbstractBC end
     } <: AbstractSnowBC
 
 A struct used to specify the snow fluxes, referred
-to as ``boundary conditions", at the surface and
+to as "boundary conditions", at the surface and
 bottom of the snowpack, for water and energy.
 
 These fluxes include turbulent surface fluxes
@@ -49,10 +49,10 @@ end
 Updates in place various volumetric water flux (m/s) and energy
 flux (W/m^2) terms for the snow model:
 
-- p.snow.turbulent fluxes (latent, sensible, and evaporative fluxes)
-- p.snow.R_n (radiative fluxes)
-- p.snow.total_water_flux
-- p.snow.total_energy_flux
+- `p.snow.turbulent fluxes` (latent, sensible, and evaporative fluxes)
+- `p.snow.R_n` (radiative fluxes)
+- `p.snow.total_water_flux`
+- `p.snow.total_energy_flux`
 
 The two latter fluxes also include contributions from fluxes due to melt and
 precipitation, but note that precipitation and melt flux are not computed or

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -253,10 +253,10 @@ of the snow, according to Equation
 Jordan (1991).
 
 We have adjusted the original equation to make the coefficients
-non-dimensional by multiplying by the first by x = ρ_ice/ρ_ice
-and the second by x², with ρ_ice in kg/m³.
+non-dimensional by multiplying by the first by x = ρ\\_ice/ρ\\_ice
+and the second by x², with ρ\\_ice in kg/m³.
 
-When ρ_snow = ρ_ice, we recover κ_snow = κ_ice.
+When ρ\\_snow = ρ\\_ice, we recover κ\\_snow = κ\\_ice.
 """
 function snow_thermal_conductivity(
     ρ_snow::FT,

--- a/src/standalone/Soil/Runoff/Runoff.jl
+++ b/src/standalone/Soil/Runoff/Runoff.jl
@@ -165,7 +165,7 @@ The runoff flux is given by Equation 12 of Niu et al. (2005),
 use in global climate models".
 
 This is currently treated implicitly (evaluated at the next value of
-ϑ_l) but not included in the Jacobian approximation. This is because
+ϑ\\_l) but not included in the Jacobian approximation. This is because
 `update_infiltration_water_flux` is called as part of the implicit tendency.
 
 $(DocStringExtensions.FIELDS)

--- a/src/standalone/Soil/Soil.jl
+++ b/src/standalone/Soil/Soil.jl
@@ -209,16 +209,22 @@ using .Biogeochemistry
                          additional_sources = (),
                          ) where {FT <: AbstractFloat}
 
-Creates a EnergyHydrology model with the given float type FT, domain, toml_dict, forcing, and prognostic land components.
+Creates a EnergyHydrology model with the given float type `FT`, `domain`,
+`toml_dict`, `forcing`, and prognostic land components.
 
-The argument `forcing` should be a NamedTuple containing two fields: `atmos` and `radiation`.
+The argument `forcing` should be a NamedTuple containing two fields: `atmos` and
+`radiation`.
 
-When running the soil model in standalone mode, `prognostic_land_components = (:soil,)`, while for running integrated land models,
-this should be a list of the component models. This value of this argument must be the same across all components in the land model.
+When running the soil model in standalone mode, `prognostic_land_components =
+(:soil,)`, while for running integrated land models, this should be a list of
+the component models. This value of this argument must be the same across all
+components in the land model.
 
-Default spatially varying parameters (for retention curve parameters, composition, and specific storativity) are provided but can be
-changed with keyword arguments. Note that these parameters must all be of the same type: either `FT` or ClimaCore Fields.
-By default they are Fields read in from data, so in practice this means if some values are provided as Floats, all of these
+Default spatially varying parameters (for retention curve parameters,
+composition, and specific storativity) are provided but can be changed with
+keyword arguments. Note that these parameters must all be of the same type:
+either `FT` or ClimaCore Fields. By default they are Fields read in from data,
+so in practice this means if some values are provided as Floats, all of these
 parameter defaults must be overwritten as Floats.
 
 `retention_parameters` should be a NamedTuple with the following fields:
@@ -305,7 +311,7 @@ end
                          S_s = ClimaCore.Fields.zeros(domain.space.subsurface) .+ 1e-3,
                          )
 
-Creates a RichardsModel model with the given float type FT, domain, earth_param_set and forcing.
+Creates a RichardsModel model with the given float type `FT`, `domain` and `forcing`.
 Here, `forcing` should be a `NamedTuple` containing a field `atmos` with the atmospheric forcing.
 
 Default spatially varying parameters (for retention curve parameters and specific storativity) are provided but can be

--- a/src/standalone/Soil/boundary_conditions.jl
+++ b/src/standalone/Soil/boundary_conditions.jl
@@ -30,17 +30,17 @@ An abstract type for boundary conditions for Richards equation.
 abstract type AbstractWaterBC <: ClimaLand.AbstractBC end
 
 """
-   MoistureStateBC <: AbstractWaterBC
+    MoistureStateBC <: AbstractWaterBC
 
 A simple concrete type of boundary condition, which enforces a
-state boundary condition ϑ_l = f(p,t) at either the top or bottom of the domain.
+state boundary condition ϑ\\_l = f(p,t) at either the top or bottom of the domain.
 """
 struct MoistureStateBC{F <: Function} <: AbstractWaterBC
     bc::F
 end
 
 """
-   WaterFluxBC <: AbstractWaterBC
+    WaterFluxBC <: AbstractWaterBC
 
 A simple concrete type of boundary condition, which enforces a
 normal flux boundary condition f(p,t) at either the top or bottom of the domain.
@@ -64,7 +64,7 @@ struct FreeDrainage <: AbstractWaterBC end
 
 
 """
-   RichardsAtmosDrivenFluxBC{F <: PrescribedPrecipitation, R <: AbstractRunoffModel} <: AbstractWaterBC
+    RichardsAtmosDrivenFluxBC{F <: PrescribedPrecipitation, R <: AbstractRunoffModel} <: AbstractWaterBC
 
 A concrete type of boundary condition intended only for use with the RichardsModel,
 which uses a prescribed precipitation rate (m/s) to compute the infiltration
@@ -73,7 +73,7 @@ into the soil.
 A runoff model is used
 to simulate surface and subsurface runoff and this is accounted
 for when setting boundary conditions. In order to run the simulation
-*without* runoff, choose runoff = NoRunoff() - this is also the default.
+*without* runoff, choose `runoff = NoRunoff()` - this is also the default.
 
 If you wish to simulate precipitation and runoff in the full `EnergyHydrology` model,
 you must use the `AtmosDrivenFluxBC` type.
@@ -437,7 +437,7 @@ An abstract type for boundary conditions for the soil heat equation.
 abstract type AbstractHeatBC <: ClimaLand.AbstractBC end
 
 """
-   TemperatureStateBC <: AbstractHeatBC
+    TemperatureStateBC <: AbstractHeatBC
 
 A simple concrete type of boundary condition, which enforces a
 state boundary condition T = f(p,t) at either the top or bottom of the domain.

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -104,15 +104,15 @@ Base.broadcastable(ps::EnergyHydrologyParameters) = tuple(ps)
         kwargs...,)
 
 EnergyHydrologyParameters has two constructors: float-type and toml dict based.
-Additional parameters must be added manually: ν, ν_ss_om, ν_ss_quartz, ν_ss_gravel, hydrology_cm, K_sat, S_s, and θ_r
-All parameters can be manually overriden via keyword arguments. Note, however,
-that certain parameters must have the same type (e.g, if a field is
-supplied for porosity, it must be supplied for all other parameters
-defined in the interior of the domain). Some parameters are defined only
-on the surface of the domain (e.g albedo), while other are defined everywhere
-(e.g. porosity). These are indicated with types `F` and `SF`. If both dry/wet albedos
-and general albedos are given as keywords, the dry/wet albedos will override the general
-albedos.
+Additional parameters must be added manually: `ν`, `ν_ss_om`, `ν_ss_quartz`,
+`ν_ss_gravel`, `hydrology_cm``, `K_sat`, `S_s`, and `θ_r`. All parameters can be
+manually overriden via keyword arguments. Note, however, that certain parameters
+must have the same type (e.g, if a field is supplied for porosity, it must be
+supplied for all other parameters defined in the interior of the domain). Some
+parameters are defined only on the surface of the domain (e.g albedo), while
+other are defined everywhere (e.g. porosity). These are indicated with types `F`
+and `SF`. If both dry/wet albedos and general albedos are given as keywords, the
+dry/wet albedos will override the general albedos.
 
 Please see the EnergyHydrologyParameters documentation for a complete list.
 """
@@ -244,9 +244,9 @@ in a porous medium by solving the Richardson-Richards equation
 and the heat equation, including terms for phase change.
 
 A variety of boundary condition types are supported, including
-FluxBC, MoistureStateBC/TemperatureStateBC,
-FreeDrainage (only for the bottom of the domain),
-and an AtmosDrivenFluxBC (under which radiative fluxes and
+`FluxBC`, `MoistureStateBC`/`TemperatureStateBC`,
+`FreeDrainage` (only for the bottom of the domain),
+and an `AtmosDrivenFluxBC` (under which radiative fluxes and
 turbulent surface fluxes are computed and used as boundary conditions).
 Please see the documentation for this boundary condition type for more
 details.
@@ -806,12 +806,12 @@ prognostic variables.
 end
 
 """
-     source!(dY::ClimaCore.Fields.FieldVector,
-             src::PhaseChange{FT},
-             Y::ClimaCore.Fields.FieldVector,
-             p::NamedTuple,
-             model
-             )
+    source!(dY::ClimaCore.Fields.FieldVector,
+            src::PhaseChange{FT},
+            Y::ClimaCore.Fields.FieldVector,
+            p::NamedTuple,
+            model
+            )
 
 Computes the source terms for phase change
 explicitly in time.
@@ -899,12 +899,12 @@ in ϑ_l, ρe_int but explicitly in θ_i.
     explicit::Bool = false
 end
 """
-     source!(dY::ClimaCore.Fields.FieldVector,
-             src::SoilSublimation{FT},
-             Y::ClimaCore.Fields.FieldVector,
-             p::NamedTuple,
-             model
-             )
+    source!(dY::ClimaCore.Fields.FieldVector,
+            src::SoilSublimation{FT},
+            Y::ClimaCore.Fields.FieldVector,
+            p::NamedTuple,
+            model
+            )
 
 Updates dY.soil.θ_i in place with a term due to sublimation; this only affects
 the surface layer of soil.
@@ -1334,7 +1334,7 @@ end
         Y,
         p,
         t,
-)
+    )
 
 A function which updates `surface_field` in place with the value for
 the total liquid water volume per unit ground area for the `EnergyHydrology`.
@@ -1366,7 +1366,7 @@ end
         Y,
         p,
         t,
-)
+    )
 
 A function which updates `surface_field` in place with the value for
 the total energy per unit ground area for the `EnergyHydrology`.

--- a/src/standalone/Soil/retention_models.jl
+++ b/src/standalone/Soil/retention_models.jl
@@ -44,7 +44,7 @@ function vanGenuchten{FT}(; α::FT, n::FT) where {FT}
 end
 
 """
-   BrooksCorey{FT} <: AbstractSoilHydrologyClosure{FT}
+    BrooksCorey{FT} <: AbstractSoilHydrologyClosure{FT}
 
 The Brooks and Corey soil hydrology closure, chosen when the
 hydraulic conductivity and matric potential are modeled

--- a/src/standalone/Soil/rre.jl
+++ b/src/standalone/Soil/rre.jl
@@ -54,13 +54,13 @@ A model for simulating the flow of water in a porous medium
 by solving the Richardson-Richards Equation.
 
 A variety of boundary condition types are supported, including
-FluxBC, RichardsAtmosDrivenFluxBC, MoistureStateBC, and FreeDrainage
+`FluxBC`, `RichardsAtmosDrivenFluxBC`, `MoistureStateBC`, and `FreeDrainage`
 (only for the bottom of the domain).
 
-If you wish to
-simulate soil hydrology under the context of a prescribed precipitation
-volume flux (m/s) as a function of time, the RichardsAtmosDrivenFluxBC
-type should be chosen. Please see the documentation for more details.
+If you wish to simulate soil hydrology under the context of a prescribed
+precipitation volume flux (m/s) as a function of time, the
+`RichardsAtmosDrivenFluxBC` type should be chosen. Please see the documentation
+for more details.
 
 $(DocStringExtensions.FIELDS)
 """
@@ -485,7 +485,7 @@ end
         Y,
         p,
         t,
-)
+    )
 
 A function which updates `surface_field` in place with the value for
 the total liquid water volume per unit ground area for the `RichardsModel`.

--- a/src/standalone/Soil/soil_albedo.jl
+++ b/src/standalone/Soil/soil_albedo.jl
@@ -56,14 +56,14 @@ end
         SF <: Union{FT, ClimaCore.Fields.Field},
     } <: AbstractSoilAlbedoParameterization
 
-A parameterization for soil albedo: the soil albedo is 
+A parameterization for soil albedo: the soil albedo is
 defined in two bands (PAR and NIR), and can spatially vary or
 be set to scalar. However, it varies temporally due to a
 dependence on soil water content at the surface,
-via the effective saturation S(θ_sfc):
-α = α_wet*S + α_dry*(1-S)
+via the effective saturation S(θ\\_sfc):
+α = α\\_wet*S + α\\_dry*(1-S)
 
-We use a value for θ_sfc averaged over the depth `albedo_calc_top_thickness`.
+We use a value for θ\\_sfc averaged over the depth `albedo_calc_top_thickness`.
 If the model resolution is such that the first layer is thicker than this depth,
 the value from the first layer is used.
 
@@ -128,16 +128,16 @@ Calculates and updates PAR and NIR albedo as a function of volumetric soil water
 the top of the soil. If the soil layers are larger than the specified `albedo_calc_top_thickness`,
 the water content of the top layer is used in the calclulation. For the PAR and NIR bands,
 
-α_band = α_{band,dry} * (1 - S_e) +  α_{band,wet} * (S_e)
+α\\_band = α\\_{band,dry} * (1 - S\\_e) +  α\\_{band,wet} * (S\\_e)
 
-where S_e is the relative soil wetness above some depth, `albedo_calc_top_thickness`. This
+where S\\_e is the relative soil wetness above some depth, `albedo_calc_top_thickness`. This
 is a modified version of Equation (1) of:
 
 Braghiere, R. K., Wang, Y., Gagné-Landmann, A., Brodrick, P. G., Bloom, A. A., Norton,
 A. J., et al. (2023). The importance of hyperspectral soil albedo information for improving
 Earth system model projections. AGU Advances, 4, e2023AV000910. https://doi.org/10.1029/2023AV000910
 
-where effective saturation is used in place of volumetric soil water content.The dry and wet
+where effective saturation is used in place of volumetric soil water content. The dry and wet
 albedo values come from a global soil color map and soil color to albedo map from CLM.
 
 CLM reference: Lawrence, P.J., and Chase, T.N. 2007. Representing a MODIS consistent land surface in the Community Land Model

--- a/src/standalone/Soil/soil_hydrology_parameterizations.jl
+++ b/src/standalone/Soil/soil_hydrology_parameterizations.jl
@@ -13,10 +13,10 @@ export volumetric_liquid_fraction,
 
 A pointwise function returning the volumetric liquid fraction
 given the augmented liquid fraction and the effective porosity.
-The output is guaranteed to be in (θ_r, ν_eff].
+The output is guaranteed to be in `(θ_r, ν_eff]`.
 
-For Richards model, ν_eff = ν; and the clipping below is not required,
-(and will do nothing; ν_eff_safe = ν_eff), but we leave it in for a 
+For Richards model, `ν_eff = ν`; and the clipping below is not required,
+(and will do nothing; `ν_eff_safe = ν_eff`), but we leave it in for a
 simpler interface.
 """
 function volumetric_liquid_fraction(ϑ_l::FT, ν_eff::FT, θ_r::FT) where {FT}
@@ -63,7 +63,7 @@ function matric_potential(cm::vanGenuchten{FT}, S::FT) where {FT}
 end
 
 """
-     inverse_matric_potential(cm::vanGenuchten{FT}, ψ::FT) where {FT}
+    inverse_matric_potential(cm::vanGenuchten{FT}, ψ::FT) where {FT}
 
 A point-wise function returning the effective saturation, given
 the matric potential, using the
@@ -127,10 +127,10 @@ function pressure_head(
 end
 
 """
-   dψdϑ(cm::vanGenuchten{FT}, ϑ, ν_eff, θ_r, S_s)
+    dψdϑ(cm::vanGenuchten{FT}, ϑ, ν_eff, θ_r, S_s)
 
 Computes and returns the derivative of the pressure head
-with respect to ϑ for the van Genuchten formulation.
+with respect to `ϑ` for the van Genuchten formulation.
 """
 function dψdϑ(cm::vanGenuchten{FT}, ϑ, ν_eff, θ_r, S_s) where {FT}
     # effective saturation clips ν_eff and ϑ
@@ -153,7 +153,7 @@ end
 
 
 """
-     hydraulic_conductivity(cm::vanGenuchten{FT}, K_sat::FT, S::FT) where {FT}
+    hydraulic_conductivity(cm::vanGenuchten{FT}, K_sat::FT, S::FT) where {FT}
 
 A point-wise function returning the hydraulic conductivity, using the
 van Genuchten formulation.
@@ -186,7 +186,7 @@ function matric_potential(cm::BrooksCorey{FT}, S::FT) where {FT}
 end
 
 """
-     inverse_matric_potential(cm::BrooksCorey{FT}, ψ::FT) where {FT}
+    inverse_matric_potential(cm::BrooksCorey{FT}, ψ::FT) where {FT}
 
 A point-wise function returning the effective saturation, given
 the matric potential, using the

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -443,7 +443,7 @@ end
         g1 = clm_medlyn_g1(domain.space.surface),
     ) where {FT <: AbstractFloat}
 
-Creates a MedlynConductanceModel using default parameters of type FT.
+Creates a `MedlynConductanceModel` using default parameters of type `FT`.
 
 The `conductance_parameters` argument is a NamedTuple that contains
 - `g1`: a Float or ClimaCore Field representing the slope parameter (PA^{1/2})
@@ -663,7 +663,7 @@ end
         sif = Lee2015SIFModel{FT}(),
     ) where {FT, PSE}
 
-Creates a CanopyModel with the provided domain, forcing, and parameters.
+Creates a `CanopyModel` with the provided `domain`, `forcing`, and `parameters`.
 
 Defaults are provided for each canopy component model, which can be overridden
 by passing in a different instance of that type of model. Default parameters are also provided
@@ -671,11 +671,12 @@ for each canopy component, and can be changed with keyword arguments. Please see
 of each component model for details on the default parameters.
 
 The required argument `forcing` should be a NamedTuple with the following field:
-- `atmos`: a PrescribedAtmosphere or CoupledAtmosphere object
-- `radiation`: a PrescribedRadiativeFluxes or CoupledRadiativeFluxes object
-- `ground`: a PrescribedGroundConditions or PrognosticGroundConditions object
+- `atmos`: a `PrescribedAtmosphere` or `CoupledAtmosphere` object
+- `radiation`: a `PrescribedRadiativeFluxes` or `CoupledRadiativeFluxes` object
+- `ground`: a `PrescribedGroundConditions` or `PrognosticGroundConditions` object
 
-The required argument `LAI` should be a ClimaUtilities TimeVaryingInput for leaf area index.
+The required argument `LAI` should be a `ClimaUtilities.TimeVaryingInputs.TimeVaryingInput`
+for leaf area index.
 
 When running the canopy model in standalone mode, set `prognostic_land_components = (:canopy,)`,
 while for running integrated land models, this should be a list of the individual models.
@@ -1092,7 +1093,7 @@ Base.broadcastable(C::CanopyModel) = tuple(C)
         Y,
         p,
         t,
-)
+    )
 
 A function which updates `surface_field` in place with the value for
 the total energy per unit ground area for the `CanopyModel`.
@@ -1117,7 +1118,7 @@ end
         Y,
         p,
         t,
-)
+    )
 
 A function which updates `surface_field` in place with the value for
 the total liquid water volume per unit ground area for the `CanopyModel`.

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -326,8 +326,8 @@ prognostic_vars(model::PlantHydraulicsModel) = (:ϑ_l,)
 
 A function which returns the names of the auxiliary
 variables of the `PlantHydraulicsModel`,
-the water potential `ψ` (m), the volume flux*cross section `fa` (1/s),
-and the volume flux*root cross section in the roots `fa_roots` (1/s),
+the water potential `ψ` (m), the volume flux\\*cross section `fa` (1/s),
+and the volume flux\\*root cross section in the roots `fa_roots` (1/s),
 where the cross section can be represented by an area index.
 """
 auxiliary_vars(model::PlantHydraulicsModel) = (:ψ, :fa, :fa_roots, :area_index)
@@ -418,9 +418,9 @@ mean for effective conducticity between the two layers
 
 To account for different path lengths in the two compartments Δz1 and
 Δz2, we would require the following conductance k (1/s)
-k_eff = K1/Δz1*K2/Δz2/(K1/Δz1+K2/Δz2)
+k\\_eff = K1/Δz1*K2/Δz2/(K1/Δz1+K2/Δz2)
 and a water flux of
-F = -k_eff * (ψ1 +z1 - ψ2 - z2) (m/s).
+F = -k\\_eff * (ψ1 +z1 - ψ2 - z2) (m/s).
 
 This currently assumes the path lengths are equal.
 """

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -27,7 +27,7 @@ abstract type AbstractCanopyBC <: ClimaLand.AbstractBC end
     } <: AbstractCanopyBC
 
 A struct used to specify the canopy fluxes, referred
-to as ``boundary conditions", at the surface and
+to as "boundary conditions", at the surface and
 bottom of the canopy, for water and energy.
 
 These fluxes include turbulent surface fluxes

--- a/src/standalone/Vegetation/canopy_energy.jl
+++ b/src/standalone/Vegetation/canopy_energy.jl
@@ -9,8 +9,8 @@ export PrescribedCanopyTempModel,
 """
     AbstractCanopyEnergyModel{FT}
 
-An abstract struct for the Canopy Energy Models. Both PrescribedCanopyTempModel and
-BigLeafEnergyModel are subtypes of this abstract type.
+An abstract struct for the Canopy Energy Models. Both `PrescribedCanopyTempModel` and
+`BigLeafEnergyModel` are subtypes of this abstract type.
 """
 abstract type AbstractCanopyEnergyModel{FT} <: AbstractCanopyComponent{FT} end
 

--- a/src/standalone/Vegetation/component_models.jl
+++ b/src/standalone/Vegetation/component_models.jl
@@ -45,7 +45,7 @@ passed in as an argument.
 ClimaLand.prognostic_vars(::AbstractCanopyComponent) = ()
 
 """
-   prognostic_domain_names(m::AbstractCanopyComponent)
+    prognostic_domain_names(m::AbstractCanopyComponent)
 
 Returns the domain names for the prognostic variables in the form of a tuple.
 """
@@ -60,7 +60,7 @@ passed in as an argument.
 ClimaLand.auxiliary_vars(::AbstractCanopyComponent) = ()
 
 """
-   auxiliary_domain_names(m::AbstractCanopyComponent)
+    auxiliary_domain_names(m::AbstractCanopyComponent)
 
 Returns the domain names for the auxiliary variables in the form of a tuple.
 """

--- a/src/standalone/Vegetation/photosynthesis_farquhar.jl
+++ b/src/standalone/Vegetation/photosynthesis_farquhar.jl
@@ -73,7 +73,7 @@ end
 Base.eltype(::FarquharParameters{FT}) where {FT} = FT
 
 """
-   FarquharModel{FT, FP <: FarquharParameters{FT}}
+    FarquharModel{FT, FP <: FarquharParameters{FT}}
 
 A photosynthesis model taking leaf-level Vcmax25 and multiple other
 constants and predicting dark respiration at the leaf level, net

--- a/src/standalone/Vegetation/pmodel.jl
+++ b/src/standalone/Vegetation/pmodel.jl
@@ -175,15 +175,15 @@ end
            F <: Union{FT, ClimaCore.Fields.Field},
            } <: AbstractPhotosynthesisModel{FT}
 
-    An implementation of the optimality photosynthesis model "P-model v1.0" of Stocker et al. (2020).
+An implementation of the optimality photosynthesis model "P-model v1.0" of Stocker et al. (2020).
 
-    Stocker, B. D., Wang, H., Smith, N. G., Harrison, S. P., Keenan, T. F., Sandoval, D., Davis, T.,
-        and Prentice, I. C.: P-model v1.0: an optimality-based light use efficiency model for simulating
-        ecosystem gross primary production, Geosci. Model Dev., 13, 1545–1581,
-        https://doi.org/10.5194/gmd-13-1545-2020, 2020.
+Stocker, B. D., Wang, H., Smith, N. G., Harrison, S. P., Keenan, T. F., Sandoval, D., Davis, T.,
+    and Prentice, I. C.: P-model v1.0: an optimality-based light use efficiency model for simulating
+    ecosystem gross primary production, Geosci. Model Dev., 13, 1545–1581,
+    https://doi.org/10.5194/gmd-13-1545-2020, 2020.
 
-    The P-model computes photosynthesis rates at the canopy level, and ci, Γstar, Ko, Kc are in
-    units of Pa.
+The P-model computes photosynthesis rates at the canopy level, and ci, Γstar, Ko, Kc are in
+units of Pa.
 """
 struct PModel{
     FT,
@@ -284,22 +284,22 @@ Args:
 
 Returns: named tuple with the following keys and descriptions:
 Output name         Description (units)
-    "gpp"           Gross primary productivity (kg m^-2 s^-1)
-    "gammastar"     CO2 compensation point (Pa)
-    "kmm"           Effective MM coefficient for Rubisco-limited photosynthesis (Pa)
-    "ns_star"       Viscosity of water normalized to 25 deg C (unitless)
-    "chi"           Optimal ratio of intercellular to ambient CO2 (unitless)
-    "xi"            Sensitivity of χ to VPD (Pa^1/2)
-    "mj"            CO2 limitation factor for light-limited photosynthesis (unitless)
-    "mc"            CO2 limitation factor for Rubisco-limited photosynthesis (unitless)
-    "ci"            Intercellular CO2 concentration (Pa)
-    "iwue"          Intrinsic water use efficiency (Pa)
-    "gs"            Stomatal conductance (mol m^-2 s^-1 Pa^-1)
-    "vcmax"         Maximum rate of carboxlation (mol m^-2 s^-1)
-    "vcmax25"       Vcmax normalized to 25°C via modified-Arrhenius type function (mol m^-2 s^-1)
-    "jmax"          Maximum rate of electron transport (mol m^-2 s^-1)
-    "jmax25"        Jmax normalized to 25°C via modified-Arrhenius type function (mol m^-2 s^-1)
-    "Rd"            Dark respiration rate (mol m^-2 s^-1)
+- "gpp"           Gross primary productivity (kg m^-2 s^-1)
+- "gammastar"     CO2 compensation point (Pa)
+- "kmm"           Effective MM coefficient for Rubisco-limited photosynthesis (Pa)
+- "ns_star"       Viscosity of water normalized to 25 deg C (unitless)
+- "chi"           Optimal ratio of intercellular to ambient CO2 (unitless)
+- "xi"            Sensitivity of χ to VPD (Pa^1/2)
+- "mj"            CO2 limitation factor for light-limited photosynthesis (unitless)
+- "mc"            CO2 limitation factor for Rubisco-limited photosynthesis (unitless)
+- "ci"            Intercellular CO2 concentration (Pa)
+- "iwue"          Intrinsic water use efficiency (Pa)
+- "gs"            Stomatal conductance (mol m^-2 s^-1 Pa^-1)
+- "vcmax"         Maximum rate of carboxlation (mol m^-2 s^-1)
+- "vcmax25"       Vcmax normalized to 25°C via modified-Arrhenius type function (mol m^-2 s^-1)
+- "jmax"          Maximum rate of electron transport (mol m^-2 s^-1)
+- "jmax25"        Jmax normalized to 25°C via modified-Arrhenius type function (mol m^-2 s^-1)
+- "Rd"            Dark respiration rate (mol m^-2 s^-1)
 """
 function compute_full_pmodel_outputs(
     parameters::PModelParameters{FT},
@@ -1487,7 +1487,6 @@ end
 Computes the unitless factor `mc = (ci - Γstar)/(ci+Kmm)` (for C3 plants)
 and `mj = 1` for C4 plants, where the light assimilation rate is Aj = J/4 mj.
 """
-
 function compute_mc(is_c3::AbstractFloat, args...)
     return is_c3 > 0.5 ? c3_compute_mc(args...) : c4_compute_mc(args...)
 end

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -252,8 +252,8 @@ end
 """
     ground_albedo_PAR(prognostic_land_components::Val{(:canopy,)}, ground::PrescribedGroundConditions, _...)
 
-Returns the ground albedo in the PAR for a PrescribedGroundConditions driver. In this case,
-the prognostic_land_components only contain `:canopy`, because the canopy is being run in standalone
+Returns the ground albedo in the PAR for a `PrescribedGroundConditions` driver. In this case,
+the `prognostic_land_components` only contain `:canopy`, because the canopy is being run in standalone
 mode.
 """
 function ground_albedo_PAR(
@@ -267,8 +267,8 @@ end
 """
     ground_albedo_NIR(prognostic_land_components::Val{(:canopy,)}, ground::PrescribedGroundConditions, _...)
 
-Returns the ground albedo in the NIR for a PrescribedGroundConditions driver. In this case,
-the prognostic_land_components only contain `:canopy`, because the canopy is being run in standalone
+Returns the ground albedo in the NIR for a `PrescribedGroundConditions` driver. In this case,
+the `prognostic_land_components` only contain `:canopy`, because the canopy is being run in standalone
 mode.
 """
 function ground_albedo_NIR(


### PR DESCRIPTION
This PR clean up the documentation a bit more. For example, the function signatures were not properly aligned with four spaces which lead to inconsistent formatting. Also, this PR changes `_` to `\\_` when appropriate.