### PR TITLE
follow UTC offset sign convention; fix Ozark timezone

### DIFF
--- a/docs/src/tutorials/shared_utilities/driver_tutorial.jl
+++ b/docs/src/tutorials/shared_utilities/driver_tutorial.jl
@@ -49,8 +49,8 @@ import ClimaParams
 
 # Assume the local_datetime array is read in from the data file.
 local_datetime = DateTime(2013):Dates.Hour(1):DateTime(2013, 1, 7); # one week, hourly data
-# Timezone (offset of local time from UTC in hrs)
-time_offset = 7;
+# Timezone (offset of local time from UTC in hrs) for the Missouri Ozark site
+time_offset = -6;
 # Site latitude and longitude
 lat = 38.7441; # degree
 long = -92.2000; # degree

--- a/experiments/standalone/Vegetation/no_vegetation.jl
+++ b/experiments/standalone/Vegetation/no_vegetation.jl
@@ -26,7 +26,7 @@ default_params_filepath =
     joinpath(pkgdir(ClimaLand), "toml", "default_parameters.toml")
 toml_dict = LP.create_toml_dict(FT, default_params_filepath)
 
-time_offset = 7
+time_offset = -6
 lat = FT(38.7441) # degree
 long = FT(-92.2000) # degree
 land_domain = Point(; z_sfc = FT(0.0), longlat = (long, lat))

--- a/experiments/standalone/Vegetation/timestep_test.jl
+++ b/experiments/standalone/Vegetation/timestep_test.jl
@@ -67,7 +67,7 @@ default_params_filepath =
 toml_dict = LP.create_toml_dict(FT, default_params_filepath)
 
 # Site-specific information
-time_offset = 7 # difference from UTC in hours
+time_offset = -6 # difference from UTC in hours
 lat = FT(38.7441) # degree
 long = FT(-92.2000) # degree
 land_domain = Point(; z_sfc = FT(0.0), longlat = (long, lat))

--- a/experiments/standalone/Vegetation/varying_lai.jl
+++ b/experiments/standalone/Vegetation/varying_lai.jl
@@ -25,7 +25,7 @@ default_params_filepath =
     joinpath(pkgdir(ClimaLand), "toml", "default_parameters.toml")
 toml_dict = LP.create_toml_dict(FT, default_params_filepath)
 
-time_offset = 7
+time_offset = -6
 lat = FT(38.7441) # degree
 long = FT(-92.2000) # degree
 land_domain = Point(; z_sfc = FT(0.0), longlat = (long, lat))

--- a/experiments/standalone/Vegetation/varying_lai_with_stem.jl
+++ b/experiments/standalone/Vegetation/varying_lai_with_stem.jl
@@ -25,7 +25,7 @@ default_params_filepath =
     joinpath(pkgdir(ClimaLand), "toml", "default_parameters.toml")
 toml_dict = LP.create_toml_dict(FT, default_params_filepath)
 
-time_offset = 7
+time_offset = -6
 lat = FT(38.7441) # degree
 long = FT(-92.2000) # degree
 land_domain = Point(; z_sfc = FT(0.0), longlat = (long, lat))

--- a/ext/fluxnet_simulations/US-Ha1.jl
+++ b/ext/fluxnet_simulations/US-Ha1.jl
@@ -32,11 +32,15 @@ end
 Returns geographical information for US-Ha1 (Massachusetts Harvard Forest) Fluxnet site.
 The values are provided as defaults, and can be overwritten by passing the corresponding
 keyword arguments to this function.
+
+The `time_offset` is the difference from UTC in hours
+and excludes daylight savings time, following Fluxnet convention.
+For this site, the local time is UTC-5 for Eastern Standard Time (EST).
 """
 function FluxnetSimulations.get_location(
     FT,
     ::Val{:US_Ha1};
-    time_offset = 5,
+    time_offset = -5,
     lat = FT(42.5378),
     long = FT(-72.1715),
 )

--- a/ext/fluxnet_simulations/US-MOz.jl
+++ b/ext/fluxnet_simulations/US-MOz.jl
@@ -32,11 +32,15 @@ end
 Returns geographical information for US-MOz (Missouri Ozark) Fluxnet site.
 The values are provided as defaults, and can be overwritten by passing the
 corresponding keyword arguments to this function.
+
+The `time_offset` is the difference from UTC in hours
+and excludes daylight savings time, following Fluxnet convention.
+For this site, the local time is UTC-6 for Central Standard Time (CST).
 """
 function FluxnetSimulations.get_location(
     FT,
     ::Val{:US_MOz};
-    time_offset = 7,
+    time_offset = -6,
     lat = FT(38.7441),
     long = FT(-92.2000),
 )

--- a/ext/fluxnet_simulations/US-NR1.jl
+++ b/ext/fluxnet_simulations/US-NR1.jl
@@ -32,11 +32,15 @@ end
 Returns geographical information for US-NR1 (Colorado Niwot Ridge) Fluxnet site.
 The values are provided as defaults, and can be overwritten by passing the
 corresponding keyword arguments to this function.
+
+The `time_offset` is the difference from UTC in hours
+and excludes daylight savings time, following Fluxnet convention.
+For this site, the local time is UTC-7 for Mountain Standard Time (MST).
 """
 function FluxnetSimulations.get_location(
     FT,
     ::Val{:US_NR1};
-    time_offset = 7,
+    time_offset = -7,
     lat = FT(40.0329),
     long = FT(-105.5464),
 )

--- a/ext/fluxnet_simulations/US-Var.jl
+++ b/ext/fluxnet_simulations/US-Var.jl
@@ -31,11 +31,15 @@ end
 Returns geographical information for US-Var (California Vaira Ranch Ione) Fluxnet site.
 The values are provided as defaults, and can be overwritten by passing the
 corresponding keyword arguments to this function.
+
+The `time_offset` is the difference from UTC in hours
+and excludes daylight savings time, following Fluxnet convention.
+For this site, the local time is UTC-8 for Pacific Standard Time (PST).
 """
 function FluxnetSimulations.get_location(
     FT,
     ::Val{:US_Var};
-    time_offset = 8,
+    time_offset = -8,
     lat = FT(38.4133),
     long = FT(-120.9508),
 )

--- a/ext/fluxnet_simulations/forcing.jl
+++ b/ext/fluxnet_simulations/forcing.jl
@@ -93,7 +93,7 @@ function FluxnetSimulations.prescribed_forcing_fluxnet(
     local_datetime =
         local_datetime_start .+
         (local_datetime_end .- local_datetime_start) ./ 2
-    UTC_datetime = local_datetime .+ Dates.Hour(hour_offset_from_UTC)
+    UTC_datetime = local_datetime .- Dates.Hour(hour_offset_from_UTC)
 
     # The TimeVaryingInput interface for columns expects the time in seconds
     # from the start date of the simulation
@@ -227,11 +227,11 @@ end
     get_maxLAI_at_site(date, lat, long;
                        ncd_path = ClimaLand.Artifacts.modis_lai_single_year_path(;year = Dates.year(date)))
 
-A helper function to get the maximum LAI at a site from the MODIS LAI data for the 
-year corresponding to `date`. This is used in some simulations to 
+A helper function to get the maximum LAI at a site from the MODIS LAI data for the
+year corresponding to `date`. This is used in some simulations to
 set the root area index.
 
-By default, this uses MODIS data for the year desired; the default file 
+By default, this uses MODIS data for the year desired; the default file
 at `ncd_path` is expected to contain latitude and longitude in variables
 "lat" and "lon", and LAI in the variable "lai". The function finds the maximum LAI
 at the closest latitude and longitude to the given `lat` and `long` values over all dates
@@ -332,7 +332,7 @@ function FluxnetSimulations.get_data_dates(
     local_datetime =
         local_datetime_start .+
         (local_datetime_end .- local_datetime_start) ./ 2
-    UTC_datetime = local_datetime .+ Dates.Hour(hour_offset_from_UTC)
+    UTC_datetime = local_datetime .- Dates.Hour(hour_offset_from_UTC)
     earliest_date, latest_date = extrema(UTC_datetime)
     Dates.value(start_offset) < 0 && error("start_offset must be non-negative")
     if !isnothing(duration) && Dates.value(duration) < 0
@@ -423,7 +423,7 @@ ClimaLand diagnostics are averaged, accumulated, or otherwise reduced
 over a time period (e.g. hourly, daily, monthly). They are saved with the first date following
 that average period. For example, the hourly average from 11-noon is saved with a timestamp of
 noon. To make a true comparison to Fluxnet data, therefore, we must use halfhourly diagnostics in ClimaLAnd,
-and return the UTC time that corresponds to the end 
+and return the UTC time that corresponds to the end
 of the averaging period in fluxnet; this is true by default. If `timestamp_end = false`,
 we return the point halfway between TIMESTAMP_START and TIMESTAMP_END
 """
@@ -459,9 +459,9 @@ function FluxnetSimulations.get_comparison_data(
             string.(Int.(data[:, column_name_map["TIMESTAMP_END"]])),
             "yyyymmddHHMM",
         )
-    data_dt = Second(local_datetime_end[2] - local_datetime_end[1]).value # seconds  
+    data_dt = Second(local_datetime_end[2] - local_datetime_end[1]).value # seconds
     if timestamp_end
-        UTC_datetime = local_datetime_end .+ Dates.Hour(hour_offset_from_UTC)
+        UTC_datetime = local_datetime_end .- Dates.Hour(hour_offset_from_UTC)
     else
         local_datetime_start =
             DateTime.(
@@ -471,7 +471,7 @@ function FluxnetSimulations.get_comparison_data(
         local_datetime =
             local_datetime_start .+
             (local_datetime_end .- local_datetime_start) ./ 2
-        UTC_datetime = local_datetime .+ Dates.Hour(hour_offset_from_UTC)
+        UTC_datetime = local_datetime .- Dates.Hour(hour_offset_from_UTC)
     end
     gpp = FluxnetSimulations.get_comparison_data(
         data,

--- a/ext/fluxnet_simulations/initial_conditions.jl
+++ b/ext/fluxnet_simulations/initial_conditions.jl
@@ -11,7 +11,7 @@ updates `Y` in place with an estimated set of initial conditions
 based on the fluxnet observations at `site_ID` at the `start_date` in UTC,
 and the type of the `model`.
 In order to convert between local time and UTC, the hour offset from
-UTC is required. 
+UTC is required.
 """
 function FluxnetSimulations.make_set_fluxnet_initial_conditions(
     site_ID,
@@ -51,7 +51,7 @@ function set_fluxnet_ic!(
     (data, columns) = readdlm(fluxnet_csv_path, ','; header = true)
     # Convert local datetime to time in UTC
     local_datetime = DateTime.(string.(Int.(data[:, 1])), "yyyymmddHHMM")
-    UTC_datetime = local_datetime .+ Dates.Hour(hour_offset_from_UTC)
+    UTC_datetime = local_datetime .- Dates.Hour(hour_offset_from_UTC)
     Δ_date = UTC_datetime .- start_date
     for component in ClimaLand.land_components(model)
         set_fluxnet_ic!(Y, data, columns, Δ_date, getproperty(model, component))
@@ -65,11 +65,11 @@ Sets the values of Y.soil in place with:
 - \vartheta_l: observed value of SWC at the surface at the observation date closest to the start date, unless this is larger than 90% of porosity.
 - θ_i: no ice (θ_i = 0)
 - \rho e_int: an internal energy computed using the above θ_l, θ_i, and the temperature of the soil
-  in the first layer, at the observation date closest to the start date. If the soil 
+  in the first layer, at the observation date closest to the start date. If the soil
   temperature is not available, the air temperature is used.
 
 Here, `Y` is the prognostic field vector, `data` is the raw data for the site read from
-a CSV file, `columns` is the list of column names, 
+a CSV file, `columns` is the list of column names,
 `Δ_date` is the vector of date differences between the observations (in UTC) and the
 start date (in UTC), and `model` indicates which part of `Y` we are updating, and how to update it,
 via different methods of `set_fluxnet_ic!`.

--- a/src/shared_utilities/Domains.jl
+++ b/src/shared_utilities/Domains.jl
@@ -861,9 +861,7 @@ function top_center_to_surface(center_field::ClimaCore.Fields.Field)
     N = ClimaCore.Spaces.nlevels(center_space)
     surface_space = obtain_surface_space(center_space)
     return ClimaCore.Fields.Field(
-        ClimaCore.Fields.field_values(
-            ClimaCore.Fields.level(center_field, N),
-        ),
+        ClimaCore.Fields.field_values(ClimaCore.Fields.level(center_field, N)),
         surface_space,
     )
 end

--- a/test/integrated/fluxnet_sim.jl
+++ b/test/integrated/fluxnet_sim.jl
@@ -27,7 +27,7 @@ import ClimaLand.FluxnetSimulations as FluxnetSimulations
     (; time_offset, lat, long) =
         FluxnetSimulations.get_location(FT, Val(site_ID))
 
-    @test time_offset == 5
+    @test time_offset == -5
     @test lat == FT(42.5378)
     @test long == FT(-72.1715)
 
@@ -147,8 +147,8 @@ end
 
     # geographical info
     (; time_offset, lat, long) =
-        FluxnetSimulations.get_location(FT, Val(site_ID), time_offset = 5)
-    @test time_offset == 5
+        FluxnetSimulations.get_location(FT, Val(site_ID))
+    @test time_offset == -6
     @test lat == FT(38.7441)
     @test long == FT(-92.2000)
 
@@ -233,7 +233,7 @@ end
     (; time_offset, lat, long) =
         FluxnetSimulations.get_location(FT, Val(site_ID))
 
-    @test time_offset == 7
+    @test time_offset == -7
     @test lat == FT(40.0329)
     @test long == FT(-105.5464)
 
@@ -317,7 +317,7 @@ end
 
     (; time_offset, lat, long) =
         FluxnetSimulations.get_location(FT, Val(site_ID))
-    @test time_offset == 8
+    @test time_offset == -8
     @test lat == FT(38.4133)
     @test long == FT(-120.9508)
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Up to now, our fluxnet sites have been using UTC offsets that are internally consistent but not following the standard convention. This PR fixes their signs and updates how they're used to remain consistent.

Also, the timezone for MOz was wrong and is now fixed.

## To do
- [ ] check sign of fluxnet2015 dataset utc offsets

## Content
- [x] fix timezone/UTC offset for MOz fluxnet site - previously we had 7 (mountain standard time) but this should be -6 (central standard time)
- [x] fix sign of UTC offsets - for North American sites these should be negative following the standard convention

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
