### PR TITLE
return volumetric liquid content instead of augmented liquid water

### DIFF
--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -951,7 +951,7 @@ end
     SoilCanopyModel,
     LandModel,
     EnergyHydrology,
-} p.soil.θ_l
+} Y.soil.ϑ_l
 @diagnostic_compute "soil_ice_content" Union{
     SoilCanopyModel,
     LandModel,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Our prognostic variable for soil water is the augmented liquid fraction. This can be larger than porosity, in which case the retention curve relationship specifies a corresponding (positive) pressure. This positive pressure would drive flow away from the saturated regions to bring the augmented liquid fraction back to porosity.

Whenever the true volumetric liquid fraction is required, we should use \theta_l (in `p`) since this is limited to be less than porosity. Above porosity, our prognostic variable reflects a pressure and shouldnt really be interpreted as a volume of water larger than the available pore space (except for when conserving mass). 

This PR changes the diagnostic we compare to data for surface soil moisture in the first 10cm to use theta_l, but we still define our "soil water content" diagnostic (depth resolved) to be the state Y.soil.\vartheta_l.



## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
