### PR TITLE
Improve diagnostics test speed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ ClimaLand.jl Release Notes
 main
 -------
 - Switch to use the Vast filesystem on central
+- `define_diagnostics!` renamed to `construct_diagnostics`
+  PR[#1526](https://github.com/CliMA/ClimaLand.jl/pull/1526)
 
 v1.0.0
 ------

--- a/docs/src/diagnostics/developers_diagnostics.md
+++ b/docs/src/diagnostics/developers_diagnostics.md
@@ -10,10 +10,10 @@ We want to provide users with default options, but also the possibility to defin
 Internally, this is done by using the [`ClimaDiagnostics.jl`](https://github.com/CliMA/ClimaDiagnostics.jl) package, that provides the functionality to produce a
 [`ClimaLand.Diagnostics`](https://github.com/CliMA/ClimaLand.jl/tree/main/src/Diagnostics/Diagnostics.jl) module in the src/Diagnostics.jl folder. In this folder,
  - `Diagnostics.jl` defines the module,
- - `diagnostic.jl` defines `ALL_DIAGNOSTICS`, a Dict containing all diagnostics variables defined in `define_diagnostics.jl`, it also defines the function
+ - `diagnostic.jl` defines `ALL_DIAGNOSTICS`, a Dict containing all diagnostics variables defined in `construct_diagnostics.jl`, it also defines the function
  `add_diagnostic_variable!` which defines a method to add diagnostic variables to ALL\_DIAGNOSTICS, finally it contains a function `get_diagnostic_variable` which returns a
  `DiagnosticVariable` from its `short_name`, if it exists.
- - `define_diagnostics.jl`, mentioned above, contains a function `define_diagnostics!(land_model)` which contains all default diagnostic variables by calling.
+ - `construct_diagnostics.jl`, mentioned above, contains a function `construct_diagnostics(land_model)` which contains all default diagnostic variables by calling.
  `add_diagnostic_variable!`, and dispatch off the type of land\_model to define how to compute a diagnostic (for example, surface temperature is computed in `p.bucket.T_sfc` in the bucket model).
  - `land_compute_methods.jl` defines how to compute diagnostics for various ClimaLand models.
 
@@ -82,7 +82,7 @@ The `@with_error` macro define helper functions returning error messages if a us
 
 # Define diagnostics
 
-Once the compute functions have been defined, they are added to `define_diagnostics!(land_model)`, which adds diagnostics variables to ALL\_DIAGNOSTICS dict,
+Once the compute functions have been defined, they are added to `construct_diagnostics(land_model)`, which adds diagnostics variables to ALL\_DIAGNOSTICS dict,
 defined in diagnostic.jl. In these functions, you also define a `short_name`, `long_name`, `standard_name`, `units` and `comment`. For example:
 
 ```Julia

--- a/docs/src/diagnostics/make_diagnostic_table.jl
+++ b/docs/src/diagnostics/make_diagnostic_table.jl
@@ -3,7 +3,7 @@ using PrettyTables
 
 # Print all available diagnostics to an ASCII table
 
-CL.Diagnostics.define_diagnostics!(nothing; requested_diags = nothing)
+CL.Diagnostics.construct_diagnostics(nothing; requested_diags = nothing)
 short_names = []
 long_names = []
 units = []

--- a/docs/src/diagnostics/users_diagnostics.md
+++ b/docs/src/diagnostics/users_diagnostics.md
@@ -118,7 +118,7 @@ rather than computing one, like the Bowen ratio above. For example,
 
 ### Add that diagnostic(s) variable to your list of variables
 
-These functions are defined in `src/diagnostics/define_diagnostics.jl`.
+These functions are defined in `src/diagnostics/construct_diagnostics.jl`.
 
 ```Julia
  add_diagnostic_variable!(

--- a/src/diagnostics/construct_diagnostics.jl
+++ b/src/diagnostics/construct_diagnostics.jl
@@ -1,11 +1,11 @@
 """
-    define_diagnostics!(land_model; requested_diags = nothing)
+    construct_diagnostics(land_model; requested_diags = nothing)
 
 Calls `add_diagnostic_variable!` for all available variables specializing the
 compute function for `land_model`. If `requested_diags` is not `nothing`, diagnostics are
 only added if their `short_name` is in `requested_diags`.
 """
-function define_diagnostics!(land_model; requested_diags = nothing)
+function construct_diagnostics(land_model; requested_diags = nothing)
     ### Conservation ###
     add_diagnostic_variable!(
         requested_diags;

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -183,7 +183,7 @@ function default_diagnostics(
         @assert all([var in possible_diags for var in output_vars])
         diagnostics = output_vars
     end
-    define_diagnostics!(model; requested_diags = diagnostics)
+    construct_diagnostics(model; requested_diags = diagnostics)
 
     default_outputs = common_diagnostics(
         Val(reduction_period),
@@ -254,7 +254,7 @@ function default_diagnostics(
         @assert all([var in possible_diags for var in output_vars])
         diagnostics = output_vars
     end
-    define_diagnostics!(land_model; requested_diags = diagnostics)
+    construct_diagnostics(land_model; requested_diags = diagnostics)
 
     default_outputs = common_diagnostics(
         Val(reduction_period),

--- a/src/diagnostics/diagnostic.jl
+++ b/src/diagnostics/diagnostic.jl
@@ -200,8 +200,8 @@ include("land_compute_methods.jl")
 # Default diagnostics and higher level interfaces
 include("default_diagnostics.jl")
 
-# define_diagnostics.jl contains the list of all the diagnostics
-include("define_diagnostics.jl")
+# construct_diagnostics.jl contains the list of all the diagnostics
+include("construct_diagnostics.jl")
 
 if pkgversion(ClimaDiagnostics) < v"0.2.13"
     # Default diagnostic resolution given a Space (approximately one point per

--- a/test/diagnostics/diagnostics_tests.jl
+++ b/test/diagnostics/diagnostics_tests.jl
@@ -112,7 +112,7 @@ using Statistics
     # ClimaDiagnostics
 
     diags = ["rn", "lhf"]
-    ClimaLand.Diagnostics.define_diagnostics!(model; requested_diags = diags)
+    ClimaLand.Diagnostics.construct_diagnostics(model; requested_diags = diags)
 
     tmpdir = mktempdir(".")
     nc_writer = ClimaDiagnostics.Writers.NetCDFWriter(


### PR DESCRIPTION
The diagnostics tests can take a very long
time (8 min on gha). This commit makes two
changes to speed this test up.

1. Override some constructors inside the @testset

The diagnostics tests do not need a real jacobian, and they do not need to perform a real step. This commit adds constructors for the implicit and explicit tendency updates, cache update, boundary fluxes update, and jacobian compuation which do nothing. It also uses a fake
field matrix and solver.

2. Change define_diagnsotics! and default_diagnostics to only add valid diagnostics. Constructing a DiagnosticVariable is expensive, and this reduces the number of useless ones created.


The speedup I get from this PR is much larger when I run locally. It makes gha ci a few minutes faster, and the buildkite gpu tests ~8 min faster.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
