### PR TITLE
Precomopile CUDA RT

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,7 @@ env:
   SLURM_KILL_BAD_EXIT: 1
   JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/default"
   JULIA_CUDA_MEMORY_POOL: "cuda"
+  JULIA_MAX_NUM_PRECOMPILE_FILES: 100
 
 
 steps:
@@ -25,11 +26,11 @@ steps:
 
       - echo "--- Instantiate experiments"
       - "julia --project=.buildkite -e 'using Pkg; Pkg.develop(;path=\".\"); Pkg.instantiate(;verbose=true)'"
-      - "julia --project=.buildkite -e 'using Pkg; Pkg.status()'"
+      - "julia --project=.buildkite -e 'using Pkg; Pkg.precompile(;strict=true); using CUDA; CUDA.precompile_runtime(); Pkg.status()'"
 
       - echo "--- Instantiate test"
       - "julia --project=test -e 'using Pkg; Pkg.develop(;path=\".\"); Pkg.add(\"MPI\"); Pkg.add(\"CUDA\"); Pkg.instantiate(;verbose=true)'"
-      - "julia --project=test -e 'using Pkg; Pkg.status()'"
+      - "julia --project=test -e 'using Pkg; Pkg.precompile(;strict=true); using CUDA; CUDA.precompile_runtime(); Pkg.status()'"
 
     agents:
       slurm_gpus: 1
@@ -38,6 +39,7 @@ steps:
       slurm_ntasks_per_node: 8
     env:
       JULIA_NUM_PRECOMPILE_TASKS: 8
+      JULIA_MAX_NUM_PRECOMPILE_FILES: 50
 
   - wait
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Reduce buildkite ci duration 



## Content
- increase number of precompiled files. I don't know if this helps, but this is what ClimaAtmos does
- precompile the CUDA runtime. The CUDA.jl docs say to do this when running on a cluster.

~~Buildkite on main takes an hour and 15 minutes. This changes it to take 1 hour.~~
It seems like this sometimes speeds up ci.
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
