### PR TITLE
Tr/nn gpu

### DIFF
--- a/.buildkite/Manifest-v1.11.toml
+++ b/.buildkite/Manifest-v1.11.toml
@@ -502,7 +502,7 @@ uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
 version = "0.3.0"
 
 [[deps.ClimaLand]]
-deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
+deps = ["Adapt", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
 version = "1.1.1"
@@ -511,13 +511,13 @@ weakdeps = ["BSON", "CSV", "CairoMakie", "ClimaAnalysis", "DataFrames", "Delimit
     [deps.ClimaLand.extensions]
     FluxnetSimulationsExt = ["DelimitedFiles"]
     LandSimulationVisualizationExt = ["CairoMakie", "ClimaAnalysis", "GeoMakie", "Printf", "StatsBase"]
-    NeuralSnowExt = ["CSV", "DataFrames", "HTTP", "Flux", "StatsBase", "BSON"]
+    NeuralSnowExt = ["Adapt", "CSV", "DataFrames", "HTTP", "Flux", "StatsBase", "BSON"]
 
 [[deps.ClimaParams]]
 deps = ["Dates", "TOML"]
-git-tree-sha1 = "ba6c8d484f60df3bcf501d027c9080dcee098d3c"
+git-tree-sha1 = "5ade630eb2f88bd670f316b7fb9f8001adc772c2"
 uuid = "5c42b081-d73a-476f-9059-fd94b934656c"
-version = "1.0.5"
+version = "1.0.7"
 
 [[deps.ClimaTimeSteppers]]
 deps = ["ClimaComms", "DataStructures", "DiffEqBase", "KernelAbstractions", "Krylov", "LinearAlgebra", "LinearOperators", "NVTX", "SciMLBase", "StaticArrays"]
@@ -2292,7 +2292,7 @@ version = "3.2.4+0"
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
-version = "0.8.5+0"
+version = "0.8.1+4"
 
 [[deps.OpenMPI_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML", "Zlib_jll"]
@@ -3087,9 +3087,9 @@ version = "1.10.0"
 
 [[deps.TaylorSeries]]
 deps = ["LinearAlgebra", "Markdown", "SparseArrays"]
-git-tree-sha1 = "dbb2073ed3d0b356405abb7562bfb3326f9cb5fe"
+git-tree-sha1 = "4a5ddc4036946d3a7900b5776b0872e36d848a29"
 uuid = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
-version = "0.20.9"
+version = "0.20.10"
 weakdeps = ["IntervalArithmetic", "JLD2", "RecursiveArrayTools", "StaticArrays"]
 
     [deps.TaylorSeries.extensions]

--- a/.buildkite/Manifest.toml
+++ b/.buildkite/Manifest.toml
@@ -499,7 +499,7 @@ uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
 version = "0.3.0"
 
 [[deps.ClimaLand]]
-deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
+deps = ["Adapt", "ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "SciMLBase", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
 version = "1.1.1"
@@ -508,7 +508,7 @@ weakdeps = ["BSON", "CSV", "CairoMakie", "ClimaAnalysis", "DataFrames", "Delimit
     [deps.ClimaLand.extensions]
     FluxnetSimulationsExt = ["DelimitedFiles"]
     LandSimulationVisualizationExt = ["CairoMakie", "ClimaAnalysis", "GeoMakie", "Printf", "StatsBase"]
-    NeuralSnowExt = ["CSV", "DataFrames", "HTTP", "Flux", "StatsBase", "BSON"]
+    NeuralSnowExt = ["Adapt", "CSV", "DataFrames", "HTTP", "Flux", "StatsBase", "BSON"]
 
 [[deps.ClimaParams]]
 deps = ["Dates", "TOML"]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,7 +51,7 @@ steps:
 
       - label: "Snow Col de Porte"
         command: "julia --color=yes --project=.buildkite experiments/standalone/Snow/snowmip_simulation.jl cdp"
-        artifact_paths: "experiments/standalone/Snow/cdp/output_active/*png"
+        artifact_paths: "experiments/standalone/Snow/cpu/cdp/output_active/*png"
 
       - label: "Varying LAI, no stem compartment"
         command: "julia --color=yes --project=.buildkite experiments/standalone/Vegetation/varying_lai.jl"
@@ -177,7 +177,6 @@ steps:
         key: "global_bucket_temporalmap_cpu"
         command: "julia --color=yes --project=.buildkite experiments/standalone/Bucket/global_bucket_temporalmap.jl"
         artifact_paths:
-        artifact_paths:
           - "experiments/standalone/Bucket/artifacts_temporalmap_cpu/output_0000/*png"
           - "experiments/standalone/Bucket/artifacts_temporalmap_cpu/*html"
           - "experiments/standalone/Bucket/artifacts_temporalmap_cpu/*html"
@@ -227,6 +226,15 @@ steps:
           - "experiments/standalone/Bucket/artifacts_temporalmap_gpu/output_0000/*png"
           - "experiments/standalone/Bucket/artifacts_temporalmap_gpu/*html"
           - "experiments/standalone/Bucket/artifacts_temporalmap_gpu/*html"
+
+      - label: "Snow Col de Porte GPU"
+        command: "julia --color=yes --project=.buildkite experiments/standalone/Snow/snowmip_simulation.jl cdp"
+        artifact_paths: "experiments/standalone/Snow/gpu/cdp/output_active/*png"
+        agents:
+          slurm_ntasks: 1
+          slurm_gpus: 1
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
 
   - group: "CPU/GPU comparisons"
     steps:

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Clima Land Team"]
 version = "1.1.1"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 ClimaDiagnostics = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
@@ -39,9 +40,10 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [extensions]
 FluxnetSimulationsExt = ["DelimitedFiles"]
 LandSimulationVisualizationExt = ["CairoMakie", "ClimaAnalysis", "GeoMakie", "Printf", "StatsBase"]
-NeuralSnowExt = ["CSV", "DataFrames", "HTTP", "Flux", "StatsBase", "BSON"]
+NeuralSnowExt = ["Adapt", "CSV", "DataFrames", "HTTP", "Flux", "StatsBase", "BSON"]
 
 [compat]
+Adapt = "4.3.0"
 BSON = "0.3.9"
 CSV = "0.10.14"
 CairoMakie = "0.12.5, 0.13, 0.14, 0.15"

--- a/docs/src/tutorials/standalone/Snow/base_tutorial.jl
+++ b/docs/src/tutorials/standalone/Snow/base_tutorial.jl
@@ -123,7 +123,14 @@ x_train, y_train = DataTools.make_data(usedata, pred_vars, target, out_scale);
 # We then create the model itself given the hyperparameters specified
 # above, and indicate which features are to be used to determine the
 # boundary constraints on the network.
-model = ModelTools.make_model(nfeatures, n, z_idx, p_idx, in_scale = in_scales)
+model = ModelTools.make_model(
+    Float64,
+    nfeatures,
+    n,
+    z_idx,
+    p_idx,
+    in_scale = in_scales,
+)
 
 # As training updates are better with the scaled data, we have to modify
 # the timescale and output scaling of the model structure prior to training.

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -453,6 +453,7 @@ function ceres_albedo_dataset_path(; context = nothing)
     )
 end
 
+# TODO: This should be a ClimaArtifact
 neural_snow_znetwork_link() =
     "https://caltech.box.com/shared/static/ay7cv0rhuiytrqbongpeq2y7m3cimhm4.bson"
 

--- a/test/standalone/Snow/tool_tests.jl
+++ b/test/standalone/Snow/tool_tests.jl
@@ -217,15 +217,15 @@ if !isnothing(DataToolsExt)
         z_idx = 1
         swe_idx = 2
         p_idx = 7
-        model = ModelTools.make_model(nfeatures, n, z_idx, p_idx)
+        model = ModelTools.make_model(Float32, nfeatures, n, z_idx, p_idx)
         ps = ModelTools.get_model_ps(model)
         for item in ps
             item[:] .= Float32(1.0)
         end
 
-        test_input = Matrix{Float32}(ones(nfeatures, 8))
+        test_input = Matrix{Float32}(ones(nfeatures, 1))
         @test model(test_input)[1] == 1968
-        @test size(model(test_input)) == (1, 8)
+        @test size(model(test_input)) == (1,)
         @test sum(length, ps) == nfeatures * (n * (2 * nfeatures + 1) + 2) + 1
         ModelTools.setoutscale!(model, 0.5)
         @test model[:final_scale].weight[3, 3] == 0.5
@@ -269,8 +269,8 @@ if !isnothing(DataToolsExt)
         data = CSV.read(HTTP.get(data_download_link).body, DataFrame)
         data = data[data[!, :id] .== 1286, :]
         data = DataTools.prep_data(data)
-        zmodel = ModelTools.make_model(nfeatures, 4, z_idx, p_idx)
-        swemodel = ModelTools.make_model(nfeatures, 5, swe_idx, p_idx)
+        zmodel = ModelTools.make_model(Float32, nfeatures, 4, z_idx, p_idx)
+        swemodel = ModelTools.make_model(Float32, nfeatures, 5, swe_idx, p_idx)
         zmodel_state =
             BSON.load(IOBuffer(HTTP.get(modelz_download_link).body))[:zstate]
         swemodel_state =
@@ -299,33 +299,6 @@ if !isnothing(DataToolsExt)
         @test zerr ≈ 0.1 atol = 0.05
         @test sweerr ≈ 0.05 atol = 0.03
 
-        out_scale = maximum(abs.(data[!, :dzdt]))
-        x_train, y_train =
-            DataTools.make_data(data, pred_vars, :dzdt, out_scale)
-        ps = ModelTools.get_model_ps(zmodel)
-        ModelTools.settimescale!(zmodel, 86400 * out_scale)
-        ModelTools.setoutscale!(zmodel, 1.0)
-        callback_check = [0.0]
-        function call_check(val = callback_check)
-            val[1] += 1
-        end
-        nepochs = 10
-        ModelTools.trainmodel!(
-            zmodel,
-            x_train,
-            y_train,
-            2,
-            1,
-            nepochs = nepochs,
-            cb = call_check,
-        )
-        @test callback_check[1] == nepochs
-        ModelTools.setoutscale!(zmodel, out_scale)
-        ModelTools.settimescale!(zmodel, 86400.0)
-        pred_series, _, _ = ModelTools.make_timeseries(zmodel, data, Day(1))
-        series_err =
-            sqrt(sum((pred_series .- true_series) .^ 2) ./ length(pred_series))
-        @test series_err <= 0.2
     end
 
     @testset "Testing NeuralSnow module" begin
@@ -359,7 +332,7 @@ if !isnothing(DataToolsExt)
         )
 
         #Test extension utilities
-        z_model = NeuralSnow.get_znetwork()
+        z_model = NeuralSnow.get_znetwork(FT)
         @test typeof(z_model) <: Flux.Chain
         z32 = NeuralSnow.converted_model_type(z_model, FT)
         @test eltype(z32[1].layers[1].weight) == FT
@@ -375,7 +348,7 @@ if !isnothing(DataToolsExt)
             FT,
             α = test_alph,
             Δt = Δt;
-            model = NeuralSnow.get_znetwork(),
+            model = NeuralSnow.get_znetwork(FT),
         )
         @test dens_model2.α == FT(test_alph)
         @test dens_model2.z_model[:final_scale].weight[2, 2] == FT(1 / Δt)
@@ -393,69 +366,56 @@ if !isnothing(DataToolsExt)
               (:S, :S_l, :U, :Z, :P_avg, :T_avg, :R_avg, :Qrel_avg, :u_avg)
 
         Y.snow.S .= FT(0.1)
-        # The snow module is broken when using CUDA because the density model is stored in
-        # the snow parameters, but the network is not copied to the GPU.
-        if ClimaComms.device() isa ClimaComms.CUDADevice
-            @test_broken Y.snow.U .=
-                ClimaLand.Snow.energy_from_T_and_swe.(
-                    Y.snow.S,
-                    FT(273.0),
-                    Ref(model.parameters),
-                )
-        else
-            Y.snow.U .=
-                ClimaLand.Snow.energy_from_T_and_swe.(
-                    Y.snow.S,
-                    FT(273.0),
-                    Ref(model.parameters),
-                )
-            Y.snow.Z .= FT(0.2)
-            set_initial_cache! = ClimaLand.make_set_initial_cache(model)
-            t0 = FT(0.0)
-            set_initial_cache!(p, Y, t0)
-            oldρ = p.snow.ρ_snow
-            NeuralSnow.update_density_and_depth!(
-                p.snow.ρ_snow,
-                p.snow.z_snow,
-                model.parameters.density,
-                Y,
-                p,
-                model.parameters,
+        Y.snow.U .=
+            ClimaLand.Snow.energy_from_T_and_swe.(
+                Y.snow.S,
+                FT(273.0),
+                Ref(model.parameters),
             )
-            @test p.snow.z_snow == Y.snow.Z
-            @test p.snow.ρ_snow == oldρ
-            output1 =
-                NeuralSnow.eval_nn(dens_model2, FT.([0, 0, 0, 0, 0, 0, 0])...)
+        Y.snow.Z .= FT(0.2)
+        set_initial_cache! = ClimaLand.make_set_initial_cache(model)
+        t0 = FT(0.0)
+        set_initial_cache!(p, Y, t0)
+        oldρ = p.snow.ρ_snow
+        NeuralSnow.update_density_and_depth!(
+            p.snow.ρ_snow,
+            p.snow.z_snow,
+            model.parameters.density,
+            Y,
+            p,
+            model.parameters,
+        )
+        @test p.snow.z_snow == Y.snow.Z
+        @test p.snow.ρ_snow == oldρ
+        output1 = NeuralSnow.eval_nn(dens_model2, FT.([0, 0, 0, 0, 0, 0, 0])...)
 
-            @test eltype(output1) == FT
-            @test output1 == 0.0f0
+        @test eltype(output1) == FT
+        @test output1 == 0.0f0
 
-            zerofield = similar(Y.snow.Z)
-            zerofield .= FT(0)
-            dY = similar(Y)
-            NeuralSnow.update_dzdt!(dY.snow.Z, dens_model2, Y)
-            @test dY.snow.Z == zerofield
+        zerofield = similar(Y.snow.Z)
+        zerofield .= FT(0)
+        dY = similar(Y)
+        NeuralSnow.update_dzdt!(dY.snow.Z, dens_model2, Y)
+        @test dY.snow.Z == zerofield
 
-            Z = FT(0.5)
-            S = FT(0.1)
-            dzdt = FT(1 / Δt)
-            dsdt = FT(1 / Δt)
-            @test NeuralSnow.clip_dZdt(S, Z, dsdt, dzdt, Δt) == dzdt
+        Z = FT(0.5)
+        S = FT(0.1)
+        dzdt = FT(1 / Δt)
+        dsdt = FT(1 / Δt)
+        @test NeuralSnow.clip_dZdt(S, Z, dsdt, dzdt, Δt) == dzdt
 
-            @test NeuralSnow.clip_dZdt(Z, S, dsdt, dzdt, Δt) ≈ FT(1.4 / Δt)
+        @test NeuralSnow.clip_dZdt(Z, S, dsdt, dzdt, Δt) ≈ FT(1.4 / Δt)
 
-            @test NeuralSnow.clip_dZdt(S, Z, FT(-S / Δt), dzdt, Δt) ≈
-                  FT(-Z / Δt)
+        @test NeuralSnow.clip_dZdt(S, Z, FT(-S / Δt), dzdt, Δt) ≈ FT(-Z / Δt)
 
 
-            dswe_by_precip = 0.1
-            Y.snow.P_avg .= FT(dswe_by_precip / Δt)
-            exp_tendency! = ClimaLand.make_compute_exp_tendency(model)
-            exp_tendency!(dY, Y, p, FT(0.0))
-            @test parent(dY.snow.Z)[1] * Δt > dswe_by_precip
-            new_dYP = FT(test_alph) .* (p.drivers.P_snow .- Y.snow.P_avg)
-            @test dY.snow.P_avg == new_dYP
-        end
+        dswe_by_precip = 0.1
+        Y.snow.P_avg .= FT(dswe_by_precip / Δt)
+        exp_tendency! = ClimaLand.make_compute_exp_tendency(model)
+        exp_tendency!(dY, Y, p, FT(0.0))
+        @test Array(parent(dY.snow.Z))[1] * Δt > dswe_by_precip
+        new_dYP = FT(test_alph) .* (p.drivers.P_snow .- Y.snow.P_avg)
+        @test dY.snow.P_avg == new_dYP
 
     end
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

Make snow depth nn model gpu compatible. 

The cpu and gpu plots look different, especially for phase change flux and water runoff. See #1590


## Content
- Uses Adapt to make nn static. Fix type allocations in nn to make gpu compatible.
- Model can no longer be trained in ClimaLand because weights are static. This could be supported if needed.
- Model can no longer use matrix inputs for batch evaluation. 

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
