### PR TITLE
bug fix to prevent division by zero when soil is very dry

### DIFF
--- a/src/standalone/Soil/soil_heat_parameterizations.jl
+++ b/src/standalone/Soil/soil_heat_parameterizations.jl
@@ -71,9 +71,7 @@ function phase_change_source(
 
     ψT = _LH_f0 / _grav * log(T / Tf_depressed) * heaviside(Tf_depressed - T)
     # Equation (23) of Dall'Amico
-    θstar =
-        inverse_matric_potential(hydrology_cm, min(ψw0 + ψT, FT(0))) *
-        (ν - θ_r) + θ_r
+    θstar = inverse_matric_potential(hydrology_cm, ψw0 + ψT) * (ν - θ_r) + θ_r
     return (θ_l - θstar) / τ
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
If the soil is very dry, psi_ w0 can become large and negative. The argument of the exponential function in the line changed can then become large and negative (e.g. -hundreds), which, at Float32, makes Tf_depressed = 0. This then causes NaNs in the following line where we divide by it. If the soil is very dry, the theory we are using basically says the freezing point is lowered so much that the soil water will not freeze. so it doesnt really matter if we say Tf_depressed is 1K or epsilon K - in either case, the actual soil T will never reach this.

Future work would be to improve/adjust the theory (I dont think the freezing point depression actually approaches 0K...)


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
