### PR TITLE
Add tests and buildkite for calibration pipeline

### DIFF
--- a/.buildkite/calibration/pipeline.yml
+++ b/.buildkite/calibration/pipeline.yml
@@ -1,0 +1,54 @@
+agents:
+  queue: clima
+  slurm_mem: 8G
+  modules: climacommon
+
+steps:
+  - label: "init :GPU:"
+    command:
+      - echo "--- Instantiate"
+
+      - "julia --project -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
+      - "julia --project -e 'using Pkg; Pkg.status()'"
+
+      - julia --project=.buildkite -e 'using Pkg; Pkg.instantiate(;verbose=true)'
+      - julia --project=.buildkite -e 'using Pkg; Pkg.precompile()'
+      - julia --project=.buildkite -e 'using CUDA; CUDA.precompile_runtime()'
+      - julia --project=.buildkite -e 'using Pkg; Pkg.status()'
+
+    agents:
+      slurm_gpus: 1
+      slurm_cpus_per_task: 8
+    env:
+      JULIA_NUM_PRECOMPILE_TASKS: 8
+      JULIA_MAX_NUM_PRECOMPILE_FILES: 50
+
+  - wait
+
+  - label: "Generate observations"
+    command:
+      - julia --color=yes --project=.buildkite/ experiments/calibration/generate_observations.jl
+    env:
+      # Generating observations doesn't require a CUDA, but these environment
+      # variables may be loaded in the slurm script
+      CLIMACOMMS_DEVICE: "CUDA"
+      CLIMACOMMS_CONTEXT: "SINGLETON"
+
+  - wait
+
+  - label: "Calibration"
+    command:
+      - julia --color=yes --project=.buildkite/ experiments/calibration/run_calibration.jl
+    agents:
+      slurm_time: 2:00:00
+      slurm_gpus: 1
+    env:
+      CLIMACOMMS_DEVICE: "CUDA"
+      CLIMACOMMS_CONTEXT: "SINGLETON"
+    artifact_paths: "experiments/calibration/land_model/**/*.png"
+
+  - wait
+
+  - label: "Test calibration results"
+    command:
+      - julia --color=yes --project=.buildkite/ experiments/calibration/test/test_calibration.jl

--- a/experiments/calibration/run_calibration.jl
+++ b/experiments/calibration/run_calibration.jl
@@ -13,10 +13,10 @@ include(joinpath(pkgdir(ClimaLand), "experiments/calibration/api.jl"))
 const CALIBRATE_CONFIG = CalibrateConfig(;
     short_names = ["lwu"],
     minibatch_size = 1,
-    n_iterations = 3,
+    n_iterations = 1,
     sample_date_ranges = [("2007-12-1", "2007-12-1")],
     extend = Dates.Month(3),
-    spinup = Dates.Month(3),
+    spinup = Dates.Month(0),
     nelements = (101, 15),
     output_dir = "experiments/calibration/land_model",
     rng_seed = 42,

--- a/experiments/calibration/test/test_calibration.jl
+++ b/experiments/calibration/test/test_calibration.jl
@@ -1,0 +1,48 @@
+# Calibration End-to-End Test Suite
+
+# This file contains tests designed to be run after a test calibration and may
+# not necessarily work with a different calibration configuration.
+
+using Test
+import ClimaLand
+import Statistics: std
+
+# Needed to access CalibrateConfig
+include(
+    joinpath(pkgdir(ClimaLand), "experiments/calibration/run_calibration.jl"),
+)
+
+@testset "Observations" begin
+    (; obs_vec_filepath, sample_date_ranges, short_names) = CALIBRATE_CONFIG
+    isfile(obs_vec_filepath) || error("Cannot find the observations generated")
+    obs_vec = JLD2.load_object(obs_vec_filepath)
+
+    @test length(sample_date_ranges) == length(obs_vec)
+
+    metadata = first(EKP.get_metadata(first(obs_vec)))
+    @test metadata.attributes["short_name"] == first(short_names)
+    @test Dates.Second(first(metadata.dims["time"])) +
+          Dates.DateTime(metadata.attributes["start_date"]) ==
+          first(first(sample_date_ranges))
+    @test Dates.Second(last(metadata.dims["time"])) +
+          Dates.DateTime(metadata.attributes["start_date"]) ==
+          first(last(sample_date_ranges))
+end
+
+@testset "Calibration results" begin
+    isdir(CALIBRATE_CONFIG.output_dir) || error(
+        "Cannot find output directory of calibration. These tests will not work without first running a test calibration",
+    )
+
+    (; output_dir, n_iterations) = CALIBRATE_CONFIG
+    ekp = JLD2.load_object(ClimaCalibrate.ekp_path(output_dir, n_iterations))
+
+    @test EKP.get_N_iterations(ekp) == n_iterations
+
+    # Spread should decrease
+    ekp_u = EKP.get_u(ekp)
+    spreads = map(std, ekp_u)
+    @test 0.1 * first(spreads) > last(spreads)
+end
+
+nothing


### PR DESCRIPTION
closes #1370

This PR adds a new buildkite for testing a calibration which can be found here: https://buildkite.com/clima/climaland-calibrate-e2e

The calibration is meant to be short and exercise every single line of the calibration code rather than test a realistic calibration like a perfect model calibration.