### PR TITLE
use linear interpolation for canopy parameters, high resolution forcing

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -58,7 +58,7 @@ The soil model takes in 2 forcing objects, atmosphere and radiation,
 which we read in from ERA5 data.
 ```julia
 era5_ncdata_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2008_path(; lowres = true);
+    ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path();
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -57,12 +57,12 @@ dt = 1000.0;
 The soil model takes in 2 forcing objects, atmosphere and radiation,
 which we read in from ERA5 data.
 ```julia
-era5_ncdata_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path();
+use_lowres_forcing = true;
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
-    era5_ncdata_path,
-    surface_space,
     start_date,
+    stop_date
+    use_lowres_forcing,
+    surface_space,
     earth_param_set,
     FT,
 );

--- a/docs/src/tutorials/global/bucket.jl
+++ b/docs/src/tutorials/global/bucket.jl
@@ -68,17 +68,18 @@ bucket_parameters = BucketModelParameters(
 
 # Low-resolution forcing data from ERA5 is used here,
 # but high-resolution should be used for production runs.
-era5_ncdata_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
+use_lowres_forcing = true
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
-    era5_ncdata_path,
-    domain.space.surface,
     start_date,
+    stop_date,
+    use_lowres_forcing,
+    domain.space.surface,
     earth_param_set,
     FT;
     max_wind_speed = 25.0,
     time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
     regridder_type = :InterpolationsRegridder,
+    context,
 );
 
 # Make the model:

--- a/docs/src/tutorials/global/bucket.jl
+++ b/docs/src/tutorials/global/bucket.jl
@@ -68,10 +68,8 @@ bucket_parameters = BucketModelParameters(
 
 # Low-resolution forcing data from ERA5 is used here,
 # but high-resolution should be used for production runs.
-era5_ncdata_path = ClimaLand.Artifacts.era5_land_forcing_data2008_path(;
-    context,
-    lowres = true,
-)
+era5_ncdata_path =
+    ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     domain.space.surface,

--- a/docs/src/tutorials/global/snowy_land.jl
+++ b/docs/src/tutorials/global/snowy_land.jl
@@ -49,10 +49,8 @@ domain = ClimaLand.Domains.global_domain(FT; context, nelements);
 
 # Low-resolution forcing data from ERA5 is used here,
 # but high-resolution should be used for production runs.
-era5_ncdata_path = ClimaLand.Artifacts.era5_land_forcing_data2008_path(;
-    context,
-    lowres = true,
-)
+era5_ncdata_path =
+    ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
 forcing = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     domain.space.surface,

--- a/docs/src/tutorials/global/snowy_land.jl
+++ b/docs/src/tutorials/global/snowy_land.jl
@@ -49,17 +49,18 @@ domain = ClimaLand.Domains.global_domain(FT; context, nelements);
 
 # Low-resolution forcing data from ERA5 is used here,
 # but high-resolution should be used for production runs.
-era5_ncdata_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
+use_lowres_forcing = true
 forcing = ClimaLand.prescribed_forcing_era5(
-    era5_ncdata_path,
-    domain.space.surface,
     start_date,
+    stop_date,
+    use_lowres_forcing,
+    domain.space.surface,
     earth_param_set,
     FT;
     max_wind_speed = 25.0,
     time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
     regridder_type = :InterpolationsRegridder,
+    context,
 );
 
 # MODIS LAI is prescribed for the canopy model:

--- a/docs/src/tutorials/shared_utilities/driver_tutorial.jl
+++ b/docs/src/tutorials/shared_utilities/driver_tutorial.jl
@@ -136,9 +136,36 @@ cb = ClimaLand.DriverUpdateCallback(updatefunc, 3600.0 * 3, t0);
 
 # # Using ERA5 data
 # If you wish to force your ClimaLand simulation with ERA5 reanalysis data, there is a helper function
-# which can make this easier than specifying each atmospheric variable as individual `TimeVaryingInput`
+# makes this easier than specifying each atmospheric variable as individual `TimeVaryingInput`
 # objects, and then making the `PrescribedAtmosphere` struct.
-# You first need a local path to the netcdf file with the ERA5 data. This file must have the following variables:
+# ClimaLand provides two ERA5 NetCDF datasets:
+# - A high-resolution dataset with data on a 1x1 degree grid, available from 1979 to 2024.
+#  This dataset is about 8.5 GB per year of data.
+# - A low-resolution dataset with data on a 8x8 degree grid, available for the year 2008.
+#  This dataset is about 350 MB in size.
+# The low-resolution dataset is best for local simulations and for use in examples
+# in the documentation, but for production runs on compute clusters we recommend using the
+# high-resolution data.
+
+# To use the ERA5 data, you need to provide the `start_date` and `stop_date` of your simulation,
+# which should be within the range of dates covered by the dataset you are using (unless you are using
+# the low-resolution dataset for 2008, which will be reused for each year of simulation).
+# You'll also provide a flag `use_lowres_forcing` which is true if you want to use the low-resolution
+# dataset, and false otherwise.
+# Finally, you need the `surface_space` of your simulation (corresponding to the grid being used),
+# the ClimaLand `earth_param_set`, and the floating point type of the simulation `FT`.
+# Then you can access the atmospheric and radiative drivers like this:
+
+# ```julia
+# atmos, radiation = ClimaLand.prescribed_forcing_era5(start_date,
+#                                                      stop_date,
+#                                                      use_lowres_forcing,
+#                                                      surface_space,
+#                                                      earth_param_set,
+#                                                      FT)
+# ```
+
+# Each forcing dataset contains the following variables:
 # - "tp" Total precipitation as a mass/m^2/hour (accumulated over an hour)
 # - "sf" Snow precipitation as a mass/m^2/hour (accumulated over an hour)
 # - "u10n", "v10n", Neutral wind speed components in the horizontal, at 10m, in m/s
@@ -147,17 +174,3 @@ cb = ClimaLand.DriverUpdateCallback(updatefunc, 3600.0 * 3, t0);
 # - "sp", Surface pressure in Pa
 # - "ssrd", Downwelling shortwave radiation in J/m^2/hour (accumulated over an hour)
 # - "strd", Downwelling longwave radiation J/m^2/hour (accumulated over an hour)
-
-# You also need the `surface_space` of your simulation (corresponding to the grid being used), the floating point
-# type of the simulation `FT`, the ClimaLand `earth_param_set`, and the `start_date`,
-# which should be a date after the first date
-# in your ERA5 netcdf file and before the last date. Then you can access the atmospheric and radiative
-# drivers like:
-
-# ```julia
-# atmos, radiation = ClimaLand.prescribed_forcing_era5(era5_ncdata_path,
-#                                                      surface_space,
-#                                                      start_date,
-#                                                      earth_param_set,
-#                                                      FT)
-# ```

--- a/docs/src/tutorials/standalone/Canopy/changing_canopy_parameterizations.jl
+++ b/docs/src/tutorials/standalone/Canopy/changing_canopy_parameterizations.jl
@@ -47,8 +47,7 @@ dt = 1000.0;
 # We also set up a constant leaf area index (LAI); for an example reading LAI from
 # MODIS data, please see the [canopy_tutorial.jl tutorial](https://clima.github.io/ClimaLand.jl/stable/generated/standalone/Canopy/canopy_tutorial/).
 # This differs from the soil example because we have the extra inputs of the ground conditions and LAI.
-era5_ncdata_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2008_path(; lowres = true);
+era5_ncdata_path = ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path();
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,

--- a/docs/src/tutorials/standalone/Canopy/changing_canopy_parameterizations.jl
+++ b/docs/src/tutorials/standalone/Canopy/changing_canopy_parameterizations.jl
@@ -47,11 +47,12 @@ dt = 1000.0;
 # We also set up a constant leaf area index (LAI); for an example reading LAI from
 # MODIS data, please see the [canopy_tutorial.jl tutorial](https://clima.github.io/ClimaLand.jl/stable/generated/standalone/Canopy/canopy_tutorial/).
 # This differs from the soil example because we have the extra inputs of the ground conditions and LAI.
-era5_ncdata_path = ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path();
+use_lowres_forcing = true
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
-    era5_ncdata_path,
-    surface_space,
     start_date,
+    stop_date,
+    use_lowres_forcing,
+    surface_space,
     earth_param_set,
     FT,
 );

--- a/docs/src/tutorials/standalone/Canopy/default_canopy.jl
+++ b/docs/src/tutorials/standalone/Canopy/default_canopy.jl
@@ -50,11 +50,12 @@ dt = 1000.0;
 # We also set up a constant leaf area index (LAI); for an example reading LAI from
 # MODIS data, please see the [canopy_tutorial.jl tutorial](https://clima.github.io/ClimaLand.jl/stable/generated/standalone/Canopy/canopy_tutorial/).
 # This differs from the soil example because we have the extra inputs of the ground conditions and LAI.
-era5_ncdata_path = ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path();
+use_lowres_forcing = true
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
-    era5_ncdata_path,
-    surface_space,
     start_date,
+    stop_date,
+    use_lowres_forcing,
+    surface_space,
     earth_param_set,
     FT,
 );

--- a/docs/src/tutorials/standalone/Canopy/default_canopy.jl
+++ b/docs/src/tutorials/standalone/Canopy/default_canopy.jl
@@ -50,8 +50,7 @@ dt = 1000.0;
 # We also set up a constant leaf area index (LAI); for an example reading LAI from
 # MODIS data, please see the [canopy_tutorial.jl tutorial](https://clima.github.io/ClimaLand.jl/stable/generated/standalone/Canopy/canopy_tutorial/).
 # This differs from the soil example because we have the extra inputs of the ground conditions and LAI.
-era5_ncdata_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2008_path(; lowres = true);
+era5_ncdata_path = ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path();
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,

--- a/docs/src/tutorials/standalone/Soil/changing_soil_parameterizations.jl
+++ b/docs/src/tutorials/standalone/Soil/changing_soil_parameterizations.jl
@@ -37,17 +37,19 @@ longlat = FT.((-118.1, 34.1));
 domain = Domains.Column(; zlim = (zmin, zmax), nelements = 10, longlat);
 surface_space = domain.space.surface;
 
-# We choose the start_date, which is required to setup the forcing,
+# We choose the start and stop dates, which are required to setup the forcing,
 # which in turn is required by the model.
 start_date = DateTime(2008);
+stop_date = start_date + Second(60 * 60 * 72);
 
 # The soil model takes in 2 forcing objects, atmosphere and radiation,
 # which we read in from ERA5 data.
-era5_ncdata_path = ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path();
+use_lowres_forcing = true
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
-    era5_ncdata_path,
-    surface_space,
     start_date,
+    stop_date,
+    use_lowres_forcing,
+    surface_space,
     earth_param_set,
     FT,
 );

--- a/docs/src/tutorials/standalone/Soil/changing_soil_parameterizations.jl
+++ b/docs/src/tutorials/standalone/Soil/changing_soil_parameterizations.jl
@@ -43,8 +43,7 @@ start_date = DateTime(2008);
 
 # The soil model takes in 2 forcing objects, atmosphere and radiation,
 # which we read in from ERA5 data.
-era5_ncdata_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2008_path(; lowres = true);
+era5_ncdata_path = ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path();
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,

--- a/experiments/benchmarks/richards.jl
+++ b/experiments/benchmarks/richards.jl
@@ -81,7 +81,7 @@ function setup_prob(t0, tf, Δt; nelements = (101, 15))
 
     start_date = DateTime(2008)
     era5_ncdata_path =
-        ClimaLand.Artifacts.era5_land_forcing_data2008_path(; context)
+        ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
 
     # Below, the preprocess_func argument is used to
     # 1. Convert precipitation to be negative (as it is downwards)

--- a/experiments/benchmarks/snowy_land.jl
+++ b/experiments/benchmarks/snowy_land.jl
@@ -87,10 +87,8 @@ function setup_prob(
     surface_space = domain.space.surface
 
     # Forcing data
-    era5_ncdata_path = ClimaLand.Artifacts.era5_land_forcing_data2008_path(;
-        context,
-        lowres = true,
-    )
+    era5_ncdata_path =
+        ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
         era5_ncdata_path,
         surface_space,

--- a/experiments/benchmarks/snowy_land.jl
+++ b/experiments/benchmarks/snowy_land.jl
@@ -87,15 +87,16 @@ function setup_prob(
     surface_space = domain.space.surface
 
     # Forcing data
-    era5_ncdata_path =
-        ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
+    use_lowres_forcing = true
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
-        era5_ncdata_path,
-        surface_space,
         start_date,
+        stop_date,
+        use_lowres_forcing,
+        surface_space,
         earth_param_set,
         FT;
         time_interpolation_method = time_interpolation_method,
+        context,
     )
     forcing = (; atmos, radiation)
 

--- a/experiments/calibration/model_interface.jl
+++ b/experiments/calibration/model_interface.jl
@@ -72,7 +72,9 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
         )
     else
         era5_ncdata_path =
-            ClimaLand.Artifacts.era5_land_forcing_data2008_path(; context)
+            ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(;
+                context,
+            )
     end
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
         era5_ncdata_path,

--- a/experiments/calibration/model_interface.jl
+++ b/experiments/calibration/model_interface.jl
@@ -63,27 +63,18 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
         LinearInterpolation(PeriodicCalendar())
     surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
     surface_space = domain.space.surface
-    # Forcing data
-    if LONGER_RUN
-        era5_ncdata_path = ClimaLand.Artifacts.find_era5_year_paths(
-            start_date,
-            stop_date;
-            context,
-        )
-    else
-        era5_ncdata_path =
-            ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(;
-                context,
-            )
-    end
+    # Forcing data - high resolution for longer runs, low resolution for shortruns
+    use_lowres_forcing = !LONGER_RUN
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
-        era5_ncdata_path,
-        surface_space,
         start_date,
+        stop_date,
+        use_lowres_forcing,
+        surface_space,
         earth_param_set,
         FT;
         max_wind_speed = 25.0,
         time_interpolation_method = era5_time_interpolation_method,
+        context,
     )
     forcing = (; atmos, radiation)
 

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -53,15 +53,16 @@ dt = 450.0
 stop_date = start_date + Dates.Second(3600)
 
 # Forcing data
-era5_ncdata_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
+use_lowres_forcing = true
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
-    era5_ncdata_path,
-    surface_space,
     start_date,
+    stop_date,
+    use_lowres_forcing,
+    surface_space,
     earth_param_set,
     FT;
-    time_interpolation_method = time_interpolation_method,
+    time_interpolation_method,
+    context,
 )
 
 soil_forcing = (; atmos, radiation)

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -54,7 +54,7 @@ stop_date = start_date + Dates.Second(3600)
 
 # Forcing data
 era5_ncdata_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2008_path(; context)
+    ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,

--- a/experiments/integrated/global/global_soil_canopy_pmodel.jl
+++ b/experiments/integrated/global/global_soil_canopy_pmodel.jl
@@ -55,15 +55,16 @@ dt = 450.0
 stop_date = start_date + Dates.Second(3600)
 
 # Forcing data
-era5_ncdata_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
+use_lowres_forcing = true
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
-    era5_ncdata_path,
-    surface_space,
     start_date,
+    stop_date,
+    use_lowres_forcing,
+    surface_space,
     earth_param_set,
     FT;
-    time_interpolation_method = time_interpolation_method,
+    time_interpolation_method,
+    context,
 )
 
 soil_forcing = (; atmos, radiation)

--- a/experiments/integrated/global/global_soil_canopy_pmodel.jl
+++ b/experiments/integrated/global/global_soil_canopy_pmodel.jl
@@ -56,7 +56,7 @@ stop_date = start_date + Dates.Second(3600)
 
 # Forcing data
 era5_ncdata_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2008_path(; context)
+    ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,

--- a/experiments/long_runs/bucket.jl
+++ b/experiments/long_runs/bucket.jl
@@ -54,7 +54,7 @@ function setup_model(FT, start_date, domain, earth_param_set, Δt, toml_dict)
 
     # Forcing data
     era5_ncdata_path =
-        ClimaLand.Artifacts.era5_land_forcing_data2008_path(; context)
+        ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
         era5_ncdata_path,
         surface_space,

--- a/experiments/long_runs/bucket.jl
+++ b/experiments/long_runs/bucket.jl
@@ -48,22 +48,31 @@ diagnostics_outdir = joinpath(root_path, "global_diagnostics")
 outdir =
     ClimaUtilities.OutputPathGenerator.generate_output_path(diagnostics_outdir)
 
-function setup_model(FT, start_date, domain, earth_param_set, Δt, toml_dict)
+function setup_model(
+    FT,
+    start_date,
+    stop_date,
+    domain,
+    earth_param_set,
+    Δt,
+    toml_dict,
+    context,
+)
     surface_space = domain.space.surface
-    subsurface_space = domain.space.subsurface
 
     # Forcing data
-    era5_ncdata_path =
-        ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
+    use_lowres_forcing = true
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
-        era5_ncdata_path,
-        surface_space,
         start_date,
+        stop_date,
+        use_lowres_forcing,
+        surface_space,
         earth_param_set,
         FT;
         max_wind_speed = 25.0,
         time_interpolation_method,
         regridder_type,
+        context,
     )
 
     albedo = PrescribedBaregroundAlbedo(toml_dict, surface_space)
@@ -98,7 +107,16 @@ toml_dict = LP.create_toml_dict(FT)
 params = LP.LandParameters(toml_dict)
 
 # Model
-model = setup_model(FT, start_date, domain, params, Δt, toml_dict)
+model = setup_model(
+    FT,
+    start_date,
+    stop_date,
+    domain,
+    params,
+    Δt,
+    toml_dict,
+    context,
+)
 
 # IC function
 function set_ic!(Y, p, t, bucket)

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -50,23 +50,33 @@ diagnostics_outdir = joinpath(root_path, "regional_diagnostics")
 outdir =
     ClimaUtilities.OutputPathGenerator.generate_output_path(diagnostics_outdir)
 
-function setup_model(FT, context, start_date, Δt, domain, toml_dict)
+function setup_model(
+    FT,
+    context,
+    start_date,
+    stop_date,
+    Δt,
+    domain,
+    toml_dict,
+    context,
+)
     earth_param_set = LP.LandParameters(toml_dict)
     surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
     surface_space = domain.space.surface
 
     # Forcing data
-    era5_ncdata_path =
-        ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
+    use_lowres_forcing = true
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
-        era5_ncdata_path,
-        surface_space,
         start_date,
+        stop_date,
+        use_lowres_forcing,
+        surface_space,
         earth_param_set,
         FT;
         max_wind_speed = 25.0,
         time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
         interpolation_method = Interpolations.Linear(),
+        context,
     )
     forcing = (; atmos, radiation)
 
@@ -152,7 +162,16 @@ domain = ClimaLand.Domains.HybridBox(;
     dz_tuple = FT.((10.0, 0.05)),
 )
 toml_dict = LP.create_toml_dict(FT)
-model = setup_model(FT, context, start_date, Δt, domain, toml_dict)
+model = setup_model(
+    FT,
+    context,
+    start_date,
+    stop_date,
+    Δt,
+    domain,
+    toml_dict,
+    context,
+)
 
 simulation = LandSimulation(start_date, stop_date, Δt, model; outdir)
 ClimaLand.Simulations.solve!(simulation)

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -57,7 +57,7 @@ function setup_model(FT, context, start_date, Δt, domain, toml_dict)
 
     # Forcing data
     era5_ncdata_path =
-        ClimaLand.Artifacts.era5_land_forcing_data2008_path(; context)
+        ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
         era5_ncdata_path,
         surface_space,

--- a/experiments/long_runs/low_res_snowy_land_rh.jl
+++ b/experiments/long_runs/low_res_snowy_land_rh.jl
@@ -55,10 +55,8 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
     surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
     surface_space = domain.space.surface
     # Forcing data
-    era5_ncdata_path = ClimaLand.Artifacts.era5_land_forcing_data2008_path(;
-        context,
-        lowres = true,
-    )
+    era5_ncdata_path =
+        ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
     atmos, radiation = ClimaLand.prescribed_perturbed_rh_era5(
         era5_ncdata_path,
         surface_space,

--- a/experiments/long_runs/low_res_snowy_land_temp.jl
+++ b/experiments/long_runs/low_res_snowy_land_temp.jl
@@ -55,10 +55,8 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
     surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
     surface_space = domain.space.surface
     # Forcing data
-    era5_ncdata_path = ClimaLand.Artifacts.era5_land_forcing_data2008_path(;
-        context,
-        lowres = true,
-    )
+    era5_ncdata_path =
+        ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
     atmos, radiation = ClimaLand.prescribed_perturbed_temperature_era5(
         era5_ncdata_path,
         surface_space,

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -74,7 +74,9 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
         )
     else
         era5_ncdata_path =
-            ClimaLand.Artifacts.era5_land_forcing_data2008_path(; context)
+            ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(;
+                context,
+            )
     end
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
         era5_ncdata_path,

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -65,27 +65,18 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
         LinearInterpolation(PeriodicCalendar())
     surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
     surface_space = domain.space.surface
-    # Forcing data
-    if LONGER_RUN
-        era5_ncdata_path = ClimaLand.Artifacts.find_era5_year_paths(
-            start_date,
-            stop_date;
-            context,
-        )
-    else
-        era5_ncdata_path =
-            ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(;
-                context,
-            )
-    end
+    # Forcing data - high resolution for longer runs, low resolution for shortruns
+    use_lowres_forcing = !LONGER_RUN
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
-        era5_ncdata_path,
-        surface_space,
         start_date,
+        stop_date,
+        use_lowres_forcing,
+        surface_space,
         earth_param_set,
         FT;
         max_wind_speed = 25.0,
         time_interpolation_method = era5_time_interpolation_method,
+        context,
     )
     forcing = (; atmos, radiation)
 

--- a/experiments/long_runs/snowy_land_pmodel.jl
+++ b/experiments/long_runs/snowy_land_pmodel.jl
@@ -74,7 +74,9 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
         )
     else
         era5_ncdata_path =
-            ClimaLand.Artifacts.era5_land_forcing_data2008_path(; context)
+            ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(;
+                context,
+            )
     end
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
         era5_ncdata_path,

--- a/experiments/long_runs/snowy_land_pmodel.jl
+++ b/experiments/long_runs/snowy_land_pmodel.jl
@@ -65,27 +65,18 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
         LinearInterpolation(PeriodicCalendar())
     surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
     surface_space = domain.space.surface
-    # Forcing data
-    if LONGER_RUN
-        era5_ncdata_path = ClimaLand.Artifacts.find_era5_year_paths(
-            start_date,
-            stop_date;
-            context,
-        )
-    else
-        era5_ncdata_path =
-            ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(;
-                context,
-            )
-    end
+    # Forcing data - high resolution for longer runs, low resolution for shortruns
+    use_lowres_forcing = !LONGER_RUN
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
-        era5_ncdata_path,
-        surface_space,
         start_date,
+        stop_date,
+        use_lowres_forcing,
+        surface_space,
         earth_param_set,
         FT;
         max_wind_speed = 25.0,
         time_interpolation_method = era5_time_interpolation_method,
+        context,
     )
     forcing = (; atmos, radiation)
 

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -64,22 +64,18 @@ nelements = (101, 15)
 domain = ClimaLand.Domains.global_domain(FT; context, nelements)
 toml_dict = LP.create_toml_dict(FT)
 params = LP.LandParameters(toml_dict)
-# Forcing data
-if LONGER_RUN
-    era5_ncdata_path =
-        ClimaLand.Artifacts.find_era5_year_paths(start_date, stop_date; context)
-else
-    era5_ncdata_path =
-        ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
-end
+# Forcing data - high resolution for longer runs, low resolution for shortruns
+use_lowres_forcing = !LONGER_RUN
 forcing = ClimaLand.prescribed_forcing_era5(
-    era5_ncdata_path,
-    domain.space.surface,
     start_date,
+    stop_date,
+    use_lowres_forcing,
+    domain.space.surface,
     params,
     FT;
     max_wind_speed = 25.0,
     time_interpolation_method,
+    context,
 )
 model = ClimaLand.Soil.EnergyHydrology{FT}(domain, forcing, toml_dict)
 diagnostics = ClimaLand.default_diagnostics(

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -70,7 +70,7 @@ if LONGER_RUN
         ClimaLand.Artifacts.find_era5_year_paths(start_date, stop_date; context)
 else
     era5_ncdata_path =
-        ClimaLand.Artifacts.era5_land_forcing_data2008_path(; context)
+        ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
 end
 forcing = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,

--- a/experiments/standalone/Bucket/bucket_era5.jl
+++ b/experiments/standalone/Bucket/bucket_era5.jl
@@ -32,7 +32,7 @@ import ClimaUtilities
 import ClimaUtilities.TimeVaryingInputs:
     TimeVaryingInput, LinearInterpolation, PeriodicCalendar
 import ClimaUtilities.OutputPathGenerator: generate_output_path
-import ClimaUtilities.TimeManager: ITime
+import ClimaUtilities.TimeManager: ITime, date
 import ClimaTimeSteppers as CTS
 import NCDatasets
 using ClimaCore
@@ -139,16 +139,17 @@ albedo = PrescribedBaregroundAlbedo{FT}(α_snow, surface_space);
 bucket_parameters = BucketModelParameters(toml_dict; albedo, z_0m, z_0b, τc);
 
 # Forcing data
-era5_ncdata_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
+use_lowres_forcing = true
 bucket_atmos, bucket_rad = ClimaLand.prescribed_forcing_era5(
-    era5_ncdata_path,
+    date(t0),
+    date(tf),
+    use_lowres_forcing,
     surface_space,
-    start_date,
     earth_param_set,
     FT;
-    time_interpolation_method = time_interpolation_method,
-    regridder_type = regridder_type,
+    time_interpolation_method,
+    regridder_type,
+    context,
 )
 
 model = BucketModel(

--- a/experiments/standalone/Bucket/bucket_era5.jl
+++ b/experiments/standalone/Bucket/bucket_era5.jl
@@ -140,7 +140,7 @@ bucket_parameters = BucketModelParameters(toml_dict; albedo, z_0m, z_0b, τc);
 
 # Forcing data
 era5_ncdata_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2008_path(; context)
+    ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
 bucket_atmos, bucket_rad = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -34,7 +34,8 @@ end
     find_era5_year_paths(start_date, stop_date; context = nothing)
 
 Find the appropriate files of ERA5 forcing data to run a simuation starting on
-`start_date` and ending on `stop_date`.
+`start_date` and ending on `stop_date`. These will be returned as a list of paths,
+one for each year of data needed. The artifact contains data from 1979 to 2024.
 
 We add 1 year to the final date to ensure that everything between
 start_date and stop_date is covered. (This is needed, e.g., if the last file
@@ -51,7 +52,7 @@ function find_era5_year_paths(start_date, stop_date; context = nothing)
     )
     for year in years
         isfile(year) || error(
-            "The file $year does not exist in the forty years of ERA5 forcing data artifact",
+            "The year $year does not exist in the ERA5 forcing data artifact; please use dates between 1979 and 2024.",
         )
     end
     return years

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -58,36 +58,17 @@ function find_era5_year_paths(start_date, stop_date; context = nothing)
 end
 
 """
-    era5_land_forcing_data2008_path(; context, lowres=false)
+    era5_land_forcing_data2008_lowres_path(; context, lowres=false)
 
 Return the path to the file that contains the ERA5 forcing data for 2008.
-
-Optionally, you can pass the lowres=true keyword to download a lower spatial resolution version of the data and return the path to that file.
- If the high resolution data is not
-available locally, we also return the path to the low res data.
+Note that this uses a lower resolution of the ERA5 data, downsampled from
+1.0x1.0 degrees to 8.0x8.0 degrees.
 """
-function era5_land_forcing_data2008_path(; context = nothing, lowres = false)
-    lowres_path = joinpath(
+function era5_land_forcing_data2008_lowres_path(; context = nothing)
+    return joinpath(
         @clima_artifact("era5_land_forcing_data2008_lowres", context),
         "era5_2008_1.0x1.0_lowres.nc",
     )
-    if lowres
-        return lowres_path
-    else
-        try
-            hires_path = joinpath(
-                @clima_artifact("era5_land_forcing_data2008", context),
-                "era5_2008_1.0x1.0.nc",
-            )
-
-            return hires_path
-        catch
-            @warn(
-                "High resolution ERA5 forcing not available locally; using low resolution data instead."
-            )
-            return lowres_path
-        end
-    end
 end
 
 """

--- a/src/shared_utilities/Domains.jl
+++ b/src/shared_utilities/Domains.jl
@@ -1370,7 +1370,7 @@ function use_lowres_clm(
     return abs(lowres_scale - node_scale) < abs(highres_scale - node_scale)
 end
 
-use_lowres_clm(surface_space::ClimaCore.Spaces.PointSpace) = true
+use_lowres_clm(surface_space::ClimaCore.Spaces.PointSpace) = false
 
 
 export AbstractDomain

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -1494,11 +1494,11 @@ A helper function which constructs the `PrescribedAtmosphere` and
 `PrescribedRadiativeFluxes` from a file path pointing to the ERA5 data in a netcdf file, the
 `surface_space`, the `start_date`, and the `earth_param_set`.
 
-The argument `era5_ncdata_path` is either a list of nc files, each with all of the variables required, but with different time intervals in the different files, or else it is a single file with all the variables.
+The argument `era5_ncdata_path` is either a list of nc files, each with all of the variables required,
+but with different time intervals in the different files, or else it is a single file with all the variables.
 
 The ClimaLand default is to use nearest neighbor interpolation, but
-linear interpolation is supported
-by passing `interpolation_method = Interpolations.Linear()`.
+linear interpolation is supported by passing `interpolation_method = Interpolations.Linear()`.
 
 !!! warning "Clipped values"
     High wind speed anomalies (10-100x increase and decrease over a period of a
@@ -1512,6 +1512,8 @@ function prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,
     start_date,
+    stop_date,
+    use_lowres_forcing,
     earth_param_set,
     FT;
     gustiness = 1,
@@ -1519,7 +1521,9 @@ function prescribed_forcing_era5(
     c_co2 = TimeVaryingInput((t) -> 4.2e-4),
     time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
     regridder_type = :InterpolationsRegridder,
-    interpolation_method = Interpolations.Constant(),
+    lowres_forcing = false,
+    interpolation_method = lowres_forcing ? Interpolations.Constant() :
+                           Interpolations.Linear(),
 )
     # Pass a list of files in all cases
     era5_ncdata_path isa String && (era5_ncdata_path = [era5_ncdata_path])

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -1478,24 +1478,31 @@ function make_update_drivers(d::PrescribedSoilOrganicCarbon{FT}) where {FT}
 end
 
 """
-     prescribed_forcing_era5(era5_ncdata_path,
-                             surface_space,
-                             start_date,
-                             earth_param_set,
-                             FT;
-                             gustiness=1,
-                             max_wind_speed = nothing,
-                             c_co2 = TimeVaryingInput((t) -> 4.2e-4),
-                             time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
-                             regridder_type = :InterpolationsRegridder,
-                             interpolation_method = Interpolations.Constant(),)
+    prescribed_forcing_era5(start_date,
+                            stop_date,
+                            use_lowres_forcing,
+                            surface_space,
+                            earth_param_set,
+                            FT;
+                            gustiness=1,
+                            max_wind_speed = nothing,
+                            c_co2 = TimeVaryingInput((t) -> 4.2e-4),
+                            time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
+                            regridder_type = :InterpolationsRegridder,
+                            interpolation_method = Interpolations.Constant(),)
 
 A helper function which constructs the `PrescribedAtmosphere` and
-`PrescribedRadiativeFluxes` from a file path pointing to the ERA5 data in a netcdf file, the
-`surface_space`, the `start_date`, and the `earth_param_set`.
+`PrescribedRadiativeFluxes` from ERA5 data stored in NetCDF files.
 
-The argument `era5_ncdata_path` is either a list of nc files, each with all of the variables required,
-but with different time intervals in the different files, or else it is a single file with all the variables.
+There are two versions of the ERA5 data available through ClimaLand:
+- a high resolution version (1° x 1°) available for the years 1979-2024
+- a low resolution version (8° x 8°) available only for the year 2008
+
+The high resolution version will be used if `use_lowres_forcing = false`. This artifact is used
+for global runs on compute clusters, but is too large to be used for local testing.
+The low resolution version will be used if `use_lowres_forcing = true`.
+If the simulation dates are outside of 2008, the 2008 data will be reused for each year of simulation.
+This artifact is recommended for local testing or quick runs where accuracy is less critical.
 
 The ClimaLand default is to use nearest neighbor interpolation, but
 linear interpolation is supported by passing `interpolation_method = Interpolations.Linear()`.
@@ -1509,11 +1516,10 @@ linear interpolation is supported by passing `interpolation_method = Interpolati
     [here](https://confluence.ecmwf.int/display/CKB/ERA5%3A+large+10m+winds).
 """
 function prescribed_forcing_era5(
-    era5_ncdata_path,
-    surface_space,
     start_date,
     stop_date,
     use_lowres_forcing,
+    surface_space,
     earth_param_set,
     FT;
     gustiness = 1,
@@ -1521,10 +1527,29 @@ function prescribed_forcing_era5(
     c_co2 = TimeVaryingInput((t) -> 4.2e-4),
     time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
     regridder_type = :InterpolationsRegridder,
-    lowres_forcing = false,
-    interpolation_method = lowres_forcing ? Interpolations.Constant() :
-                           Interpolations.Linear(),
+    context = nothing,
 )
+    # Determine the ERA5 dataset and interpolation method based on the simulation years and resolution
+    if use_lowres_forcing
+        era5_ncdata_path =
+            ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(;
+                context,
+            )
+        interpolation_method = Interpolations.Constant()
+        # We can use the 2008 forcing outside of that year, but we need periodic boundaries for the time
+        if year(start_date) != 2008 ||
+           (year(stop_date) != 2008 && stop_date != DateTime(2009, 1, 1))
+            time_interpolation_method = LinearInterpolation(PeriodicCalendar())
+        end
+    else
+        era5_ncdata_path = ClimaLand.Artifacts.find_era5_year_paths(
+            start_date,
+            stop_date;
+            context,
+        )
+        interpolation_method = Interpolations.Linear()
+    end
+
     # Pass a list of files in all cases
     era5_ncdata_path isa String && (era5_ncdata_path = [era5_ncdata_path])
 

--- a/src/standalone/Vegetation/spatially_varying_parameters.jl
+++ b/src/standalone/Vegetation/spatially_varying_parameters.jl
@@ -14,12 +14,12 @@ import ClimaLand: use_lowres_clm, Artifacts
             Interpolations.Flat(),
             Interpolations.Flat(),
         ),
-        interpolation_method = Interpolations.Constant(),
-        lowres=use_lowres_clm(surface_space),
+        interpolation_method = Interpolations.Linear(),
+        lowres = use_lowres_clm(surface_space),
     )
 
 Reads spatially varying parameters for the canopy radiative transfer schemes,
- from NetCDF files based on CLM and MODIS data, and regrids them to the grid defined by the
+from NetCDF files based on CLM and MODIS data, and regrids them to the grid defined by the
 `surface_space` of the Clima simulation. Returns a NamedTuple of ClimaCore
 Fields.
 
@@ -32,13 +32,17 @@ The values correspond to the value of the dominant PFT at each point.
 
 The NetCDF files are stored in ClimaArtifacts and more detail on their origin
 is provided there. The keyword arguments `regridder_type`, `extrapolation_bc`, and
-`regridder_kwargs` 
+`regridder_kwargs`
 affect the regridding by (1) changing how we interpolate to ClimaCore points which
 are not in the data, and (2) changing how extrapolate to points beyond the range of the
-data, and (3) changed the spatial interpolation method. 
+data, and (3) changed the spatial interpolation method.
+
 The keyword argument lowres is a flag that determines if the 0.9x1.25 or 0.125x0.125
 resolution CLM data artifact is used. If the lowres flag is not provided, the clm artifact
 with the closest resolution to the surface_space is used.
+
+By default linear interpolation is used. This can be changed to nearest neighbor by passing
+`interpolation_method = Interpolations.Constant()`, but linear interpolation is recommended.
 """
 function clm_canopy_radiation_parameters(
     surface_space;
@@ -48,7 +52,7 @@ function clm_canopy_radiation_parameters(
         Interpolations.Flat(),
         Interpolations.Flat(),
     ),
-    interpolation_method = Interpolations.Constant(),
+    interpolation_method = Interpolations.Linear(),
     lowres = use_lowres_clm(surface_space),
 )
     context = ClimaComms.context(surface_space)
@@ -121,8 +125,8 @@ end
             Interpolations.Flat(),
             Interpolations.Flat(),
         ),
-        interpolation_method = Interpolations.Constant(),
-        lowres=use_lowres_clm(surface_space),
+        interpolation_method = Interpolations.Linear(),
+        lowres = use_lowres_clm(surface_space),
     )
 
 Reads spatially varying parameters for the canopy, from NetCDF files
@@ -138,13 +142,17 @@ The values correspond to the value of the dominant PFT at each point.
 
 The NetCDF files are stored in ClimaArtifacts and more detail on their origin
 is provided there. The keyword arguments `regridder_type`, `extrapolation_bc`, and
-`regridder_kwargs` 
+`regridder_kwargs`
 affect the regridding by (1) changing how we interpolate to ClimaCore points which
 are not in the data, and (2) changing how extrapolate to points beyond the range of the
-data, and (3) changed the spatial interpolation method. 
- The keyword argument lowres is a flag that determines if the 0.9x1.25 or 0.125x0.125
+data, and (3) changed the spatial interpolation method.
+
+The keyword argument lowres is a flag that determines if the 0.9x1.25 or 0.125x0.125
 resolution CLM data artifact is used. If the lowres flag is not provided, the clm artifact
 with the closest resolution to the surface_space is used.
+
+By default linear interpolation is used. This can be changed to nearest neighbor by passing
+`interpolation_method = Interpolations.Constant()`, but linear interpolation is recommended.
 """
 function clm_photosynthesis_parameters(
     surface_space;
@@ -154,7 +162,7 @@ function clm_photosynthesis_parameters(
         Interpolations.Flat(),
         Interpolations.Flat(),
     ),
-    interpolation_method = Interpolations.Constant(),
+    interpolation_method = Interpolations.Linear(),
     lowres = use_lowres_clm(surface_space),
 )
     context = ClimaComms.context(surface_space)
@@ -189,8 +197,8 @@ end
             Interpolations.Flat(),
             Interpolations.Flat(),
         ),
-        interpolation_method = Interpolations.Constant(),
-        lowres=use_lowres_clm(surface_space),
+        interpolation_method = Interpolations.Linear(),
+        lowres = use_lowres_clm(surface_space),
     )
 
 Reads spatially varying rooting depth for the canopy, from a NetCDF file
@@ -202,13 +210,17 @@ The values correspond to the value of the dominant PFT at each point.
 
 The NetCDF files are stored in ClimaArtifacts and more detail on their origin
 is provided there. The keyword arguments `regridder_type`, `extrapolation_bc`, and
-`regridder_kwargs` 
+`regridder_kwargs`
 affect the regridding by (1) changing how we interpolate to ClimaCore points which
 are not in the data, and (2) changing how extrapolate to points beyond the range of the
-data, and (3) changed the spatial interpolation method. 
- The keyword argument lowres is a flag that determines if the 0.9x1.25 or 0.125x0.125
+data, and (3) changed the spatial interpolation method.
+
+The keyword argument lowres is a flag that determines if the 0.9x1.25 or 0.125x0.125
 resolution CLM data artifact is used. If the lowres flag is not provided, the clm artifact
 with the closest resolution to the surface_space is used.
+
+By default linear interpolation is used. This can be changed to nearest neighbor by passing
+`interpolation_method = Interpolations.Constant()`, but linear interpolation is recommended.
 """
 function clm_rooting_depth(
     surface_space;
@@ -218,7 +230,7 @@ function clm_rooting_depth(
         Interpolations.Flat(),
         Interpolations.Flat(),
     ),
-    interpolation_method = Interpolations.Constant(),
+    interpolation_method = Interpolations.Linear(),
     lowres = use_lowres_clm(surface_space),
 )
     context = ClimaComms.context(surface_space)
@@ -243,8 +255,8 @@ end
             Interpolations.Flat(),
             Interpolations.Flat(),
         ),
-        interpolation_method = Interpolations.Constant(),
-        lowres=use_lowres_clm(surface_space),
+        interpolation_method = Interpolations.Linear(),
+        lowres = use_lowres_clm(surface_space),
     )
 
 Reads spatially varying g1 for the canopy, from a NetCDF file
@@ -256,13 +268,17 @@ The values correspond to the value of the dominant PFT at each point.
 
 The NetCDF files are stored in ClimaArtifacts and more detail on their origin
 is provided there. The keyword arguments `regridder_type`, `extrapolation_bc`, and
-`regridder_kwargs` 
+`regridder_kwargs`
 affect the regridding by (1) changing how we interpolate to ClimaCore points which
 are not in the data, and (2) changing how extrapolate to points beyond the range of the
-data, and (3) changed the spatial interpolation method. 
- The keyword argument lowres is a flag that determines if the 0.9x1.25 or 0.125x0.125
+data, and (3) changed the spatial interpolation method.
+
+The keyword argument lowres is a flag that determines if the 0.9x1.25 or 0.125x0.125
 resolution CLM data artifact is used. If the lowres flag is not provided, the clm artifact
 with the closest resolution to the surface_space is used.
+
+By default linear interpolation is used. This can be changed to nearest neighbor by passing
+`interpolation_method = Interpolations.Constant()`, but linear interpolation is recommended.
 """
 function clm_medlyn_g1(
     surface_space;
@@ -272,7 +288,7 @@ function clm_medlyn_g1(
         Interpolations.Flat(),
         Interpolations.Flat(),
     ),
-    interpolation_method = Interpolations.Constant(),
+    interpolation_method = Interpolations.Linear(),
     lowres = use_lowres_clm(surface_space),
 )
     context = ClimaComms.context(surface_space)

--- a/test/diagnostics/diagnostics_tests.jl
+++ b/test/diagnostics/diagnostics_tests.jl
@@ -166,11 +166,12 @@ start_date = DateTime(2008);
 stop_date = start_date + Second(60 * 60 * 72);
 dt = 1000.0;
 
-era5_ncdata_path = ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path();
+use_lowres_forcing = true
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
-    era5_ncdata_path,
-    surface_space,
     start_date,
+    stop_date,
+    use_lowres_forcing,
+    surface_space,
     earth_param_set,
     FT,
 );

--- a/test/diagnostics/diagnostics_tests.jl
+++ b/test/diagnostics/diagnostics_tests.jl
@@ -166,8 +166,7 @@ start_date = DateTime(2008);
 stop_date = start_date + Second(60 * 60 * 72);
 dt = 1000.0;
 
-era5_ncdata_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2008_path(; lowres = true);
+era5_ncdata_path = ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path();
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,

--- a/test/integrated/full_land.jl
+++ b/test/integrated/full_land.jl
@@ -194,14 +194,15 @@ domain = ClimaLand.Domains.global_domain(
 surface_space = domain.space.surface;
 start_date = DateTime(2008);
 stop_date = start_date + Second(Δt)
-era5_ncdata_path =
-    ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
+use_lowres_forcing = true
 forcing = ClimaLand.prescribed_forcing_era5(
-    era5_ncdata_path,
-    domain.space.surface,
     start_date,
+    stop_date,
+    use_lowres_forcing,
+    domain.space.surface,
     earth_param_set,
     FT;
+    context,
 )
 LAI = ClimaLand.Canopy.prescribed_lai_modis(
     domain.space.surface,

--- a/test/integrated/full_land.jl
+++ b/test/integrated/full_land.jl
@@ -194,10 +194,8 @@ domain = ClimaLand.Domains.global_domain(
 surface_space = domain.space.surface;
 start_date = DateTime(2008);
 stop_date = start_date + Second(Δt)
-era5_ncdata_path = ClimaLand.Artifacts.era5_land_forcing_data2008_path(;
-    context,
-    lowres = true,
-)
+era5_ncdata_path =
+    ClimaLand.Artifacts.era5_land_forcing_data2008_lowres_path(; context)
 forcing = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     domain.space.surface,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Before this PR, we use nearest neighbor (constant) interpolation for soil parameters, canopy parameters, and low and high resolution forcing data.

This PR keeps nearest neighbor for soil parameters and low resolution forcing, but switches to linear interpolation for canopy parameters and high resolution forcing. These are just the defaults and can still be changed in all of these cases.


## Content
- [x] canopy params: always use linear interp (note default in docstring)
- [x] 2008 forcing data: always use lowres, update function name and docstring
- [x] prescribed_forcing_era5: get path internally rather than taking it as an arg; ask user for start_date, stop_date, use_lowres_forcing

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
