### PR TITLE
check for coupled forcing in diagnostic setups

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ ClimaLand.jl Release Notes
 
 main
 -------
+- ![][badge-🐛bugfix] Check for coupled forcing in available diagnostics PR[#1434](https://github.com/CliMA/ClimaLand.jl/pull/1434)
 - Remove the unused integrated constructors based on args and types PR[#1408](https://github.com/CliMA/ClimaLand.jl/pull/1408)
 - Add moisture stress component to the canopy model PR[#1387](https://github.com/CliMA/ClimaLand.jl/pull/1387)
 

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -394,7 +394,7 @@ function compute_precip!(
     Y,
     p,
     t,
-    land_model::Union{EnergyHydrology, SoilCanopyModel, LandModel},
+    land_model::Union{EnergyHydrology, CanopyModel, SoilCanopyModel, LandModel},
 )
     soil = get_soil(land_model)
     if isnothing(out)

--- a/test/shared_utilities/drivers.jl
+++ b/test/shared_utilities/drivers.jl
@@ -202,6 +202,28 @@ end
     @test all(rh .- soln .≈ 0)
 end
 
+@testset "CoupledAtmosphere and CoupledRadiativeFluxes initialization" begin
+    domain = ClimaLand.Domains.global_domain(FT)
+    coords = ClimaLand.Domains.coordinates(domain)
+
+    atmos = ClimaLand.CoupledAtmosphere{FT}()
+    radiation = ClimaLand.CoupledRadiativeFluxes{FT}()
+    p = (; drivers = ClimaLand.initialize_drivers((atmos, radiation), coords))
+
+    @test keys(p.drivers) == (
+        :P_liq,
+        :P_snow,
+        :c_co2,
+        :T,
+        :P,
+        :q,
+        :SW_d,
+        :LW_d,
+        :cosθs,
+        :frac_diff,
+    )
+end
+
 @testset "CoupledRadiativeFluxes" begin
     start_date = DateTime(Date(2020, 6, 15), Time(12, 0, 0))
     domain = ClimaLand.Domains.HybridBox(;
@@ -292,8 +314,5 @@ end
         # no change
         @test p_soil_driver.drivers.ψ == (zero_instance .- 1)
         @test p_soil_driver.drivers.T_ground == (zero_instance .- 1)
-
-
-
     end
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
There are 2 diagnostics we aren't able to compute when using CoupledAtmosphere/CoupledRadiativeFluxes because the required variables are not stored: wind speed and net radiation. This PR checks the forcing type and computes the diagnostics correctly based on that. This is done in the same way we handle other diagnostics that are only available in certain cases (e.g. runoff diagnostics).

Closes #1422
