### PR TITLE
update pmodel and moisture stress params after calibration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ ClimaLand.jl Release Notes
 
 main
 -------
+- Update default pmodel parameters PR[#1482](https://github.com/CliMA/ClimaLand.jl/pull/1482)
 - Use linear interpolation with a periodic calendar in time by default for ERA5 forcing PR[#1468](https://github.com/CliMA/ClimaLand.jl/pull/1468)
 - `PrescribedAtmosphere` fields can't be `nothing` PR[#1438](https://github.com/CliMA/ClimaLand.jl/pull/1438)
 - ![][badge-🐛bugfix] Check for coupled forcing in available diagnostics PR[#1434](https://github.com/CliMA/ClimaLand.jl/pull/1434)

--- a/experiments/long_runs/snowy_land_pmodel.jl
+++ b/experiments/long_runs/snowy_land_pmodel.jl
@@ -102,6 +102,9 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
     # Construct the P model manually since it is not a default
     photosynthesis = PModel{FT}(domain, toml_dict)
     conductance = PModelConductance{FT}(toml_dict)
+    # Use the soil moisture stress function based on soil moisture only
+    soil_moisture_stress =
+        ClimaLand.Canopy.PiecewiseMoistureStressModel{FT}(domain, toml_dict)
 
     canopy = ClimaLand.Canopy.CanopyModel{FT}(
         surface_domain,
@@ -112,6 +115,7 @@ function setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
         hydraulics,
         photosynthesis,
         conductance,
+        soil_moisture_stress,
         z_0m,
         z_0b,
     )

--- a/test/standalone/Vegetation/test_soil_moisture_stress.jl
+++ b/test/standalone/Vegetation/test_soil_moisture_stress.jl
@@ -92,7 +92,7 @@ for FT in (Float32, Float64)
         )
         @test θ_r == sms.θ_low
         @test ν == sms.θ_high
-        βm_expected = FT(0.5)
+        βm_expected = FT(0.5)^sms.c
         βm_computed = compute_piecewise_moisture_stress(
             sms.θ_high,
             sms.θ_low,

--- a/toml/default_parameters.toml
+++ b/toml/default_parameters.toml
@@ -1,6 +1,6 @@
 # Moisture stress models
 [moisture_stress_c]
-value = 1.0
+value = 0.51
 type = "float"
 description = "unitless"
 tag = "SoilMoistureStress"
@@ -177,13 +177,13 @@ tag = "WuWuSnowCoverFractionModel"
 
 # P model parameters
 ["pmodel_cstar"]
-value = 0.41
+value = 0.28
 type = "float"
 description = "4 * dA/dJmax, assumed to be a constant marginal cost (Wang 2017, Stocker 2020)"
 tag = "PModelParameters"
 
 ["pmodel_β"]
-value = 146
+value = 145
 type = "float"
 description = "Unit cost ratio of Vcmax to transpiration (Stocker 2020)"
 tag = "PModelParameters"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Update params in our default toml after calibration.
<img width="4000" height="1000" alt="constrained_params_and_error" src="https://github.com/user-attachments/assets/8aafb8f8-83a0-4763-8da8-fc23e196b40e" />

Longer runs were here:
https://buildkite.com/clima/climaland-long-runs/builds/4254#01999d1d-b1aa-4bc1-8ab3-e36fbff5d86b
but I would rerun them after merging this to make sure latest main is being used
Long run
https://buildkite.com/clima/climaland-long-runs/builds/4265
## To-do



## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
