### PR TITLE
Construct earth_param_set internally for drivers

### DIFF
--- a/docs/src/APIs/parameters.md
+++ b/docs/src/APIs/parameters.md
@@ -60,13 +60,12 @@ of constructing one.
 ```julia
 import ClimaLand.Parameters as LP
 
-# Store parameters for running long runs
+# Store default parameters
 toml_dict = LP.create_toml_dict(FT)
 
-# Store parameters for running bucket model
-bucket_params_filepath =
-    joinpath(pkgdir(ClimaLand), "toml", "bucket_parameters.toml")
-toml_dict = LP.create_toml_dict(FT, bucket_params_filepath)
+# Use default parameters overwritten by the parameters in override_files
+LP.create_toml_dict(FT; override_files = ["override.toml"])
+
 ```
 
 # FAQ

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -32,8 +32,7 @@ Note: we use SI units unless otherwise specified.
 See our [Physical Units](https://clima.github.io/ClimaLand.jl/stable/physical_units/) documentation for more information.
 ```julia
 FT = Float32
-toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict);
+toml_dict = LP.create_toml_dict(FT);
 ```
 
 We will run this simulation on a column domain with 1 meter depth, at a lat/lon location
@@ -63,7 +62,7 @@ atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 );
 ```

--- a/docs/src/tutorials/calibration/obs_site_level_calibration.jl
+++ b/docs/src/tutorials/calibration/obs_site_level_calibration.jl
@@ -61,7 +61,6 @@ const FT = Float32
 
 # Initialize land parameters and site configuration.
 toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict)
 site_ID = "US-MOz"
 site_ID_val = FluxnetSimulations.replace_hyphen(site_ID);
 
@@ -101,7 +100,7 @@ forcing = FluxnetSimulations.prescribed_forcing_fluxnet(
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 );
 

--- a/docs/src/tutorials/calibration/perfect_model_site_level_calibration.jl
+++ b/docs/src/tutorials/calibration/perfect_model_site_level_calibration.jl
@@ -68,7 +68,6 @@ const FT = Float32
 
 # Initialize land parameters and site configuration.
 toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict)
 site_ID = "US-MOz"
 site_ID_val = FluxnetSimulations.replace_hyphen(site_ID)
 
@@ -103,7 +102,7 @@ forcing = FluxnetSimulations.prescribed_forcing_fluxnet(
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 );
 

--- a/docs/src/tutorials/global/bucket.jl
+++ b/docs/src/tutorials/global/bucket.jl
@@ -51,7 +51,6 @@ domain =
 
 # Parameters:
 toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict)
 α_snow = FT(0.8)
 albedo = PrescribedBaregroundAlbedo{FT}(α_snow, domain.space.surface)
 bucket_parameters = BucketModelParameters(
@@ -76,7 +75,7 @@ atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     domain.space.surface,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT;
     max_wind_speed = 25.0,
     time_interpolation_method = LinearInterpolation(PeriodicCalendar()),

--- a/docs/src/tutorials/global/snowy_land.jl
+++ b/docs/src/tutorials/global/snowy_land.jl
@@ -32,7 +32,6 @@ diagnostics_outdir = joinpath(root_path, "global_diagnostics")
 outdir =
     ClimaUtilities.OutputPathGenerator.generate_output_path(diagnostics_outdir);
 toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict);
 
 # Set timestep, start\_date, stop\_date:
 Δt = 450.0
@@ -57,7 +56,7 @@ forcing = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     domain.space.surface,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT;
     max_wind_speed = 25.0,
     time_interpolation_method = LinearInterpolation(PeriodicCalendar()),

--- a/docs/src/tutorials/integrated/changing_snowy_land_parameterizations.jl
+++ b/docs/src/tutorials/integrated/changing_snowy_land_parameterizations.jl
@@ -46,7 +46,6 @@ import ClimaLand.LandSimVis as LandSimVis;
 
 const FT = Float32;
 toml_dict = LP.create_toml_dict(FT);
-earth_param_set = LP.LandParameters(toml_dict);
 
 # We will use prescribed atmospheric and radiative forcing from the
 # US-NR1 tower.  We also
@@ -81,7 +80,7 @@ forcing = FluxnetSimulations.prescribed_forcing_fluxnet(
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 );
 # LAI for the site - this uses our interface for working with MODIS data.

--- a/docs/src/tutorials/integrated/fluxnet_data.jl
+++ b/docs/src/tutorials/integrated/fluxnet_data.jl
@@ -26,7 +26,6 @@ import ClimaLand.FluxnetSimulations as FluxnetSimulations
 # parameter set holding constants used across CliMA Models.
 const FT = Float32;
 toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict);
 
 # Pick a site ID; convert the dash to an underscore:
 site_ID = "US-NR1";
@@ -67,7 +66,7 @@ site_ID_val = FluxnetSimulations.replace_hyphen(site_ID)
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 );
 # The atmosphere object holds the air temperature, pressure, specific

--- a/docs/src/tutorials/integrated/snowy_land_fluxnet_tutorial.jl
+++ b/docs/src/tutorials/integrated/snowy_land_fluxnet_tutorial.jl
@@ -38,7 +38,6 @@ import ClimaLand.LandSimVis as LandSimVis;
 
 const FT = Float32;
 toml_dict = LP.create_toml_dict(FT);
-earth_param_set = LP.LandParameters(toml_dict);
 
 # We will use prescribed atmospheric and radiative forcing from the
 # US-NR1 tower.  We also
@@ -73,7 +72,7 @@ forcing = FluxnetSimulations.prescribed_forcing_fluxnet(
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 );
 # LAI for the site - this uses our interface for working with MODIS data.

--- a/docs/src/tutorials/integrated/soil_canopy_fluxnet_tutorial.jl
+++ b/docs/src/tutorials/integrated/soil_canopy_fluxnet_tutorial.jl
@@ -42,7 +42,6 @@ import ClimaLand.LandSimVis as LandSimVis;
 
 const FT = Float32;
 toml_dict = LP.create_toml_dict(FT);
-earth_param_set = LP.LandParameters(toml_dict);
 
 # We will use prescribed atmospheric and radiative forcing from the
 # US-MOz tower.
@@ -77,7 +76,7 @@ forcing = FluxnetSimulations.prescribed_forcing_fluxnet(
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 );
 # LAI for the site - this uses our interface for working with MODIS data.

--- a/docs/src/tutorials/shared_utilities/driver_tutorial.jl
+++ b/docs/src/tutorials/shared_utilities/driver_tutorial.jl
@@ -149,7 +149,7 @@ cb = ClimaLand.DriverUpdateCallback(updatefunc, 3600.0 * 3, t0);
 # - "strd", Downwelling longwave radiation J/m^2/hour (accumulated over an hour)
 
 # You also need the `surface_space` of your simulation (corresponding to the grid being used), the floating point
-# type of the simulation `FT`, the ClimaLand `earth_param_set`, and the `start_date`,
+# type of the simulation `FT`, the `toml_dict`, and the `start_date`,
 # which should be a date after the first date
 # in your ERA5 netcdf file and before the last date. Then you can access the atmospheric and radiative
 # drivers like:
@@ -158,6 +158,6 @@ cb = ClimaLand.DriverUpdateCallback(updatefunc, 3600.0 * 3, t0);
 # atmos, radiation = ClimaLand.prescribed_forcing_era5(era5_ncdata_path,
 #                                                      surface_space,
 #                                                      start_date,
-#                                                      earth_param_set,
+#                                                      toml_dict,
 #                                                      FT)
 # ```

--- a/docs/src/tutorials/standalone/Bucket/bucket_tutorial.jl
+++ b/docs/src/tutorials/standalone/Bucket/bucket_tutorial.jl
@@ -169,8 +169,7 @@ FT = Float32;
 # are combined in the object `BucketModelParameters` as follows:
 import ClimaLand
 import ClimaLand.Parameters as LP
-toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict);
+toml_dict = LP.create_toml_dict(FT);
 
 # Set up the model domain. At every surface coordinate point, we'll solve
 # an ODE for `W` and `Ws`, and for every subsurface point, we solve for `T`.
@@ -251,7 +250,7 @@ bucket_atmos = PrescribedAtmosphere(
     TimeVaryingInput(P_atmos),
     start_date,
     h_atmos,
-    earth_param_set,
+    toml_dict,
 );
 
 # Prescribed radiation -- a prescribed downwelling SW diurnal cycle, with a

--- a/docs/src/tutorials/standalone/Canopy/canopy_tutorial.jl
+++ b/docs/src/tutorials/standalone/Canopy/canopy_tutorial.jl
@@ -64,7 +64,6 @@ import ClimaLand.LandSimVis as LandSimVis
 
 const FT = Float32;
 toml_dict = LP.create_toml_dict(FT);
-earth_param_set = LP.LandParameters(toml_dict);
 
 # We will use prescribed atmospheric and radiative forcing from the
 # US-MOz tower.
@@ -114,7 +113,7 @@ domain = Point(; z_sfc = FT(0.0), longlat = (long, lat));
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 );
 

--- a/docs/src/tutorials/standalone/Canopy/changing_canopy_parameterizations.jl
+++ b/docs/src/tutorials/standalone/Canopy/changing_canopy_parameterizations.jl
@@ -25,7 +25,6 @@ import ClimaLand.LandSimVis as LandSimVis
 # which holds constants used across CliMA models.
 FT = Float32
 toml_dict = LP.create_toml_dict(FT);
-earth_param_set = LP.LandParameters(toml_dict);
 
 # We will run this simulation on a point domain at a lat/lon location
 # near Pasadena, California.
@@ -53,7 +52,7 @@ atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 );
 ground = PrescribedGroundConditions{FT}();

--- a/docs/src/tutorials/standalone/Canopy/default_canopy.jl
+++ b/docs/src/tutorials/standalone/Canopy/default_canopy.jl
@@ -28,7 +28,6 @@ import ClimaLand.LandSimVis as LandSimVis
 # which holds constants used across CliMA models.
 FT = Float32
 toml_dict = LP.create_toml_dict(FT);
-earth_param_set = LP.LandParameters(toml_dict);
 
 # We will run this simulation on a point domain at a lat/lon location
 # near Pasadena, California.
@@ -56,7 +55,7 @@ atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 );
 ground = PrescribedGroundConditions{FT}();

--- a/docs/src/tutorials/standalone/Soil/changing_soil_parameterizations.jl
+++ b/docs/src/tutorials/standalone/Soil/changing_soil_parameterizations.jl
@@ -28,7 +28,6 @@ using Dates
 # Choose a floating point precision, and get the parameter set, which holds constants used across CliMA models.
 FT = Float32
 toml_dict = LP.create_toml_dict(FT);
-earth_param_set = LP.LandParameters(toml_dict);
 
 # We will run this simulation on a column domain with 1 meter depth, at a lat/lon location near Pasadena, California.
 zmax = FT(0)
@@ -49,7 +48,7 @@ atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 );
 

--- a/docs/src/tutorials/standalone/Soil/evaporation.jl
+++ b/docs/src/tutorials/standalone/Soil/evaporation.jl
@@ -84,7 +84,7 @@ atmos = PrescribedAtmosphere(
     TimeVaryingInput(P_atmos),
     start_date,
     h_atmos,
-    earth_param_set;
+    toml_dict;
     gustiness = gustiness,
 );
 

--- a/docs/src/tutorials/standalone/Soil/evaporation_gilat_loess.jl
+++ b/docs/src/tutorials/standalone/Soil/evaporation_gilat_loess.jl
@@ -105,7 +105,7 @@ atmos = PrescribedAtmosphere(
     TimeVaryingInput(P_atmos),
     start_date,
     h_atmos,
-    earth_param_set;
+    toml_dict;
     gustiness = gustiness,
 )
 

--- a/docs/src/tutorials/standalone/Soil/soil_energy_hydrology.jl
+++ b/docs/src/tutorials/standalone/Soil/soil_energy_hydrology.jl
@@ -96,9 +96,7 @@ import ClimaLand.Parameters as LP
 
 # Choose a floating point precision, and get the parameter set, which holds constants used across CliMA models:
 FT = Float32
-toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict);
-
+toml_dict = LP.create_toml_dict(FT);
 
 # # Create the model
 # Set the values of other parameters required by the model:

--- a/docs/src/tutorials/standalone/Soil/sublimation.jl
+++ b/docs/src/tutorials/standalone/Soil/sublimation.jl
@@ -66,7 +66,7 @@ atmos = PrescribedAtmosphere(
     TimeVaryingInput(P_atmos),
     start_date,
     h_atmos,
-    earth_param_set;
+    toml_dict;
     gustiness = gustiness,
 );
 

--- a/experiments/benchmarks/bucket.jl
+++ b/experiments/benchmarks/bucket.jl
@@ -110,7 +110,7 @@ function setup_prob(t0, tf, Δt; nelements = (200, 7))
         TimeVaryingInput(P_atmos),
         start_date,
         h_atmos,
-        earth_param_set,
+        toml_dict,
     )
 
     # Prescribed radiation -- a prescribed downwelling SW diurnal cycle, with a

--- a/experiments/benchmarks/snowy_land.jl
+++ b/experiments/benchmarks/snowy_land.jl
@@ -81,7 +81,6 @@ function setup_prob(
     nelements = (101, 15),
 )
     toml_dict = LP.create_toml_dict(FT)
-    earth_param_set = LP.LandParameters(toml_dict)
     domain = ClimaLand.Domains.global_domain(FT; nelements = nelements)
     surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
     surface_space = domain.space.surface
@@ -95,7 +94,7 @@ function setup_prob(
         era5_ncdata_path,
         surface_space,
         start_date,
-        earth_param_set,
+        toml_dict,
         FT;
         time_interpolation_method = time_interpolation_method,
     )

--- a/experiments/calibration/model_interface.jl
+++ b/experiments/calibration/model_interface.jl
@@ -57,7 +57,6 @@ device_suffix = device isa ClimaComms.CPUSingleThreaded ? "cpu" : "gpu"
 root_path = "snowy_land_longrun_$(device_suffix)"
 
 function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
-    earth_param_set = LP.LandParameters(toml_dict)
     era5_time_interpolation_method =
         LONGER_RUN ? LinearInterpolation() :
         LinearInterpolation(PeriodicCalendar())
@@ -78,7 +77,7 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
         era5_ncdata_path,
         surface_space,
         start_date,
-        earth_param_set,
+        toml_dict,
         FT;
         max_wind_speed = 25.0,
         time_interpolation_method = era5_time_interpolation_method,

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -30,7 +30,6 @@ using CairoMakie, ClimaAnalysis, GeoMakie, Printf, StatsBase
 import ClimaLand.LandSimVis as LandSimVis
 const FT = Float64
 toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict)
 climaland_dir = pkgdir(ClimaLand)
 site_ID = "US-MOz"
 site_ID_val = FluxnetSimulations.replace_hyphen(site_ID)
@@ -156,7 +155,7 @@ pft_pcts = [
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 )
 

--- a/experiments/integrated/fluxnet/ozark_pmodel.jl
+++ b/experiments/integrated/fluxnet/ozark_pmodel.jl
@@ -23,7 +23,6 @@ import ClimaLand.LandSimVis as LandSimVis
 
 const FT = Float64
 toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict)
 climaland_dir = pkgdir(ClimaLand)
 prognostic_land_components = (:canopy, :snow, :soil, :soilco2)
 
@@ -109,7 +108,7 @@ dt = Float64(450) # 7.5 minutes
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 )
 

--- a/experiments/integrated/fluxnet/ozark_soilsnow.jl
+++ b/experiments/integrated/fluxnet/ozark_soilsnow.jl
@@ -111,7 +111,7 @@ forcing = FluxnetSimulations.prescribed_forcing_fluxnet(
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 )
 

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -24,7 +24,6 @@ import ClimaLand.LandSimVis as LandSimVis
 
 const FT = Float64
 toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict)
 climaland_dir = pkgdir(ClimaLand)
 prognostic_land_components = (:canopy, :snow, :soil, :soilco2)
 
@@ -113,7 +112,7 @@ dt = Float64(450) # 7.5 minutes
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 )
 

--- a/experiments/integrated/fluxnet/vaira_paper.jl
+++ b/experiments/integrated/fluxnet/vaira_paper.jl
@@ -24,7 +24,6 @@ import ClimaLand.LandSimVis as LandSimVis
 
 const FT = Float64
 toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict)
 climaland_dir = pkgdir(ClimaLand)
 prognostic_land_components = (:canopy, :snow, :soil, :soilco2)
 site_ID = "US-Var"
@@ -107,7 +106,7 @@ stop_date = start_date + Year(1)
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 )
 

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -37,7 +37,6 @@ device_suffix =
 
 FT = Float64
 toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict)
 prognostic_land_components = (:canopy, :soil, :soilco2)
 
 # Set up the domain
@@ -59,7 +58,7 @@ atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT;
     time_interpolation_method = time_interpolation_method,
 )

--- a/experiments/integrated/global/global_soil_canopy_pmodel.jl
+++ b/experiments/integrated/global/global_soil_canopy_pmodel.jl
@@ -37,7 +37,6 @@ device_suffix =
 
 FT = Float64
 toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict)
 prognostic_land_components = (:canopy, :soil, :soilco2)
 
 # Set up the domain
@@ -61,7 +60,7 @@ atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT;
     time_interpolation_method = time_interpolation_method,
 )

--- a/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
+++ b/experiments/integrated/performance/conservation/ozark_conservation_setup.jl
@@ -104,7 +104,7 @@ prognostic_land_components = (:canopy, :soil, :soilco2)
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 )
 

--- a/experiments/integrated/performance/integrated_timestep_test.jl
+++ b/experiments/integrated/performance/integrated_timestep_test.jl
@@ -180,7 +180,7 @@ radiation = ClimaLand.PrescribedRadiativeFluxes(
     LW_IN,
     start_date,
     θs = zenith_angle,
-    earth_param_set = earth_param_set,
+    toml_dict = toml_dict,
 );
 
 # Soil model setup

--- a/experiments/integrated/performance/integrated_timestep_test.jl
+++ b/experiments/integrated/performance/integrated_timestep_test.jl
@@ -159,7 +159,7 @@ atmos = ClimaLand.PrescribedAtmosphere(
     atmos_p,
     start_date,
     atmos_h,
-    earth_param_set,
+    toml_dict,
 );
 LW_IN = TimeVaryingInput((t) -> 5.67e-8 * 298.0^4)
 SW_IN = TimeVaryingInput((t) -> 500.0)

--- a/experiments/long_runs/bucket.jl
+++ b/experiments/long_runs/bucket.jl
@@ -131,6 +131,7 @@ simulation = LandSimulation(
 @info "Timestep: $Δt s"
 @info "Start Date: $start_date"
 @info "Stop Date: $stop_date"
+CP.log_parameter_information(toml_dict, joinpath(root_path, "parameters.toml"))
 solve!(simulation);
 
 short_names = ["tsfc", "lhf", "shf", "wsoil"]

--- a/experiments/long_runs/bucket.jl
+++ b/experiments/long_runs/bucket.jl
@@ -48,7 +48,7 @@ diagnostics_outdir = joinpath(root_path, "global_diagnostics")
 outdir =
     ClimaUtilities.OutputPathGenerator.generate_output_path(diagnostics_outdir)
 
-function setup_model(FT, start_date, domain, earth_param_set, Δt, toml_dict)
+function setup_model(FT, start_date, domain, Δt, toml_dict)
     surface_space = domain.space.surface
     subsurface_space = domain.space.subsurface
 
@@ -59,7 +59,7 @@ function setup_model(FT, start_date, domain, earth_param_set, Δt, toml_dict)
         era5_ncdata_path,
         surface_space,
         start_date,
-        earth_param_set,
+        toml_dict,
         FT;
         max_wind_speed = 25.0,
         time_interpolation_method,
@@ -95,10 +95,9 @@ domain =
 
 # Parameters
 toml_dict = LP.create_toml_dict(FT)
-params = LP.LandParameters(toml_dict)
 
 # Model
-model = setup_model(FT, start_date, domain, params, Δt, toml_dict)
+model = setup_model(FT, start_date, domain, Δt, toml_dict)
 
 # IC function
 function set_ic!(Y, p, t, bucket)

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -155,6 +155,7 @@ toml_dict = LP.create_toml_dict(FT)
 model = setup_model(FT, context, start_date, Δt, domain, toml_dict)
 
 simulation = LandSimulation(start_date, stop_date, Δt, model; outdir)
+CP.log_parameter_information(toml_dict, joinpath(root_path, "parameters.toml"))
 ClimaLand.Simulations.solve!(simulation)
 
 LandSimVis.make_heatmaps(simulation; savedir = root_path, date = stop_date)

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -51,7 +51,6 @@ outdir =
     ClimaUtilities.OutputPathGenerator.generate_output_path(diagnostics_outdir)
 
 function setup_model(FT, context, start_date, Δt, domain, toml_dict)
-    earth_param_set = LP.LandParameters(toml_dict)
     surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
     surface_space = domain.space.surface
 
@@ -62,7 +61,7 @@ function setup_model(FT, context, start_date, Δt, domain, toml_dict)
         era5_ncdata_path,
         surface_space,
         start_date,
-        earth_param_set,
+        toml_dict,
         FT;
         max_wind_speed = 25.0,
         time_interpolation_method = LinearInterpolation(PeriodicCalendar()),

--- a/experiments/long_runs/low_res_snowy_land_rh.jl
+++ b/experiments/long_runs/low_res_snowy_land_rh.jl
@@ -164,6 +164,7 @@ simulation =
 @info "Timestep: $Δt s"
 @info "Start Date: $start_date"
 @info "Stop Date: $stop_date"
+CP.log_parameter_information(toml_dict, joinpath(root_path, "parameters.toml"))
 ClimaLand.Simulations.solve!(simulation)
 
 LandSimVis.make_annual_timeseries(simulation; savedir = root_path)

--- a/experiments/long_runs/low_res_snowy_land_temp.jl
+++ b/experiments/long_runs/low_res_snowy_land_temp.jl
@@ -164,6 +164,7 @@ simulation =
 @info "Timestep: $Δt s"
 @info "Start Date: $start_date"
 @info "Stop Date: $stop_date"
+CP.log_parameter_information(toml_dict, joinpath(root_path, "parameters.toml"))
 ClimaLand.Simulations.solve!(simulation)
 
 LandSimVis.make_annual_timeseries(simulation; savedir = root_path)

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -59,7 +59,6 @@ outdir =
     ClimaUtilities.OutputPathGenerator.generate_output_path(diagnostics_outdir)
 
 function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
-    earth_param_set = LP.LandParameters(toml_dict)
     era5_time_interpolation_method =
         LONGER_RUN ? LinearInterpolation() :
         LinearInterpolation(PeriodicCalendar())
@@ -80,7 +79,7 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
         era5_ncdata_path,
         surface_space,
         start_date,
-        earth_param_set,
+        toml_dict,
         FT;
         max_wind_speed = 25.0,
         time_interpolation_method = era5_time_interpolation_method,

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -174,6 +174,7 @@ simulation = LandSimulation(start_date, stop_date, Δt, model; outdir)
 @info "Timestep: $Δt s"
 @info "Start Date: $start_date"
 @info "Stop Date: $stop_date"
+CP.log_parameter_information(toml_dict, joinpath(root_path, "parameters.toml"))
 ClimaLand.Simulations.solve!(simulation)
 
 LandSimVis.make_annual_timeseries(simulation; savedir = root_path)

--- a/experiments/long_runs/snowy_land_pmodel.jl
+++ b/experiments/long_runs/snowy_land_pmodel.jl
@@ -59,7 +59,6 @@ outdir =
     ClimaUtilities.OutputPathGenerator.generate_output_path(diagnostics_outdir)
 
 function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
-    earth_param_set = LP.LandParameters(toml_dict)
     era5_time_interpolation_method =
         LONGER_RUN ? LinearInterpolation() :
         LinearInterpolation(PeriodicCalendar())
@@ -80,7 +79,7 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
         era5_ncdata_path,
         surface_space,
         start_date,
-        earth_param_set,
+        toml_dict,
         FT;
         max_wind_speed = 25.0,
         time_interpolation_method = era5_time_interpolation_method,

--- a/experiments/long_runs/snowy_land_pmodel.jl
+++ b/experiments/long_runs/snowy_land_pmodel.jl
@@ -181,6 +181,7 @@ simulation = LandSimulation(start_date, stop_date, Δt, model; outdir)
 @info "Timestep: $Δt s"
 @info "Start Date: $start_date"
 @info "Stop Date: $stop_date"
+CP.log_parameter_information(toml_dict, joinpath(root_path, "parameters.toml"))
 ClimaLand.Simulations.solve!(simulation)
 
 LandSimVis.make_annual_timeseries(simulation; savedir = root_path)

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -101,6 +101,7 @@ simulation =
 @info "Timestep: $Δt s"
 @info "Start Date: $start_date"
 @info "Stop Date: $stop_date"
+CP.log_parameter_information(toml_dict, joinpath(root_path, "parameters.toml"))
 ClimaLand.Simulations.solve!(simulation)
 
 short_names = ["swc", "sie", "si", "et"]

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -63,7 +63,7 @@ stop_date = LONGER_RUN ? DateTime(2020) : DateTime(2010)
 nelements = (101, 15)
 domain = ClimaLand.Domains.global_domain(FT; context, nelements)
 toml_dict = LP.create_toml_dict(FT)
-params = LP.LandParameters(toml_dict)
+
 # Forcing data
 if LONGER_RUN
     era5_ncdata_path =
@@ -76,7 +76,7 @@ forcing = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     domain.space.surface,
     start_date,
-    params,
+    toml_dict,
     FT;
     max_wind_speed = 25.0,
     time_interpolation_method,

--- a/experiments/standalone/Biogeochemistry/experiment.jl
+++ b/experiments/standalone/Biogeochemistry/experiment.jl
@@ -90,7 +90,7 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
         TimeVaryingInput(atmos_p),
         UTC_DATETIME,
         atmos_h,
-        earth_param_set;
+        toml_dict;
         c_co2 = TimeVaryingInput(atmos_co2),
     )
 

--- a/experiments/standalone/Bucket/bucket_era5.jl
+++ b/experiments/standalone/Bucket/bucket_era5.jl
@@ -77,7 +77,6 @@ FT = Float64;
 context = ClimaComms.context()
 ClimaComms.init(context)
 toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict);
 # Use separate output directory for CPU and GPU runs to avoid race condition
 device_suffix =
     typeof(context.device) <: ClimaComms.CPUSingleThreaded ? "cpu" : "gpu"
@@ -140,7 +139,7 @@ bucket_atmos, bucket_rad = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT;
     time_interpolation_method = time_interpolation_method,
     regridder_type = regridder_type,

--- a/experiments/standalone/Bucket/global_bucket_function.jl
+++ b/experiments/standalone/Bucket/global_bucket_function.jl
@@ -65,8 +65,7 @@ anim_plots = false
 FT = Float64;
 context = ClimaComms.context()
 ClimaComms.init(context)
-toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict);
+toml_dict = LP.create_toml_dict(FT);
 # Use separate output directory for CPU and GPU runs to avoid race condition
 device_suffix =
     typeof(context.device) <: ClimaComms.CPUSingleThreaded ? "cpu" : "gpu"
@@ -120,7 +119,7 @@ bucket_atmos = PrescribedAtmosphere(
     TimeVaryingInput(P_atmos),
     start_date,
     h_atmos,
-    earth_param_set,
+    toml_dict,
 );
 
 # Prescribed radiation -- a prescribed downwelling SW diurnal cycle, with a

--- a/experiments/standalone/Bucket/global_bucket_temporalmap.jl
+++ b/experiments/standalone/Bucket/global_bucket_temporalmap.jl
@@ -73,8 +73,7 @@ end
 FT = Float64;
 context = ClimaComms.context()
 ClimaComms.init(context)
-toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict);
+toml_dict = LP.create_toml_dict(FT);
 # Use separate output directory for CPU and GPU runs to avoid race condition
 device_suffix =
     typeof(context.device) <: ClimaComms.CPUSingleThreaded ? "cpu" : "gpu"
@@ -136,7 +135,7 @@ function setup_prob(start_date, stop_date, Δt, outdir)
         TimeVaryingInput(P_atmos),
         start_date,
         h_atmos,
-        earth_param_set,
+        toml_dict,
     )
 
     # Prescribed radiation -- a prescribed downwelling SW diurnal cycle, with a

--- a/experiments/standalone/Snow/process_snowmip.jl
+++ b/experiments/standalone/Snow/process_snowmip.jl
@@ -106,7 +106,7 @@ atmos = PrescribedAtmosphere(
     P_atmos,
     start_date,
     h_atmos,
-    earth_param_set,
+    toml_dict,
 )
 forcing = (; atmos, radiation)
 # Snow data

--- a/experiments/standalone/Snow/process_snowmip.jl
+++ b/experiments/standalone/Snow/process_snowmip.jl
@@ -84,7 +84,7 @@ radiation = ClimaLand.PrescribedRadiativeFluxes(
     LW_d,
     start_date;
     θs = zenith_angle,
-    earth_param_set = earth_param_set,
+    toml_dict = toml_dict,
 )
 
 

--- a/experiments/standalone/Vegetation/no_vegetation.jl
+++ b/experiments/standalone/Vegetation/no_vegetation.jl
@@ -21,8 +21,7 @@ using DelimitedFiles
 import ClimaLand.FluxnetSimulations as FluxnetSimulations
 
 const FT = Float32;
-toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict);
+toml_dict = LP.create_toml_dict(FT);
 
 time_offset = -6
 lat = FT(38.7441) # degree
@@ -43,7 +42,7 @@ dt = 225.0;
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 )
 ground = PrescribedGroundConditions{FT}(;

--- a/experiments/standalone/Vegetation/timestep_test.jl
+++ b/experiments/standalone/Vegetation/timestep_test.jl
@@ -61,8 +61,7 @@ using DelimitedFiles
 import ClimaLand.FluxnetSimulations as FluxnetSimulations
 
 const FT = Float64;
-toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict);
+toml_dict = LP.create_toml_dict(FT);
 
 # Site-specific information
 time_offset = -6 # difference from UTC in hours
@@ -83,7 +82,7 @@ stop_date = start_date + Day(N_days) + Second(80)
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 )
 ground = PrescribedGroundConditions{FT}(;

--- a/experiments/standalone/Vegetation/varying_lai.jl
+++ b/experiments/standalone/Vegetation/varying_lai.jl
@@ -20,8 +20,7 @@ using DelimitedFiles
 import ClimaLand.FluxnetSimulations as FluxnetSimulations
 import ClimaUtilities.OutputPathGenerator: generate_output_path
 const FT = Float32;
-toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict);
+toml_dict = LP.create_toml_dict(FT);
 
 time_offset = -6
 lat = FT(38.7441) # degree
@@ -40,7 +39,7 @@ dt = 225.0;
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 )
 ground = PrescribedGroundConditions{FT}(;

--- a/experiments/standalone/Vegetation/varying_lai_with_stem.jl
+++ b/experiments/standalone/Vegetation/varying_lai_with_stem.jl
@@ -20,8 +20,7 @@ import ClimaUtilities.OutputPathGenerator: generate_output_path
 using DelimitedFiles
 import ClimaLand.FluxnetSimulations as FluxnetSimulations
 const FT = Float32;
-toml_dict = LP.create_toml_dict(FT)
-earth_param_set = LP.LandParameters(toml_dict);
+toml_dict = LP.create_toml_dict(FT);
 
 time_offset = -6
 lat = FT(38.7441) # degree
@@ -40,7 +39,7 @@ dt = FT(225);
     time_offset,
     atmos_h,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 )
 

--- a/ext/fluxnet_simulations/forcing.jl
+++ b/ext/fluxnet_simulations/forcing.jl
@@ -221,7 +221,7 @@ function FluxnetSimulations.prescribed_forcing_fluxnet(
         LW_d,
         start_date,
         θs = zenith_angle,
-        earth_param_set = earth_param_set,
+        toml_dict = toml_dict,
     )
     return (; atmos, radiation)
 end

--- a/ext/fluxnet_simulations/forcing.jl
+++ b/ext/fluxnet_simulations/forcing.jl
@@ -8,7 +8,7 @@ import ClimaParams as CP
                                 long,
                                 hour_offset_from_UTC,
                                 start_date,
-                                earth_param_set,
+                                toml_dict::CP.ParamDict,
                                 FT;
                                 gustiness=1,
                                 split_precip= true,
@@ -17,7 +17,7 @@ import ClimaParams as CP
 A helper function which constructs the `PrescribedAtmosphere` and `PrescribedRadiativeFluxes`
 from a file path pointing to the Fluxnet data in a csv file, the start date, latitude, longitude,
 the hour offset of the site from UTC (local_time + offset = time in UTC),
-and the earth_param_set.
+and the `toml_dict`.
 
 This requires (1) reading in the data, (2) removing missing values,
  (3) converting units, (4) computing the specific humidity and percent of

--- a/ext/fluxnet_simulations/forcing.jl
+++ b/ext/fluxnet_simulations/forcing.jl
@@ -1,4 +1,6 @@
 using NCDatasets
+import ClimaParams as CP
+
 
 """
      prescribed_forcing_fluxnet(site_ID,
@@ -44,12 +46,13 @@ function FluxnetSimulations.prescribed_forcing_fluxnet(
     hour_offset_from_UTC,
     atmos_h,
     start_date, # in UTC
-    earth_param_set,
+    toml_dict::CP.ParamDict,
     FT;
     split_precip = true,
     gustiness = 1,
     c_co2 = TimeVaryingInput((t) -> 4.2e-4),
 )
+    earth_param_set = LP.LandParameters(toml_dict)
     thermo_params = LP.thermodynamic_parameters(earth_param_set)
 
     fluxnet_csv_path = ClimaLand.Artifacts.experiment_fluxnet_data_path(site_ID)
@@ -200,7 +203,7 @@ function FluxnetSimulations.prescribed_forcing_fluxnet(
         atmos_P,
         start_date,
         atmos_h,
-        earth_param_set;
+        toml_dict;
         c_co2,
     )
 

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -701,12 +701,13 @@ struct PrescribedRadiativeFluxes{
         LW_d,
         start_date;
         θs = nothing,
-        earth_param_set = nothing,
+        toml_dict::Union{CP.ParamDict, Nothing} = nothing,
         frac_diff = nothing,
     )
-        if isnothing(earth_param_set)
+        if isnothing(toml_dict)
             thermo_params = nothing
         else
+            earth_param_set = LP.LandParameters(toml_dict)
             thermo_params = LP.thermodynamic_parameters(earth_param_set)
         end
         args = (SW_d, frac_diff, LW_d, start_date, θs, thermo_params)
@@ -1664,7 +1665,7 @@ function prescribed_forcing_era5(
         LW_d,
         start_date;
         θs = zenith_angle,
-        earth_param_set = earth_param_set,
+        toml_dict = toml_dict,
         frac_diff = frac_diff,
     )
     return (; atmos, radiation)

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -1481,7 +1481,7 @@ end
      prescribed_forcing_era5(era5_ncdata_path,
                              surface_space,
                              start_date,
-                             earth_param_set,
+                             toml_dict::CP.ParamDict,
                              FT;
                              gustiness=1,
                              max_wind_speed = nothing,
@@ -1492,7 +1492,7 @@ end
 
 A helper function which constructs the `PrescribedAtmosphere` and
 `PrescribedRadiativeFluxes` from a file path pointing to the ERA5 data in a netcdf file, the
-`surface_space`, the `start_date`, and the `earth_param_set`.
+`surface_space`, the `start_date`, and the `toml_dict`.
 
 The argument `era5_ncdata_path` is either a list of nc files, each with all of the variables required, but with different time intervals in the different files, or else it is a single file with all the variables.
 
@@ -1512,7 +1512,7 @@ function prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,
     start_date,
-    earth_param_set,
+    toml_dict::CP.ParamDict,
     FT;
     gustiness = 1,
     max_wind_speed = nothing,
@@ -1521,6 +1521,7 @@ function prescribed_forcing_era5(
     regridder_type = :InterpolationsRegridder,
     interpolation_method = Interpolations.Constant(),
 )
+    earth_param_set = LP.LandParameters(toml_dict)
     # Pass a list of files in all cases
     era5_ncdata_path isa String && (era5_ncdata_path = [era5_ncdata_path])
 

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -158,10 +158,11 @@ struct PrescribedAtmosphere{
         P,
         start_date,
         h::FT,
-        earth_param_set;
+        toml_dict::CP.ParamDict;
         gustiness = FT(1),
         c_co2 = TimeVaryingInput((t) -> 4.2e-4),
     ) where {FT}
+        earth_param_set = LP.LandParameters(toml_dict)
         thermo_params = LP.thermodynamic_parameters(earth_param_set)
         args = (liquid_precip, snow_precip, T, u, q, P, c_co2, start_date)
         return new{typeof(h), typeof.(args)..., typeof(thermo_params)}(
@@ -1607,7 +1608,7 @@ function prescribed_forcing_era5(
         P_atmos,
         start_date,
         h_atmos,
-        earth_param_set;
+        toml_dict;
         gustiness = FT(gustiness),
         c_co2 = c_co2,
     )
@@ -1724,7 +1725,7 @@ function prescribed_analytic_forcing(
         TimeVaryingInput(P_atmos),
         start_date,
         h_atmos,
-        LP.LandParameters(toml_dict),
+        toml_dict,
     ),
     radiation = PrescribedRadiativeFluxes(
         FT,

--- a/src/shared_utilities/perturbed_drivers.jl
+++ b/src/shared_utilities/perturbed_drivers.jl
@@ -208,7 +208,7 @@ function prescribed_perturbed_temperature_era5(
         P_atmos,
         start_date,
         h_atmos,
-        earth_param_set;
+        toml_dict;
         gustiness = FT(gustiness),
         c_co2 = c_co2,
     )
@@ -398,7 +398,7 @@ function prescribed_perturbed_rh_era5(
         P_atmos,
         start_date,
         h_atmos,
-        earth_param_set;
+        toml_dict;
         gustiness = FT(gustiness),
         c_co2 = c_co2,
     )

--- a/src/shared_utilities/perturbed_drivers.jl
+++ b/src/shared_utilities/perturbed_drivers.jl
@@ -266,7 +266,7 @@ function prescribed_perturbed_temperature_era5(
         LW_d,
         start_date;
         θs = zenith_angle,
-        earth_param_set = earth_param_set,
+        toml_dict = toml_dict,
         frac_diff = frac_diff,
     )
     return (; atmos, radiation)
@@ -454,7 +454,7 @@ function prescribed_perturbed_rh_era5(
         LW_d,
         start_date;
         θs = zenith_angle,
-        earth_param_set = earth_param_set,
+        toml_dict = toml_dict,
         frac_diff = frac_diff,
     )
     return (; atmos, radiation)

--- a/src/shared_utilities/perturbed_drivers.jl
+++ b/src/shared_utilities/perturbed_drivers.jl
@@ -82,10 +82,10 @@ function perturbed_rh_specific_humidity_from_dewpoint(
 end
 
 """
-     prescribed_perturbed_temperature_era5(era5_ncdata_path,
+    prescribed_perturbed_temperature_era5(era5_ncdata_path,
                              surface_space,
                              start_date,
-                             earth_param_set,
+                             toml_dict::CP.ParamDict,
                              ΔT,
                              FT;
                              gustiness=1,
@@ -97,7 +97,7 @@ end
 
 A helper function which constructs the `PrescribedAtmosphere` and `PrescribedRadiativeFluxes`
 from a file path pointing to the ERA5 data in a netcdf file, the surface_space, the start date,
-and the earth_param_set, applying a change in the instantaneous temperature at each point
+and the `toml_dict`, applying a change in the instantaneous temperature at each point
 of ΔT, while keeping the relative humidity fixed. The LW_d shifts as LW_d -> LW_d + aΔT, with
 a= 2W/m^2/K a surface climate sensitivity parameter.
 
@@ -107,7 +107,7 @@ function prescribed_perturbed_temperature_era5(
     era5_ncdata_path,
     surface_space,
     start_date,
-    earth_param_set,
+    toml_dict::CP.ParamDict,
     ΔT,
     FT;
     gustiness = 1,
@@ -117,6 +117,7 @@ function prescribed_perturbed_temperature_era5(
     regridder_type = :InterpolationsRegridder,
     interpolation_method = Interpolations.Constant(),
 )
+    earth_param_set = LP.LandParameters(toml_dict)
     # Pass a list of files in all cases
     era5_ncdata_path isa String && (era5_ncdata_path = [era5_ncdata_path])
     _ρ_liq = LP.ρ_cloud_liq(earth_param_set)
@@ -277,7 +278,7 @@ end
      prescribed_perturbed_rh_era5(era5_ncdata_path,
                              surface_space,
                              start_date,
-                             earth_param_set,
+                             toml_dict::CP.ParamDict,
                              Δrh,
                              FT;
                              gustiness=1,
@@ -289,7 +290,7 @@ end
 
 A helper function which constructs the `PrescribedAtmosphere` and `PrescribedRadiativeFluxes`
 from a file path pointing to the ERA5 data in a netcdf file, the surface_space, the start date,
-and the earth_param_set, applying a change in the instantaneous change to relative
+and the `toml_dict`, applying a change in the instantaneous change to relative
 humidity at each point
 of Δrh. The perturbed rh is clipped to be within the range (0,1].
 
@@ -299,7 +300,7 @@ function prescribed_perturbed_rh_era5(
     era5_ncdata_path,
     surface_space,
     start_date,
-    earth_param_set,
+    toml_dict::CP.ParamDict,
     Δrh,
     FT;
     gustiness = 1,
@@ -309,6 +310,7 @@ function prescribed_perturbed_rh_era5(
     regridder_type = :InterpolationsRegridder,
     interpolation_method = Interpolations.Constant(),
 )
+    earth_param_set = LP.LandParameters(toml_dict)
     # Pass a list of files in all cases
     era5_ncdata_path isa String && (era5_ncdata_path = [era5_ncdata_path])
     _ρ_liq = LP.ρ_cloud_liq(earth_param_set)

--- a/test/diagnostics/diagnostics_tests.jl
+++ b/test/diagnostics/diagnostics_tests.jl
@@ -154,7 +154,6 @@ FT = Float32
 default_params_filepath =
     joinpath(pkgdir(ClimaLand), "toml", "default_parameters.toml")
 toml_dict = LP.create_toml_dict(FT);
-earth_param_set = LP.LandParameters(toml_dict);
 
 zmax = FT(0)
 zmin = FT(-1.0)
@@ -172,7 +171,7 @@ atmos, radiation = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     surface_space,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT,
 );
 

--- a/test/integrated/full_land.jl
+++ b/test/integrated/full_land.jl
@@ -202,7 +202,7 @@ forcing = ClimaLand.prescribed_forcing_era5(
     era5_ncdata_path,
     domain.space.surface,
     start_date,
-    earth_param_set,
+    toml_dict,
     FT;
 )
 LAI = ClimaLand.Canopy.prescribed_lai_modis(

--- a/test/shared_utilities/drivers.jl
+++ b/test/shared_utilities/drivers.jl
@@ -48,19 +48,8 @@ end
 
 @testset "Driver update functions" begin
     toml_dict = LP.create_toml_dict(FT)
-    earth_param_set = LP.LandParameters(toml_dict)
     f = TimeVaryingInput((t) -> 10.0)
-    pa = ClimaLand.PrescribedAtmosphere(
-        f,
-        f,
-        f,
-        f,
-        f,
-        f,
-        f,
-        FT(1),
-        earth_param_set,
-    )
+    pa = ClimaLand.PrescribedAtmosphere(f, f, f, f, f, f, f, FT(1), toml_dict)
     pr = ClimaLand.PrescribedRadiativeFluxes(FT, f, f, f)
     domain = ClimaLand.Domains.HybridBox(;
         xlim = FT.((1.0, 2.0)),

--- a/test/standalone/Bucket/albedo_types.jl
+++ b/test/standalone/Bucket/albedo_types.jl
@@ -179,7 +179,6 @@ end
 
 @testset "Test PrescribedBaregroundAlbedo - albedo from map, FT = $FT" begin
     toml_dict = LP.create_toml_dict(FT)
-    earth_param_set = LP.LandParameters(toml_dict)
     varname = "sw_alb"
     path = ClimaLand.Artifacts.bareground_albedo_dataset_path()
     α_snow = FT(0.8)
@@ -231,7 +230,7 @@ end
                 TimeVaryingInput(P_atmos),
                 start_date,
                 h_atmos,
-                earth_param_set,
+                toml_dict,
             )
             τc = FT(1.0)
             bucket_parameters =
@@ -273,7 +272,6 @@ end
 for (name, infile_path, varname) in name_ds_var_list
     @testset "Test PrescribedSurfaceAlbedo - albedo from map over time, FT = $FT" begin
         toml_dict = LP.create_toml_dict(FT)
-        earth_param_set = LP.LandParameters(toml_dict)
 
         σS_c = FT(0.2)
         W_f = FT(0.15)
@@ -334,7 +332,7 @@ for (name, infile_path, varname) in name_ds_var_list
                     TimeVaryingInput(P_atmos),
                     start_date,
                     h_atmos,
-                    earth_param_set,
+                    toml_dict,
                 )
                 τc = FT(1.0)
                 bucket_parameters = BucketModelParameters(

--- a/test/standalone/Bucket/snow_bucket_tests.jl
+++ b/test/standalone/Bucket/snow_bucket_tests.jl
@@ -85,7 +85,7 @@ for FT in (Float32, Float64)
             TimeVaryingInput(P_atmos),
             start_date,
             h_atmos,
-            earth_param_set,
+            toml_dict,
         )
 
         τc = FT(10.0)
@@ -204,7 +204,7 @@ for FT in (Float32, Float64)
                 TimeVaryingInput(P_atmos),
                 start_date,
                 h_atmos,
-                earth_param_set,
+                toml_dict,
             )
 
             τc = FT(10.0)
@@ -318,7 +318,7 @@ for FT in (Float32, Float64)
                 TimeVaryingInput(P_atmos),
                 start_date,
                 h_atmos,
-                earth_param_set,
+                toml_dict,
             )
 
             τc = FT(10.0)
@@ -432,7 +432,7 @@ for FT in (Float32, Float64)
             TimeVaryingInput(P_atmos),
             start_date,
             h_atmos,
-            earth_param_set,
+            toml_dict,
         )
 
         τc = FT(10.0)

--- a/test/standalone/Bucket/soil_bucket_tests.jl
+++ b/test/standalone/Bucket/soil_bucket_tests.jl
@@ -145,7 +145,7 @@ for FT in (Float32, Float64)
                 TimeVaryingInput(P_atmos),
                 start_date,
                 h_atmos,
-                earth_param_set,
+                toml_dict,
             )
             τc = FT(100.0)
             bucket_parameters =

--- a/test/standalone/Snow/conservation.jl
+++ b/test/standalone/Snow/conservation.jl
@@ -28,8 +28,6 @@ for FT in (Float32, Float64)
 
     t0 = 0.0
 
-    earth_param_set = LP.LandParameters(toml_dict)
-
     start_date = DateTime(2005)
     Δt = FT(180.0)
     parameters = SnowParameters(toml_dict, Δt)
@@ -53,7 +51,7 @@ for FT in (Float32, Float64)
         P_atmos,
         start_date,
         h_atmos,
-        earth_param_set,
+        toml_dict,
     )
 
     @testset "Snow model total energy and water, FT = $FT" begin

--- a/test/standalone/Snow/snow.jl
+++ b/test/standalone/Snow/snow.jl
@@ -15,7 +15,6 @@ import ClimaLand.Parameters as LP
 @testset "Snow Model" begin
     FT = Float32
     toml_dict = LP.create_toml_dict(FT)
-    earth_param_set = LP.LandParameters(toml_dict)
 
     start_date = DateTime(2005)
     Δt = FT(180.0)
@@ -41,7 +40,7 @@ import ClimaLand.Parameters as LP
         P_atmos,
         start_date,
         h_atmos,
-        earth_param_set,
+        toml_dict,
     )
     model = ClimaLand.Snow.SnowModel(
         parameters = parameters,

--- a/test/standalone/Snow/tool_tests.jl
+++ b/test/standalone/Snow/tool_tests.jl
@@ -332,7 +332,6 @@ if !isnothing(DataToolsExt)
         #Model setup:
         FT = Float32
         toml_dict = LP.create_toml_dict(FT)
-        earth_param_set = LP.LandParameters(toml_dict)
         start_date = DateTime(2005)
         Δt = FT(180.0)
         domain = Point(; z_sfc = FT(0))
@@ -356,7 +355,7 @@ if !isnothing(DataToolsExt)
             P_atmos,
             start_date,
             h_atmos,
-            earth_param_set,
+            toml_dict,
         )
 
         #Test extension utilities

--- a/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
+++ b/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
@@ -43,7 +43,6 @@ for FT in (Float32, Float64)
         UTC_DATETIME = Dates.now()
         atmos_h = FT(30)
         atmos_co2 = (t) -> 1.0
-        earth_param_set = LP.LandParameters(toml_dict)
 
         atmos = ClimaLand.PrescribedAtmosphere(
             TimeVaryingInput(precipitation_function),
@@ -54,7 +53,7 @@ for FT in (Float32, Float64)
             TimeVaryingInput(atmos_p),
             UTC_DATETIME,
             atmos_h,
-            earth_param_set;
+            toml_dict;
             c_co2 = TimeVaryingInput(atmos_co2),
         )
         ν = FT(0.6)
@@ -121,7 +120,6 @@ for FT in (Float32, Float64)
         UTC_DATETIME = Dates.now()
         atmos_h = FT(30)
         atmos_co2 = (t) -> 1.0
-        earth_param_set = LP.LandParameters(toml_dict)
 
         atmos = ClimaLand.PrescribedAtmosphere(
             TimeVaryingInput(precipitation_function),
@@ -132,7 +130,7 @@ for FT in (Float32, Float64)
             TimeVaryingInput(atmos_p),
             UTC_DATETIME,
             atmos_h,
-            earth_param_set;
+            toml_dict;
             c_co2 = TimeVaryingInput(atmos_co2),
         )
         ν = FT(0.6)

--- a/test/standalone/Soil/climate_drivers.jl
+++ b/test/standalone/Soil/climate_drivers.jl
@@ -72,7 +72,7 @@ for FT in (Float32, Float64)
             TimeVaryingInput(P_atmos),
             start_date,
             h_atmos,
-            earth_param_set,
+            toml_dict,
         )
         @test atmos.gustiness == FT(1)
         top_bc = ClimaLand.Soil.AtmosDrivenFluxBC(atmos, radiation)

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -77,7 +77,7 @@ import ClimaParams
             TimeVaryingInput(P_atmos),
             start_date,
             h_atmos,
-            earth_param_set;
+            toml_dict;
             c_co2 = TimeVaryingInput(c_atmos),
         )
 
@@ -520,7 +520,7 @@ end
             TimeVaryingInput(P_atmos),
             start_date,
             h_atmos,
-            earth_param_set;
+            toml_dict;
             c_co2 = TimeVaryingInput(c_atmos),
         )
         radiation = PrescribedRadiativeFluxes(
@@ -773,7 +773,7 @@ end
             TimeVaryingInput(P_atmos),
             start_date,
             h_atmos,
-            earth_param_set;
+            toml_dict;
             c_co2 = TimeVaryingInput(c_atmos),
         )
         radiation = PrescribedRadiativeFluxes(

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -97,7 +97,7 @@ import ClimaParams
             TimeVaryingInput(longwave_radiation),
             start_date;
             θs = zenith_angle,
-            earth_param_set = earth_param_set,
+            toml_dict = toml_dict,
         )
 
         # Set up canopy model with all the components
@@ -529,7 +529,7 @@ end
             TimeVaryingInput(longwave_radiation),
             start_date;
             θs = zenith_angle,
-            earth_param_set = earth_param_set,
+            toml_dict = toml_dict,
         )
 
         # Plant Hydraulics
@@ -782,7 +782,7 @@ end
             TimeVaryingInput(longwave_radiation),
             start_date;
             θs = zenith_angle,
-            earth_param_set = earth_param_set,
+            toml_dict = toml_dict,
         )
         ground = PrescribedGroundConditions{FT}()
         forcing = (; atmos, radiation, ground)

--- a/test/standalone/Vegetation/conservation.jl
+++ b/test/standalone/Vegetation/conservation.jl
@@ -56,7 +56,7 @@ for FT in (Float32, Float64)
         LW_d,
         start_date;
         θs = zenith_angle,
-        earth_param_set = earth_param_set,
+        toml_dict = toml_dict,
     )
     # Atmos forcing
     precip = TimeVaryingInput((t) -> eltype(t)(0)) # no precipitation

--- a/test/standalone/Vegetation/conservation.jl
+++ b/test/standalone/Vegetation/conservation.jl
@@ -74,7 +74,7 @@ for FT in (Float32, Float64)
         P_atmos,
         start_date,
         h_atmos,
-        earth_param_set,
+        toml_dict,
     )
     # Ground forcing
     ground = PrescribedGroundConditions{FT}()

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -198,7 +198,7 @@ for FT in (Float32, Float64)
             TimeVaryingInput(longwave_radiation),
             start_date;
             θs = zenith_angle,
-            earth_param_set = earth_param_set,
+            toml_dict = toml_dict,
         )
         Δz = FT(1.0) # height of compartments
         n_stem = Int64(5) # number of stem elements

--- a/test/standalone/Vegetation/plant_hydraulics_test.jl
+++ b/test/standalone/Vegetation/plant_hydraulics_test.jl
@@ -189,7 +189,7 @@ for FT in (Float32, Float64)
             TimeVaryingInput(P_atmos),
             start_date,
             h_atmos,
-            earth_param_set;
+            toml_dict;
             c_co2 = TimeVaryingInput(c_atmos),
         )
         radiation = PrescribedRadiativeFluxes(


### PR DESCRIPTION
closes #1424 - This PR adds logging for parameters for long runs and make some functions take in `toml_dict` instead of `earth_param_set`.