### PR TITLE
Add vegetation standalone documentation pages

### DIFF
--- a/docs/list_standalone_models.jl
+++ b/docs/list_standalone_models.jl
@@ -7,7 +7,6 @@ standalone_models = [
         "Photosynthesis" => [
             "Farquhar model" => "standalone/pages/vegetation/photosynthesis/farquhar_model.md",
             "P-model" => "standalone/pages/vegetation/photosynthesis/pmodel.md",
-            "Optimality model" => "standalone/pages/vegetation/photosynthesis/optimality_model.md",
         ]
         "Stomatal conductance" => [
             "Medlyn model" => "standalone/pages/vegetation/stomatal_conductance/medlyn_model.md",
@@ -15,6 +14,23 @@ standalone_models = [
         ]
         "Plant hydraulics" => [
             "Van Genuchten model" => "standalone/pages/vegetation/plant_hydraulics/van_genuchten_model.md",
+        ]
+        "Solar Induced Fluorescence" => [
+            "Lee model" => "standalone/pages/vegetation/solar_induced_fluorescence/lee_model.md",
+        ]
+        "Canopy structure" => [
+            "Prescribed structure" => "standalone/pages/vegetation/canopy_structure/prescribed_structure.md",
+        ]
+        "Canopy energy" => [
+            "Physics" => "standalone/pages/vegetation/canopy_energy/canopy_energy.md",
+        ]
+        "Soil moisture stress" => [
+            "Piecewise model" => "standalone/pages/vegetation/soil_moisture_stress/piecewise_model.md",
+            "Tuzet model" => "standalone/pages/vegetation/soil_moisture_stress/tuzet_model.md",
+            "No moisture stress" => "standalone/pages/vegetation/soil_moisture_stress/no_moisture_stress.md",
+        ]
+        "Autotrophic respiration" => [
+            "JULES model" => "standalone/pages/vegetation/autotrophic_respiration/jules_model.md",
         ]
     ]
     "Soil" => [

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -275,3 +275,59 @@
   url       = {https://doi.org/10.17190/AMF/1871137},
   note      = {Dataset}
 }
+
+@article{Lee2015,
+  author  = {Lee, J-E. and Frankenberg, C. and van der Tol, C. and Berry, J. and Guanter, L. and Boyce, C. K. and Fisher, J. B. and Morrow, E. and Worden, J. and Asefi, S. and Badgley, G. and Saatchi, S.},
+  title   = {Forest productivity and water stress in Amazonia: observations from {GOSAT} chlorophyll fluorescence},
+  journal = {Global Change Biology},
+  year    = {2015},
+  volume  = {21},
+  number  = {9},
+  pages   = {3469--3477},
+  doi     = {10.1111/gcb.12948}
+}
+
+@article{Tuzet2003,
+  author       = {Tuzet, A. and Perrier, A. and Leuning, R.},
+  title        = {A coupled model of stomatal conductance, photosynthesis and transpiration},
+  journal      = {Plant, Cell \& Environment},
+  year         = {2003},
+  volume       = {26},
+  number       = {7},
+  pages        = {1097--1116},
+  doi          = {10.1046/j.1365-3040.2003.01035.x}
+}
+
+@article{Duursma2012,
+  author       = {Duursma, R. A. and Medlyn, B. E.},
+  title        = {MAESPA: A model to study interactions between water limitation, environmental drivers and vegetation function at tree and stand levels, with an example application to CO2 × drought interactions},
+  journal      = {Geoscientific Model Development},
+  year         = {2012},
+  volume       = {5},
+  number       = {4},
+  pages        = {919--940},
+  doi          = {10.5194/gmd-5-919-2012}
+}
+
+@article{Egea2011,
+  author       = {Egea, G. and Verhoef, A. and Vidale, P.~L.},
+  title        = {On the treatment of plant water stress in coupled photosynthesis–stomatal conductance models: implications for large-scale modeling},
+  journal      = {Agricultural and Forest Meteorology},
+  year         = {2011},
+  volume       = {151},
+  number       = {10},
+  pages        = {1370--1384},
+  doi          = {10.1016/j.agrformet.2011.05.019}
+}
+
+@article{Clark2011,
+  author    = {Clark, D. B. and Mercado, L. M. and Sitch, S. and Jones, C. D. and Gedney, N. and Best, M. J. and Pryor, M. and Rooney, G. G. and Essery, R. L. H. and Blyth, E. and Boucher, O. and Harding, R. J. and Huntingford, C. and Cox, P. M.},
+  title     = {The Joint UK Land Environment Simulator (JULES), model description--Part 2: carbon fluxes and vegetation dynamics},
+  journal   = {Geoscientific Model Development},
+  volume    = {4},
+  number    = {3},
+  pages     = {701--722},
+  year      = {2011},
+  doi       = {10.5194/gmd-4-701-2011},
+  url       = {https://doi.org/10.5194/gmd-4-701-2011}
+}

--- a/docs/src/standalone/pages/vegetation/autotrophic_respiration/jules_model.md
+++ b/docs/src/standalone/pages/vegetation/autotrophic_respiration/jules_model.md
@@ -1,0 +1,89 @@
+# Autotrophic Respiration
+
+This page documents the autotrophic respiration model by [Clark2011](@citet), used in the JULES model.
+The ClimaLand code can be found [here](https://github.com/CliMA/ClimaLand.jl/blob/main/src/standalone/Vegetation/autotrophic_respiration.jl#L240).
+
+---
+
+## Model formulation
+
+Autotrophic respiration of the canopy is partitioned into maintenance and growth components.
+At the canopy level, the respiration flux (mol CO$_2$ m$^{-2}$ s$^{-1}$) is
+
+```math
+R_a = \Bigl(R_{pm} + R_g\Bigr)\; \frac{1 - \exp\!\left(-K \, LAI \, \Omega\right)}{K \, \Omega},
+```
+
+where $R_{pm}$ is the maintenance respiration (mol CO$_2$ m$^{-2}$ s$^{-1}$), $R_g$ is the growth respiration (mol CO$_2$ m$^{-2}$ s$^{-1}$), $K$ is the canopy extinction coefficient (–), $LAI$ is the leaf area index (m$^2$ leaf m$^{-2}$ ground), and $\Omega$ is a clumping factor (–).
+
+---
+
+### Nitrogen allocation
+
+Nitrogen is distributed among leaves, roots, and stems according to
+
+```math
+S_c = \eta_{sl}\, h\, LAI \, H(SAI), \qquad
+R_c = \sigma_l \, RAI
+```
+
+```math
+n_m = \frac{Vc_{max25}}{n_e}, \qquad
+N_l = n_m \, \sigma_l \, LAI, \qquad
+N_r = \mu_r \, n_m \, R_c, \qquad
+N_s = \mu_s \, n_m \, S_c
+```
+
+where:
+
+ $H$ is the Heaviside function (–),
+
+ $Vc_{max25}$ is the leaf-level maximum carboxylation rate at 25 °C (mol CO$_2$ m$^{-2}$ s$^{-1}$),
+
+ $n_e$ is the conversion factor from $Vc_{max25}$ to nitrogen (mol CO$_2$ m$^{-2}$ s$^{-1}$ kg C$^{-1}$),
+
+ $\eta_{sl}$ is the live stem wood coefficient (kg C m$^{-3}$),
+
+ $h$ is the canopy height (m),
+
+ $\sigma_l$ is the specific leaf density (kg C m$^{-2}$ leaf),
+
+ $\mu_r$ is the root-to-leaf nitrogen ratio (–),
+
+ $\mu_s$ is the stem-to-leaf nitrogen ratio (–),
+
+ $N_l, N_r, N_s$ are the nitrogen contents in leaves, roots, and stems (kg N m$^{-2}$ ground),
+
+ $S_c$ is the stem carbon pool (kg C m$^{-2}$ ground),
+
+ $R_c$ is the root carbon pool (kg C m$^{-2}$ ground),
+
+ $n_m$ is the nitrogen per unit carboxylation capacity (kg N mol$^{-1}$ CO$_2$ m$^{2}$ s).
+
+---
+
+### Maintenance respiration
+
+```math
+R_{pm} = R_d \,\Bigl(\beta + \frac{N_r + N_s}{\max(N_l, \, \epsilon)}\Bigr),
+```
+
+where $R_d$ is a base respiration rate (mol CO$_2$ m$^{-2}$ s$^{-1}$), $\beta$ is a parameter scaling leaf respiration (–), and $\epsilon$ is machine epsilon (–) for numerical stability.
+
+---
+
+### Growth respiration
+
+```math
+R_g = R_{el} \, \Bigl(A_n - R_{pm}\Bigr),
+```
+
+where $R_{el}$ is the relative contribution of growth respiration (–), and $A_n$ is the net assimilation rate (mol CO$_2$ m$^{-2}$ s$^{-1}$).
+
+---
+
+## Notes
+
+- This formulation follows the approach used in large-scale ecosystem models such as JULES (Clark et al., 2011).
+- Growth respiration is proportional to net assimilation after subtracting maintenance costs.
+- Maintenance respiration scales with tissue nitrogen pools.

--- a/docs/src/standalone/pages/vegetation/canopy_energy/canopy_energy.md
+++ b/docs/src/standalone/pages/vegetation/canopy_energy/canopy_energy.md
@@ -1,0 +1,48 @@
+# Canopy Energy Balance (Bigleaf)
+
+This page documents the **canopy energy** module used in ClimaLand’s vegetation standalone runs.
+The ClimaLand code can be found [here](https://github.com/CliMA/ClimaLand.jl/blob/main/src/standalone/Vegetation/canopy_energy.jl).
+
+---
+
+## Prognostic canopy temperature
+
+The canopy temperature is modeled prognostically. Its time tendency is given by
+
+```math
+\frac{dT_c}{dt} =
+\frac{
+    LW_n + SW_n - (\mathrm{SHF} + \mathrm{LHF}) + F_\mathrm{roots}
+}{
+    a_c \cdot \max(A_\mathrm{leaf} + A_\mathrm{stem}, \epsilon)
+},
+```
+
+where
+
+ $T_{c}$ is the canopy temperature (K),
+
+ $LW_{n}$ is the net long-wave radiation (W m$^{-2}$), positive if increasing canopy energy,
+
+ $SW_{n}$ is the net short-wave radiation (W m$^{-2}$), positive if increasing canopy energy
+
+ $\mathrm{SHF}$ is the sensible heat flux (W m$^{-2}$), positive if decreasing canopy energy,
+
+ $\mathrm{LHF}$ is the latent heat flux (W m$^{-2}$), positive if decreasing canopy energy,
+
+ $F_{\mathrm{roots}}$ is the energy flux associated with root–soil water transport (W m$^{-2}$), positive if increasing canopy energy,
+
+ $a_{c}$ is the canopy heat capacity per unit area (J m$^{-2}$ K$^{-1}$),
+
+ $A_{\mathrm{leaf}}$ and $A_{\mathrm{stem}}$ are the leaf and stem area indices (–),
+
+ and $\epsilon$ is the machine epsilon for numerical stability.
+
+---
+
+## Root energy flux
+
+- In **standalone mode** with prescribed ground conditions, this flux is set to zero.
+- In coupled runs with a **prognostic soil model**, the flux is included to conserve energy, since the soil model accounts for the energy in soil water.
+
+---

--- a/docs/src/standalone/pages/vegetation/canopy_structure/prescribed_structure.md
+++ b/docs/src/standalone/pages/vegetation/canopy_structure/prescribed_structure.md
@@ -1,0 +1,8 @@
+# Canopy Structure (Prescribed)
+
+The canopy structure is prescribed. the following states are read from maps:
+  - Leaf area index (**LAI**) and rooting depth.
+
+The Following are scalars:
+  - Stem area index (SAI), root area index (RAI) and canopy height.
+

--- a/docs/src/standalone/pages/vegetation/soil_moisture_stress/no_moisture_stress.md
+++ b/docs/src/standalone/pages/vegetation/soil_moisture_stress/no_moisture_stress.md
@@ -1,0 +1,6 @@
+# no moisture stress
+
+While the [Piecewise  model](@ref "Piecewise Soil Moisture Stress") and
+[Tuzet model](@ref "Tuzet Soil Moisture (Water Potential) Stress") have a scaler, $\beta$,
+that multiply leaf net assimilation and stomatal conductance by 0 to 1 depending on moisture stress,
+we also allow the option to use no sensitivity to moisture stress ($\beta$ is always equal to 1).

--- a/docs/src/standalone/pages/vegetation/soil_moisture_stress/piecewise_model.md
+++ b/docs/src/standalone/pages/vegetation/soil_moisture_stress/piecewise_model.md
@@ -1,0 +1,63 @@
+# Piecewise Soil Moisture Stress
+
+This page documents the **piecewise** (linear/threshold with curvature) soil moisture stress function used in ClimaLand's vegetation module. The stress factor $\beta \in [0,1]$ scales leaf photosynthesis (and thus stomatal conductance) as soil moisture declines, following a simple, interpretable formulation. See [Egea2011](@citet), the ClimaLand code is [here](https://github.com/CliMA/ClimaLand.jl/blob/main/src/standalone/Vegetation/soil_moisture_stress.jl).
+
+---
+
+## Summary
+- **Purpose:** convert soil wetness to a *stress multiplier* that reduces assimilation and stomatal conductance.
+- **Inputs:** volumetric soil water content $\theta$ (or relative water content), model thresholds.
+- **Outputs:** scalar stress factor $\beta$ applied within the photosynthesis/stomatal sub-models.
+
+---
+
+## Model formulation
+
+Let $\theta$ be the volumetric water content at some depth. Define two thresholds:
+
+First, $\theta_{low}$ — **wilting** (or residual) water content: below this, stress is total ($\beta = 0$).
+
+Second, $\theta_{high}$ — **Field capacity (or porosity)** water content: above this, no stress ($\beta = 1$).
+
+With $\theta_{low} < \theta_{high}$, the stress factor is
+
+```math
+\beta(\theta) =
+\begin{cases}
+0, & \theta \leq \theta_{low}, \\
+\left( \dfrac{\theta - \theta_{low}}{\theta_{high} - \theta_{low}} \right)^c, & \theta_{low} < \theta < \theta_{high}, \\
+1, & \theta \geq \theta_{high}. \\
+\end{cases}
+```
+
+---
+
+## Variables & units
+
+| Quantity | Symbol | Units | Notes |
+|---|:--:|:--:|---|
+| Volumetric water content | $\theta$ | m³ m⁻³ | root-zone or layer-weighted |
+| Low water content threshold | $\theta_{low}$ | m³ m⁻³ | wilting point or residual  |
+| High water content threshold | $\theta_{high}$ | m³ m⁻³ | field capacity or porosity |
+| Stress multiplier | $\beta$ | – | 0 (full stress) … 1 (no stress) |
+| Curvature parameter | $c$ | – | controls concavity of the stress response |
+
+---
+
+## Parameters
+
+| Parameter | Description | Example range |
+|---|---|---|
+| $\theta_{low}$ | lower threshold (wilting or residual) | 0.05–0.15 |
+| $\theta_{high}$ | upper threshold (field capacity or porosity) | 0.55–0.75 |
+| $c$ | curvature parameter shaping the transition | 1–5 |
+
+---
+
+## Numerical details & coupling
+
+Soil moisture, $\theta$, is either prescribed as a single value in the root zone (for standalone canopy models, with a prescribed soil component), or else we compute $\beta$ as a factor of depth using $\theta$ as a function of depth, as specified by the prognostic soil model. In the latter case, we then average $\beta(z)$ over the column using the root distribution function (also a function of$z$), as a weighting factor.
+
+Scalar stress, $\beta$, multiplies leaf assimilation, $A_{n}$, which in turn reduces $g_{s}$ that scales with $A_{n}$.
+
+---

--- a/docs/src/standalone/pages/vegetation/soil_moisture_stress/tuzet_model.md
+++ b/docs/src/standalone/pages/vegetation/soil_moisture_stress/tuzet_model.md
@@ -1,0 +1,41 @@
+# Tuzet Soil Moisture (Water Potential) Stress
+
+This page documents the **Tuzet** stress function used to scale leaf net assimilation and stomatal conductance as a function of plant water potential. It provides a smooth, sigmoidal decline in conductance with decreasing (more negative) leaf/xylem water potential. See [Tuzet2003](@citet) and [Duursma2012](@citet). The ClimaLand code can be found [here](https://github.com/CliMA/ClimaLand.jl/blob/main/src/standalone/Vegetation/soil_moisture_stress.jl).
+
+---
+
+## Summary
+- **Purpose:** compute a water‑status stress multiplier $\beta \in [0,1]$ from leaf (or xylem) water potential.
+- **Inputs:** leaf/xylem water potential $\psi$ (Pa), parameters controlling the midpoint and slope.
+- **Outputs:** scalar stress factor $\beta$ applied within stomatal/photosynthesis sub‑models.
+
+---
+
+## Model formulation
+
+We compute the stress factor using the following formulation:
+
+```math
+\beta = \min\Bigg(1, \frac{1 + e^{s_c \, p_c}}{1 + e^{s_c \, (p_c - p_{leaf})}}\Bigg)
+```
+
+with
+
+The leaf water pressure $p_{leaf}$ (Pa),
+
+The reference water pressure $p_{c}$ (Pa),
+
+The sensitivity to low water pressure $s_{c}$ (Pa$^{-1}$).
+
+---
+
+## Variables & units
+
+| Quantity | Symbol | Units | Notes |
+|---|:--:|:--:|---|
+| Leaf water pressure | $p_{leaf}$ | Pa | typically ≤ 0 (tension) |
+| Reference potential | $p_{c}$ | Pa | location of curve midpoint |
+| Sensitivity | $s_{c}$ | Pa⁻¹ | slope/steepness of response |
+| Stress multiplier | $\beta$ | – | 0 (full stress) … 1 (no stress) |
+
+---

--- a/docs/src/standalone/pages/vegetation/solar_induced_fluorescence/lee_model.md
+++ b/docs/src/standalone/pages/vegetation/solar_induced_fluorescence/lee_model.md
@@ -1,0 +1,95 @@
+# Solar-Induced Fluorescence (SIF)
+
+## Lee 2015 model
+
+This page documents Lee 2015 model for the solar-induced fluorescence (SIF) module in ClimaLand, implemented in `src/standalone/Vegetation/solar_induced_fluorescence.jl`. SIF is computed at a single wavelength (755 nm) and represents the emission from the canopy surface. See [Lee2015](@citet).
+The ClimaLand code page for this model can be found [here](https://github.com/CliMA/ClimaLand.jl/blob/main/src/standalone/Vegetation/solar_induced_fluorescence.jl).
+
+---
+
+## Model formulation
+
+SIF at 755 nm is computed following Lee et al. (2015).
+
+First, we compute the dark-adapted heat-loss rate coefficient $k_d$ as
+
+```math
+k_d = \max\left(k_{d,p1}(T_c - T_{freeze}) + k_{d,p2},\; k_{d,min}\right).
+```
+
+Here, $k_{d,p1}$ and $k_{d,p2}$ are parameters for heat loss in dark-adapted conditions (Tol et al. 2014, unitless), $k_{d,min}$ is the minimum allowed value of $k_d$, $T_c$ is canopy temperature (K), and $T_{freeze}$ is the freezing temperature threshold (K).
+
+Next, we define
+
+```math
+x = 1 - \frac{J}{J_{max}},
+```
+
+where $J$ is the electron transport rate (mol m⁻² s⁻¹) and $J_{max}$ is the maximum electron transport capacity (mol m⁻² s⁻¹).
+
+The light-adapted heat-loss rate coefficient $k_n$ is then given by
+
+```math
+k_n = (k_{n,p1}x - k_{n,p2})x,
+```
+
+where $k_{n,p1}$ and $k_{n,p2}$ are parameters for light-adapted conditions (Lee et al. 2013, unitless).
+
+The baseline photochemical yield $\phi_{p0}$ is computed as
+
+```math
+\phi_{p0} = \frac{k_p}{\max(k_f + k_p + k_n,\; \varepsilon(FT))},
+```
+
+where $k_p$ is the rate coefficient for photochemical quenching, $k_f$ is the rate coefficient for fluorescence, and $\varepsilon(FT)$ denotes the machine epsilon for the floating-point type $FT$.
+
+The effective photochemical yield is then
+
+```math
+\phi_p = \frac{J}{J_{max}}\,\phi_{p0}.
+```
+
+The fluorescence yield $\phi_f$ is computed as
+
+```math
+\phi_f = \frac{k_f}{\max(k_f + k_d + k_n,\; \varepsilon(FT))}(1 - \phi_p).
+```
+
+To convert from leaf-level fluorescence to observed signal, we compute
+
+```math
+\kappa = \kappa_{p1} V_{cmax25}^{leaf} \times 10^6 + \kappa_{p2},
+```
+
+where $V_{cmax25}^{leaf}$ is the maximum carboxylation rate at 25 °C (leaf level, mol m⁻² s⁻¹, internally converted to μmol), and $\kappa_{p1}, \kappa_{p2}$ are slope and intercept parameters from Lee et al. (2015).
+
+The emitted fluorescence flux is
+
+```math
+F = APAR_{canopy}^{moles}\, \phi_f,
+```
+
+where $APAR_{canopy}^{moles}$ is the absorbed photosynthetically active radiation by the canopy (mol m⁻² s⁻¹).
+
+Finally, the solar-induced fluorescence at 755 nm is
+
+```math
+SIF_{755} = \frac{F}{\max(\kappa,\; \varepsilon(FT))},
+```
+
+where $F$ is the emitted flux and $\kappa$ is the conversion factor relating leaf-level to observed fluorescence. $SIF_{755}$ is expressed in W m⁻².
+
+
+## Model Parameters
+
+| Symbol | Description | Units | Value |
+|--------|-------------|-------|-------|
+| $kf$ | Rate coefficient for fluorescence | unitless | 0.05 |
+| $kd_{p1}$ | Parameter for heat loss in dark-adapted conditions (Tol et al. 2014) | unitless | 0.03 |
+| $kd_{p2}$ | Parameter for heat loss in dark-adapted conditions (Tol et al. 2014) | unitless | 0.0273 |
+| $min_{kd}$ | Minimum heat-loss coefficient in dark-adapted conditions (Tol et al. 2014) | unitless | 0.087 |
+| $kn_{p1}$ | Parameter for heat loss in light-adapted conditions (Lee et al. 2013) | unitless | 6.2473 |
+| $kn_{p2}$ | Parameter for heat loss in light-adapted conditions (Lee et al. 2013) | unitless | 0.5944 |
+| $kp$ | Rate coefficient for photochemical quenching | unitless | 4.0 |
+| $\kappa_{p1}$ | Slope relating leaf-level to observed fluorescence (Lee et al. 2015) | μmol⁻¹ m² s | 0.045 |
+| $\kappa_{p2}$ | Intercept relating leaf-level to observed fluorescence (Lee et al. 2015) | unitless | 7.85 |


### PR DESCRIPTION
closes #1414 
closes #1461 

This commits adds documentation pages for standalone vegetation solar induced fluorescence, canopy energy, canopy structure, autotrophic respiration, and soil moisture stress

https://clima.github.io/ClimaLand.jl/previews/PR1437/