### PR TITLE
document models, optimizable params, parameter logging

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -72,6 +72,7 @@ pages = Any[
     "Additional resources" => [
         "Model structure" => "model_structure.md",
         "Repository structure" => "repo_structure.md",
+        "Available Models and Parameterizations" => "available_models.md",
         "Analyzing model output" => [
             "Diagnostics" => diagnostics,
             "Leaderboard" => "leaderboard/leaderboard.md",

--- a/docs/src/APIs/parameters.md
+++ b/docs/src/APIs/parameters.md
@@ -1,5 +1,21 @@
 # Parameters
 
+## Default parameters
+ClimaLand provides a file `toml/default_parameters.toml` containing default parameters.
+For each parameter, this file includes its name, type, default value, units,
+and model or parameterization it is used for.
+
+ClimaLand interacts with TOML parameter files via ClimaParams and ClimaLand.Parameters.
+To use the default parameter file, we create a parameter dictionary as follows:
+```julia
+import ClimaLand.Parameters as LP
+
+# Store default parameters
+toml_dict = LP.create_toml_dict(FT)
+```
+The dictionary `toml_dict` can then be passed to parameterization and model
+constructors, and the parameters values defined there will be used.
+
 ## How can I check that a parameter is actually being used?
 
 `ClimaParams` provides the function [`ClimaParams.log_parameter_information`](https://clima.github.io/ClimaParams.jl/dev/API/#ClimaParams.log_parameter_information)

--- a/docs/src/available_models.md
+++ b/docs/src/available_models.md
@@ -1,0 +1,105 @@
+# Available Models and Parameterizations
+
+## Standalone and integrated models
+As described in the [ClimaLand model structure](@ref) page, ClimaLand contains a variety of standalone
+and integrated models. A complete list of available models is provided here.
+
+### ClimaLand standalone models
+
+This table shows the abstract type (where applicable) and concrete type for each model.
+Abstract types are a concept originating in object-oriented programming
+that allow us to create a hierarchy of model types.
+For example, we can define an abstract type `AbstractSoilModel`, and then
+create specific models `RichardsModel` and `EnergyHydrology` as subtypes.
+This helps organize models and makes it easier to write functions that work
+with any model in the group via multiple dispatch on the abstract type.
+For more information about abstract types, please see the [Julia manual](https://docs.julialang.org/en/v1/manual/types/#man-abstract-types).
+
+| Abstract model type                | Model name                |
+|------------------------------------|---------------------------|
+| `AbstractSoilModel`                | `RichardsModel`           |
+|                                    | `EnergyHydrology`         |
+| N/A                                | `CanopyModel`             |
+| `AbstractSnowModel`                | `SnowModel`               |
+| `AbstractSoilBiogeochemistryModel` | `SoilCO2Model`            |
+| `AbstractBucketModel`              | `BucketModel`             |
+| `AbstractSurfaceWaterModel`        | `PondModel`               |
+
+### ClimaLand integrated models
+| Integrated model name      | Component standalone models |
+|----------------------------|-----------------------------|
+| `LandModel`                | `EnergyHydrology`           |
+|                            | `CanopyModel`               |
+|                            | `SoilCO2Model`              |
+|                            | `SnowModel`                 |
+| `SoilCanopyModel`          | `EnergyHydrology`           |
+|                            | `CanopyModel`               |
+|                            | `SoilCO2Model`              |
+| `SoilSnowModel`            | `EnergyHydrology`           |
+|                            | `SnowModel`                 |
+| `LandSoilBiogeochemistry`  | `EnergyHydrologyModel`      |
+|                            | `SoilCO2Model`              |
+| `LandHydrology`            | `RichardsModel`             |
+|                            | `PondModel`                 |
+
+## Model parameterizations
+
+Each model contains one or more parameterizations, often with several options
+to choose from. The following tables show all available parameterizations
+to clarify the different model setups.
+
+We also note the default option for each parameterization.
+This is what the model will use automatically when built with just the basic
+inputs (domain, forcing data, and TOML parameter file), without customizing
+the parameterizations yourself.
+The defaults are only explicitly shown here for standalone models but
+are also inherited by any integrated model containing a given standalone model,
+unless otherwise noted.
+
+### Soil Models
+
+#### `EnergyHydrology`
+| Parameterization type                | Available options                 |
+|--------------------------------------|-----------------------------------|
+| `AbstractSoilAlbedoParameterization` | `CLMTwoBandSoilAlbedo` (default)  |
+|                                      | `ConstantTwoBandSoilAlbedo`       |
+| `AbstractRunoffModel`                | `TOPMODELRunoff` (default)        |
+|                                      | `SurfaceRunoff`                   |
+|                                      | `NoRunoff`                        |
+| `AbstractSoilHydrologyClosure`       | `vanGenuchten` (default)          |
+|                                      | `BrooksCorey`                     |
+
+#### `RichardsModel`
+| Parameterization type                | Available options                 |
+|--------------------------------------|-----------------------------------|
+| `AbstractRunoffModel`                | `TOPMODELRunoff` (default)        |
+|                                      | `SurfaceRunoff`                   |
+|                                      | `NoRunoff`                        |
+| `AbstractSoilHydrologyClosure`       | `vanGenuchten` (default)          |
+|                                      | `BrooksCorey`                     |
+
+### `CanopyModel`
+| Parameterization type                 | Available options                                           |
+| ------------------------------------- | ------------------------------------------------------------|
+| `AbstractAutotrophicRespirationModel` | `AutotrophicRespirationModel` (default)                     |
+| `AbstractRadiationModel`              | `TwoStreamModel` (default)                                  |
+|                                       | `BeerLambertModel`                                          |
+| `AbstractPhotosynthesisModel`         | `FarquharModel` (default)                                   |
+|                                       | `PModel`                                                    |
+| `AbstractStomatalConductanceModel`    | `MedlynConductanceModel` (default)                          |
+|                                       | `PModelConductance`                                         |
+| `AbstractPlantHydraulicsModel`        | `PlantHydraulicsModel` (default)                            |
+| `AbstractSoilMoistureStressModel`     | `TuzetMoistureStressModel` (default)                        |
+|                                       | `PiecewiseMoistureStressModel`                              |
+| `AbstractSIFModel`                    | `Lee2015SIFModel` (default)                                 |
+| `AbstractCanopyEnergyModel`           | `PrescribedCanopyTempModel` (default, in standalone canopy) |
+|                                       | `BigLeafEnergyModel` (default, in integrated models)        |
+
+### `SnowModel`
+| Parameterization type            | Available options                       |
+| -------------------------------- | ----------------------------------------|
+| `AbstractDensityModel`           | `MinimumDensityModel` (default)         |
+|                                  | `NeuralDepthModel`                      |
+| `AbstractAlbedoModel`            | `ConstantAlbedoModel` (default)         |
+|                                  | `ZenithAngleAlbedoModel`                |
+| `AbstractSnowCoverFractionModel` | `WuWuSnowCoverFractionModel` (default)  |

--- a/docs/src/calibration.md
+++ b/docs/src/calibration.md
@@ -424,3 +424,11 @@ and `extend`.
     the simulation extend past `2008-9-1` with `extend`. For calibrating with
     monthly averages, `extend` should be `Dates.Month(1)` and for calibrating
     with seasonal averages, `extend` should be `Dates.Month(3)`.
+
+## Which parameters can I calibrate?
+ClimaLand.jl provides a full list of spatially-constant parameters that may be
+calibrated in `toml/default_parameters.toml`. For each parameter, this file
+includes the parameter name, type, default value, units, and model or
+parameterization it is used for.
+Please see that file to see which parameters could be calibrated
+for your model of interest.

--- a/docs/src/model_structure.md
+++ b/docs/src/model_structure.md
@@ -6,7 +6,12 @@ Here, we explain the internal organization of ClimaLand models.
 A core concept of ClimaLand's design is the presence of _standalone_ and _integrated_ models.
 In ClimaLand's framework, the land system is divided into individual components: soil, vegetation (or canopy), and snow. Each of these components can be run individually (_standalone_) or combined together (_integrated_).
 
-As an example, the soil model `EnergyHydrology` and the canopy model `CanopyModel` can each be set up and run on their own in standalone mode. Or, a user can set up the integrated `SoilCanopyModel`, which internally constructs each of these models and runs them in tandem, computing relevant interaction terms at each timestep.
+As an example, the soil model `EnergyHydrology` and the canopy model `CanopyModel`
+can each be set up and run on their own in standalone mode. Or, a user can set up
+the integrated `SoilCanopyModel`, which internally constructs each of these models
+and runs them in tandem, computing relevant interaction terms at each timestep.
+For a complete list of standalone and integrated models implemented in ClimaLand,
+please see the page [Available Models and Parameterizations](@ref).
 
 ## Model variables
 

--- a/docs/src/tutorials/global/snowy_land.jl
+++ b/docs/src/tutorials/global/snowy_land.jl
@@ -33,6 +33,14 @@ outdir =
     ClimaUtilities.OutputPathGenerator.generate_output_path(diagnostics_outdir);
 toml_dict = LP.create_toml_dict(FT)
 
+# We can optionally save the simulation parameters to a file for later reference.
+# Here we specify the filepath where we want to save the parameters, and then
+# ClimaParams handles the saving.
+# Note that any parameters overwritten via keyword arguments when constructing
+# models will not be reflected in this file.
+parameter_log_file = joinpath(root_path, "parameters.toml")
+CP.log_parameter_information(toml_dict, parameter_log_file)
+
 # Set timestep, start\_date, stop\_date:
 Δt = 450.0
 start_date = DateTime(2008)

--- a/docs/src/tutorials/integrated/snowy_land_fluxnet_tutorial.jl
+++ b/docs/src/tutorials/integrated/snowy_land_fluxnet_tutorial.jl
@@ -119,6 +119,14 @@ simulation = Simulations.LandSimulation(
 );
 solve!(simulation);
 
+# We can optionally save the simulation parameters to a file for later reference.
+# Here we specify the filepath where we want to save the parameters, and then
+# ClimaParams handles the saving.
+# Note that any parameters overwritten via keyword arguments when constructing
+# models will not be reflected in this file (in this example there are none).
+parameter_log_file = "snowy_land_fluxnet_parameters.toml"
+CP.log_parameter_information(toml_dict, parameter_log_file)
+
 # # Plotting results
 LandSimVis.make_diurnal_timeseries(
     simulation;

--- a/docs/src/tutorials/integrated/soil_canopy_fluxnet_tutorial.jl
+++ b/docs/src/tutorials/integrated/soil_canopy_fluxnet_tutorial.jl
@@ -122,6 +122,14 @@ simulation = Simulations.LandSimulation(
 );
 solve!(simulation);
 
+# We can optionally save the simulation parameters to a file for later reference.
+# Here we specify the filepath where we want to save the parameters, and then
+# ClimaParams handles the saving.
+# Note that any parameters overwritten via keyword arguments when constructing
+# models will not be reflected in this file (in this example there are none).
+parameter_log_file = "soil_canopy_fluxnet_parameters.toml"
+CP.log_parameter_information(toml_dict, parameter_log_file)
+
 # # Plotting results, ignoring the first 20 days as spinup
 LandSimVis.make_diurnal_timeseries(
     simulation;

--- a/docs/src/tutorials/standalone/Canopy/default_canopy.jl
+++ b/docs/src/tutorials/standalone/Canopy/default_canopy.jl
@@ -114,6 +114,14 @@ simulation = LandSimulation(
 # Now we can run the simulation!
 solve!(simulation);
 
+# We can optionally save the simulation parameters to a file for later reference.
+# Here we specify the filepath where we want to save the parameters, and then
+# ClimaParams handles the saving.
+# Note that any parameters overwritten via keyword arguments when constructing
+# models will not be reflected in this file (in this example there are none).
+parameter_log_file = "default_canopy_parameters.toml"
+CP.log_parameter_information(toml_dict, parameter_log_file)
+
 # Let's plot some results, for example diurnally averaged canopy temperature and transpiration over time:
 LandSimVis.make_diurnal_timeseries(
     simulation;


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Addresses the first 3 bullet points of #1441, summarized as:
- Refer to default parameters TOML from the "Parameters" docs page
- Add a page with tables of available models and parameterizations
- Show in some tutorials how to use the ClimaParams logging function

## Content
- [x] in calibration docs page, reference default_parameters.toml as list of optimizable parameters
- [x] in parameters docs page, again reference default_parameters.toml and show how to use it
- [x] add parameter logging calls to a few tutorials (already in parameters docs page and experiments)
- [x] add tables showing standalone models, integrated models and their components, and available parameterizations
- [x] link to the page with these tables from "ClimaLand model structure"


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.

doc preview: https://clima.github.io/ClimaLand.jl/previews/PR1464/
