### PR TITLE
add ILAMB to dev docs

### DIFF
--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -193,3 +193,17 @@ steps:
         - slurm_time: "2:00:00"
       concurrency: 1
       concurrency_group: "ilamb-run"
+
+    - wait
+
+    - label: "Deploy ILAMB leaderboard to gh-pages"
+      command:
+        - mkdir -p ILAMB
+        - tar xzf $$ILAMB_ROOT/buildkite/ilamb_leaderboard.tar.gz -C ILAMB --strip-components=1
+        - git clone --depth 1 --branch gh-pages https://github.com/CliMA/ClimaLand.jl.git gh-pages-repo
+        - rm -rf gh-pages-repo/dev/ILAMB
+        - mkdir -p gh-pages-repo/dev
+        - cp -r ILAMB gh-pages-repo/dev/
+        - cd gh-pages-repo && git add dev/ILAMB && git commit -m "Update ILAMB leaderboard from build $BUILDKITE_BUILD_NUMBER" && git push origin gh-pages
+      env:
+        ILAMB_ROOT: "/net/sampo/data1/ilamb"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -76,6 +76,7 @@ pages = Any[
     "Calibration and benchmark" => [
         "Calibrating model parameters" => "calibration.md",
         "Model Benchmark" => "leaderboard/leaderboard.md",
+        "ILAMB Leaderboard" => "ILAMB/index.html",
     ],
     "Running on GPU or with MPI" => "architectures.md",
     "Additional resources" => [


### PR DESCRIPTION
longrun buildkite pipeline pushes ILAMB docs to /dev in gh-pages 