### PR TITLE
add swu and lwu diagnostics, update bucket calib and long run to make leaderboard plots

### DIFF
--- a/experiments/calibration/models/bucket.jl
+++ b/experiments/calibration/models/bucket.jl
@@ -106,7 +106,10 @@ function ClimaCalibrate.forward_model(iteration, member, ::Type{BucketModel})
     output_writer =
         ClimaDiagnostics.NetCDFWriter(diagnostic_domain, outdir; start_date)
 
+    # Need to include "lhf", "shf", "lwu", "swu" because plotting the
+    # leaderboard requires these diagnostics
     short_names = CALIBRATE_CONFIG.short_names
+    short_names = unique!([short_names; ["lhf", "shf", "lwu", "swu"]])
     diagnostics = ClimaLand.Diagnostics.default_diagnostics(
         model,
         start_date;

--- a/experiments/calibration/observation_map.jl
+++ b/experiments/calibration/observation_map.jl
@@ -154,10 +154,7 @@ function ClimaCalibrate.analyze_iteration(
     plot_output_path = ClimaCalibrate.path_to_iteration(output_dir, iteration)
     plot_constrained_params_and_errors(plot_output_path, ekp, prior)
 
-    # Leaderboard plots can only be plotted when the model is LandModel
-    model_type = CALIBRATE_CONFIG.model_type
-    model_type == ClimaLand.LandModel || return nothing
-
+    # Leaderboard plots can only be plotted when the model saves swu, lwu, shf, lhf diagnostics
     # Plot ERA5 bias plots for only the first ensemble member
     # This can take a while to plot, so we plot only one of the members.
     # We choose the first ensemble member because the parameters for the first

--- a/experiments/long_runs/bucket.jl
+++ b/experiments/long_runs/bucket.jl
@@ -129,11 +129,16 @@ simulation = LandSimulation(
 CP.log_parameter_information(toml_dict, joinpath(root_path, "parameters.toml"))
 solve!(simulation);
 
-short_names = ["tsfc", "lhf", "shf", "wsoil"]
+short_names = ["tsfc", "lhf", "shf", "wsoil", "swu", "lwu"]
 LandSimVis.make_annual_timeseries(simulation; savedir = root_path, short_names)
 LandSimVis.make_heatmaps(
     simulation;
     savedir = root_path,
     short_names,
     date = stop_date,
+)
+LandSimVis.make_leaderboard_plots(
+    simulation;
+    savedir = root_path,
+    leaderboard_data_sources = ["ERA5"],
 )

--- a/ext/LandSimulationVisualizationExt.jl
+++ b/ext/LandSimulationVisualizationExt.jl
@@ -45,7 +45,7 @@ end
 A default method for `make_leaderboard_plots` notifying the user that these plots have not been enable for their domain/model combination.
 """
 function LandSimVis.make_leaderboard_plots(m, d, diag)
-    @info "Leaderboard plots not configured for your model type and/or your model domain. Model type must be LandModel, and the domain must be global."
+    @info "Leaderboard plots not configured for your model type and/or your model domain. Model type must be LandModel or BucketModel, and the domain must be global."
 end
 
 """
@@ -69,6 +69,33 @@ function LandSimVis.make_leaderboard_plots(
     diagnostics;
     savedir = ".",
     leaderboard_data_sources = ["ERA5", "ILAMB"],
+)
+    # assert that data spans multiple years and is monthly output?
+    # check that the short_names include the appropriate variables for the data source?
+    diagdir = first(diagnostics).output_writer.output_dir
+    short_names = [d.variable.short_name for d in diagnostics]
+    diagnostics_folder_path = diagdir
+    leaderboard_base_path = savedir
+    for data_source in leaderboard_data_sources
+        compute_monthly_leaderboard(
+            leaderboard_base_path,
+            diagnostics_folder_path,
+            data_source,
+        )
+        compute_seasonal_leaderboard(
+            leaderboard_base_path,
+            diagnostics_folder_path,
+            data_source,
+        )
+    end
+end
+
+function LandSimVis.make_leaderboard_plots(
+    model::ClimaLand.Bucket.BucketModel,
+    domain::ClimaLand.Domains.SphericalShell,
+    diagnostics;
+    savedir = ".",
+    leaderboard_data_sources = ["ERA5"],
 )
     # assert that data spans multiple years and is monthly output?
     # check that the short_names include the appropriate variables for the data source?

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -443,6 +443,8 @@ function get_possible_diagnostics(model::BucketModel)
         "lhf",
         "rae",
         "shf",
+        "swu",
+        "lwu",
         "vflux",
         "rhosfc",
         "tsoil",


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
add swu and lwu diagnostics
update bucket calib and long run to make leaderboard plots

We can then calibrate the bucket with lwu, shf, lhf, and compare to observed swu, lwu, shf, lhf (assuming no calibration of swu since albedo is prescribed- but we can still compare with observations).

## To-do


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
