### PR TITLE
Tr/fix codecov

### DIFF
--- a/.github/workflows/UpdateCaches.yml
+++ b/.github/workflows/UpdateCaches.yml
@@ -1,0 +1,47 @@
+name: update_caches
+on:
+    schedule:
+        - cron: "0 0 * * *"
+
+jobs:
+  update_caches:
+    name: ci ${{ matrix.version }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.10'
+          - '1.11'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+      - name: Cache Julia depot
+        id: cache-depot
+        uses: actions/cache@v4
+        with:
+            # Julia depot, without scratchspaces, logs, and artifacts
+            path: |
+                ~/.julia/packages
+                ~/.julia/compiled
+                ~/.julia/registries
+            # The cache key includes the OS, Julia version, and the project's dependencies
+            key: ${{ matrix.os }}-julia-${{ matrix.version }}-${{ hashFiles('**/Project.toml', '**/Manifest.toml') }}
+            # Fallback keys to use if the primary key isn't found
+            restore-keys: |
+                ${{ matrix.os }}-julia-${{ matrix.version }}-
+                ${{ matrix.os }}-julia-
+      - uses: julia-actions/julia-buildpkg@v1
+        if: steps.cache-depot.outputs.cache-hit != 'true'
+        # runtests to download any artifacts used in tests
+      - name: Run tests
+        if: steps.cache-depot.outputs.cache-hit != 'true'
+        uses: julia-actions/julia-runtest@v1
+        with:
+            coverage: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
         with:
           file: lcov.info
       - uses: codecov/codecov-action@v5
+        if: ${{ matrix.version == '1.10' }} && ${{ matrix.os == 'ubuntu-latest' }}
         with:
-          file: lcov.info
-          token: ${{secrets.CODECOV_TOKEN}}
+          files: lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: ci
 on:
   push:
-    branches:
-      - main
     tags: '*'
   pull_request:
 
@@ -32,11 +30,10 @@ jobs:
       - name: Restore cached Julia depot
         uses: actions/cache/restore@v4
         with:
-          # load cached Julia depot, without scratchspaces and logs
+          # load cached Julia depot, without scratchspaces, logs, and artifacts
           path: |
             ~/.julia/packages
             ~/.julia/compiled
-            ~/.julia/artifacts
             ~/.julia/registries
           # The cache key includes the OS, Julia version, and the project's dependencies
           key: ${{ matrix.os }}-julia-${{ matrix.version }}-${{ hashFiles('**/Project.toml', '**/Manifest.toml') }}
@@ -59,15 +56,3 @@ jobs:
           files: lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - name: Cache Julia depot if main branch
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: actions/cache/save@v4
-        with:
-          # Cache Julia's depot, without scratchspaces and logs
-          path: |
-            ~/.julia/packages
-            ~/.julia/compiled
-            ~/.julia/artifacts
-            ~/.julia/registries
-          # Recompute the cache  key
-          key: ${{ matrix.os }}-julia-${{ matrix.version }}-${{ hashFiles('**/Project.toml', '**/Manifest.toml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,17 +29,15 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-      - name: Cache Julia depot
-        uses: actions/cache@v4
+      - name: Restore cached Julia depot
+        uses: actions/cache/restore@v4
         with:
-          # Cache Julia's depot
+          # load cached Julia depot, without scratchspaces and logs
           path: |
             ~/.julia/packages
             ~/.julia/compiled
             ~/.julia/artifacts
-            ~/.julia/scratchspaces
             ~/.julia/registries
-            ~/.julia/logs
           # The cache key includes the OS, Julia version, and the project's dependencies
           key: ${{ matrix.os }}-julia-${{ matrix.version }}-${{ hashFiles('**/Project.toml', '**/Manifest.toml') }}
           # Fallback keys to use if the primary key isn't found
@@ -61,3 +59,15 @@ jobs:
           files: lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Cache Julia depot if main branch
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: actions/cache/save@v4
+        with:
+          # Cache Julia's depot, without scratchspaces and logs
+          path: |
+            ~/.julia/packages
+            ~/.julia/compiled
+            ~/.julia/artifacts
+            ~/.julia/registries
+          # Recompute the cache  key
+          key: ${{ matrix.os }}-julia-${{ matrix.version }}-${{ hashFiles('**/Project.toml', '**/Manifest.toml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: ci
 on:
   push:
+    branches:
+      - main
     tags: '*'
   pull_request:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,17 @@ jobs:
             ${{ matrix.os }}-julia-${{ matrix.version }}-
             ${{ matrix.os }}-julia-
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - if: ${{ matrix.version != '1.10' || matrix.os != 'ubuntu-latest' }}
+        uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: false
+      - if: ${{ matrix.version == '1.10' && matrix.os == 'ubuntu-latest' }}
+        uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
         with:
           file: lcov.info
       - uses: codecov/codecov-action@v5
-        if: ${{ matrix.version == '1.10' }} && ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.version == '1.10' && matrix.os == 'ubuntu-latest' }}
         with:
           files: lcov.info
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,12 @@ jobs:
             ${{ matrix.os }}-julia-${{ matrix.version }}-
             ${{ matrix.os }}-julia-
       - uses: julia-actions/julia-buildpkg@v1
-      - if: ${{ matrix.version != '1.10' || matrix.os != 'ubuntu-latest' }}
+      - name: Run tests
         uses: julia-actions/julia-runtest@v1
         with:
-          coverage: false
+          coverage: ${{ matrix.version == '1.10' && matrix.os == 'ubuntu-latest' }}
       - if: ${{ matrix.version == '1.10' && matrix.os == 'ubuntu-latest' }}
-        uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
+        uses: julia-actions/julia-processcoverage@v1
         with:
           file: lcov.info
       - uses: codecov/codecov-action@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,16 +20,13 @@ jobs:
         with:
           version: '1.11'
       - name: Cache Julia depot
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           # Cache Julia's depot
           path: |
             ~/.julia/packages
             ~/.julia/compiled
-            ~/.julia/artifacts
-            ~/.julia/scratchspaces
             ~/.julia/registries
-            ~/.julia/logs
           # The cache key includes the OS, Julia version, and the project's dependencies
           key: ubuntu-latest-julia-1.11-${{ hashFiles('**/Project.toml', '**/Manifest.toml') }}
           # Fallback keys to use if the primary key isn't found

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -27,16 +27,13 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - name: Cache Julia depot
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           # Cache Julia's depot
           path: |
             ~/.julia/packages
             ~/.julia/compiled
-            ~/.julia/artifacts
-            ~/.julia/scratchspaces
             ~/.julia/registries
-            ~/.julia/logs
           # The cache key includes the OS, Julia version, and the project's dependencies
           key: ubuntu-latest-julia-${{ matrix.version }}-${{ hashFiles('**/Project.toml', '**/Manifest.toml') }}
           # Fallback keys to use if the primary key isn't found

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -31,16 +31,13 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - name: Cache Julia depot
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           # Cache Julia's depot
           path: |
             ~/.julia/packages
             ~/.julia/compiled
-            ~/.julia/artifacts
-            ~/.julia/scratchspaces
             ~/.julia/registries
-            ~/.julia/logs
           # The cache key includes the OS, Julia version, and the project's dependencies
           key: ubuntu-latest-julia-${{ matrix.version }}-${{ hashFiles('**/Project.toml', '**/Manifest.toml') }}
           # Fallback keys to use if the primary key isn't found


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

Codecov was not being submitted because the token was missing for the repo. This is now fixed (this pr does not need to merged for that). Instead of submitting a codecov report for each os/Julia combo, only one of which is used, this only submits a codecov for a single version. Coverage is also disabled for the other tests, which should make them run slightly faster.



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
