### PR TITLE
Fix bugs related to supporting canopy prescribed temp; improve IC

### DIFF
--- a/src/simulations/initial_conditions.jl
+++ b/src/simulations/initial_conditions.jl
@@ -1,6 +1,7 @@
 import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
 import ClimaUtilities.Regridders: InterpolationsRegridder
 import Interpolations
+using ClimaCore
 
 export make_set_initial_state_from_file
 
@@ -217,6 +218,7 @@ function make_set_initial_state_from_file(
 ) where {FT}
     function set_ic!(Y, p, t0, land)
         atmos = land.soil.boundary_conditions.top.atmos
+        # Snow IC
         evaluate!(p.snow.T, atmos.T, t0)
         set_snow_initial_conditions!(
             Y,
@@ -225,11 +227,10 @@ function make_set_initial_state_from_file(
             ic_path,
             land.snow.parameters,
         )
+        # SoilCO2 IC
         Y.soilco2.C .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
-        Y.canopy.hydraulics.ϑ_l.:1 .= land.canopy.hydraulics.parameters.ν
-        evaluate!(Y.canopy.energy.T, atmos.T, t0)
-        T_bounds = extrema(Y.canopy.energy.T)
-
+        # Soil IC
+        T_bounds = extrema(p.snow.T)
         set_soil_initial_conditions!(
             Y,
             land.soil.parameters.ν,
@@ -239,6 +240,36 @@ function make_set_initial_state_from_file(
             land.soil,
             T_bounds,
         )
+        # Canopy IC
+        # Set canopy moisture variable by setting canopy potential(moisture) equal 
+        # to soil potential (soil moisture), averaged over the soil layers,
+        # which would correspond to approximate steady state
+        if land.canopy.hydraulics isa ClimaLand.Canopy.PlantHydraulicsModel
+            @. p.soil.ψ = ClimaLand.Soil.pressure_head(
+                land.soil.parameters.hydrology_cm,
+                land.soil.parameters.θ_r,
+                Y.soil.ϑ_l,
+                land.soil.parameters.ν - Y.soil.θ_i,
+                land.soil.parameters.S_s,
+            )
+            ψ_roots = ClimaCore.Fields.zeros(axes(Y.canopy.hydraulics.ϑ_l.:1))
+            z = land.soil.domain.fields.z
+            tmp = @. ClimaLand.Canopy.root_distribution(
+                z,
+                land.canopy.biomass.rooting_depth,
+            ) * p.soil.ψ / land.soil.domain.fields.depth
+            ClimaCore.Operators.column_integral_definite!(ψ_roots, tmp)
+            Y.canopy.hydraulics.ϑ_l.:1 .=
+                ClimaLand.Canopy.PlantHydraulics.inverse_water_retention_curve.(
+                    land.canopy.hydraulics.parameters.retention_model,
+                    ψ_roots,
+                    land.canopy.hydraulics.parameters.ν,
+                    land.canopy.hydraulics.parameters.S_s,
+                ) .* land.canopy.hydraulics.parameters.ν
+        end
+        if land.canopy.energy isa ClimaLand.Canopy.BigLeafEnergyModel
+            evaluate!(Y.canopy.energy.T, atmos.T, t0)
+        end
     end
     return set_ic!
 end

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -679,10 +679,6 @@ function CanopyModel{FT}(;
         ClimaLand.Domains.SphericalSurface,
     },
 ) where {FT, B, PSE}
-    if typeof(energy) <: PrescribedCanopyTempModel{FT}
-        @info "Using the PrescribedAtmosphere air temperature as the canopy temperature"
-        @assert typeof(boundary_conditions.atmos) <: PrescribedAtmosphere{FT}
-    end
 
     if typeof(photosynthesis) <: PModel{FT}
         @assert typeof(conductance) <: PModelConductance{FT} "When using PModel for photosynthesis, you must also use PModelConductance for stomatal conductance"
@@ -782,11 +778,6 @@ function CanopyModel{FT}(
     sif = Lee2015SIFModel{FT}(toml_dict),
 ) where {FT}
     (; atmos, radiation, ground) = forcing
-
-    if typeof(energy) <: PrescribedCanopyTempModel{FT}
-        @info "Using the PrescribedAtmosphere air temperature as the canopy temperature"
-        @assert typeof(atmos) <: PrescribedAtmosphere{FT}
-    end
 
     # Confirm that each spatially-varying parameter is on the correct domain
     for component in [


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
- Makes it possible to run global runs offline and coupled to atmos using the PrescribedCanopyTemperature parameterization
- Makes setting the IC more general (does not assume Y.canopy.energy.T is present) and also sets the canopy moisture content in a way that I think is more stable (this was required in #1483 but that never merged).


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
