### PR TITLE
Use periodic calendar for ERA5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ ClimaLand.jl Release Notes
 
 main
 -------
+- Use linear interpolation with a periodic calendar in time by default for ERA5 forcing PR[#1468](https://github.com/CliMA/ClimaLand.jl/pull/1468)
 - `PrescribedAtmosphere` fields can't be `nothing` PR[#1438](https://github.com/CliMA/ClimaLand.jl/pull/1438)
 - ![][badge-🐛bugfix] Check for coupled forcing in available diagnostics PR[#1434](https://github.com/CliMA/ClimaLand.jl/pull/1434)
 - ![breaking change][badge-💥breaking] Move the area indices and rooting depth to the biomass component PR[#1388](https://github.com/CliMA/ClimaLand.jl/pull/1388)

--- a/docs/src/tutorials/shared_utilities/driver_tutorial.jl
+++ b/docs/src/tutorials/shared_utilities/driver_tutorial.jl
@@ -174,3 +174,18 @@ cb = ClimaLand.DriverUpdateCallback(updatefunc, 3600.0 * 3, t0);
 # - "sp", Surface pressure in Pa
 # - "ssrd", Downwelling shortwave radiation in J/m^2/hour (accumulated over an hour)
 # - "strd", Downwelling longwave radiation J/m^2/hour (accumulated over an hour)
+
+# Please note that the default era5 forcing uses linear interpolation in space and time.
+# If your simulation encompasses a time that is beyond the extrema of the data,
+# the corresponding day/time from the last year of data will be repeated.
+# This corresponds to a value of `time_interpolation_method = LinearInterpolation(PeriodicCalendar())
+# `time_interpolation_method = LinearInterpolation(PeriodicCalendar(Dates.Year(1), DateTime(Dates.year(stop_date))))`.
+# To repeat the first year of data instead, you can specify to repeat the start date's year, i.e.:
+# `time_interpolation_method = LinearInterpolation(PeriodicCalendar(Dates.Year(1), DateTime(Dates.year(start_date))))`.
+# Or, to repeat the entire time series of data you can call `PeriodicCalendar` without any arguments:
+# `time_interpolation_method = LinearInterpolation(PeriodicCalendar())`.
+# This behavior can be changed by passing in a time_interpolation_method. Another
+# option that be be useful is `time_interpolation_method = LinearInterpolation(Flat())`,
+# which uses the last (first) value of the data repeatedly when outside the bounds
+# of the data. For more details, please see the documentation string for
+# ` ClimaLand.prescribed_forcing_era5` or ClimaUtilities.

--- a/experiments/calibration/model_interface.jl
+++ b/experiments/calibration/model_interface.jl
@@ -44,12 +44,6 @@ import JLD2
 import EnsembleKalmanProcesses as EKP
 
 const FT = Float64;
-# If you want to do a very long run locally, you can enter `export
-# LONGER_RUN=""` in the terminal and run this script. If you want to do a very
-# long run on Buildkite manually, then make a new build and pass `LONGER_RUN=""`
-# as an environment variable. In both cases, the value of `LONGER_RUN` does not
-# matter.
-const LONGER_RUN = haskey(ENV, "LONGER_RUN") ? true : false
 context = ClimaComms.context()
 ClimaComms.init(context)
 device = ClimaComms.device()
@@ -57,9 +51,6 @@ device_suffix = device isa ClimaComms.CPUSingleThreaded ? "cpu" : "gpu"
 root_path = "snowy_land_longrun_$(device_suffix)"
 
 function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
-    era5_time_interpolation_method =
-        LONGER_RUN ? LinearInterpolation() :
-        LinearInterpolation(PeriodicCalendar())
     surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
     surface_space = domain.space.surface
     # Forcing data - always use high resolution for calibration runs
@@ -70,7 +61,6 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
         toml_dict,
         FT;
         max_wind_speed = 25.0,
-        time_interpolation_method = era5_time_interpolation_method,
         context,
     )
     forcing = (; atmos, radiation)

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -51,7 +51,8 @@ start_date = DateTime(2008);
 dt = 450.0
 stop_date = start_date + Dates.Second(3600)
 
-# Forcing data
+# Forcing data - this is run on Caltech central,
+# which only has low resolution forcing data
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
     start_date,
     stop_date,
@@ -60,6 +61,7 @@ atmos, radiation = ClimaLand.prescribed_forcing_era5(
     FT;
     time_interpolation_method,
     context,
+    use_lowres_forcing = true,
 )
 
 soil_forcing = (; atmos, radiation)

--- a/experiments/integrated/global/global_soil_canopy_pmodel.jl
+++ b/experiments/integrated/global/global_soil_canopy_pmodel.jl
@@ -53,7 +53,8 @@ start_date = DateTime(2008);
 dt = 450.0
 stop_date = start_date + Dates.Second(3600)
 
-# Forcing data
+# Forcing data - this is run on Caltech central,
+# which only has low resolution forcing data
 atmos, radiation = ClimaLand.prescribed_forcing_era5(
     start_date,
     stop_date,
@@ -62,6 +63,7 @@ atmos, radiation = ClimaLand.prescribed_forcing_era5(
     FT;
     time_interpolation_method,
     context,
+    use_lowres_forcing = true,
 )
 
 soil_forcing = (; atmos, radiation)

--- a/experiments/long_runs/bucket.jl
+++ b/experiments/long_runs/bucket.jl
@@ -37,7 +37,6 @@ using CairoMakie, GeoMakie, ClimaAnalysis
 import ClimaLand.LandSimVis as LandSimVis
 
 const FT = Float64;
-time_interpolation_method = LinearInterpolation(PeriodicCalendar())
 regridder_type = :InterpolationsRegridder
 context = ClimaComms.context()
 ClimaComms.init(context)
@@ -59,7 +58,6 @@ function setup_model(FT, start_date, stop_date, domain, Δt, toml_dict, context)
         toml_dict,
         FT;
         max_wind_speed = 25.0,
-        time_interpolation_method,
         regridder_type,
         context,
     )

--- a/experiments/long_runs/land_region.jl
+++ b/experiments/long_runs/land_region.jl
@@ -63,8 +63,6 @@ function setup_model(FT, context, start_date, stop_date, Δt, domain, toml_dict)
         toml_dict,
         FT;
         max_wind_speed = 25.0,
-        time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
-        interpolation_method = Interpolations.Linear(),
         context,
     )
     forcing = (; atmos, radiation)

--- a/experiments/long_runs/low_res_snowy_land_rh.jl
+++ b/experiments/long_runs/low_res_snowy_land_rh.jl
@@ -65,7 +65,6 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
         -0.2,
         FT;
         max_wind_speed = 25.0,
-        time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
     )
     forcing = (; atmos, radiation)
 

--- a/experiments/long_runs/low_res_snowy_land_temp.jl
+++ b/experiments/long_runs/low_res_snowy_land_temp.jl
@@ -65,7 +65,6 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
         10.0,
         FT;
         max_wind_speed = 25.0,
-        time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
     )
     forcing = (; atmos, radiation)
 

--- a/experiments/long_runs/snowy_land.jl
+++ b/experiments/long_runs/snowy_land.jl
@@ -59,9 +59,6 @@ outdir =
     ClimaUtilities.OutputPathGenerator.generate_output_path(diagnostics_outdir)
 
 function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
-    era5_time_interpolation_method =
-        LONGER_RUN ? LinearInterpolation() :
-        LinearInterpolation(PeriodicCalendar())
     surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
     surface_space = domain.space.surface
     # Forcing data
@@ -72,7 +69,6 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
         toml_dict,
         FT;
         max_wind_speed = 25.0,
-        time_interpolation_method = era5_time_interpolation_method,
         context,
     )
     forcing = (; atmos, radiation)

--- a/experiments/long_runs/snowy_land_pmodel.jl
+++ b/experiments/long_runs/snowy_land_pmodel.jl
@@ -59,9 +59,6 @@ outdir =
     ClimaUtilities.OutputPathGenerator.generate_output_path(diagnostics_outdir)
 
 function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
-    era5_time_interpolation_method =
-        LONGER_RUN ? LinearInterpolation() :
-        LinearInterpolation(PeriodicCalendar())
     surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
     surface_space = domain.space.surface
     # Forcing data - high resolution
@@ -72,7 +69,6 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
         toml_dict,
         FT;
         max_wind_speed = 25.0,
-        time_interpolation_method = era5_time_interpolation_method,
         context,
     )
     forcing = (; atmos, radiation)

--- a/experiments/long_runs/soil.jl
+++ b/experiments/long_runs/soil.jl
@@ -52,8 +52,6 @@ root_path = "soil_longrun_$(device_suffix)"
 diagnostics_outdir = joinpath(root_path, "global_diagnostics")
 outdir =
     ClimaUtilities.OutputPathGenerator.generate_output_path(diagnostics_outdir)
-time_interpolation_method =
-    LONGER_RUN ? LinearInterpolation() : LinearInterpolation(PeriodicCalendar())
 
 # If not LONGER_RUN, run for 2 years; note that the forcing from 2008 is repeated.
 # If LONGER run, run for 20 years, with the correct forcing each year.
@@ -72,7 +70,6 @@ forcing = ClimaLand.prescribed_forcing_era5(
     toml_dict,
     FT;
     max_wind_speed = 25.0,
-    time_interpolation_method,
     context,
 )
 model = ClimaLand.Soil.EnergyHydrology{FT}(domain, forcing, toml_dict)

--- a/experiments/standalone/Bucket/bucket_era5.jl
+++ b/experiments/standalone/Bucket/bucket_era5.jl
@@ -3,9 +3,8 @@
 # The code sets up and runs the bucket for 7 days using albedo read in from
 # a file containing static data over the globe or on a region, and ERA5 atmospheric and
 # radiative forcings.
-# Moving forward, this driver will serve as our more complex global bucket run,
-# eventually running for a longer time period (1+ year) and using temporally
-# varying atmospheric and radiative forcing data.
+# Since this is run on Caltech's central cluster, we use the low-resolution
+# forcing.
 # This driver is used to verify that this more complex version of the model can
 # run on both CPU and GPU, with only minor computational differences between the results.
 
@@ -142,6 +141,7 @@ bucket_atmos, bucket_rad = ClimaLand.prescribed_forcing_era5(
     time_interpolation_method,
     regridder_type,
     context,
+    use_lowres_forcing = true,
 )
 
 model = BucketModel(

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -1502,7 +1502,8 @@ There are two versions of the ERA5 data available through ClimaLand:
 - a low resolution version (8° x 8°) available only for the year 2008
 
 The high resolution version will be used if `use_lowres_forcing = false` (the default).
-This artifact is used for global runs on compute clusters, but is too large to be used for local testing.
+This artifact is used for global runs on compute clusters, but is too large to be used for local testing,
+and requires you to have acquired the data in advance.
 The low resolution version will be used if `use_lowres_forcing = true`.
 If the simulation dates are outside of 2008, the 2008 data will be reused for each year of simulation.
 This artifact is recommended for local testing or quick runs where accuracy is less critical.
@@ -1532,9 +1533,7 @@ and linear spatial interpolation for high resolution forcing.
 
 !!! note "Full high resolution dataset available on clima cluster only"
     The full 40 year dataset of high resolution ERA5 data is only available on the
-    clima cluster. The artifact exists on central but contains only the year 2008.
-    When running on central with the high resolution data, please ensure you
-    include `PeriodicCalendar` boundary conditions for the time interpolation method.
+    clima cluster. 
 """
 function prescribed_forcing_era5(
     start_date,

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -1489,7 +1489,7 @@ end
                             gustiness=1,
                             max_wind_speed = nothing,
                             c_co2 = TimeVaryingInput((t) -> 4.2e-4),
-                            time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
+                            time_interpolation_method = LinearInterpolation(PeriodicCalendar(Dates.Year(1), DateTime(Dates.year(stop_date)))),
                             regridder_type = :InterpolationsRegridder,
                             context = nothing,
                             )
@@ -1507,8 +1507,20 @@ The low resolution version will be used if `use_lowres_forcing = true`.
 If the simulation dates are outside of 2008, the 2008 data will be reused for each year of simulation.
 This artifact is recommended for local testing or quick runs where accuracy is less critical.
 
-The ClimaLand default is to use nearest neighbor interpolation for low resolution forcing,
-and linear interpolation for high resolution forcing.
+The method for temporal interpolation is controlled via the `time_interpolation_method` kwarg. 
+We suggest `LinearInterpolation(PeriodicCalendar())`, which implies linear interpolation in time;
+the inner argument implies how extrapolation outside the bounds of the data is handled. For example,
+the ERA5 forcing data we use is hourly, which implies Dec 31 of the last year of the data, at midnight,
+is not in the data. With the PeriodicCalendar(Dates.Year(1), DateTime(Dates.year(stop_date)))
+option, the interpolated value at Dec 31 at midnight of the previous year will
+be used. For the low-resolution forcing data, which only exists for 2008, multi-year runs will repeat
+the forcing. If this behavior is not what you want, you can change the extrapolation argument to
+error `LinearInterpolation(Throw())` or extrapolate by using the last value ``LinearInterpolation(Flat())`.
+More information is available in the ClimaUtilities documentation:
+https://clima.github.io/ClimaUtilities.jl/dev/inputs/#Extrapolation-boundary-conditions.
+
+The ClimaLand default is to use nearest neighbor spatial interpolation for low resolution forcing,
+and linear spatial interpolation for high resolution forcing.
 
 !!! warning "Clipped values"
     High wind speed anomalies (10-100x increase and decrease over a period of a
@@ -1534,7 +1546,9 @@ function prescribed_forcing_era5(
     gustiness = 1,
     max_wind_speed = nothing,
     c_co2 = TimeVaryingInput((t) -> 4.2e-4),
-    time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
+    time_interpolation_method = LinearInterpolation(
+        PeriodicCalendar(Dates.Year(1), DateTime(Dates.year(stop_date))),
+    ),
     regridder_type = :InterpolationsRegridder,
     context = nothing,
 )

--- a/src/shared_utilities/perturbed_drivers.jl
+++ b/src/shared_utilities/perturbed_drivers.jl
@@ -91,7 +91,7 @@ end
                              gustiness=1,
                              max_wind_speed = nothing,
                              c_co2 = TimeVaryingInput((t) -> 4.2e-4),
-                             time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
+                             time_interpolation_method = LinearInterpolation(PeriodicCalendar(Dates.Year(1), DateTime(Dates.year(stop_date)))),
                              regridder_type = :InterpolationsRegridder,
                              interpolation_method = Interpolations.Constant(),)
 
@@ -113,7 +113,9 @@ function prescribed_perturbed_temperature_era5(
     gustiness = 1,
     max_wind_speed = nothing,
     c_co2 = TimeVaryingInput((t) -> 4.2e-4),
-    time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
+    time_interpolation_method = LinearInterpolation(
+        PeriodicCalendar(Dates.Year(1), DateTime(Dates.year(stop_date))),
+    ),
     regridder_type = :InterpolationsRegridder,
     interpolation_method = Interpolations.Constant(),
 )
@@ -284,7 +286,7 @@ end
                              gustiness=1,
                              max_wind_speed = nothing,
                              c_co2 = TimeVaryingInput((t) -> 4.2e-4),
-                             time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
+                             time_interpolation_method = LinearInterpolation(PeriodicCalendar(Dates.Year(1), DateTime(Dates.year(stop_date)))),
                              regridder_type = :InterpolationsRegridder,
                              interpolation_method = Interpolations.Constant(),)
 
@@ -306,7 +308,9 @@ function prescribed_perturbed_rh_era5(
     gustiness = 1,
     max_wind_speed = nothing,
     c_co2 = TimeVaryingInput((t) -> 4.2e-4),
-    time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
+    time_interpolation_method = LinearInterpolation(
+        PeriodicCalendar(Dates.Year(1), DateTime(Dates.year(stop_date))),
+    ),
     regridder_type = :InterpolationsRegridder,
     interpolation_method = Interpolations.Constant(),
 )


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Since the last timestamp in ERA5 data is 11pm on Dec 31 of a given year, simulations will fail in the last hour unless we provide an extrapolation BC to LinearInterpolation(). Here we make it so we always use the periodic calendar, and describe for users how to change this if they want.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
