### PR TITLE
remove PrognosticSoilConditions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ ClimaLand.jl Release Notes
 main
 -------
 
+- Remove `PrognosticSoilConditions` in favor of using `PrognosticGroundConditions` more generally PR[#1411](https://github.com/CliMA/ClimaLand.jl/pull/1411)
+
 v0.20.0
 -------
 - ![][badge-🐛bugfix] Correctly compare atmos/canopy heights when atmos height is Field or Float PR[#1394](https://github.com/CliMA/ClimaLand.jl/pull/1394)

--- a/docs/src/APIs/ClimaLand.md
+++ b/docs/src/APIs/ClimaLand.md
@@ -50,7 +50,6 @@ ClimaLand.RunoffBC
 
 ```@docs
 ClimaLand.RootExtraction
-ClimaLand.PrognosticSoilConditions
 ```
 
 ## LandSoilBiogeochemistry

--- a/docs/src/APIs/Drivers.md
+++ b/docs/src/APIs/Drivers.md
@@ -11,6 +11,7 @@ ClimaLand.PrescribedRadiativeFluxes
 ClimaLand.PrescribedSoilOrganicCarbon
 ClimaLand.CoupledAtmosphere
 ClimaLand.CoupledRadiativeFluxes
+ClimaLand.PrognosticGroundConditions
 ClimaLand.AbstractAtmosphericDrivers
 ClimaLand.AbstractRadiativeDrivers
 ClimaLand.turbulent_fluxes!

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -255,7 +255,7 @@ hydraulics = Canopy.PlantHydraulicsModel{FT}(
 # Set up energy model
 energy = Canopy.BigLeafEnergyModel{FT}(; ac_canopy)
 
-ground = ClimaLand.PrognosticSoilConditions{FT}()
+ground = ClimaLand.PrognosticGroundConditions{FT}()
 canopy_forcing = (; atmos, radiation, ground)
 # Construct the canopy model using defaults for autotrophic respiration and SIF models
 canopy = Canopy.CanopyModel{FT}(

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -87,7 +87,7 @@ drivers = Soil.Biogeochemistry.SoilDrivers(
 soilco2 = Soil.Biogeochemistry.SoilCO2Model{FT}(domain, drivers)
 
 # Now we set up the canopy model, which mostly use defaults for:
-ground = ClimaLand.PrognosticSoilConditions{FT}()
+ground = ClimaLand.PrognosticGroundConditions{FT}()
 canopy_domain = ClimaLand.obtain_surface_domain(domain)
 canopy_forcing = (; atmos, radiation, ground)
 

--- a/experiments/integrated/global/global_soil_canopy_pmodel.jl
+++ b/experiments/integrated/global/global_soil_canopy_pmodel.jl
@@ -89,7 +89,7 @@ drivers = Soil.Biogeochemistry.SoilDrivers(
 soilco2 = Soil.Biogeochemistry.SoilCO2Model{FT}(domain, drivers)
 
 # Now we set up the canopy model, which mostly use defaults for:
-ground = ClimaLand.PrognosticSoilConditions{FT}()
+ground = ClimaLand.PrognosticGroundConditions{FT}()
 canopy_domain = ClimaLand.obtain_surface_domain(domain)
 canopy_forcing = (; atmos, radiation, ground)
 

--- a/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
+++ b/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
@@ -193,7 +193,7 @@ hydraulics = Canopy.PlantHydraulicsModel{FT}(
 # Set up energy model
 energy = Canopy.BigLeafEnergyModel{FT}(; ac_canopy)
 
-ground = ClimaLand.PrognosticSoilConditions{FT}()
+ground = ClimaLand.PrognosticGroundConditions{FT}()
 canopy_forcing = (; atmos, radiation, ground)
 # Construct the canopy model using defaults for autotrophic respiration and SIF models
 canopy = Canopy.CanopyModel{FT}(

--- a/experiments/integrated/performance/integrated_timestep_test.jl
+++ b/experiments/integrated/performance/integrated_timestep_test.jl
@@ -283,7 +283,7 @@ hydraulics = Canopy.PlantHydraulicsModel{FT}(
 z_0m = FT(0.13) * h_canopy
 z_0b = FT(0.1) * z_0m
 canopy_domain = obtain_surface_domain(land_domain)
-ground = ClimaLand.PrognosticSoilConditions{FT}()
+ground = ClimaLand.PrognosticGroundConditions{FT}()
 canopy_forcing = (; atmos, radiation, ground)
 canopy = Canopy.CanopyModel{FT}(
     canopy_domain,

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -262,7 +262,7 @@ end
             (;
                 atmos = forcing.atmos,
                 radiation = forcing.radiation,
-                ground = ClimaLand.PrognosticSoilConditions{FT}(),
+                ground = ClimaLand.PrognosticGroundConditions{FT}(),
             ),
             LAI,
             toml_dict;

--- a/src/integrated/land_radiation.jl
+++ b/src/integrated/land_radiation.jl
@@ -17,7 +17,7 @@ end
 
 """
     Canopy.canopy_radiant_energy_fluxes!(p::NamedTuple,
-                                         s::Union{PrognosticGroundConditions,PrognosticSoilConditions},
+                                         s::PrognosticGroundConditions,
                                          canopy,
                                          radiation::PrescribedRadiativeFluxes,
                                          earth_param_set::PSE,
@@ -37,7 +37,7 @@ and `p.canopy.radiative_transfer.SW_n`.
 """
 function Canopy.canopy_radiant_energy_fluxes!(
     p::NamedTuple,
-    s::Union{PrognosticGroundConditions, PrognosticSoilConditions},
+    s::PrognosticGroundConditions,
     canopy,
     radiation::AbstractRadiativeDrivers,
     earth_param_set::PSE,
@@ -50,7 +50,7 @@ end
 """
     Canopy.ground_albedo_PAR(
         prognostic_land_components::Val{(:canopy, :soil, :soilco2)},
-        ground::PrognosticSoilConditions,
+        ground,
         Y,
         p,
         t,
@@ -60,7 +60,7 @@ A method of Canopy.Canopy.ground_albedo_PAR for a prognostic soil.
 """
 function Canopy.ground_albedo_PAR(
     prognostic_land_components::Val{(:canopy, :soil, :soilco2)},
-    ground::PrognosticSoilConditions,
+    ground,
     Y,
     p,
     t,
@@ -71,7 +71,7 @@ end
 """
     Canopy.ground_albedo_NIR(
         prognostic_land_components::Val{(:canopy, :soil, :soilco2)},
-        ground::PrognosticSoilConditions,
+        ground,
         Y,
         p,
         t,
@@ -81,7 +81,7 @@ A method of Canopy.ground_albedo_NIR for a prognostic soil.
 """
 function Canopy.ground_albedo_NIR(
     prognostic_land_components::Val{(:canopy, :soil, :soilco2)},
-    ground::PrognosticSoilConditions,
+    ground,
     Y,
     p,
     t,
@@ -93,7 +93,7 @@ end
 """
     Canopy.ground_albedo_PAR(
         prognostic_land_components::Val{(:canopy, :snow, :soil, :soilco2)},
-        ground::PrognosticGroundConditions,
+        ground,
         Y,
         p,
         t,
@@ -104,7 +104,7 @@ the Canopy update_aux! function.
 """
 function Canopy.ground_albedo_PAR(
     prognostic_land_components::Val{(:canopy, :snow, :soil, :soilco2)},
-    ground::PrognosticGroundConditions,
+    ground,
     Y,
     p,
     t,
@@ -118,7 +118,7 @@ end
 """
     Canopy.ground_albedo_NIR(
         prognostic_land_components::Val{(:canopy, :snow, :soil, :soilco2)},
-        ground::PrognosticGroundConditions,
+        ground,
         Y,
         p,
         t,
@@ -129,7 +129,7 @@ the Canopy update_aux! function.
 """
 function Canopy.ground_albedo_NIR(
     prognostic_land_components::Val{(:canopy, :snow, :soil, :soilco2)},
-    ground::PrognosticGroundConditions,
+    ground,
     Y,
     p,
     t,

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -68,7 +68,7 @@ struct SoilCanopyModel{
         @assert Soil.PhaseChange{FT}() in soil.sources
         @assert canopy.hydraulics.transpiration isa
                 Canopy.PlantHydraulics.DiagnosticTranspiration{FT}
-        @assert canopy_bc.ground isa PrognosticSoilConditions{FT}
+        @assert canopy_bc.ground isa PrognosticGroundConditions{FT}
         @assert soilco2.drivers.met isa Soil.Biogeochemistry.PrognosticMet
 
         return new{FT, MM, SM, VM}(soilco2, soil, canopy)
@@ -101,7 +101,7 @@ end
             (;
                 atmos = forcing.atmos,
                 radiation = forcing.radiation,
-                ground = ClimaLand.PrognosticSoilConditions{FT}(),
+                ground = ClimaLand.PrognosticGroundConditions{FT}(),
             ),
             LAI,
             toml_dict;
@@ -142,7 +142,7 @@ function SoilCanopyModel{FT}(
         (;
             atmos = forcing.atmos,
             radiation = forcing.radiation,
-            ground = ClimaLand.PrognosticSoilConditions{FT}(),
+            ground = ClimaLand.PrognosticGroundConditions{FT}(),
         ),
         LAI,
         toml_dict;
@@ -218,7 +218,7 @@ function SoilCanopyModel{FT}(;
     )
 
     transpiration = Canopy.PlantHydraulics.DiagnosticTranspiration{FT}()
-    ground_conditions = PrognosticSoilConditions{FT}()
+    ground_conditions = PrognosticGroundConditions{FT}()
     if :energy in propertynames(canopy_component_args)
         energy_model = canopy_component_types.energy(
             canopy_component_args.energy.parameters,

--- a/src/integrated/soil_canopy_root_interactions.jl
+++ b/src/integrated/soil_canopy_root_interactions.jl
@@ -52,7 +52,7 @@ end
 """
     PlantHydraulics.root_water_flux_per_ground_area!(
         fa::ClimaCore.Fields.Field,
-        s::Union{PrognosticSoilConditions, PrognosticGroundConditions},
+        s::PrognosticGroundConditions,
         model::Canopy.PlantHydraulics.PlantHydraulicsModel,
         Y::ClimaCore.Fields.FieldVector,
         p::NamedTuple,
@@ -71,7 +71,7 @@ roots and soil at each soil layer.
 """
 function PlantHydraulics.root_water_flux_per_ground_area!(
     fa::ClimaCore.Fields.Field,
-    s::Union{PrognosticSoilConditions, PrognosticGroundConditions},
+    s::PrognosticGroundConditions,
     model::Canopy.PlantHydraulics.PlantHydraulicsModel,
     Y::ClimaCore.Fields.FieldVector,
     p::NamedTuple,
@@ -83,7 +83,7 @@ end
 """
     root_energy_flux_per_ground_area!(
         fa_energy::ClimaCore.Fields.Field,
-        s::Union{PrognosticSoilConditions, PrognosticGroundConditions},
+        s::PrognosticGroundConditions,
         model::Canopy.AbstractCanopyEnergyModel,
         Y::ClimaCore.Fields.FieldVector,
         p::NamedTuple,
@@ -104,7 +104,7 @@ must account for it as well.
 """
 function Canopy.root_energy_flux_per_ground_area!(
     fa_energy::ClimaCore.Fields.Field,
-    s::Union{PrognosticSoilConditions, PrognosticGroundConditions},
+    s::PrognosticGroundConditions,
     model::Canopy.AbstractCanopyEnergyModel,
     Y::ClimaCore.Fields.FieldVector,
     p::NamedTuple,

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -1128,21 +1128,13 @@ function PrescribedGroundConditions{FT}(;
 end
 
 """
-     PrognosticSoilConditions <: AbstractGroundConditions
-
- A type of AbstractGroundConditions to use when the soil model is prognostic and
-of type `EnergyHydrology`. `PrognosticSoilConditions` functions as a flag and is used for dispatch
-with the canopy model.
-"""
-struct PrognosticSoilConditions{FT} <: AbstractGroundConditions{FT} end
-
-"""
      PrognosticGroundConditions <: Canopy.AbstractGroundConditions
 
-A type of AbstractGroundConditions to use when the soil model is prognostic and
-of type `EnergyHydrology`, and the snow model is prognostic and included.
+A type of AbstractGroundConditions to use when running the CanopyModel
+as part of an integrated model, i.e. with a prognostic `EnergyHydrology`
+soil model and either with or without a snow model.
 
-Note that this struct is linked with the EnergyHydrology/SnowModel model. If we ever had a different
+Note that this struct is linked with the `EnergyHydrology`/`SnowModel` models. If we ever had a different
 soil model, we might need to construct a different `PrognosticGroundConditions` because
 the fields may be stored in different places.
 """

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -591,7 +591,7 @@ of each component model for details on the default parameters.
 The required argument `forcing` should be a NamedTuple with the following field:
 - `atmos`: a PrescribedAtmosphere or CoupledAtmosphere object
 - `radiation`: a PrescribedRadiativeFluxes or CoupledRadiativeFluxes object
-- `ground`: a PrescribedGroundConditions, PrognosticGroundConditions, or PrognosticSoilConditions object
+- `ground`: a PrescribedGroundConditions or PrognosticGroundConditions object
 
 The required argument `LAI` should be a ClimaUtilities TimeVaryingInput for leaf area index.
 

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -6,7 +6,7 @@ import ClimaUtilities.TimeVaryingInputs:
 import ClimaUtilities.TimeManager: ITime
 import NCDatasets, ClimaCore, Interpolations # Needed to load TimeVaryingInputs
 using ..ClimaLand.Canopy: AbstractCanopyComponent, set_canopy_prescribed_field!
-using ClimaLand: AbstractGroundConditions, PrescribedGroundConditions
+using ClimaLand: PrescribedGroundConditions
 using ClimaCore
 import ClimaLand.Parameters as LP
 import ClimaParams as CP

--- a/test/diagnostics/diagnostics_tests.jl
+++ b/test/diagnostics/diagnostics_tests.jl
@@ -301,7 +301,7 @@ end
 end
 
 @testset "Invalid diagnostic variable" begin
-    ground = ClimaLand.PrognosticSoilConditions{FT}()
+    ground = ClimaLand.PrognosticGroundConditions{FT}()
     LAI = TimeVaryingInput((t) -> FT(1.0))
     model = ClimaLand.SoilCanopyModel{FT}(
         (; atmos, radiation, ground),

--- a/test/integrated/soil_canopy_lsm.jl
+++ b/test/integrated/soil_canopy_lsm.jl
@@ -46,7 +46,7 @@ for FT in (Float32, Float64)
         # Canopy model
         canopy_domain = ClimaLand.Domains.obtain_surface_domain(domain)
         LAI = TimeVaryingInput((t) -> FT(1.0))
-        ground = ClimaLand.PrognosticSoilConditions{FT}()
+        ground = ClimaLand.PrognosticGroundConditions{FT}()
         canopy_forcing = (; atmos, radiation, ground)
         canopy = Canopy.CanopyModel{FT}(
             canopy_domain,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Instead of having two types `PrognosticSoilConditions` and `PrognosticGroundConditions`, use `PrognosticGroundConditions` anytime the canopy is run as part of an integrated model. Dispatch on `prognostic_land_components` instead wherever necessary.

closes #1272

## Content
- [x] in ground albedo functions, dispatch on `prognostic_land_components` instead of `PrognosticXConditions` type
- [x] use `PrognosticGroundConditions` instead of `PrognosticSoilConditions` for SoilCanopyModel


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
