### PR TITLE
Update canopy docs

### DIFF
--- a/docs/src/tutorials/standalone/Canopy/changing_canopy_parameterizations.jl
+++ b/docs/src/tutorials/standalone/Canopy/changing_canopy_parameterizations.jl
@@ -28,17 +28,17 @@ toml_dict = LP.create_toml_dict(FT);
 earth_param_set = LP.LandParameters(toml_dict);
 
 # We will run this simulation on a point domain at a lat/lon location
-# near Pasadena, California.
+# near Yellowstone National Park.
 # This is different from the soil example, which ran on a column, because the
 # soil model has depth and the canopy model does not.
-longlat = FT.((-118.1, 34.1))
+longlat = FT.((-110.6, 44.6))
 domain = Domains.Point(; z_sfc = FT(0.0), longlat);
 surface_space = domain.space.surface;
 
 # We choose the initial and final simulation times as DatesTimes, and a timestep in seconds.
 start_date = DateTime(2008);
 stop_date = start_date + Second(60 * 60 * 72);
-dt = 1000.0;
+dt = 900.0;
 
 # Whereas the soil model takes in 2 forcing objects (atmosphere and radiation),
 # the canopy takes in 3 (atmosphere, radiation, and ground). Here we read in the
@@ -100,7 +100,7 @@ radiative_transfer_parameters = Canopy.BeerLambertParameters(
     α_NIR_leaf,
 );
 radiative_transfer = Canopy.BeerLambertModel(radiative_transfer_parameters);
-# Note these parameters must all be scalars (or a single instance of a G_Function) or fields of floats and a field of a G_Function.
+# Note these parameters must all be scalars (or a single instance of a G\_Function) or fields of floats and a field of a G\_Function.
 
 # All three of these methods will construct a `BeerLambertModel`;
 # the first will use the default parameters, while the second and third use the custom parameters.
@@ -159,6 +159,7 @@ simulation = LandSimulation(
     dt,
     model;
     set_ic!,
+    updateat = Second(dt),
     user_callbacks = (),
     diagnostics,
 );

--- a/docs/src/tutorials/standalone/Canopy/default_canopy.jl
+++ b/docs/src/tutorials/standalone/Canopy/default_canopy.jl
@@ -31,17 +31,17 @@ toml_dict = LP.create_toml_dict(FT);
 earth_param_set = LP.LandParameters(toml_dict);
 
 # We will run this simulation on a point domain at a lat/lon location
-# near Pasadena, California.
+# near Yellowstone National Park.
 # This is different from the soil example, which ran on a column, because the
 # soil model has depth and the canopy model does not.
-longlat = FT.((-118.1, 34.1))
+longlat = FT.((-110.6, 44.6))
 domain = Domains.Point(; z_sfc = FT(0.0), longlat);
 surface_space = domain.space.surface;
 
 # We choose the initial and final simulation times as DatesTimes, and a timestep in seconds.
 start_date = DateTime(2008);
 stop_date = start_date + Second(60 * 60 * 72);
-dt = 1000.0;
+dt = 900.0;
 
 # Whereas the soil model takes in 2 forcing objects (atmosphere and radiation),
 # the canopy takes in 3 (atmosphere, radiation, and ground). Here we read in the
@@ -108,6 +108,7 @@ simulation = LandSimulation(
     dt,
     model;
     set_ic!,
+    updateat = Second(dt),
     user_callbacks = (),
     diagnostics,
 );


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Make a couple plots in the docs look nicer by making dt an even divisor of the diagnostic output, updating more frequently, and changing the location to not be over the ocean (this was due to the very low resolution of the forcing, not the lat/lon)


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
