### PR TITLE
Make directory to save ILAMB files first

### DIFF
--- a/experiments/ilamb/ilamb_conversion.jl
+++ b/experiments/ilamb/ilamb_conversion.jl
@@ -381,6 +381,7 @@ Given the directory `output_dir` with NetCDF files produced by ClimaDiagnostics,
 create NetCDF files compatible with ILAMB in the directory `save_dir`.
 """
 function make_compatible_with_ILAMB(output_dir, save_dir)
+    !ispath(save_dir) && mkpath(save_dir)
     nc_filepaths = find_netcdf_files_for_ilamb(output_dir)
     for nc_filepath in nc_filepaths
         make_ilamb_netcdf_file(nc_filepath, save_dir)


### PR DESCRIPTION
See https://buildkite.com/clima/climaland-long-runs/builds/4412#019b0108-d2c0-43f9-8a19-0f7a0f2f80a9 for the error message when making the ILAMB leaderboard.

This error message appeared, because there is no directory to save the NetCDF file and NCDatasets.jl will not make the directory if it does not exist. To fix this, we check if the path exists and if it doesn't exist, then make the path.