### PR TITLE
Fix relative vs absolute path bug with ILAMB

### DIFF
--- a/experiments/ilamb/ilamb_setup.jl
+++ b/experiments/ilamb/ilamb_setup.jl
@@ -30,6 +30,9 @@ function setup_run_for_ilamb(
     commit_id::String,
     num_models_to_keep::Integer,
 )
+    ilamb_diagnostics_dir = abspath(ilamb_diagnostics_dir)
+    ilamb_models_parent_dir = abspath(ilamb_models_parent_dir)
+    ilamb_build_dir = abspath(ilamb_build_dir)
     # Verify directories exist
     isdir(ilamb_diagnostics_dir) ||
         error("$ilamb_diagnostics_dir is not a directory")
@@ -73,7 +76,7 @@ end
 Create symbolic links in `model_dir` that point to the diagnostics produced
 from the long runs in `ilamb_diagnostics_dir`.
 
-Creating symbolic links is preferred over copy files to avoid unnecessary data
+Creating symbolic links is preferred over copying files to avoid unnecessary data
 duplication.
 """
 function create_symlinks(ilamb_diagnostics_dir::String, model_dir::String)
@@ -107,7 +110,7 @@ function create_symlinks(ilamb_diagnostics_dir::String, model_dir::String)
 end
 
 """
-    validate_symlinks(model_dir::String)
+    validate_symlinks(MODELS_dir::String)
 
 Validate the symbolic links in `MODELS` directory.
 
@@ -119,9 +122,9 @@ are deleted, then the symbolic links will be invalid.
 Note that this does not remove the directory if all the symlinks associated with
 a particular run is deleted.
 """
-function validate_symlinks(model_dir::String)
+function validate_symlinks(MODELS_dir::String)
     model_dirs = String[]
-    for maybe_dir in readdir(model_dir, join = true)
+    for maybe_dir in readdir(MODELS_dir, join = true)
         isdir(maybe_dir) && push!(model_dirs, maybe_dir)
     end
 

--- a/experiments/ilamb/tests/test_ilamb_setup.jl
+++ b/experiments/ilamb/tests/test_ilamb_setup.jl
@@ -3,14 +3,16 @@ include(joinpath(@__DIR__, "..", "ilamb_setup.jl"))
 using Test
 
 """
-    make_dummy_ilamb_diagnostics(tempdir, dirname)
+    make_dummy_ilamb_diagnostics(dirname)
 
 Make a directory in `tempdir` with the name `dirname` and create two
 NetCDF files named "evspsbl_Lmon_CliMA_historical_r1i1p1f1_gn_200003-201902.nc"
 and "gpp_Lmon_CliMA_historical_r1i1p1f1_gn_200003-201902.nc" in the directory.
+
+Note that `ilamb_diag_dir` is intentionally not an absolute path.
 """
-function make_dummy_ilamb_diagnostics(tempdir, dirname)
-    ilamb_diag_dir = mkdir(joinpath(tempdir, dirname))
+function make_dummy_ilamb_diagnostics(dirname)
+    ilamb_diag_dir = mkdir(dirname)
     evspsbl_filepath = touch(
         joinpath(
             ilamb_diag_dir,
@@ -23,7 +25,7 @@ function make_dummy_ilamb_diagnostics(tempdir, dirname)
             "gpp_Lmon_CliMA_historical_r1i1p1f1_gn_200003-201902.nc",
         ),
     )
-    return ilamb_diag_dir, evspsbl_filepath, gpp_filepath
+    return ilamb_diag_dir, abspath(evspsbl_filepath), abspath(gpp_filepath)
 end
 
 function populate_build_dir(build_dir, model_dir)
@@ -37,132 +39,134 @@ end
 
 @testset "Perfect setup for ILAMB using dummy directories and NetCDF files" begin
     tempdir = mktempdir(cleanup = false)
-    @info "Perfect setup for ILAMB" tempdir
+    cd(tempdir) do
+        @info "Perfect setup for ILAMB" tempdir
 
-    # Make dummy ILAMB diagnostics
-    ilamb_diag_dir, evspsbl_filepath, gpp_filepath =
-        make_dummy_ilamb_diagnostics(tempdir, "ilamb_diagnostics")
+        # Make dummy ILAMB diagnostics
+        ilamb_diag_dir, evspsbl_filepath, gpp_filepath =
+            make_dummy_ilamb_diagnostics("ilamb_diagnostics")
 
-    # Make dummy ILAMB directory
-    ilamb_root_dir = mkdir(joinpath(tempdir, "ilamb"))
+        # Make dummy ILAMB directory
+        ilamb_root_dir = mkdir(joinpath(tempdir, "ilamb"))
 
-    commit_id = "4242424"
-    buildkite_id = "1"
+        commit_id = "4242424"
+        buildkite_id = "1"
 
-    ilamb_build_dir = joinpath(ilamb_root_dir, "_build")
-    num_models_to_keep = 2
-    setup_run_for_ilamb(
-        ilamb_diag_dir,
-        ilamb_root_dir,
-        ilamb_build_dir,
-        buildkite_id,
-        commit_id,
-        num_models_to_keep,
-    )
+        ilamb_build_dir = joinpath(ilamb_root_dir, "_build")
+        num_models_to_keep = 2
+        setup_run_for_ilamb(
+            ilamb_diag_dir,
+            ilamb_root_dir,
+            ilamb_build_dir,
+            buildkite_id,
+            commit_id,
+            num_models_to_keep,
+        )
 
-    # Test existence of directories and symlinks
-    MODELS_dir = joinpath(ilamb_root_dir, "MODELS")
-    model_name = "$(buildkite_id)_$(Dates.Date(Dates.now()))_$commit_id"
-    model_dir = joinpath(MODELS_dir, model_name)
-    symlink_evspsbl = joinpath(
-        model_dir,
-        "evspsbl_Lmon_CliMA_historical_r1i1p1f1_gn_200003-201902.nc",
-    )
-    symlink_gpp = joinpath(
-        model_dir,
-        "gpp_Lmon_CliMA_historical_r1i1p1f1_gn_200003-201902.nc",
-    )
-    @test isdir(MODELS_dir)
-    @test isdir(model_dir)
-    @test islink(symlink_evspsbl)
-    @test islink(symlink_gpp)
-    @test readlink(symlink_evspsbl) == evspsbl_filepath
-    @test readlink(symlink_gpp) == gpp_filepath
+        # Test existence of directories and symlinks
+        MODELS_dir = joinpath(ilamb_root_dir, "MODELS")
+        model_name = "$(buildkite_id)_$(Dates.Date(Dates.now()))_$commit_id"
+        model_dir = joinpath(MODELS_dir, model_name)
+        symlink_evspsbl = joinpath(
+            model_dir,
+            "evspsbl_Lmon_CliMA_historical_r1i1p1f1_gn_200003-201902.nc",
+        )
+        symlink_gpp = joinpath(
+            model_dir,
+            "gpp_Lmon_CliMA_historical_r1i1p1f1_gn_200003-201902.nc",
+        )
+        @test isdir(MODELS_dir)
+        @test isdir(model_dir)
+        @test islink(symlink_evspsbl)
+        @test islink(symlink_gpp)
+        @test readlink(symlink_evspsbl) == evspsbl_filepath
+        @test readlink(symlink_gpp) == gpp_filepath
 
-    # Remove files from first setup which simulates deleting old simulation runs
-    rm(evspsbl_filepath)
-    rm(gpp_filepath)
+        # Remove files from first setup which simulates deleting old simulation runs
+        rm(evspsbl_filepath)
+        rm(gpp_filepath)
 
-    # After ILAMB ran, populate the build directory with stuff
-    populate_build_dir(ilamb_build_dir, model_dir)
+        # After ILAMB ran, populate the build directory with stuff
+        populate_build_dir(ilamb_build_dir, model_dir)
 
-    # Make another ILAMB diagnostics (simulating another run) and set up the
-    # dummy run for ILAMB again
-    ilamb_diag_dir2, evspsbl_filepath2, gpp_filepath2 =
-        make_dummy_ilamb_diagnostics(tempdir, "ilamb_diagnostics1")
-    commit_id = "4242425"
-    buildkite_id = "2"
-    @test_logs (:info, r"Invalid symlink found") match_mode = :any setup_run_for_ilamb(
-        ilamb_diag_dir2,
-        ilamb_root_dir,
-        ilamb_build_dir,
-        buildkite_id,
-        commit_id,
-        num_models_to_keep,
-    )
+        # Make another ILAMB diagnostics (simulating another run) and set up the
+        # dummy run for ILAMB again
+        ilamb_diag_dir2, evspsbl_filepath2, gpp_filepath2 =
+            make_dummy_ilamb_diagnostics("ilamb_diagnostics1")
+        commit_id = "4242425"
+        buildkite_id = "2"
+        @test_logs (:info, r"Invalid symlink found") match_mode = :any setup_run_for_ilamb(
+            ilamb_diag_dir2,
+            ilamb_root_dir,
+            ilamb_build_dir,
+            buildkite_id,
+            commit_id,
+            num_models_to_keep,
+        )
 
-    model_name2 = "$(buildkite_id)_$(Dates.Date(Dates.now()))_$commit_id"
-    model_dir2 = joinpath(MODELS_dir, model_name2)
-    symlink_evspsbl = joinpath(
-        model_dir2,
-        "evspsbl_Lmon_CliMA_historical_r1i1p1f1_gn_200003-201902.nc",
-    )
-    symlink_gpp = joinpath(
-        model_dir2,
-        "gpp_Lmon_CliMA_historical_r1i1p1f1_gn_200003-201902.nc",
-    )
-    @test islink(symlink_evspsbl)
-    @test islink(symlink_gpp)
-    @test readlink(symlink_evspsbl) == evspsbl_filepath2
-    @test readlink(symlink_gpp) == gpp_filepath2
+        model_name2 = "$(buildkite_id)_$(Dates.Date(Dates.now()))_$commit_id"
+        model_dir2 = joinpath(MODELS_dir, model_name2)
+        symlink_evspsbl = joinpath(
+            model_dir2,
+            "evspsbl_Lmon_CliMA_historical_r1i1p1f1_gn_200003-201902.nc",
+        )
+        symlink_gpp = joinpath(
+            model_dir2,
+            "gpp_Lmon_CliMA_historical_r1i1p1f1_gn_200003-201902.nc",
+        )
+        @test islink(symlink_evspsbl)
+        @test islink(symlink_gpp)
+        @test readlink(symlink_evspsbl) == evspsbl_filepath2
+        @test readlink(symlink_gpp) == gpp_filepath2
 
-    populate_build_dir(ilamb_build_dir, model_dir2)
+        populate_build_dir(ilamb_build_dir, model_dir2)
 
-    # Cleaning the build directory should remove the old png file from
-    # populate_build_dir
-    files_in_build_dir =
-        basename.([
-            joinpath(root, file) for
-            (root, _, files) in walkdir(ilamb_build_dir) for file in files
-        ])
-    png_files_in_build_dir =
-        filter(filename -> endswith(filename, ".png"), files_in_build_dir)
+        # Cleaning the build directory should remove the old png file from
+        # populate_build_dir
+        files_in_build_dir =
+            basename.([
+                joinpath(root, file) for
+                (root, _, files) in walkdir(ilamb_build_dir) for file in files
+            ])
+        png_files_in_build_dir =
+            filter(filename -> endswith(filename, ".png"), files_in_build_dir)
 
-    @test length(png_files_in_build_dir) == 1
-    @test first(png_files_in_build_dir) == "benchmark_$(model_name2).png"
+        @test length(png_files_in_build_dir) == 1
+        @test first(png_files_in_build_dir) == "benchmark_$(model_name2).png"
 
-    # Make another ILAMB diagnostics (simulating another run) to test if
-    # the first model is deleted
-    ilamb_diag_dir3, evspsbl_filepath3, gpp_filepath3 =
-        make_dummy_ilamb_diagnostics(tempdir, "ilamb_diagnostics2")
-    commit_id = "4242426"
-    buildkite_id = "3"
-    setup_run_for_ilamb(
-        ilamb_diag_dir3,
-        ilamb_root_dir,
-        ilamb_build_dir,
-        buildkite_id,
-        commit_id,
-        num_models_to_keep,
-    )
+        # Make another ILAMB diagnostics (simulating another run) to test if
+        # the first model is deleted
+        ilamb_diag_dir3, evspsbl_filepath3, gpp_filepath3 =
+            make_dummy_ilamb_diagnostics("ilamb_diagnostics2")
+        commit_id = "4242426"
+        buildkite_id = "3"
+        setup_run_for_ilamb(
+            ilamb_diag_dir3,
+            ilamb_root_dir,
+            ilamb_build_dir,
+            buildkite_id,
+            commit_id,
+            num_models_to_keep,
+        )
 
-    model_name3 = "$(buildkite_id)_$(Dates.Date(Dates.now()))_$commit_id"
-    model_dir3 = joinpath(MODELS_dir, model_name3)
-    populate_build_dir(ilamb_build_dir, model_dir3)
+        model_name3 = "$(buildkite_id)_$(Dates.Date(Dates.now()))_$commit_id"
+        model_dir3 = joinpath(MODELS_dir, model_name3)
+        populate_build_dir(ilamb_build_dir, model_dir3)
 
-    @test !isdir(model_dir)
-    @test isdir(model_dir2)
-    @test isdir(model_dir3)
+        @test !isdir(model_dir)
+        @test isdir(model_dir2)
+        @test isdir(model_dir3)
 
-    files_in_build_dir =
-        basename.([
-            joinpath(root, file) for
-            (root, _, files) in walkdir(ilamb_build_dir) for file in files
-        ])
-    @test length(files_in_build_dir) == 3
-    @test isfile(joinpath(ilamb_build_dir, "benchmark_$model_name2.nc"))
-    @test isfile(joinpath(ilamb_build_dir, "benchmark_$model_name3.nc"))
-    @test isfile(joinpath(ilamb_build_dir, "benchmark_$model_name3.png"))
+        files_in_build_dir =
+            basename.([
+                joinpath(root, file) for
+                (root, _, files) in walkdir(ilamb_build_dir) for file in files
+            ])
+        @test length(files_in_build_dir) == 3
+        @test isfile(joinpath(ilamb_build_dir, "benchmark_$model_name2.nc"))
+        @test isfile(joinpath(ilamb_build_dir, "benchmark_$model_name3.nc"))
+        @test isfile(joinpath(ilamb_build_dir, "benchmark_$model_name3.png"))
+    end
 end
 
 @testset "Model name from simulation" begin


### PR DESCRIPTION
Checking ILAMB on the latest long run, the symlinks to the ILAMB diagnostics were not created properly. See https://buildkite.com/clima/climaland-long-runs/builds/4431#019b2515-5cce-4c81-81cb-7146e14fd1e4.

When creating the symlinks, the path to the NetCDF files are relative paths instead of absolute paths. Then, these symlinks are considered invalided and are removed from the model directory.

The solution to this is to use absolute paths for the directories.

