### PR TITLE
water content instead of matric potential in prescribed ground

### DIFF
--- a/docs/src/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/src/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -123,13 +123,13 @@ domain = Point(; z_sfc = FT(0.0), longlat = (long, lat));
 
 # For this canopy, we are running in standalone mode, which means we need to
 # use a prescribed soil driver, defined as follows:
-ψ_soil = FT(0.0)
+θ_soil = FT(0.47)
 T_soil = FT(298.0)
 ground = PrescribedGroundConditions{FT}(;
     α_PAR = FT(0.2),
     α_NIR = FT(0.4),
     T = TimeVaryingInput(t -> T_soil),
-    ψ = TimeVaryingInput(t -> ψ_soil),
+    θ = TimeVaryingInput(t -> θ_soil),
     ϵ = FT(0.99),
 );
 forcing = (; atmos, radiation, ground);

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -51,7 +51,7 @@ Base.@kwdef struct EnergyHydrologyParameters{
     K_sat::F
     "The specific storativity (1/m)"
     S_s::F
-    "The residual water fraction (m^3/m^3"
+    "The residual water fraction (m^3/m^3)"
     θ_r::F
     "Ice impedance factor for the hydraulic conductivity"
     Ω::FT
@@ -106,7 +106,7 @@ Base.broadcastable(ps::EnergyHydrologyParameters) = tuple(ps)
 EnergyHydrologyParameters has two constructors: float-type and toml dict based.
 Additional parameters must be added manually: `ν`, `ν_ss_om`, `ν_ss_quartz`,
 `ν_ss_gravel`, `hydrology_cm``, `K_sat`, `S_s`, and `θ_r`. All parameters can be
-manually overriden via keyword arguments. Note, however, that certain parameters
+manually overridden via keyword arguments. Note, however, that certain parameters
 must have the same type (e.g, if a field is supplied for porosity, it must be
 supplied for all other parameters defined in the interior of the domain). Some
 parameters are defined only on the surface of the domain (e.g albedo), while

--- a/src/standalone/Soil/rre.jl
+++ b/src/standalone/Soil/rre.jl
@@ -16,7 +16,7 @@ struct RichardsParameters{
     K_sat::F
     "The specific storativity (1/m)"
     S_s::F
-    "The residual water fraction (m^3/m^3"
+    "The residual water fraction (m^3/m^3)"
     θ_r::F
 end
 

--- a/src/standalone/Soil/spatially_varying_parameters.jl
+++ b/src/standalone/Soil/spatially_varying_parameters.jl
@@ -27,17 +27,17 @@ of CLM data for the PAR and NIR albedo of wet and dry soil.
 
 The NetCDF files are stored in ClimaArtifacts and more detail on their origin
 is provided there. The keyword arguments `regridder_type`, `extrapolation_bc`, and
-`interpolation_method` 
+`interpolation_method`
 affect the regridding by (1) changing how we interpolate to ClimaCore points which
 are not in the data, and (2) changing how extrapolate to points beyond the range of the
-data, and (3) changed the spatial interpolation method. 
+data, and (3) changed the spatial interpolation method.
 The keyword argument lowres is a flag that determines if the 0.9x1.25 or 0.125x0.125
 resolution CLM data artifact is used. If the lowres flag is not provided, the clm artifact
 with the closest resolution to the surface_space is used.
 
-Since these parameters are read from discretized data sets, 
+Since these parameters are read from discretized data sets,
 they carry an inherent land/sea mask. This land/sea mask may not match the
-underlying land sea mask of the simulation. 
+underlying land sea mask of the simulation.
 """
 function clm_soil_albedo_parameters(
     surface_space;
@@ -94,7 +94,7 @@ Reads spatially varying van Genuchten parameters for the soil model, from NetCDF
 based the van Genuchten data product from Gupta et al 2020,
  and regrids them to the grid defined by the
 `subsurface_space` and `surface_space` of the Clima simulation, as appropriate.
-Returns a NamedTuple of ClimaCore Fields. 
+Returns a NamedTuple of ClimaCore Fields.
 
 In particular, this file returns a field for
 - (α, n, m) (van Genuchten parameters)
@@ -104,17 +104,17 @@ In particular, this file returns a field for
 
 The NetCDF files are stored in ClimaArtifacts and more detail on their origin
 is provided there. The keyword arguments `regridder_type`, `extrapolation_bc`, and
-`interpolation_method` 
+`interpolation_method`
 affect the regridding by (1) changing how we interpolate to ClimaCore points which
 are not in the data, and (2) changing how extrapolate to points beyond the range of the
 data, and (3) changed the spatial interpolation method.
 
-Since these parameters are read from discretized data sets, 
+Since these parameters are read from discretized data sets,
 they carry an inherent land/sea mask. This land/sea mask may not match the
 underlying land sea mask of the simulation. While values over the ocean do
 not matter, we need to ensure that values in the simulation are set to
 something physical, even if they are not set in the data.
-In the future, this should be handled by ClimaUtilities via extrpolation.
+In the future, this should be handled by ClimaUtilities via extrapolation.
 Here we set them manually.
 """
 function soil_vangenuchten_parameters(
@@ -250,14 +250,14 @@ Reads spatially varying parameters for the soil model, from NetCDF files
 based on SoilGrids,
  and regrids them to the grid defined by the
 `subsurface_space` and `surface_space` of the Clima simulation, as appropriate.
-Returns a NamedTuple of ClimaCore Fields. 
+Returns a NamedTuple of ClimaCore Fields.
 
 In particular, this file returns a field for
 - various texture variables: volumetric fractions of organic matter, coarse fragments, and quartz.
 
 The NetCDF files are stored in ClimaArtifacts and more detail on their origin
 is provided there. The keyword arguments `regridder_type`, `extrapolation_bc`, and
-`interpolation_method` 
+`interpolation_method`
 affect the regridding by (1) changing how we interpolate to ClimaCore points which
 are not in the data, and (2) changing how extrapolate to points beyond the range of the
 data, and (3) changed the spatial interpolation method.
@@ -338,7 +338,7 @@ parameterization; this is read from a nc file and then regridded
 to the simulation grid.
 
 The keyword arguments `regridder_type`, `extrapolation_bc`, and
-`interpolation_method` 
+`interpolation_method`
 affect the regridding by (1) changing how we interpolate to ClimaCore points which
 are not in the data, and (2) changing how extrapolate to points beyond the range of the
 data, and (3) changed the spatial interpolation method.

--- a/src/standalone/Vegetation/soil_moisture_stress.jl
+++ b/src/standalone/Vegetation/soil_moisture_stress.jl
@@ -186,6 +186,8 @@ end
     )
 
 This updates the soil moisture stress factor according to the piecewise soil moisture stress model.
+It calls the function `update_piecewise_soil_moisture_stress!`, which has different methods
+for `PrognosticGroundConditions` and `PrescribedGroundConditions`.
 """
 function update_soil_moisture_stress!(
     p,
@@ -200,8 +202,9 @@ end
 """
     update_piecewise_soil_moisture_stress!(ground::PrescribedGroundConditions, p, Y, model, canopy)
 
-Updates the soil moisture stress using the piecewise model for Prescribed
-GroundConditions (p.drivers.θ prescribed).
+Updates the soil moisture stress using the piecewise model for PrescribedGroundConditions.
+Since θ is prescribed, we access the relevant parameters from the moisture
+stress model and compute the stress factor directly from `p.drivers.θ`.
 """
 function update_piecewise_soil_moisture_stress!(
     ground::PrescribedGroundConditions,
@@ -210,7 +213,10 @@ function update_piecewise_soil_moisture_stress!(
     model,
     canopy,
 )
-    @error(
-        "You cannot use the PiecewiseSoilMoistureStress model with a prescribed soil yet."
+    @. p.canopy.soil_moisture_stress.βm = compute_piecewise_moisture_stress(
+        model.θ_high,
+        model.θ_low,
+        model.c,
+        p.drivers.θ,
     )
 end

--- a/test/shared_utilities/drivers.jl
+++ b/test/shared_utilities/drivers.jl
@@ -257,8 +257,8 @@ end
         dest = [-1.0]
         t = 2.0
 
-        evaluate!(dest, soil_driver.ψ, t)
-        @test dest[1] == FT(0.0)
+        evaluate!(dest, soil_driver.θ, t)
+        @test dest[1] == FT(0.4)
         evaluate!(dest, soil_driver.T, t)
         @test dest[1] == FT(298.0)
 
@@ -272,7 +272,7 @@ end
         zero_instance = ClimaCore.Fields.zeros(axes(coords.surface))
         p_soil_driver = (;
             drivers = (;
-                ψ = copy(zero_instance),
+                θ = copy(zero_instance),
                 T_ground = copy(zero_instance),
             )
         )
@@ -280,20 +280,17 @@ end
               p_soil_driver.drivers
         update_drivers! = make_update_drivers((soil_driver,))
         update_drivers!(p_soil_driver, 0.0)
-        @test p_soil_driver.drivers.ψ == zero_instance
+        @test p_soil_driver.drivers.θ == zero_instance .+ FT(0.4)
         @test p_soil_driver.drivers.T_ground == zero_instance .+ 298
 
         @test ClimaLand.initialize_drivers((prognostic_soil_driver,), coords) ==
               (;)
         update_drivers! = make_update_drivers((prognostic_soil_driver,))
-        p_soil_driver.drivers.ψ .= -1
+        p_soil_driver.drivers.θ .= FT(0.1)
         p_soil_driver.drivers.T_ground .= -1
         update_drivers!(p_soil_driver, 0.0)
         # no change
-        @test p_soil_driver.drivers.ψ == (zero_instance .- 1)
+        @test p_soil_driver.drivers.θ == (zero_instance .+ FT(0.1))
         @test p_soil_driver.drivers.T_ground == (zero_instance .- 1)
-
-
-
     end
 end

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -222,7 +222,7 @@ import ClimaParams
                 :LW_d,
                 :cosθs,
                 :frac_diff,
-                :ψ,
+                :θ,
                 :T_ground,
             )
             # Check that structure of Y is valid (will error if not)
@@ -1456,7 +1456,7 @@ end
                 :LW_d,
                 :cosθs,
                 :frac_diff,
-                :ψ,
+                :θ,
                 :T_ground,
             )
             # Check that structure of Y is valid (will error if not)
@@ -1534,7 +1534,7 @@ end
             :LW_d,
             :cosθs,
             :frac_diff,
-            :ψ,
+            :θ,
             :T_ground,
         )
         # Check that structure of Y is valid (will error if not)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Part of Yuchen's PR #1330

Switches from storing matric potential in `PrescribedGroundConditions` to storing water content. This is a quantity more likely to be available in input from data or users.

Closes #1412

## Content
- [x] store \theta instead of \psi in PrescribedGroundConditions
- [x] convert water content to matrix potential in PlantHydraulics
- [x] confirm standalone canopy results are unchanged

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
