### PR TITLE
New doc structure

### DIFF
--- a/docs/list_of_apis.jl
+++ b/docs/list_of_apis.jl
@@ -32,5 +32,4 @@ apis = [
         "Simulations" => "APIs/Simulations.md",
         "Solver Functions" => "APIs/SolverFunctions.md",
     ],
-    "Parameters" => "APIs/parameters.md",
 ]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -66,27 +66,28 @@ include("list_standalone_models.jl")
 include("list_diagnostics.jl")
 pages = Any[
     "Home" => "index.md",
+    "Fundamental Concepts" => "fundamental_concepts.md",
     "Running your first simulation" => "getting_started.md",
+    "Available Models and Parameterizations" => "available_models.md",
+    "Parameters" => "parameters.md",
     "Tutorials" => tutorials,
+    "Writing and accessing outputs" => diagnostics,
     "Model Equations" => standalone_models,
+    "Calibration and benchmark" => [
+        "Calibrating model parameters" => "calibration.md",
+        "Model Benchmark" => "leaderboard/leaderboard.md",
+    ],
+    "Running on GPU or with MPI" => "architectures.md",
     "Additional resources" => [
-        "Model structure" => "model_structure.md",
         "Repository structure" => "repo_structure.md",
-        "Available Models and Parameterizations" => "available_models.md",
-        "Analyzing model output" => [
-            "Diagnostics" => diagnostics,
-            "Leaderboard" => "leaderboard/leaderboard.md",
-        ],
-        "Running on GPU or with MPI" => "architectures.md",
-        "Calibration" => "calibration.md",
         "Restarting a simulation" => "restarts.md",
         "Software utilities" => [
             "ITime type" => "itime.md",
             "Shared utilities" => "shared_utilities.md",
         ],
         "Physical units" => "physical_units.md",
-        "Julia background" => "julia.md",
     ],
+    "Julia background" => "julia.md",
     "APIs" => apis,
     "Contributor guide" => "contributing.md",
     "References" => "references.md",

--- a/docs/src/available_models.md
+++ b/docs/src/available_models.md
@@ -1,7 +1,7 @@
 # Available Models and Parameterizations
 
 ## Standalone and integrated models
-As described in the [ClimaLand model structure](@ref) page, ClimaLand contains a variety of standalone
+As described in the [ClimaLand fundamental concepts](@ref) page, ClimaLand contains a variety of standalone
 and integrated models. A complete list of available models is provided here.
 
 ### ClimaLand standalone models

--- a/docs/src/fundamental_concepts.md
+++ b/docs/src/fundamental_concepts.md
@@ -1,6 +1,4 @@
-# ClimaLand model structure
-
-Here, we explain the internal organization of ClimaLand models.
+# ClimaLand fundamental concepts
 
 ## Standalone and integrated models
 A core concept of ClimaLand's design is the presence of _standalone_ and _integrated_ models.

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -11,7 +11,25 @@ using Pkg
 Pkg.add(ClimaLand)
 ```
 
-## Running a simple soil model
+## Steps to run a model
+
+To run a model, you will always need to do these steps:
+- Import dependencies. You need some libraries to run the model.
+- Choose floating point precision: Float32 or Float64.
+- Import [parameters via .toml files](@ref parameters_page). You need some constants and parameters values to run the model.
+- Define your domain. This specifies where you are solving the equations: globally (on the sphere),
+in a region (in a box), or at a site (in a column). See the [tutorial to ClimaLand domains!](@ref "Domain Tutorial")
+- Set your simulation period: start date, end date, timestep.
+- Set the forcings (for example, air temperature, precipitations).
+- Set the initial conditions. Differential equations required initial conditions to solve.
+For some simulations (e.g., global land simualtions), we provide default initial condition ("ic") functions,
+but in many cases you need to create your own `set_ic!` function.
+- Set how output is saved. For some simulations (e.g., global land simulations), we use the default diagnostic output,
+corresponding to monthly averages of specific variables saved to netcdf files.
+For your use case, you may wish to change these defaults.
+See [writing and accessing outputs](@ref "Using ClimaLand Diagnostics to save simulation output").
+
+## Example: running a simple soil model
 
 Now that we have Julia installed, let's set up and run a simple ClimaLand simulation!
 You can follow along by copying the following code segments into your REPL.

--- a/docs/src/parameters.md
+++ b/docs/src/parameters.md
@@ -1,4 +1,4 @@
-# Parameters
+# [Parameters](@id parameters_page)
 
 ## Default parameters
 ClimaLand provides a file `toml/default_parameters.toml` containing default parameters.

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -337,7 +337,7 @@ function PlantHydraulicsModel{FT}(
                 [zmin], # surface at ground level
                 [h_stem * i for i in 1:n_stem], # stem compartments
                 [h_stem * n_stem + h_leaf * j for j in 1:n_leaf], # leaf compartments
-            )
+            ),
         )
     compartment_midpoints =
         FT.(
@@ -347,7 +347,7 @@ function PlantHydraulicsModel{FT}(
                     h_stem * n_stem + h_leaf * (j - 1) + h_leaf / 2 for
                     j in 1:n_leaf
                 ], # leaf compartments
-            )
+            ),
         )
 
     parameters = PlantHydraulics.PlantHydraulicsParameters(;


### PR DESCRIPTION
closes #1462 

This new documentation structure is primarily targeted to scientists who use land surface models, and secondly to developers who may not be familiar with ClimaLand yet.
The goal in this commit is to have sections expected for a land model (run the model, model outputs, calibration, benchmark, etc.)

https://clima.github.io/ClimaLand.jl/previews/PR1457/

TODO:

From Julia:
- [x] "Model Outputs" could be more specific - maybe "Accessing Model Outputs" or "Analyzing Model Outputs"?
- [x] It might be helpful to have the "Julia Background" page visible at the top level. It can be near the bottom, but I think many people wouldn't expect we necessarily have a page like that, so more visibility would be useful
- [x] We could make the "Model Calibration" page a section instead, and move the calibration tutorials there so everything's in one place (credit to Kat for this suggestion!)
- [x] We could also rename to "Calibrating Model Parameters", unless "Model Calibration" is widely used and understood to refer to parameters
- [x] We should also expose the "Parameters" docs page to users more because it has a lot of useful information and right now it's hidden in the API docs. I would propose we copy everything above "API" on that page to a new docs page "Model Parameters" (or a similar name) which is available at the top level

From Kat:
- [x] Benchmark could be a subsection of calibration

