### PR TITLE
fix typos in docs

### DIFF
--- a/docs/src/calibration.md
+++ b/docs/src/calibration.md
@@ -33,8 +33,8 @@ the key ingredients introduced above:
 (EKP) is at the center of CliMA's calibration efforts. EKP implements a suite of
 Ensemble Kalman methods to find a (locally) optimal parameter set `U` for a
 model `G` to fit noisy `Γ` observational data `Y`. These methods are optimized
-for problems where the model `G` is computationally expensive and no analtyic
-derivatives are available, as in the case of weather forcasting, where Ensemble
+for problems where the model `G` is computationally expensive and no analytic
+derivatives are available, as in the case of weather forecasting, where Ensemble
 Kalman techniques have a long history of success.
 
 Large calibration campaigns often require supercomputers and while direct use of
@@ -394,9 +394,9 @@ simulation data is done in `process_member_data` in
 
 !!! note "Time conventions"
     Different data sources have different conventions for time. For example,
-    data sources use January 1, January 15, and Feburary 1 for the monthly
+    data sources use January 1, January 15, and February 1 for the monthly
     average of January. For the diagnostics saved from a CliMA simulation, the
-    current convention is to save the monthly average on Feburary 1. You must
+    current convention is to save the monthly average on February 1. You must
     ensure that the time conventions are the same. For calibration, we choose
     the start of the time reduction, so for this example, the time associated
     with the monthly average of January is January 1. For seasonal averages, the

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -22,7 +22,7 @@ in a region (in a box), or at a site (in a column). See the [tutorial to ClimaLa
 - Set your simulation period: start date, end date, timestep.
 - Set the forcings (for example, air temperature, precipitations).
 - Set the initial conditions. Differential equations required initial conditions to solve.
-For some simulations (e.g., global land simualtions), we provide default initial condition ("ic") functions,
+For some simulations (e.g., global land simulations), we provide default initial condition ("ic") functions,
 but in many cases you need to create your own `set_ic!` function.
 - Set how output is saved. For some simulations (e.g., global land simulations), we use the default diagnostic output,
 corresponding to monthly averages of specific variables saved to netcdf files.

--- a/docs/src/repo_structure.md
+++ b/docs/src/repo_structure.md
@@ -13,13 +13,13 @@ The repo also has 3 CI-related folders, containing workflows that are run at eac
 
 - .buildkite: contains a script that runs a variety of ClimaLand simulations, largely from the experiments and tests folders. These runs are carried out as part of CI and must run without error in order to merge a PR.
 - .dev: contains useful tools for developers, such as a format checker for Julia (which is run as part of CI and must pass before a PR can be merged into main).
-- .github: contains various Github Actions scripts, for example, this documentation website is built each time a change is push to `ClimaLand`.
+- .github: contains various Github Actions scripts, for example, this documentation website is built each time a change is pushed to `ClimaLand`.
 
-as well as 9 files:
+As well as 9 files:
 
 - .gitignore: [commonly used git file](https://git-scm.com/docs/gitignore), contains files, files type, and folders that should be ignored by git.
 - LICENSE: License file of `ClimaLand`, you can [read it](https://github.com/CliMA/ClimaLand.jl/blob/main/LICENSE) to learn about legal practice regarding use of `ClimaLand` open source code.
-- Project.toml: The Julia programming language requires a `Project.toml` file to create an environment, which specify dependencies of a project as well as its version, name, authors and a unique identifier number (uuid). Every Julia registered package has a `Project.toml` file.
+- Project.toml: The Julia programming language requires a `Project.toml` file to create an environment, which specifies dependencies of a project as well as its version, name, authors and a unique identifier number (uuid). Every Julia registered package has a `Project.toml` file.
 - README.md: This markdown file contains the info that you can read on [ClimaLand GitHub web page](https://github.com/CliMA/ClimaLand.jl)
 - logo.svg and logo-white.svg: The logos used in the README
 - Artifacts.toml: This file contains `Pkg` artifacts declarations
@@ -36,11 +36,11 @@ The folder /docs contains:
 - a `/src` folder: It is recommended to put your markdown pages inside this folder. Each markdown file (.md extension text file) is a page accessible through the menu of the documentation. For example, `docs/src/contributing.md` contains the text you can read on the documentation "contribution guide" menu. The path to this .md file and the name of the menu is set in the `docs/make.jl` file.
 - a `make.jl` file: This Julia file contains your documentation website structure. Running this file will build your website pages, you can run it locally, but it is commonly built remotely via .github/workflows/docs.yml to generate the github static page hosted on the [gh-pages branch](https://github.com/CliMA/ClimaLand.jl/tree/gh-pages).
 
-Note: the documentation can have submenu. For example, `APIs` have submenu `ClimaLand` which has many submenu... This structure is built in our current framework via a file `docs/list_of_apis.jl` in that example, which is then included in `docs/make.jl`.
+Note: the documentation can have submenus. For example, `APIs` have submenu `ClimaLand` which has many submenus... This structure is built in our current framework via a file `docs/list_of_apis.jl` in that example, which is then included in `docs/make.jl`.
 
 ## /experiments folder
 
-The `experiments` folder contains four folders. It contains a folder for `integrated` models and a folder for `standalone` models. These two folders are meant to provide users with simple examples of ClimaLand runs. The files contains meteorological inputs (such as precipitation), values for every parameters, and the domains and timestepper are specified.
+The `experiments` folder contains four folders. It contains a folder for `integrated` models and a folder for `standalone` models. These two folders are meant to provide users with simple examples of ClimaLand runs. The files contain meteorological inputs (such as precipitation), values for every parameter, and the domains and timestepper are specified.
 
 For example, `/experiments/integrated/fluxnet/` contains:
 
@@ -49,12 +49,12 @@ For example, `/experiments/integrated/fluxnet/` contains:
 - fluxnet_simulation.jl: Contains the site-generic time variables for running `ClimaLand` on
 fluxtower sites
 - pull_MODIS.jl: provides methods for interacting with the MODIS REST API at a site
-- met_drivers_FLUXNET.jl: Construct the drivers. This script includes pull_MODIS.jl
+- met_drivers_FLUXNET.jl: Constructs the drivers. This script includes pull_MODIS.jl
 defined by plant functional types instead of fully site-specific parameters.
 - plot_utils.jl: Plotting utilities for the integrated fluxnet site experiments
 - ozark_pft.jl: Runs the Ozark site (US-MOz) using plant parameters. Running this script
 will include all of the above scripts.
-- run_fluxnet.jl: Sets up integrated models and runs fluxnet expirement on a given site.
+- run_fluxnet.jl: Sets up integrated models and runs fluxnet experiment on a given site.
 Running this script will include all of the above scripts, except ozark_pft.jl
 
 and folders for four fluxnet sites. For example `/experiments/integrated/fluxnet/US-MOz` contains:
@@ -64,7 +64,7 @@ fluxtower site
 - US-MOz_simulation.jl: Contains simulation variables for running Clima Land on the US-MOz
 fluxtower site
 
-The `experiments` folder also contains a `benchmarks` folder and a `long_runs` folder. These contain experiments that are run as part of CI on the Caltech cluster. `benchmarks` is ran to ensure the model runs in a similar amount of time after changes are made. `long_runs` create
+The `experiments` folder also contains a `benchmarks` folder and a `long_runs` folder. These contain experiments that are run as part of CI on the Caltech cluster. `benchmarks` is ran to ensure the model runs in a similar amount of time after changes are made. `long_runs` creates
 outputs that can be checked for validity.
 
 ## /src folder
@@ -73,15 +73,12 @@ The `/src` folder contains the source code of `ClimaLand` models. It contains 4 
 
 - shared_utilities: This is a core folder that defines functions and data structures used across all modules and models types of `ClimaLand`. For example, `shared_utilities/models.jl` defines and export the function `make_update_aux` which will be used to create a function which updates the auxiliary parameters, stored in the vector `p`, `shared_utilities/boundary_conditions.jl` defines functions for setting boundary condition for PDE domains, etc.
 - standalone: This folder contains standalone models, which are submodels that can be run independently of each other. This is an important aspect of `ClimaLand` code design: to maximize modularity, sub-models can be run alone, and many different methods of the same sub-model can be defined via Julia multiple dispatch. The standalone folder is independent from the integrated folder.
-- integrated: This folder contains integrated models. It assembles standalone models together, as one would assemble pieces of a puzzle. Thanks to the modularity of `ClimaLand` design, many configuration of LSM can be assembled in integrated models. The same functions (`update_aux!`, `exp_tendency!`, etc.) can be used for standalone and integrated models, and an can be stepped  in the same way.
-- diagnostics: This folder contains diagnostics methods for different
-ClimaLand models. The diagnostics contains metadata such as where diagnostics variables are
-stored in those models, what is there names (short, long, standard)
-and physical units, with additional comment
+- integrated: This folder contains integrated models. It assembles standalone models together, as one would assemble pieces of a puzzle. Thanks to the modularity of `ClimaLand` design, many configurations of LSM can be assembled in integrated models. The same functions (`update_aux!`, `exp_tendency!`, etc.) can be used for standalone and integrated models, and can be stepped in the same way.
+- diagnostics: This folder contains diagnostics methods for different ClimaLand models. The diagnostics contains metadata such as where diagnostic variables are stored in those models, what their names are (short, long, standard) and physical units, with additional comments.
 
 As well as two files:
 
-- ClimaLand.jl: This file is the main Julia module of `ClimaLand.jl` repository. It contains all functions defined in `/src` in a nested way, for example `ClimaLand.X`, `ClimaLand.Soil.X`, `ClimaLand.Canopy.X`, etc. When a Julia user install and uses ClimaLand via `]add ClimaLand, using ClimaLand`, they are loading those functions, and are ready to use ClimaLand codebase.
+- ClimaLand.jl: This file is the main Julia module of `ClimaLand.jl` repository. It contains all functions defined in `/src` in a nested way, for example `ClimaLand.X`, `ClimaLand.Soil.X`, `ClimaLand.Canopy.X`, etc. When a Julia user installs and uses ClimaLand via `]add ClimaLand, using ClimaLand`, they are loading those functions, and are ready to use ClimaLand codebase.
 - Artifacts.jl: Contains functions that return the path of the given artifact name in the current context
 
 ## /lib folder
@@ -100,7 +97,7 @@ to easily and conveniently run ClimaLand at a variety of sites and globally. The
 
 ## /ext folder
 This folder has one subfolder, `/neural_snow`, which contains tools to create the neural network
-for snow and process its data. There are also two files
+for snow and process its data. There are also two files:
 
 - CreateParametersExt.jl: An extension for ClimaLand that contains constructors for model
 parameters
@@ -118,7 +115,7 @@ subfolders:
 
 `/test` also contains 3 files:
 
-- aqua.jl: Contains code quality assurance tests tha use Aqua.jl
+- aqua.jl: Contains code quality assurance tests that use Aqua.jl
 - Project.toml: Specifies dependencies needed for testing
-- runtests.jl: When `test` is ran from the package manager, this file is ran. It can also be
-manually ran using the `test` environment. This file runs all the other test scripts.
+- runtests.jl: When `test` is run from the package manager, this file is run. It can also be
+manually run using the `test` environment. This file runs all the other test scripts.

--- a/docs/src/restarts.md
+++ b/docs/src/restarts.md
@@ -119,7 +119,7 @@ restart.
     If you care about accurate accumulated diagnostics, make sure to line up your
     checkpoint and diagnostic frequencies.
 
-Similarly, `ClimaLand` does not guarantee drivers values will be set consistently
+Similarly, `ClimaLand` does not guarantee driver values will be set consistently
 across restarts. That is, the values of the forcing variables from the last step
 of the original run will not coincide with the values of the forcing variables
 upon the initial step of the restart run, unless the frequencies of


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

This PR fixed some typos in the documentation.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
