### PR TITLE
use central queue for change to Vast

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: new-central
+  queue: central
   slurm_mem: 24G
   modules: climacommon/2025_03_18
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ ClimaLand.jl Release Notes
 
 main
 -------
+- Switch to use the Vast filesystem on central
+
+v1.0.0
+------
 - Release v1 PR[#1488](https://github.com/CliMA/ClimaLand.jl/pull/1488)
 - Update benchmark scripts as they were out of date [#1490](https://github.com/CliMA/ClimaLand.jl/pull/1490)
 - ![][badge-🐛bugfix] Fix periodic calendar to use all of the data rather than repeat the last year [#1489](https://github.com/CliMA/ClimaLand.jl/pull/1489)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Necessary changes for change to Vast filesystem.

## Content
- [x] use the queue `central` instead of `new-central` for CI (other pipelines use `clima`)
- [x] rename any paths that use `central/` or `groups/`
  - I didn't find anything that uses these paths in ClimaLand
- [x] change the queue in the [buildkite pipeline](https://buildkite.com/clima/climaland-ci/settings/steps)

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
