### PR TITLE
output liquid water only, fix pipeline bug

### DIFF
--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -38,8 +38,7 @@ steps:
   - wait
 
   - group: "Global Land Models"
-    if: |
-    build.env("LONGER_RUN") == null && build.env("PERTURBED_RUN") == null
+    if: build.env("LONGER_RUN") == null && build.env("PERTURBED_RUN") == null
     steps:
 
       - label: ":snow_capped_mountain: Snowy Land"

--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -38,8 +38,8 @@ steps:
   - wait
 
   - group: "Global Land Models"
-    if: build.env("LONGER_RUN") == null
-    if: build.env("PERTURBED_RUN") == null
+    if: |
+    build.env("LONGER_RUN") == null && build.env("PERTURBED_RUN") == null
     steps:
 
       - label: ":snow_capped_mountain: Snowy Land"

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -869,10 +869,10 @@ function define_diagnostics!(land_model)
 
     add_diagnostic_variable!(
         short_name = "iwc",
-        long_name = "Integrated Soil Water Mass in first 10cm",
+        long_name = "Integrated Soil Liquid Water Mass in first 10cm",
         standard_name = "soil_10cm_water_mass",
         units = "kg/m^2",
-        comments = "The integrated water mass to a depth of 10cm",
+        comments = "The integrated liquid water mass to a depth of 10cm",
         compute! = (out, Y, p, t) ->
             compute_10cm_water_mass!(out, Y, p, t, land_model),
     )

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -454,9 +454,8 @@ function compute_10cm_water_mass!(
     depth = FT(-0.1)
     earth_param_set = soil.parameters.earth_param_set
     _ρ_liq = LP.ρ_cloud_liq(earth_param_set)
-    _ρ_ice = LP.ρ_cloud_ice(earth_param_set)
     # Convert from volumetric water content to water mass per unit volume using density
-    @. Hθ = (Y.soil.ϑ_l * _ρ_liq + Y.soil.θ_i * _ρ_ice) * heaviside(z, depth)
+    @. Hθ = (Y.soil.ϑ_l * _ρ_liq) * heaviside(z, depth)
     column_integral_definite!(∫Hθdz, Hθ)
 
     # The layering of the soil model may not coincide with 10 cm exactly, and this could lead


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR fixes two small bugs 
- in our long runs, when I added the perturbed_run flag, the logic worked out so that all the "long runs" ran at the same time as the "longer runs" did. so the LONGER_RUN flag was not working as attended. This fixes the logic in the buildkite pipeline
see here: https://buildkite.com/clima/climaland-long-runs/builds/4255
- output only liquid water for the first 10cm instead of liquid water and ice, to be comparable to the data @braghiere 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
