### PR TITLE
PrescribedAtmosphere fields can't be `nothing`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ ClimaLand.jl Release Notes
 
 main
 -------
+- `PrescribedAtmosphere` fields can't be `nothing` PR[#1438](https://github.com/CliMA/ClimaLand.jl/pull/1438)
 - ![][badge-🐛bugfix] Check for coupled forcing in available diagnostics PR[#1434](https://github.com/CliMA/ClimaLand.jl/pull/1434)
 - Remove the unused integrated constructors based on args and types PR[#1408](https://github.com/CliMA/ClimaLand.jl/pull/1408)
 - Add moisture stress component to the canopy model PR[#1387](https://github.com/CliMA/ClimaLand.jl/pull/1387)

--- a/experiments/standalone/Bucket/bucket_era5.jl
+++ b/experiments/standalone/Bucket/bucket_era5.jl
@@ -46,12 +46,7 @@ using ClimaLand.Bucket:
 using ClimaLand.Domains: coordinates, Column
 import ClimaLand.Simulations: LandSimulation, solve!
 using ClimaLand:
-    initialize,
-    make_update_aux,
-    make_exp_tendency,
-    make_set_initial_cache,
-    PrescribedAtmosphere,
-    PrescribedRadiativeFluxes
+    initialize, make_update_aux, make_exp_tendency, make_set_initial_cache
 
 """
    compute_extrema(v)

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -117,13 +117,13 @@ $(DocStringExtensions.FIELDS)
 """
 struct PrescribedAtmosphere{
     FT,
-    LP <: Union{Nothing, AbstractTimeVaryingInput},
-    SP <: Union{Nothing, AbstractTimeVaryingInput},
-    TA <: Union{Nothing, AbstractTimeVaryingInput},
-    UA <: Union{Nothing, AbstractTimeVaryingInput},
-    QA <: Union{Nothing, AbstractTimeVaryingInput},
-    RA <: Union{Nothing, AbstractTimeVaryingInput},
-    CA <: Union{Nothing, AbstractTimeVaryingInput},
+    LP <: AbstractTimeVaryingInput,
+    SP <: AbstractTimeVaryingInput,
+    TA <: AbstractTimeVaryingInput,
+    UA <: AbstractTimeVaryingInput,
+    QA <: AbstractTimeVaryingInput,
+    RA <: AbstractTimeVaryingInput,
+    CA <: AbstractTimeVaryingInput,
     DT,
     TP,
 } <: AbstractAtmosphericDrivers{FT}
@@ -675,11 +675,11 @@ $(DocStringExtensions.FIELDS)
 """
 struct PrescribedRadiativeFluxes{
     FT,
-    SW <: Union{Nothing, AbstractTimeVaryingInput},
+    SW <: AbstractTimeVaryingInput,
     FD <: Union{Nothing, AbstractTimeVaryingInput},
-    LW <: Union{Nothing, AbstractTimeVaryingInput},
+    LW <: AbstractTimeVaryingInput,
     DT,
-    T,
+    T <: Union{Nothing, Function},
     TP,
 } <: AbstractRadiativeDrivers{FT}
     "Downward shortwave radiation function of time (W/m^2): positive indicates towards surface"

--- a/test/shared_utilities/drivers.jl
+++ b/test/shared_utilities/drivers.jl
@@ -13,21 +13,10 @@ using Dates
 FT = Float32
 @testset "Default model, FT = $FT" begin
     toml_dict = LP.create_toml_dict(FT)
-    earth_param_set = LP.LandParameters(toml_dict)
-    pa = ClimaLand.PrescribedAtmosphere(
-        nothing,
-        nothing,
-        nothing,
-        nothing,
-        nothing,
-        nothing,
-        nothing,
-        FT(1),
-        earth_param_set,
-    )
-    pr = ClimaLand.PrescribedRadiativeFluxes(FT, nothing, nothing, nothing)
+    (pa, pr) = ClimaLand.prescribed_analytic_forcing(FT; toml_dict)
     liquid_precip = TimeVaryingInput((t) -> -1.0)
     pp = ClimaLand.PrescribedPrecipitation{FT}(liquid_precip)
+
     domain = ClimaLand.Domains.Plane(;
         xlim = FT.((1.0, 2.0)),
         ylim = FT.((1.0, 2.0)),


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
We have been allowing fields of a `PrescribedAtmosphere` to be Nothing, but this was only used in one test and isn't something we want to allow physically. This PR restricts fields of this object to always be TimeVaryingInputs.

Closes #461
