### PR TITLE
compute fluxes when using CoupledAtmosphere

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -505,7 +505,7 @@ version = "0.2.15"
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.0.2"
+version = "1.1.0"
 weakdeps = ["BSON", "CSV", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Flux", "GeoMakie", "HTTP", "Printf", "StatsBase"]
 
     [deps.ClimaLand.extensions]

--- a/.buildkite/Manifest.toml
+++ b/.buildkite/Manifest.toml
@@ -502,7 +502,7 @@ version = "0.2.15"
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.0.2"
+version = "1.1.0"
 weakdeps = ["BSON", "CSV", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Flux", "GeoMakie", "HTTP", "Printf", "StatsBase"]
 
     [deps.ClimaLand.extensions]

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ ClimaLand.jl Release Notes
 
 main
 -------
+- ClimaLand LandModel computes fluxes when run with a coupled atmosphere. PR[#1561]((https://github.com/CliMA/ClimaLand.jl/pull/1561)
 
 v1.0.2
 ------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaLand"
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
 authors = ["Clima Land Team"]
-version = "1.0.2"
+version = "1.1.0"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/docs/Manifest-v1.11.toml
+++ b/docs/Manifest-v1.11.toml
@@ -439,7 +439,7 @@ version = "0.2.15"
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.0.2"
+version = "1.1.0"
 weakdeps = ["BSON", "CSV", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Flux", "GeoMakie", "HTTP", "Printf", "StatsBase"]
 
     [deps.ClimaLand.extensions]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -436,7 +436,7 @@ version = "0.2.15"
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.0.2"
+version = "1.1.0"
 weakdeps = ["BSON", "CSV", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Flux", "GeoMakie", "HTTP", "Printf", "StatsBase"]
 
     [deps.ClimaLand.extensions]

--- a/docs/src/tutorials/shared_utilities/driver_tutorial.jl
+++ b/docs/src/tutorials/shared_utilities/driver_tutorial.jl
@@ -32,9 +32,7 @@
 # the start date. The start date should be in UTC.
 
 # Note: for coupled runs, corresponding types `CoupledAtmosphere`
-# and `CoupledRadiativeFluxes` exist. However, these are not defined
-# in ClimaLand, but rather inside of the Clima Coupler repository.
-
+# and `CoupledRadiativeFluxes` exist. 
 
 # # Creating site-level drivers for radiation
 

--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -590,6 +590,33 @@ function make_update_aux(model::BucketModel{FT}) where {FT}
 end
 
 """
+    turbulent_fluxes!(dest,
+                    atmos::CoupledAtmosphere,
+                    model::BucketModel,
+                    Y,
+                    p,
+                    t)
+
+Computes the turbulent surface fluxes terms at the ground for a coupled bucket.
+In this case, the coupler has already computed turbulent fluxes and updated
+them in each of the component models, so this function does nothing.
+
+Note that this function is not used for the full land model; in that case,
+the turbulent fluxes are computed by the full land model during each step.
+"""
+function ClimaLand.turbulent_fluxes!(
+    dest,
+    atmos::CoupledAtmosphere,
+    model::BucketModel,
+    Y,
+    p,
+    t,
+)
+    # coupler has done its thing behind the scenes already
+    return nothing
+end
+
+"""
     next_albedo!(next_α_sfc,
                  model_albedo::PrescribedBaregroundAlbedo{FT},
                  parameters, Y, p, t)

--- a/src/standalone/Bucket/bucket_parameterizations.jl
+++ b/src/standalone/Bucket/bucket_parameterizations.jl
@@ -29,18 +29,12 @@ function ClimaLand.surface_temperature(model::BucketModel, Y, p, t)
 end
 
 """
-    ClimaLand.surface_specific_humidity(atmos, model::BucketModel, Y, p)
+    ClimaLand.surface_specific_humidity(model::BucketModel, Y, p)
 
 a helper function which returns the surface specific humidity for the bucket
 model, which is stored in the aux state.
 """
-function ClimaLand.surface_specific_humidity(
-    atmos,
-    model::BucketModel,
-    Y,
-    p,
-    _...,
-)
+function ClimaLand.surface_specific_humidity(model::BucketModel, Y, p, _...)
     return p.bucket.q_sfc
 end
 

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -126,22 +126,15 @@ end
 
 
 """
-    ClimaLand.surface_specific_humidity(atmos::PrescribedAtmosphere, model::SnowModel, Y, p, _...)
+    ClimaLand.surface_specific_humidity(model::SnowModel, Y, p, _...)
 
 Returns the precomputed specific humidity over snow as a weighted
 fraction of the saturated specific humidity over liquid and frozen
 water.
 
-In the case of a PrescibedAtmoshere, the atmosphere thermal state is accessed
-from the drivers in the cache.
+This asumes the atmospheric surface state is stored in p.drivers.
 """
-function ClimaLand.surface_specific_humidity(
-    atmos::PrescribedAtmosphere,
-    model::SnowModel,
-    Y,
-    p,
-    _...,
-)
+function ClimaLand.surface_specific_humidity(model::SnowModel, Y, p, _...)
     @. p.snow.q_sfc = snow_surface_specific_humidity(
         p.snow.T_sfc,
         p.snow.q_l,
@@ -152,32 +145,6 @@ function ClimaLand.surface_specific_humidity(
     return p.snow.q_sfc
 end
 
-"""
-    ClimaLand.surface_specific_humidity(atmos::CoupledAtmosphere, model::SnowModel, Y, p, _...)
-
-Returns the precomputed specific humidity over snow as a weighted
-fraction of the saturated specific humidity over liquid and frozen
-water.
-
-In the case of a CoupledAtmoshere, the atmosphere thermal state is accessed
-from the atmosphere object.
-"""
-function ClimaLand.surface_specific_humidity(
-    atmos::CoupledAtmosphere,
-    model::SnowModel,
-    Y,
-    p,
-    _...,
-)
-    @. p.snow.q_sfc = snow_surface_specific_humidity(
-        p.snow.T_sfc,
-        p.snow.q_l,
-        atmos.thermal_state,
-        model.parameters,
-    )
-
-    return p.snow.q_sfc
-end
 
 """
     snow_surface_specific_humidity(T_sfc::FT, q_l::FT, atmos_ts, parameters) where {FT}

--- a/src/standalone/Soil/Soil.jl
+++ b/src/standalone/Soil/Soil.jl
@@ -89,7 +89,6 @@ import ClimaLand:
     source!,
     heaviside,
     surface_temperature,
-    surface_specific_humidity,
     surface_albedo,
     surface_emissivity,
     surface_height,
@@ -97,7 +96,8 @@ import ClimaLand:
     turbulent_fluxes!,
     get_drivers,
     total_liq_water_vol_per_area!,
-    total_energy_per_area!
+    total_energy_per_area!,
+    return_momentum_fluxes
 export RichardsModel,
     RichardsParameters,
     EnergyHydrology,

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -35,7 +35,8 @@ import ClimaLand:
     total_liq_water_vol_per_area!,
     total_energy_per_area!,
     IntervalBasedCallback,
-    Soil
+    Soil,
+    return_momentum_fluxes
 using ClimaLand: PrescribedGroundConditions, AbstractGroundConditions
 using ClimaLand.Domains: Point, Plane, SphericalSurface, get_long
 export CanopyModel

--- a/test/shared_utilities/drivers.jl
+++ b/test/shared_utilities/drivers.jl
@@ -149,6 +149,8 @@ end
         :T,
         :P,
         :q,
+        :u,
+        :thermal_state,
         :SW_d,
         :LW_d,
         :cosθs,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The integrated land has been unstable in coupled simulations, and tests point to the cause being our explicit treatment of turbulent fluxes. This PR changes turbulent fluxes to be computed in the land model's step with both prescribed and coupled atmospheres, rather than leaving this to the coupler in coupled simulations.

See https://github.com/CliMA/ClimaCoupler.jl/issues/1557 for more details.

## To-do
- [x] rename `coupler_compute_turbulent_fluxes!` to `turbulent_fluxes!`
- [x] update dispatch of `turbulent_fluxes!` so that it only does nothing for a bucket run with a coupled atmosphere

cc @kmdeck 