### PR TITLE
Expose time interp method for prescribed Bucket albedo and LAI nc data path 

### DIFF
--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -180,12 +180,14 @@ end
         albedo_file_path = ClimaLand.Artifacts.cesm2_albedo_dataset_path(),
         varname = "sw_alb",
         regridder_type = :InterpolationsRegridder,
+        time_interpolation_method = LinearInterpolation(PeriodicCalendar(Year(1), Date(2010))),
     ) where {FT}
 
 Constructor for the PrescribedSurfaceAlbedo struct.
 The `varname` must correspond to the name of the variable in the NetCDF
 file retrieved by the `get_infile` function.
 The input data file must have a time component.
+This repeats 2010 by default.
 """
 function PrescribedSurfaceAlbedo{FT}(
     start_date::Union{DateTime, DateTimeNoLeap},
@@ -193,6 +195,9 @@ function PrescribedSurfaceAlbedo{FT}(
     albedo_file_path = ClimaLand.Artifacts.cesm2_albedo_dataset_path(),
     varname = "sw_alb",
     regridder_type = :InterpolationsRegridder,
+    time_interpolation_method = LinearInterpolation(
+        PeriodicCalendar(Year(1), Date(2010)),
+    ),
 ) where {FT}
     # Verify inputs
     if typeof(space) <: ClimaCore.Spaces.PointSpace
@@ -208,10 +213,7 @@ function PrescribedSurfaceAlbedo{FT}(
     )
 
     # Construct object containing info to read in surface albedo over time
-    albedo = TimeVaryingInput(
-        data_handler,
-        method = LinearInterpolation(PeriodicCalendar(Year(1), Date(2010))), # this repeats 2010 over and over again.
-    )
+    albedo = TimeVaryingInput(data_handler, method = time_interpolation_method)
     return PrescribedSurfaceAlbedo{FT, typeof(albedo)}(albedo)
 end
 

--- a/src/standalone/Vegetation/biomass.jl
+++ b/src/standalone/Vegetation/biomass.jl
@@ -68,6 +68,7 @@ end
                           time_interpolation_method = LinearInterpolation(),
                           regridder_type = :InterpolationsRegridder,
                           interpolation_method = Interpolations.Constant(),
+                          modis_lai_ncdata_path = nothing,
                           context = ClimaComms.context(surface_space))
 
 A helper function which constructs the TimeVaryingInput object for Leaf Area
@@ -77,6 +78,9 @@ surface_space, the start and stop dates, and the earth_param_set.
 The ClimaLand default is to use nearest neighbor interpolation, but
 linear interpolation is supported
 by passing interpolation_method = Interpolations.Linear().
+
+If `modis_lai_ncdata_path` is provided, it will be used directly.
+Otherwise, the path will be inferred from the start and stop dates.
 """
 function prescribed_lai_modis(
     surface_space,
@@ -85,13 +89,16 @@ function prescribed_lai_modis(
     time_interpolation_method = LinearInterpolation(),
     regridder_type = :InterpolationsRegridder,
     interpolation_method = Interpolations.Constant(),
+    modis_lai_ncdata_path = nothing,
     context = ClimaComms.context(surface_space),
 )
-    modis_lai_ncdata_path = ClimaLand.Artifacts.modis_lai_multiyear_paths(;
-        context,
-        start_date,
-        stop_date,
-    )
+    modis_lai_ncdata_path =
+        isnothing(modis_lai_ncdata_path) ?
+        ClimaLand.Artifacts.modis_lai_multiyear_paths(;
+            context,
+            start_date,
+            stop_date,
+        ) : modis_lai_ncdata_path
     return TimeVaryingInput(
         modis_lai_ncdata_path,
         ["lai"],


### PR DESCRIPTION
Expose TimeVaryingInput time interpolation method for prescribed surface albedo in the Bucket and LAI path in prescribed MODIS LAI function, allowing users outside of ClimaLand to work with general input files.
