### PR TITLE
remove parameteric types in canopy make functions

### DIFF
--- a/src/shared_utilities/Domains.jl
+++ b/src/shared_utilities/Domains.jl
@@ -858,11 +858,11 @@ corresponding to the surface, with values equal to the topmost level.
 """
 function top_center_to_surface(center_field::ClimaCore.Fields.Field)
     center_space = axes(center_field)
-    N_minus_half = ClimaCore.Spaces.nlevels(center_space)
+    N = ClimaCore.Spaces.nlevels(center_space)
     surface_space = obtain_surface_space(center_space)
     return ClimaCore.Fields.Field(
         ClimaCore.Fields.field_values(
-            ClimaCore.Fields.level(center_field, N_minus_half),
+            ClimaCore.Fields.level(center_field, N),
         ),
         surface_space,
     )

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -879,18 +879,9 @@ function initialize_boundary_vars(model::CanopyModel{FT}, coords) where {FT}
 end
 
 """
-     ClimaLand.make_update_aux(canopy::CanopyModel{FT,
-                                                  <:AutotrophicRespirationModel,
-                                                  <:AbstractRadiationModel,
-                                                  <:AbstractPhotosynthesisModel,
-                                                  <:AbstractStomatalConductanceModel,
-                                                  <:PlantHydraulicsModel,},
-                              ) where {FT}
+     ClimaLand.make_update_aux(canopy::CanopyModel)
 
-Creates the `update_aux!` function for the `CanopyModel`; a specific
-method for `update_aux!` for the case where the canopy model components
-are of the type in the parametric type signature: `AutotrophicRespirationModel`, `AbstractRadiationModel`,
-`FarquharModel`, `MedlynConductanceModel`, and `PlantHydraulicsModel`.
+Creates the `update_aux!` function for the `CanopyModel`
 
 Please note that the plant hydraulics model has auxiliary variables
 that are updated in its prognostic `compute_exp_tendency!` function.
@@ -901,17 +892,7 @@ The other sub-components rely heavily on each other,
 so the version of the `CanopyModel` with these subcomponents
 has a single update_aux! function, given here.
 """
-function ClimaLand.make_update_aux(
-    canopy::CanopyModel{
-        FT,
-        <:AutotrophicRespirationModel,
-        <:AbstractRadiationModel,
-        <:AbstractPhotosynthesisModel,
-        <:AbstractStomatalConductanceModel,
-        <:PlantHydraulicsModel,
-        <:AbstractCanopyEnergyModel,
-    },
-) where {FT}
+function ClimaLand.make_update_aux(canopy::CanopyModel)
     function update_aux!(p, Y, t)
 
         # Extend to other fields when necessary
@@ -952,17 +933,7 @@ end
 
 Creates and returns the compute_exp_tendency! for the `CanopyModel`.
 """
-function make_compute_exp_tendency(
-    canopy::CanopyModel{
-        FT,
-        <:AutotrophicRespirationModel,
-        <:AbstractRadiationModel,
-        <:AbstractPhotosynthesisModel,
-        <:AbstractStomatalConductanceModel,
-        <:PlantHydraulicsModel,
-        <:AbstractCanopyEnergyModel,
-    },
-) where {FT}
+function make_compute_exp_tendency(canopy::CanopyModel)
     components = canopy_components(canopy)
     compute_exp_tendency_list = map(
         x -> make_compute_exp_tendency(getproperty(canopy, x), canopy),
@@ -982,17 +953,7 @@ end
 
 Creates and returns the compute_imp_tendency! for the `CanopyModel`.
 """
-function make_compute_imp_tendency(
-    canopy::CanopyModel{
-        FT,
-        <:AutotrophicRespirationModel,
-        <:AbstractRadiationModel,
-        <:AbstractPhotosynthesisModel,
-        <:AbstractStomatalConductanceModel,
-        <:PlantHydraulicsModel,
-        <:AbstractCanopyEnergyModel,
-    },
-) where {FT}
+function make_compute_imp_tendency(canopy::CanopyModel)
     components = canopy_components(canopy)
     compute_imp_tendency_list = map(
         x -> make_compute_imp_tendency(getproperty(canopy, x), canopy),
@@ -1012,17 +973,7 @@ end
 
 Creates and returns the compute_jacobian! for the `CanopyModel`.
 """
-function ClimaLand.make_compute_jacobian(
-    canopy::CanopyModel{
-        FT,
-        <:AutotrophicRespirationModel,
-        <:AbstractRadiationModel,
-        <:AbstractPhotosynthesisModel,
-        <:AbstractStomatalConductanceModel,
-        <:PlantHydraulicsModel,
-        <:AbstractCanopyEnergyModel,
-    },
-) where {FT}
+function ClimaLand.make_compute_jacobian(canopy::CanopyModel)
     components = canopy_components(canopy)
     update_jacobian_list = map(
         x -> make_compute_jacobian(getproperty(canopy, x), canopy),

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -154,15 +154,7 @@ end
 
 """
     canopy_boundary_fluxes!(p::NamedTuple,
-                            canopy::CanopyModel{
-                                FT,
-                                <:AutotrophicRespirationModel,
-                                <:AbstractRadiationModel,
-                                <:AbstractPhotosynthesisModel,
-                                <:AbstractStomatalConductanceModel,
-                                <:PlantHydraulicsModel,
-                                <:AbstractCanopyEnergyModel}
-                            },
+                            canopy::CanopyModel,
                             Y::ClimaCore.Fields.FieldVector,
                             t,
                             ) where {FT}
@@ -180,15 +172,7 @@ within the explicit tendency of the canopy model.
 """
 function canopy_boundary_fluxes!(
     p::NamedTuple,
-    canopy::CanopyModel{
-        FT,
-        <:AutotrophicRespirationModel,
-        <:AbstractRadiationModel,
-        <:AbstractPhotosynthesisModel,
-        <:AbstractStomatalConductanceModel,
-        <:PlantHydraulicsModel,
-        <:AbstractCanopyEnergyModel,
-    },
+    canopy::CanopyModel,
     Y::ClimaCore.Fields.FieldVector,
     t,
 ) where {FT}

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -157,7 +157,7 @@ end
                             canopy::CanopyModel,
                             Y::ClimaCore.Fields.FieldVector,
                             t,
-                            ) where {FT}
+                            )
 
 Computes the boundary fluxes for the canopy prognostic
 equations; updates the specific fields in the auxiliary
@@ -175,7 +175,7 @@ function canopy_boundary_fluxes!(
     canopy::CanopyModel,
     Y::ClimaCore.Fields.FieldVector,
     t,
-) where {FT}
+)
     bc = canopy.boundary_conditions
     radiation = bc.radiation
     atmos = bc.atmos


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
We do not dispatch off them; these are not needed.

They also can lead to bugs when new canopy components are introduced (if these are not all updated to reflect that)


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
