### PR TITLE
minimize optimization of tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -185,7 +185,7 @@ steps:
   - group: "GPU: unit tests and global bucket"
     steps:
       - label: "GPU runtests"
-        command: "julia --color=yes --project=test test/runtests.jl"
+        command: "julia -O0 --color=yes --project=test test/runtests.jl"
         agents:
           slurm_ntasks: 1
           slurm_gpus: 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,9 +37,9 @@ jobs:
             ubuntu-latest-julia-1.11-
             ubuntu-latest-julia-
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.precompile()'
+        run: julia -O0 --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.precompile()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia --color=yes --project=docs/ --procs=4 docs/make.jl
+        run: julia -O0 --color=yes --project=docs/ --procs=4 docs/make.jl

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -54,6 +54,6 @@ jobs:
           path: ClimaCoupler.jl
 
       - run: |
-          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ -e 'using Pkg; Pkg.instantiate()'
-          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ -e 'using Pkg; Pkg.develop(; path = ".")'
-          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ ClimaCoupler.jl/experiments/ClimaEarth/test/runtests.jl
+          julia -O0 --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ -e 'using Pkg; Pkg.instantiate()'
+          julia -O0 --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ -e 'using Pkg; Pkg.develop(; path = ".")'
+          julia -O0 --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ ClimaCoupler.jl/experiments/ClimaEarth/test/runtests.jl


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Use the minimal optimization flag `-O0` to reduce optimization of tests run in buildkite. This reduces precompilation time at the expense of increased runtime. This is only for the tests though so it should overall speed up the tests.

This got the GPU runtests to run in [32 minutes](https://buildkite.com/clima/climaland-ci/builds/9517#019a6071-e165-42a9-bf86-3bd4607b234c) as compared to [55 minutes on main](https://buildkite.com/clima/climaland-ci/builds/9516#019a6045-eea9-4346-9113-22c0553c7cb9). I expect there's some variability, but this seems like a big enough improvement to merge in. The documentation GHA also decreased from [50.5 minutes](https://github.com/CliMA/ClimaLand.jl/actions/runs/19178352163) to [43.5 minutes](https://github.com/CliMA/ClimaLand.jl/actions/runs/19178352163)