### PR TITLE
Steady state hydraulics option

### DIFF
--- a/docs/src/APIs/canopy/PlantHydraulics.md
+++ b/docs/src/APIs/canopy/PlantHydraulics.md
@@ -7,11 +7,12 @@ CurrentModule = ClimaLand.PlantHydraulics
 
 ```@docs
 ClimaLand.PlantHydraulics.AbstractPlantHydraulicsModel
+ClimaLand.PlantHydraulics.SteadyStateModel
 ClimaLand.PlantHydraulics.PlantHydraulicsModel
 ClimaLand.PlantHydraulics.PlantHydraulicsParameters
 ```
 
-## Plant Hydraulics Parameterizations
+## Prognostic Plant Hydraulics Parameterizations
 
 ```@docs
 ClimaLand.PlantHydraulics.AbstractConductivityModel
@@ -30,9 +31,10 @@ ClimaLand.Canopy.PlantHydraulicsModel{FT}(
     domain,
     toml_dict::CP.ParamDict;
 ) where {FT <: AbstractFloat}
+ClimaLand.Canopy.SteadyStateModel{FT}()
 ```
 
-## Plant Hydraulics Diagnostic Variables
+## Prognostic Hlant Hydraulics Diagnostic Variables
 
 ```@docs
 ClimaLand.PlantHydraulics.water_flux

--- a/docs/src/APIs/canopy/PlantHydraulics.md
+++ b/docs/src/APIs/canopy/PlantHydraulics.md
@@ -34,7 +34,7 @@ ClimaLand.Canopy.PlantHydraulicsModel{FT}(
 ClimaLand.Canopy.SteadyStateModel{FT}()
 ```
 
-## Prognostic Hlant Hydraulics Diagnostic Variables
+## Prognostic Plant Hydraulics Diagnostic Variables
 
 ```@docs
 ClimaLand.PlantHydraulics.water_flux

--- a/experiments/integrated/fluxnet/ozark_pmodel.jl
+++ b/experiments/integrated/fluxnet/ozark_pmodel.jl
@@ -186,27 +186,16 @@ soil_moisture_stress = PiecewiseMoistureStressModel{FT}(
     soil_params = retention_parameters,
 )
 
-# Set up plant hydraulics
+
 # Read in LAI from MODIS data
 surface_space = land_domain.space.surface;
 LAI =
     ClimaLand.Canopy.prescribed_lai_modis(surface_space, start_date, stop_date)
-# Get the maximum LAI at this site over the first year of the simulation
-maxLAI = FluxnetSimulations.get_maxLAI_at_site(start_date, lat, long);
-RAI = maxLAI * f_root_to_shoot
-hydraulics = Canopy.PlantHydraulicsModel{FT}(
-    surface_domain,
-    toml_dict;
-    n_stem,
-    n_leaf,
-    h_stem,
-    h_leaf,
-    ν = plant_ν,
-    S_s = plant_S_s,
-    conductivity_model,
-    retention_model,
-)
+
+hydraulics = Canopy.PlantHydraulics.SteadyStateModel{FT}()
 height = h_stem + h_leaf
+RAI = FT(0)
+SAI = FT(0)
 biomass =
     Canopy.PrescribedBiomassModel{FT}(; LAI, SAI, RAI, rooting_depth, height)
 

--- a/experiments/integrated/global/global_soil_canopy_pmodel.jl
+++ b/experiments/integrated/global/global_soil_canopy_pmodel.jl
@@ -98,6 +98,8 @@ LAI =
 photosynthesis = PModel{FT}(canopy_domain, toml_dict)
 conductance = PModelConductance{FT}(toml_dict)
 
+# Use steady state hydraulics
+hydraulics = ClimaLand.PlantHydraulics.SteadyStateModel{FT}()
 canopy = Canopy.CanopyModel{FT}(
     canopy_domain,
     canopy_forcing,
@@ -106,6 +108,7 @@ canopy = Canopy.CanopyModel{FT}(
     prognostic_land_components,
     photosynthesis,
     conductance,
+    hydraulics,
 )
 
 # Combine the soil and canopy models into a single prognostic land model

--- a/ext/fluxnet_simulations/initial_conditions.jl
+++ b/ext/fluxnet_simulations/initial_conditions.jl
@@ -186,26 +186,28 @@ function set_fluxnet_ic!(
     )
 
     Y.canopy.energy.T .= T_air_0
-    FT = eltype(Y.canopy.energy.T)
-    ψ_stem_0 = FT(-1e5 / 9800) # pressure in the leaf divided by rho_liquid*gravitational acceleration [m]
-    ψ_leaf_0 = FT(-2e5 / 9800)
     hydraulics = model.hydraulics
-    n_stem = hydraulics.n_stem
-    n_leaf = hydraulics.n_leaf
-    ψ_comps = n_stem > 0 ? [ψ_stem_0, ψ_leaf_0] : ψ_leaf_0
-    S_l_ini =
-        ClimaLand.Canopy.PlantHydraulics.inverse_water_retention_curve.(
-            hydraulics.parameters.retention_model,
-            ψ_comps,
-            hydraulics.parameters.ν,
-            hydraulics.parameters.S_s,
-        )
-    for i in 1:(n_stem + n_leaf)
-        Y.canopy.hydraulics.ϑ_l.:($i) .=
-            ClimaLand.Canopy.PlantHydraulics.augmented_liquid_fraction.(
+    if hydraulics isa ClimaLand.Canopy.PlantHydraulicsModel
+        FT = eltype(Y.canopy.energy.T)
+        ψ_stem_0 = FT(-1e5 / 9800) # pressure in the leaf divided by rho_liquid*gravitational acceleration [m]
+        ψ_leaf_0 = FT(-2e5 / 9800)
+        n_stem = hydraulics.n_stem
+        n_leaf = hydraulics.n_leaf
+        ψ_comps = n_stem > 0 ? [ψ_stem_0, ψ_leaf_0] : ψ_leaf_0
+        S_l_ini =
+            ClimaLand.Canopy.PlantHydraulics.inverse_water_retention_curve.(
+                hydraulics.parameters.retention_model,
+                ψ_comps,
                 hydraulics.parameters.ν,
-                S_l_ini[i],
+                hydraulics.parameters.S_s,
             )
+        for i in 1:(n_stem + n_leaf)
+            Y.canopy.hydraulics.ϑ_l.:($i) .=
+                ClimaLand.Canopy.PlantHydraulics.augmented_liquid_fraction.(
+                    hydraulics.parameters.ν,
+                    S_l_ini[i],
+                )
+        end
     end
 end
 

--- a/ext/fluxnet_simulations/initial_conditions.jl
+++ b/ext/fluxnet_simulations/initial_conditions.jl
@@ -184,29 +184,14 @@ function set_fluxnet_ic!(
         preprocess_func = x -> x + 273.15,
         val,
     )
-
-    Y.canopy.energy.T .= T_air_0
-    hydraulics = model.hydraulics
+    if model.energy isa ClimaLand.Canopy.BigLeafEnergyModel
+        Y.canopy.energy.T .= T_air_0
+    end
+    
+    hydraulics = model.hydraulics 
     if hydraulics isa ClimaLand.Canopy.PlantHydraulicsModel
-        FT = eltype(Y.canopy.energy.T)
-        ψ_stem_0 = FT(-1e5 / 9800) # pressure in the leaf divided by rho_liquid*gravitational acceleration [m]
-        ψ_leaf_0 = FT(-2e5 / 9800)
-        n_stem = hydraulics.n_stem
-        n_leaf = hydraulics.n_leaf
-        ψ_comps = n_stem > 0 ? [ψ_stem_0, ψ_leaf_0] : ψ_leaf_0
-        S_l_ini =
-            ClimaLand.Canopy.PlantHydraulics.inverse_water_retention_curve.(
-                hydraulics.parameters.retention_model,
-                ψ_comps,
-                hydraulics.parameters.ν,
-                hydraulics.parameters.S_s,
-            )
         for i in 1:(n_stem + n_leaf)
-            Y.canopy.hydraulics.ϑ_l.:($i) .=
-                ClimaLand.Canopy.PlantHydraulics.augmented_liquid_fraction.(
-                    hydraulics.parameters.ν,
-                    S_l_ini[i],
-                )
+            Y.canopy.hydraulics.ϑ_l.:($i) .= hydraulics.parameters.ν
         end
     end
 end

--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -411,7 +411,8 @@ import .Canopy:
     ground_albedo_NIR,
     canopy_radiant_energy_fluxes!,
     root_energy_flux_per_ground_area!,
-    update_piecewise_soil_moisture_stress!
+    update_piecewise_soil_moisture_stress!,
+    lai_consistency_check
 ### Concrete types of AbstractLandModels
 ### and associated methods
 include("integrated/soil_energy_hydrology_biogeochemistry.jl")

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -571,7 +571,6 @@ function get_short_diagnostics(model::LandModel)
         "precip",
         "lhf",
         "msf",
-        "lwp",
         "iwc",
         "sdr",
     ]

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -354,6 +354,15 @@ function add_diagnostics!(
     return nothing
 end
 
+function add_diagnostics!(
+    diagnostics,
+    model::CanopyModel,
+    subcomponent::ClimaLand.Canopy.PlantHydraulicsModel,
+)
+    append!(diagnostics, ["lwp", "far"])
+    return nothing
+end
+
 ## Possible diagnostics for standalone models
 """
     get_possible_diagnostics(model)
@@ -395,8 +404,6 @@ function get_possible_diagnostics(model::CanopyModel)
         "trans",
         "clhf",
         "cshf",
-        "lwp",
-        # "fa", # return a Tuple
         "far",
         "lai",
         "msf",
@@ -431,6 +438,8 @@ function get_possible_diagnostics(model::CanopyModel)
 
     # Add conditional diagnostics based on atmosphere type
     add_diagnostics!(diagnostics, model, model.boundary_conditions.atmos)
+    # Add conditional diagnostics based on hydraulics model
+    add_diagnostics!(diagnostics, model, model.hydraulics)
     return diagnostics
 end
 function get_possible_diagnostics(model::SnowModel)

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -246,26 +246,19 @@ function compute_leaf_water_potential!(
     end
 end
 
-# @diagnostic_compute "flux_per_ground_area" Union{SoilCanopyModel, LandModel} p.canopy.hydraulics.fa # return a Tuple
 @diagnostic_compute "root_flux_per_ground_area" Union{
     SoilCanopyModel,
     LandModel,
     CanopyModel,
 } p.canopy.hydraulics.fa_roots
+
+# Biomass
 @diagnostic_compute "leaf_area_index" Union{
     SoilCanopyModel,
     LandModel,
     CanopyModel,
 } p.canopy.biomass.area_index.leaf
 
-# Canopy - Soil moisture stress
-@diagnostic_compute "moisture_stress_factor" Union{
-    SoilCanopyModel,
-    LandModel,
-    CanopyModel,
-} p.canopy.soil_moisture_stress.βm
-
-# Canopy - Hydraulics
 @diagnostic_compute "root_area_index" Union{
     SoilCanopyModel,
     LandModel,
@@ -276,6 +269,14 @@ end
     LandModel,
     CanopyModel,
 } p.canopy.biomass.area_index.stem
+
+# Canopy - Soil moisture stress
+@diagnostic_compute "moisture_stress_factor" Union{
+    SoilCanopyModel,
+    LandModel,
+    CanopyModel,
+} p.canopy.soil_moisture_stress.βm
+
 
 # Canopy - Photosynthesis
 @diagnostic_compute "photosynthesis_gross_canopy" Union{

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -246,19 +246,26 @@ function compute_leaf_water_potential!(
     end
 end
 
+# @diagnostic_compute "flux_per_ground_area" Union{SoilCanopyModel, LandModel} p.canopy.hydraulics.fa # return a Tuple
 @diagnostic_compute "root_flux_per_ground_area" Union{
     SoilCanopyModel,
     LandModel,
     CanopyModel,
 } p.canopy.hydraulics.fa_roots
-
-# Biomass
 @diagnostic_compute "leaf_area_index" Union{
     SoilCanopyModel,
     LandModel,
     CanopyModel,
 } p.canopy.biomass.area_index.leaf
 
+# Canopy - Soil moisture stress
+@diagnostic_compute "moisture_stress_factor" Union{
+    SoilCanopyModel,
+    LandModel,
+    CanopyModel,
+} p.canopy.soil_moisture_stress.βm
+
+# Canopy - Hydraulics
 @diagnostic_compute "root_area_index" Union{
     SoilCanopyModel,
     LandModel,
@@ -269,14 +276,6 @@ end
     LandModel,
     CanopyModel,
 } p.canopy.biomass.area_index.stem
-
-# Canopy - Soil moisture stress
-@diagnostic_compute "moisture_stress_factor" Union{
-    SoilCanopyModel,
-    LandModel,
-    CanopyModel,
-} p.canopy.soil_moisture_stress.βm
-
 
 # Canopy - Photosynthesis
 @diagnostic_compute "photosynthesis_gross_canopy" Union{

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -69,8 +69,10 @@ struct SoilCanopyModel{
         # Runoff and sublimation are also automatically included in the soil model
         @assert RootExtraction{FT}() in soil.sources
         @assert Soil.PhaseChange{FT}() in soil.sources
-        @assert canopy.hydraulics.transpiration isa
-                Canopy.PlantHydraulics.DiagnosticTranspiration{FT}
+        if canopy.hydraulics isa Canopy.PlantHydraulics.PlantHydraulicsModel
+            @assert canopy.hydraulics.transpiration isa
+                    Canopy.PlantHydraulics.DiagnosticTranspiration{FT}
+        end
         @assert canopy_bc.ground isa PrognosticGroundConditions{FT}
         @assert soilco2.drivers.met isa PrognosticMet
 
@@ -261,8 +263,6 @@ function make_update_boundary_fluxes(
     update_soilco2_bf! = make_update_boundary_fluxes(land.soilco2)
     update_canopy_bf! = make_update_boundary_fluxes(land.canopy)
     function update_boundary_fluxes!(p, Y, t)
-        # update root extraction
-        update_root_extraction!(p, Y, t, land)
         # Radiation
         lsm_radiant_energy_fluxes!(
             p,
@@ -280,6 +280,9 @@ function make_update_boundary_fluxes(
         update_soil_bf!(p, Y, t)
         update_canopy_bf!(p, Y, t)
         update_soilco2_bf!(p, Y, t)
+
+        # update root extraction
+        update_root_extraction!(p, Y, t, land)
     end
     return update_boundary_fluxes!
 end

--- a/src/simulations/initial_conditions.jl
+++ b/src/simulations/initial_conditions.jl
@@ -231,6 +231,7 @@ function make_set_initial_state_from_file(
         Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
         # Soil IC
         T_bounds = extrema(p.snow.T)
+
         set_soil_initial_conditions!(
             Y,
             land.soil.parameters.ν,
@@ -300,7 +301,9 @@ function make_set_initial_state_from_file(
         T_bounds = extrema(p.drivers.T)
 
         Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
-        Y.canopy.hydraulics.ϑ_l.:1 .= land.canopy.hydraulics.parameters.ν
+        if land.canopy.hydraulics isa ClimaLand.Canopy.PlantHydraulicsModel
+            Y.canopy.hydraulics.ϑ_l.:1 .= land.canopy.hydraulics.parameters.ν
+        end
 
         # If the canopy model has an energy model, we need to set the initial temperature
         hasproperty(Y.canopy, :energy) &&

--- a/src/simulations/initial_conditions.jl
+++ b/src/simulations/initial_conditions.jl
@@ -301,13 +301,6 @@ function make_set_initial_state_from_file(
         T_bounds = extrema(p.drivers.T)
 
         Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
-        if land.canopy.hydraulics isa ClimaLand.Canopy.PlantHydraulicsModel
-            Y.canopy.hydraulics.ϑ_l.:1 .= land.canopy.hydraulics.parameters.ν
-        end
-
-        # If the canopy model has an energy model, we need to set the initial temperature
-        hasproperty(Y.canopy, :energy) &&
-            evaluate!(Y.canopy.energy.T, atmos.T, t0)
 
         set_soil_initial_conditions!(
             Y,
@@ -318,6 +311,37 @@ function make_set_initial_state_from_file(
             land.soil,
             T_bounds,
         )
+
+        # Canopy IC
+        # Set canopy moisture variable by setting canopy potential(moisture) equal 
+        # to soil potential (soil moisture), averaged over the soil layers,
+        # which would correspond to approximate steady state
+        if land.canopy.hydraulics isa ClimaLand.Canopy.PlantHydraulicsModel
+            @. p.soil.ψ = ClimaLand.Soil.pressure_head(
+                land.soil.parameters.hydrology_cm,
+                land.soil.parameters.θ_r,
+                Y.soil.ϑ_l,
+                land.soil.parameters.ν - Y.soil.θ_i,
+                land.soil.parameters.S_s,
+            )
+            ψ_roots = ClimaCore.Fields.zeros(axes(Y.canopy.hydraulics.ϑ_l.:1))
+            z = land.soil.domain.fields.z
+            tmp = @. ClimaLand.Canopy.root_distribution(
+                z,
+                land.canopy.biomass.rooting_depth,
+            ) * p.soil.ψ / land.soil.domain.fields.depth
+            ClimaCore.Operators.column_integral_definite!(ψ_roots, tmp)
+            Y.canopy.hydraulics.ϑ_l.:1 .=
+                ClimaLand.Canopy.PlantHydraulics.inverse_water_retention_curve.(
+                    land.canopy.hydraulics.parameters.retention_model,
+                    ψ_roots,
+                    land.canopy.hydraulics.parameters.ν,
+                    land.canopy.hydraulics.parameters.S_s,
+                ) .* land.canopy.hydraulics.parameters.ν
+        end
+        if land.canopy.energy isa ClimaLand.Canopy.BigLeafEnergyModel
+            evaluate!(Y.canopy.energy.T, atmos.T, t0)
+        end
     end
     return set_ic!
 end

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -1211,9 +1211,11 @@ function ClimaLand.make_set_initial_cache(model::CanopyModel)
         set_historical_cache!(p, Y0, model.photosynthesis, model)
         # Make sure that the hydraulics scheme and the biomass scheme are compatible
         hydraulics = model.hydraulics
-        n_stem = hydraulics.n_stem
-        n_leaf = hydraulics.n_leaf
-        lai_consistency_check.(n_stem, n_leaf, p.canopy.biomass.area_index)
+        if hydraulics isa PlantHydraulics.PlantHydraulicsModel
+            n_stem = hydraulics.n_stem
+            n_leaf = hydraulics.n_leaf
+            lai_consistency_check.(n_stem, n_leaf, p.canopy.biomass.area_index)
+        end
     end
     return set_initial_cache!
 end

--- a/src/standalone/Vegetation/autotrophic_respiration.jl
+++ b/src/standalone/Vegetation/autotrophic_respiration.jl
@@ -74,12 +74,6 @@ function update_autotrophic_respiration!(
     autotrophic_respiration::AutotrophicRespirationModel,
     canopy,
 )
-    hydraulics = canopy.hydraulics
-    n_stem = hydraulics.n_stem
-    n_leaf = hydraulics.n_leaf
-    h_canopy = hydraulics.compartment_surfaces[end]
-    i_end = n_stem + n_leaf
-    ψ = p.canopy.hydraulics.ψ
     area_index = p.canopy.biomass.area_index
     LAI = area_index.leaf
     SAI = area_index.stem
@@ -93,6 +87,7 @@ function update_autotrophic_respiration!(
     Vcmax25_leaf = get_Vcmax25_leaf(p, canopy.photosynthesis)
     Rd_leaf = get_Rd_leaf(p, canopy.photosynthesis)
     An_leaf = get_An_leaf(p, canopy.photosynthesis)
+    h_canopy = canopy.biomass.height
     @. p.canopy.autotrophic_respiration.Ra = compute_autrophic_respiration(
         autotrophic_respiration,
         Vcmax25_leaf,

--- a/src/standalone/Vegetation/autotrophic_respiration.jl
+++ b/src/standalone/Vegetation/autotrophic_respiration.jl
@@ -74,6 +74,12 @@ function update_autotrophic_respiration!(
     autotrophic_respiration::AutotrophicRespirationModel,
     canopy,
 )
+    hydraulics = canopy.hydraulics
+    n_stem = hydraulics.n_stem
+    n_leaf = hydraulics.n_leaf
+    h_canopy = hydraulics.compartment_surfaces[end]
+    i_end = n_stem + n_leaf
+    ψ = p.canopy.hydraulics.ψ
     area_index = p.canopy.biomass.area_index
     LAI = area_index.leaf
     SAI = area_index.stem
@@ -87,7 +93,6 @@ function update_autotrophic_respiration!(
     Vcmax25_leaf = get_Vcmax25_leaf(p, canopy.photosynthesis)
     Rd_leaf = get_Rd_leaf(p, canopy.photosynthesis)
     An_leaf = get_An_leaf(p, canopy.photosynthesis)
-    h_canopy = canopy.biomass.height
     @. p.canopy.autotrophic_respiration.Ra = compute_autrophic_respiration(
         autotrophic_respiration,
         Vcmax25_leaf,

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -146,7 +146,7 @@ function canopy_boundary_fluxes!(
         canopy,
         Y,
         p,
-        t,
+        t)
     if canopy.hydraulics isa PlantHydraulicsModel
         n_stem = canopy.hydraulics.n_stem
         n_leaf = canopy.hydraulics.n_leaf
@@ -165,14 +165,7 @@ function canopy_boundary_fluxes!(
     # to handle standalone canopy simulations vs integrated ones
 
     # Update the root flux of water per unit ground area in place
-    root_water_flux_per_ground_area!(
-        p,
-        bc.ground,
-        canopy.hydraulics,
-        canopy,
-        Y,
-        t,
-    )
+    root_water_flux_per_ground_area!(p, bc.ground, canopy.hydraulics, canopy, Y, t)
     # Update the root flux of energy per unit ground area in place
     root_energy_flux_per_ground_area!(p, bc.ground, canopy.energy, canopy, Y, t)
 

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -137,13 +137,7 @@ function canopy_boundary_fluxes!(
     radiation = bc.radiation
     atmos = bc.atmos
     sf_parameterization = bc.turbulent_flux_parameterization
-    root_water_flux = p.canopy.hydraulics.fa_roots
-    root_energy_flux = p.canopy.energy.fa_energy_roots
-    fa = p.canopy.hydraulics.fa
-    LAI = p.canopy.biomass.area_index.leaf
-    SAI = p.canopy.biomass.area_index.stem
     canopy_tf = p.canopy.turbulent_fluxes
-    i_end = canopy.hydraulics.n_stem + canopy.hydraulics.n_leaf
     # Compute transpiration, SHF, LHF
     ClimaLand.turbulent_fluxes!(
         canopy_tf,
@@ -153,38 +147,34 @@ function canopy_boundary_fluxes!(
         Y,
         p,
         t,
-    )
-    # Transpiration is per unit ground area, not leaf area (mult by LAI)
-    fa.:($i_end) .= PlantHydraulics.transpiration_per_ground_area(
-        canopy.hydraulics.transpiration,
-        Y,
-        p,
-        t,
-    )
+    if canopy.hydraulics isa PlantHydraulicsModel
+        n_stem = canopy.hydraulics.n_stem
+        n_leaf = canopy.hydraulics.n_leaf
+        fa = p.canopy.hydraulics.fa
+        i_end = canopy.hydraulics.n_stem + canopy.hydraulics.n_leaf
+        fa.:($i_end) .= PlantHydraulics.transpiration_per_ground_area(
+            canopy.hydraulics.transpiration,
+            Y,
+            p,
+            t,
+        )
+    end
+
     # Note that in the three functions below,
     # we dispatch off of the ground conditions `bc.ground`
     # to handle standalone canopy simulations vs integrated ones
 
     # Update the root flux of water per unit ground area in place
     root_water_flux_per_ground_area!(
-        root_water_flux,
+        p,
         bc.ground,
         canopy.hydraulics,
         canopy,
         Y,
-        p,
         t,
     )
     # Update the root flux of energy per unit ground area in place
-    root_energy_flux_per_ground_area!(
-        root_energy_flux,
-        bc.ground,
-        canopy.energy,
-        canopy,
-        Y,
-        p,
-        t,
-    )
+    root_energy_flux_per_ground_area!(p, bc.ground, canopy.energy, canopy, Y, t)
 
     # Update the canopy radiation
     canopy_radiant_energy_fluxes!(

--- a/src/standalone/Vegetation/canopy_energy.jl
+++ b/src/standalone/Vegetation/canopy_energy.jl
@@ -145,19 +145,17 @@ function make_compute_imp_tendency(
 end
 
 """
-    root_energy_flux_per_ground_area!(
-        fa_energy::ClimaCore.Fields.Field,
+    root_energy_flux_per_ground_area!(p,
         ground::PrescribedGroundConditions{FT},
         model::AbstractCanopyEnergyModel{FT},
         canopy,
         Y::ClimaCore.Fields.FieldVector,
-        p::NamedTuple,
         t,
     ) where {FT}
 
 
-A method which updates the ClimaCore.Fields.Field `fa_energy` in place
-with  the energy flux associated with the root-soil
+A method which updates the ClimaCore.Fields.Field p.canopy.energy.fa_energy_roots
+ in place with  the energy flux associated with the root-soil
 water flux for the `CanopyModel` run in standalone mode,
 with a `PrescribedGroundConditions`.This value is ignored and set to zero
 in this case.
@@ -170,15 +168,14 @@ balance; therefore, in order to conserve energy, the canopy model
 must account for it as well.
 """
 function root_energy_flux_per_ground_area!(
-    fa_energy::ClimaCore.Fields.Field,
+    p,
     ground::PrescribedGroundConditions{FT},
     model::AbstractCanopyEnergyModel{FT},
     canopy,
     Y::ClimaCore.Fields.FieldVector,
-    p::NamedTuple,
     t,
 ) where {FT}
-    fa_energy .= FT(0)
+    p.canopy.energy.fa_energy_roots .= 0
 end
 
 function ClimaLand.make_compute_jacobian(

--- a/src/standalone/Vegetation/pmodel.jl
+++ b/src/standalone/Vegetation/pmodel.jl
@@ -631,9 +631,6 @@ function set_historical_cache!(p, Y0, model::PModel, canopy)
     # drivers
     FT = eltype(parameters)
     earth_param_set = canopy.earth_param_set
-
-    ψ = p.canopy.hydraulics.ψ
-    n = canopy.hydraulics.n_leaf + canopy.hydraulics.n_stem
     grav = LP.grav(earth_param_set)
     ρ_water = LP.ρ_cloud_liq(earth_param_set)
     βm = p.canopy.soil_moisture_stress.βm

--- a/test/diagnostics/diagnostics_tests.jl
+++ b/test/diagnostics/diagnostics_tests.jl
@@ -275,7 +275,7 @@ end
     end
 
     output_writer = ClimaDiagnostics.Writers.DictWriter()
-    output_vars = ["swc", "ct", "sco2"]
+    output_vars = ["swc", "ct", "sco2", "lwp"]
     reduction_period = :every_dt
     reduction_type = :instantaneous
 
@@ -300,8 +300,12 @@ end
     )
 
     # Test that the diagnostics were correctly created and computed once at initialization
-    @test keys(simulation.diagnostics[1].output_writer.dict) ==
-          Set(["swc_1000s_inst", "ct_1000s_inst", "sco2_1000s_inst"])
+    @test keys(simulation.diagnostics[1].output_writer.dict) == Set([
+        "swc_1000s_inst",
+        "ct_1000s_inst",
+        "sco2_1000s_inst",
+        "lwp_1000s_inst",
+    ])
     @test all(
         ClimaCore.Fields.field2array(
             simulation.diagnostics[1].output_writer.dict["swc_1000s_inst"].vals[1],
@@ -316,6 +320,11 @@ end
         ClimaCore.Fields.field2array(
             simulation.diagnostics[1].output_writer.dict["sco2_1000s_inst"].vals[1],
         ) .== FT(0.000412),
+    )
+    @test all(
+        ClimaCore.Fields.field2array(
+            simulation.diagnostics[1].output_writer.dict["lwp_1000s_inst"].vals[1],
+        ) .== FT(0.0),
     )
 end
 

--- a/test/integrated/full_land.jl
+++ b/test/integrated/full_land.jl
@@ -486,3 +486,125 @@ if pkgversion(ClimaCore) >= v"0.14.30"
         check_ocean_values_Y(u, binary_mask)
     end
 end
+
+@testset "Hydraulic options, FT = Float64" begin
+    FT = Float64
+    domain = ClimaLand.Domains.Column(;
+        zlim = (FT(-1), FT(0)),
+        nelements = 10,
+        longlat = (FT(-110), FT(34)),
+    )
+    toml_dict = ClimaLand.Parameters.create_toml_dict(FT)
+    earth_param_set = LP.LandParameters(toml_dict)
+    surface_space = domain.space.surface
+    start_date = DateTime(2008)
+    era5_ncdata_path =
+        ClimaLand.Artifacts.era5_land_forcing_data2008_path(; lowres = true)
+    forcing = ClimaLand.prescribed_forcing_era5(
+        era5_ncdata_path,
+        surface_space,
+        start_date,
+        earth_param_set,
+        FT;
+    )
+    ground = ClimaLand.PrognosticGroundConditions{FT}()
+    LAI = ClimaLand.Canopy.prescribed_lai_modis(
+        surface_space,
+        start_date,
+        start_date,
+    )
+    surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
+
+    land = SoilCanopyModel{FT}(
+        forcing,
+        LAI,
+        toml_dict,
+        domain;
+        canopy = ClimaLand.CanopyModel{FT}(
+            surface_domain,
+            (; forcing.atmos, forcing.radiation, ground),
+            LAI,
+            toml_dict,
+            soil_moisture_stress = ClimaLand.Canopy.PiecewiseMoistureStressModel{
+                FT,
+            }(
+                domain,
+                toml_dict,
+            ),
+            prognostic_land_components = (:canopy, :soil, :soilco2),
+        ),
+    )
+    Y, p, _ = initialize(land)
+
+    # Create the model with a steady state hydraulics
+    land_ss = SoilCanopyModel{FT}(
+        forcing,
+        LAI,
+        toml_dict,
+        domain;
+        canopy = ClimaLand.CanopyModel{FT}(
+            surface_domain,
+            (; forcing.atmos, forcing.radiation, ground),
+            LAI,
+            toml_dict,
+            hydraulics = ClimaLand.Canopy.PlantHydraulics.SteadyStateModel{FT}(),
+            soil_moisture_stress = ClimaLand.Canopy.PiecewiseMoistureStressModel{
+                FT,
+            }(
+                domain,
+                toml_dict,
+            ),
+            prognostic_land_components = (:canopy, :soil, :soilco2),
+        ),
+    )
+    Y_ss, p_ss, _ = initialize(land_ss)
+    set_initial_cache! = make_set_initial_cache(land)
+    set_initial_cache_ss! = make_set_initial_cache(land_ss)
+    # Soil IC
+    ϑ_l0 = land.soil.parameters.ν ./ 2
+    θ_i0 = land.soil.parameters.ν ./ 5
+    T = FT(270.0)
+    ρc_s = @. ClimaLand.Soil.volumetric_heat_capacity(
+        ϑ_l0,
+        θ_i0,
+        land.soil.parameters.ρc_ds,
+        earth_param_set,
+    )
+    ρe_int0 = @. ClimaLand.Soil.volumetric_internal_energy(
+        θ_i0,
+        ρc_s,
+        T,
+        earth_param_set,
+    )
+    Y.soil.ϑ_l .= ϑ_l0
+    Y_ss.soil.ϑ_l .= ϑ_l0
+    Y.soil.θ_i .= θ_i0
+    Y_ss.soil.θ_i .= θ_i0
+    Y.soil.ρe_int = ρe_int0
+    Y_ss.soil.ρe_int = ρe_int0
+
+    # Canopy IC
+    ϑ0 = land.canopy.hydraulics.parameters.ν / 2
+    CTemp0 = FT(290.5)
+    Y.canopy.hydraulics.ϑ_l.:1 .= ϑ0
+    Y.canopy.energy.T .= CTemp0
+    Y_ss.canopy.energy.T .= CTemp0
+    Y.snow.S .= 0
+    Y_ss.snow.S .= 0
+    Y.snow.S_l .= 0
+    Y_ss.snow.S_l .= 0
+    Y.snow.U .= 0
+    Y_ss.snow.U .= 0
+    set_initial_cache!(p, Y, 0.0)
+    set_initial_cache_ss!(p_ss, Y_ss, 0.0)
+
+    @test p_ss.canopy.turbulent_fluxes.transpiration ==
+          p.canopy.turbulent_fluxes.transpiration
+    # Check that root extraction seen by soil matches transpiration
+    sfc_field = ClimaCore.Fields.zeros(domain.space.surface)
+    ClimaCore.Operators.column_integral_definite!(
+        sfc_field,
+        p_ss.root_extraction,
+    )
+    @test sfc_field == p_ss.canopy.turbulent_fluxes.transpiration
+end

--- a/test/integrated/soil_canopy_lsm.jl
+++ b/test/integrated/soil_canopy_lsm.jl
@@ -45,4 +45,121 @@ for FT in (Float32, Float64)
         )
         @test p.soil.NIR_albedo == α_soil_NIR
     end
+    @testset "Hydraulic options, FT = $FT" begin
+        domain = ClimaLand.Domains.Column(;
+            zlim = (FT(-1), FT(0)),
+            nelements = 10,
+            longlat = (FT(-110), FT(34)),
+        )
+        toml_dict = ClimaLand.Parameters.create_toml_dict(FT)
+        earth_param_set = LP.LandParameters(toml_dict)
+        surface_space = domain.space.surface
+        start_date = DateTime(2008)
+        era5_ncdata_path =
+            ClimaLand.Artifacts.era5_land_forcing_data2008_path(; lowres = true)
+        forcing = ClimaLand.prescribed_forcing_era5(
+            era5_ncdata_path,
+            surface_space,
+            start_date,
+            earth_param_set,
+            FT;
+        )
+        ground = ClimaLand.PrognosticGroundConditions{FT}()
+        LAI = ClimaLand.Canopy.prescribed_lai_modis(
+            surface_space,
+            start_date,
+            start_date,
+        )
+        surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
+
+        land = SoilCanopyModel{FT}(
+            forcing,
+            LAI,
+            toml_dict,
+            domain;
+            canopy = ClimaLand.CanopyModel{FT}(
+                surface_domain,
+                (; forcing.atmos, forcing.radiation, ground),
+                LAI,
+                toml_dict,
+                soil_moisture_stress = ClimaLand.Canopy.PiecewiseMoistureStressModel{
+                    FT,
+                }(
+                    domain,
+                    toml_dict,
+                ),
+                prognostic_land_components = (:canopy, :soil, :soilco2),
+            ),
+        )
+        Y, p, _ = initialize(land)
+
+        # Create the model with a steady state hydraulics
+        land_ss = SoilCanopyModel{FT}(
+            forcing,
+            LAI,
+            toml_dict,
+            domain;
+            canopy = ClimaLand.CanopyModel{FT}(
+                surface_domain,
+                (; forcing.atmos, forcing.radiation, ground),
+                LAI,
+                toml_dict,
+                hydraulics = ClimaLand.Canopy.PlantHydraulics.SteadyStateModel{
+                    FT,
+                }(),
+                soil_moisture_stress = ClimaLand.Canopy.PiecewiseMoistureStressModel{
+                    FT,
+                }(
+                    domain,
+                    toml_dict,
+                ),
+                prognostic_land_components = (:canopy, :soil, :soilco2),
+            ),
+        )
+        Y_ss, p_ss, _ = initialize(land_ss)
+        set_initial_cache! = make_set_initial_cache(land)
+        set_initial_cache_ss! = make_set_initial_cache(land_ss)
+        # Soil IC
+        ϑ_l0 = land.soil.parameters.ν ./ 2
+        θ_i0 = land.soil.parameters.ν ./ 5
+        T = FT(270.0)
+        ρc_s = @. ClimaLand.Soil.volumetric_heat_capacity(
+            ϑ_l0,
+            θ_i0,
+            land.soil.parameters.ρc_ds,
+            earth_param_set,
+        )
+        ρe_int0 = @. ClimaLand.Soil.volumetric_internal_energy(
+            θ_i0,
+            ρc_s,
+            T,
+            earth_param_set,
+        )
+        Y.soil.ϑ_l .= ϑ_l0
+        Y_ss.soil.ϑ_l .= ϑ_l0
+        Y.soil.θ_i .= θ_i0
+        Y_ss.soil.θ_i .= θ_i0
+        Y.soil.ρe_int = ρe_int0
+        Y_ss.soil.ρe_int = ρe_int0
+
+        # Canopy IC
+        ϑ0 = land.canopy.hydraulics.parameters.ν / 2
+        CTemp0 = FT(290.5)
+        Y.canopy.hydraulics.ϑ_l.:1 .= ϑ0
+        Y.canopy.energy.T .= CTemp0
+        Y_ss.canopy.energy.T .= CTemp0
+
+        set_initial_cache!(p, Y, 0.0)
+        set_initial_cache_ss!(p_ss, Y_ss, 0.0)
+
+        @test p_ss.canopy.turbulent_fluxes.transpiration ==
+              p.canopy.turbulent_fluxes.transpiration
+        # Check that root extraction seen by soil matches transpiration
+        sfc_field = ClimaCore.Fields.zeros(domain.space.surface)
+        ClimaCore.Operators.column_integral_definite!(
+            sfc_field,
+            p_ss.root_extraction,
+        )
+        @test sfc_field == p_ss.canopy.turbulent_fluxes.transpiration
+    end
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add a steady state plant hydraulics model. in this case the root water extraction is set to transpiration in integrated models (the soil needs it) but the canopy does not need this water flux because by definition root_water_flux = transpiration and we do not solve for the water content in the canopy. this means we still need p.root_extraction, but not p.canopy.fa_roots

## To-do
add restriction - cannot run with steady state unless you pick piecewise soil moisture stress
test long runs


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
