### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Then, you can install ClimaLand.jl by doing:
 
 ```Julia
 julia> using Pkg
-julia> Pkg.add(ClimaLand)
+julia> Pkg.add("ClimaLand")
 ```
 
 You are now ready to use `ClimaLand.jl`.


### PR DESCRIPTION
The README installation instructions were missing quotation marks around `"ClimaLand"`.
