### PR TITLE
remove PrescribedTranspiration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@ ClimaLand.jl Release Notes
 
 main
 -------
-- ClimaLand LandModel computes fluxes when run with a coupled atmosphere. PR[#1561]((https://github.com/CliMA/ClimaLand.jl/pull/1561)
+- Remove internal canopy PrescribedTranspiration type and method. PR[#1561]((https://github.com/CliMA/ClimaLand.jl/pull/1561)
+- ClimaLand LandModel computes fluxes when run with a coupled atmosphere. PR[#1538]((https://github.com/CliMA/ClimaLand.jl/pull/1538)
 
 v1.0.2
 ------

--- a/docs/src/APIs/canopy/PlantHydraulics.md
+++ b/docs/src/APIs/canopy/PlantHydraulics.md
@@ -18,9 +18,6 @@ ClimaLand.PlantHydraulics.AbstractConductivityModel
 ClimaLand.PlantHydraulics.Weibull
 ClimaLand.PlantHydraulics.AbstractRetentionModel
 ClimaLand.PlantHydraulics.LinearRetentionCurve
-ClimaLand.PlantHydraulics.AbstractTranspiration
-ClimaLand.PlantHydraulics.DiagnosticTranspiration
-ClimaLand.PlantHydraulics.PrescribedTranspiration
 ```
 
 ## Constructor Methods

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -97,8 +97,6 @@ struct LandModel{
         # Runoff and sublimation are also automatically included in the soil model
         @assert RootExtraction{FT}() in soil.sources
         @assert Soil.PhaseChange{FT}() in soil.sources
-        @assert canopy.hydraulics.transpiration isa
-                Canopy.PlantHydraulics.DiagnosticTranspiration{FT}
         @assert canopy_bc.ground isa PrognosticGroundConditions{FT}
         @assert soilco2.drivers.met isa PrognosticMet
         comparison = PrognosticMet(soil.parameters)

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -69,8 +69,6 @@ struct SoilCanopyModel{
         # Runoff and sublimation are also automatically included in the soil model
         @assert RootExtraction{FT}() in soil.sources
         @assert Soil.PhaseChange{FT}() in soil.sources
-        @assert canopy.hydraulics.transpiration isa
-                Canopy.PlantHydraulics.DiagnosticTranspiration{FT}
         @assert canopy_bc.ground isa PrognosticGroundConditions{FT}
         @assert soilco2.drivers.met isa PrognosticMet
 

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -349,6 +349,7 @@ function compute_ρ_sfc(thermo_params, ts_in, T_sfc)
     T_int = Thermodynamics.air_temperature(thermo_params, ts_in)
     Rm_int = Thermodynamics.gas_constant_air(thermo_params, ts_in)
     ρ_air = Thermodynamics.air_density(thermo_params, ts_in)
+    T_sfc = T_sfc < 0 ? eltype(T_sfc)(NaN) : T_sfc
     ρ_sfc =
         ρ_air *
         (T_sfc / T_int)^(Thermodynamics.cv_m(thermo_params, ts_in) / Rm_int)

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -291,7 +291,6 @@ end
             c = FT(4),
         ),
         retention_model = LinearRetentionCurve{FT}(a = FT(0.2 * 0.0098)),
-        transpiration = PlantHydraulics.DiagnosticTranspiration{FT}(),
     ) where {FT <: AbstractFloat}
 
 Creates a PlantHydraulicsModel on the provided domain, using paramters from `toml_dict`.
@@ -325,7 +324,6 @@ function PlantHydraulicsModel{FT}(
     S_s::FT = toml_dict["plant_S_s"], # m3/m3/MPa to m3/m3/m
     conductivity_model = PlantHydraulics.Weibull(toml_dict),
     retention_model = PlantHydraulics.LinearRetentionCurve(toml_dict),
-    transpiration = PlantHydraulics.DiagnosticTranspiration{FT}(),
 ) where {FT <: AbstractFloat}
     @assert n_stem >= 0 "Stem number must be non-negative"
     @assert n_leaf >= 0 "Leaf number must be non-negative"
@@ -365,7 +363,6 @@ function PlantHydraulicsModel{FT}(
         compartment_midpoints,
         compartment_surfaces,
         parameters,
-        transpiration,
     )
 end
 

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -133,58 +133,11 @@ function canopy_boundary_fluxes!(
     Y::ClimaCore.Fields.FieldVector,
     t,
 )
-    bc = canopy.boundary_conditions
-    radiation = bc.radiation
-    atmos = bc.atmos
-    sf_parameterization = bc.turbulent_flux_parameterization
-    root_water_flux = p.canopy.hydraulics.fa_roots
-    root_energy_flux = p.canopy.energy.fa_energy_roots
-    fa = p.canopy.hydraulics.fa
-    LAI = p.canopy.biomass.area_index.leaf
-    SAI = p.canopy.biomass.area_index.stem
-    canopy_tf = p.canopy.turbulent_fluxes
-    i_end = canopy.hydraulics.n_stem + canopy.hydraulics.n_leaf
-    # Compute transpiration, SHF, LHF
-    ClimaLand.turbulent_fluxes!(
-        canopy_tf,
-        atmos,
-        sf_parameterization,
-        canopy,
-        Y,
-        p,
-        t,
-    )
-    # Transpiration is per unit ground area, not leaf area (mult by LAI)
-    fa.:($i_end) .= PlantHydraulics.transpiration_per_ground_area(
-        canopy.hydraulics.transpiration,
-        Y,
-        p,
-        t,
-    )
-    # Note that in the three functions below,
+    # Note that in three functions below,
     # we dispatch off of the ground conditions `bc.ground`
     # to handle standalone canopy simulations vs integrated ones
 
-    # Update the root flux of water per unit ground area in place
-    root_water_flux_per_ground_area!(
-        root_water_flux,
-        bc.ground,
-        canopy.hydraulics,
-        canopy,
-        Y,
-        p,
-        t,
-    )
-    # Update the root flux of energy per unit ground area in place
-    root_energy_flux_per_ground_area!(
-        root_energy_flux,
-        bc.ground,
-        canopy.energy,
-        canopy,
-        Y,
-        p,
-        t,
-    )
+    bc = canopy.boundary_conditions
 
     # Update the canopy radiation
     canopy_radiant_energy_fluxes!(
@@ -197,6 +150,37 @@ function canopy_boundary_fluxes!(
         t,
     )
 
+    # Compute transpiration, SHF, LHF
+    ClimaLand.turbulent_fluxes!(
+        p.canopy.turbulent_fluxes,
+        bc.atmos,
+        bc.turbulent_flux_parameterization,
+        canopy,
+        Y,
+        p,
+        t,
+    )
+
+    # Update the root flux of water per unit ground area in place
+    root_water_flux_per_ground_area!(
+        p.canopy.hydraulics.fa_roots,
+        bc.ground,
+        canopy.hydraulics,
+        canopy,
+        Y,
+        p,
+        t,
+    )
+    # Update the root flux of energy per unit ground area in place
+    root_energy_flux_per_ground_area!(
+        p.canopy.energy.fa_energy_roots,
+        bc.ground,
+        canopy.energy,
+        canopy,
+        Y,
+        p,
+        t,
+    )
 end
 
 """
@@ -351,7 +335,7 @@ function canopy_compute_turbulent_fluxes_at_a_point(
         u = SVector{2, FT}(u, 0)
     end
     state_in = SurfaceFluxes.StateValues(h - d_sfc, u, ts_in)
-
+    T_sfc = T_sfc < 0 ? FT(NaN) : T_sfc
     ρ_sfc = ClimaLand.compute_ρ_sfc(thermo_params, ts_in, T_sfc)
     q_sfc = Thermodynamics.q_vap_saturation_generic(
         thermo_params,

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -204,7 +204,6 @@ import ClimaParams
             t0,
         )
 
-        @test p.canopy.hydraulics.fa.:1 == turb_fluxes_copy.transpiration
         @test p.canopy.turbulent_fluxes.shf == turb_fluxes_copy.shf
         @test p.canopy.turbulent_fluxes.lhf == turb_fluxes_copy.lhf
         @test p.canopy.turbulent_fluxes.transpiration ==
@@ -741,7 +740,6 @@ end
         Y.canopy.hydraulics .= canopy.hydraulics.parameters.ν
         Y.canopy.energy.T = FT(289)
         p.canopy.hydraulics.ψ.:1 .= NaN
-        p.canopy.hydraulics.fa.:1 .= NaN
         dY.canopy.hydraulics.ϑ_l.:1 .= NaN
 
         set_initial_cache! = make_set_initial_cache(canopy)
@@ -749,7 +747,6 @@ end
         set_initial_cache!(p, Y, t0)
 
         @test all(Array(parent(p.canopy.soil_moisture_stress.βm) .≈ FT(1)))
-        @test all(Array(parent(p.canopy.hydraulics.fa.:1)) .== FT(0))
         @test all(Array(parent(p.canopy.hydraulics.fa_roots)) .== FT(0))
         @test all(Array(parent(p.canopy.turbulent_fluxes.lhf)) .== FT(0))
         @test all(Array(parent(p.canopy.turbulent_fluxes.shf)) .== FT(0))
@@ -956,6 +953,7 @@ end
             :biomass,
             :turbulent_fluxes,
         )
+        @test propertynames(p.canopy.hydraulics) == (:ψ, :fa_roots)
         for component in ClimaLand.Canopy.canopy_components(canopy)
             # Only hydraulics has a prognostic variable
             if component == :hydraulics

--- a/test/standalone/Vegetation/test_soil_moisture_stress.jl
+++ b/test/standalone/Vegetation/test_soil_moisture_stress.jl
@@ -48,7 +48,6 @@ for FT in (Float32, Float64)
             # # set initial conditions
             Y.canopy.hydraulics.ϑ_l.:1 .= canopy.hydraulics.parameters.ν
             p.canopy.hydraulics.ψ.:1 .= NaN
-            p.canopy.hydraulics.fa.:1 .= NaN
             set_initial_cache! = make_set_initial_cache(canopy)
             set_initial_cache!(p, Y, FT(0.0))
 
@@ -58,7 +57,6 @@ for FT in (Float32, Float64)
             p.canopy.soil_moisture_stress.βm .= 0
             Y.canopy.hydraulics.ϑ_l.:1 .= canopy.hydraulics.parameters.ν / 2
             p.canopy.hydraulics.ψ.:1 .= NaN
-            p.canopy.hydraulics.fa.:1 .= NaN
             set_initial_cache! = make_set_initial_cache(canopy)
             set_initial_cache!(p, Y, FT(0.0))
             grav = LP.grav(earth_param_set)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Removes the option to prescribe transpiration, which was only used in a single test, and is not required. 

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
-Remove Prescribed vs Diagnostic Transpiration
- Transpiration is always computed now using turbulent fluxes computation
- fix test to reflect this
- fix bug in harmonic mean 


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
