### PR TITLE
revert harmonic mean fix

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -505,7 +505,7 @@ version = "0.3.0"
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.2.0"
+version = "1.2.1"
 weakdeps = ["BSON", "CSV", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Flux", "GeoMakie", "HTTP", "Printf", "StatsBase"]
 
     [deps.ClimaLand.extensions]

--- a/.buildkite/Manifest.toml
+++ b/.buildkite/Manifest.toml
@@ -502,7 +502,7 @@ version = "0.3.0"
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.2.0"
+version = "1.2.1"
 weakdeps = ["BSON", "CSV", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Flux", "GeoMakie", "HTTP", "Printf", "StatsBase"]
 
     [deps.ClimaLand.extensions]

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@ ClimaLand.jl Release Notes
 main
 ------
 
+v1.2.1
+-------
+- Previous bug fix to harmonic mean formula produces instability; revert until we can solve the issues fixing it causes [#1575](https://github.com/CliMA/ClimaLand.jl/pull/1575)
+
 v1.2.0
 -------
 - Make soil organic carbon and soil O2 prognostic; remove prescribed Soil Organic Carbon driver [#1545](https://github.com/CliMA/ClimaLand.jl/pull/1545)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaLand"
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
 authors = ["Clima Land Team"]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/docs/Manifest-v1.11.toml
+++ b/docs/Manifest-v1.11.toml
@@ -439,7 +439,7 @@ version = "0.3.0"
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.2.0"
+version = "1.2.1"
 weakdeps = ["BSON", "CSV", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Flux", "GeoMakie", "HTTP", "Printf", "StatsBase"]
 
     [deps.ClimaLand.extensions]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -436,7 +436,7 @@ version = "0.3.0"
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.2.0"
+version = "1.2.1"
 weakdeps = ["BSON", "CSV", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Flux", "GeoMakie", "HTTP", "Printf", "StatsBase"]
 
     [deps.ClimaLand.extensions]

--- a/src/standalone/Vegetation/PlantHydraulics.jl
+++ b/src/standalone/Vegetation/PlantHydraulics.jl
@@ -251,11 +251,10 @@ end
 """
     harmonic_mean(x::FT,y::FT) where {FT}
 
-Computes the harmonic mean of x >=0 and y >=0; returns zero if both
-x and y are zero.
-
+Computes the harmonic mean of x >=0 and y >=0; returns zero if either
+x or y are zero.
 """
-harmonic_mean(x::FT, y::FT) where {FT} = 2 * x * y / max(x + y, eps(FT))
+harmonic_mean(x::FT, y::FT) where {FT} = x * y / max(x + y, eps(FT))
 
 """
     water_flux(


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
By running the long runs on PRs 1563 (no NaNs), 1566 (no NaNs), 1530 (no NaNs), I determined that the NaNs are introduced in PR #1561. This should not be behavior changing, except we did change the formula for the harmonic mean to be the correct formula (previously it was off by a factor of 1/2).

Changing this back to the incorrect formula fixes the NaNs in the long runs. So, this PR reverts that change, and I opened an issue to debug this. https://github.com/CliMA/ClimaLand.jl/issues/1576

The test had to update to use the `harmonic_mean` function (as it is used in src) when computing `fa` in steady state. Previously it was not using the harmonic_mean function, but the harmonic mean was the same as each of the area indices since they were all the same. Since the harmonic_mean function has an error, we need to match that error in the test by using the function


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
