### PR TITLE
Add prognostic optimal LAI model (Zhou et al. 2025)

### DIFF
--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -46,6 +46,7 @@ steps:
     steps:
 
       - label: ":snow_capped_mountain: Snowy Land + P Model"
+        key: "snowy_land_pmodel_run"
         command:
           - julia --color=yes --project=.buildkite experiments/long_runs/snowy_land_pmodel.jl
         artifact_paths:
@@ -56,6 +57,12 @@ steps:
           slurm_time: 3:00:00
         env:
           CLIMACOMMS_DEVICE: "CUDA"
+
+      - label: "Send simulation output to Azure VM for visualization"
+        depends_on:
+          - "snowy_land_pmodel_run"
+        command:
+          - rsync -avz "/scratch/clima/slurm-buildkite/climaland-long-runs/$BUILDKITE_BUILD_NUMBER/climaland-long-runs/snowy_land_pmodel_longrun_gpu/global_diagnostics/output_active/" azure-arenchon:/home/arenchon/GitHub/ClimaViz.jl/data/climaland-longrun/
 
       - label: "Soil"
         command:
@@ -109,7 +116,6 @@ steps:
     if: build.env("LONGER_RUN") != null
     steps:
       - label: "Snowy Land, 19 years"
-        key: "snowy_land_pmodel_run"
         command:
           - julia --color=yes --project=.buildkite experiments/long_runs/snowy_land_pmodel.jl
         artifact_paths:
@@ -120,12 +126,6 @@ steps:
         env:
           CLIMACOMMS_DEVICE: "CUDA"
           LONGER_RUN: ""
-
-      - label: "Send simulation output to Azure VM for visualization"
-        depends_on:
-          - "snowy_land_pmodel_run"
-        command:
-          - rsync -avz "/scratch/clima/slurm-buildkite/climaland-long-runs/$BUILDKITE_BUILD_NUMBER/climaland-long-runs/snowy_land_pmodel_longrun_gpu/global_diagnostics/output_active/" azure-arenchon:/home/arenchon/GitHub/ClimaViz.jl/data/climaland-longrun/
 
       - label: "Soil, 20 years"
         command:

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -102,7 +102,7 @@ git-tree-sha1 = "e6d18714edfdcbd0244203146521d32df338385a"
     [[soil_params_Gupta2020_2022_lowres.download]]
     sha256 = "3e8ca24c57589eb3ccf20e52e74dd56bb46f9122048c0ee468889b1c631bb2a2"
     url = "https://caltech.box.com/shared/static/cg8ib5f6ps7wc1nn1p6wk2dnhmvwwr2p.gz"
-    
+
 [modis_clumping_index]
 git-tree-sha1 = "b849eb95c09190095e7bf021494ddeda8858af01"
 
@@ -198,3 +198,10 @@ git-tree-sha1 = "c35ba0e899040cb8153226ab751f69100f475d39"
     [[mizoguchi_soil_freezing_data.download]]
     sha256 = "0027cc080ba45ba33dc790b176ec2854353ce7dce4eae4bef72963b0dd944e0b"
     url = "https://caltech.box.com/shared/static/tn1bnqjmegyetw5kzd2ixq5pbnb05s3u.gz"
+
+[optimal_lai_inputs]
+git-tree-sha1 = "bd2ab975173bd27d03632bd2fbbae897696bf432"
+
+    [[optimal_lai_inputs.download]]
+    sha256 = "ae19213f1f17f4798a974aed88325b962299d534565da8e06b5e726bc3f3d39f"
+    url = "https://caltech.box.com/shared/static/y8igrojuyvbww0gn5zi8und9wgsqhtv5.gz"

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ main
 v1.5.3
 ------
 - Updated parameters, quantum yield for C4, canopy LW PR[#1613](https://github.com/CliMA/ClimaLand.jl/pull/1613)
+- ![][badge-✨feature] Add prognostic optimal LAI model (Zhou et al. 2025) as a biomass model (`ZhouOptimalLAIModel`), computing LAI dynamically from energy and water constraints
 
 v1.5.2
 ------
@@ -17,7 +18,7 @@ v1.5.2
 
 v1.5.1
 ------
-- Adjust RootSolvers lower compat 
+- Adjust RootSolvers lower compat
 
 v1.5.0
 ------

--- a/docs/list_of_apis.jl
+++ b/docs/list_of_apis.jl
@@ -13,6 +13,7 @@ apis = [
         "Canopy Models" => "APIs/canopy/Canopy.md",
         "Plant Hydraulics" => "APIs/canopy/PlantHydraulics.md",
         "Leaf, stem, root dynamics" => "APIs/canopy/Biomass.md",
+        "Optimal LAI" => "APIs/canopy/LAI.md",
         "Photosynthesis" => "APIs/canopy/Photosynthesis.md",
         "Radiative Transfer" => "APIs/canopy/RadiativeTransfer.md",
         "Energy" => "APIs/canopy/CanopyEnergy.md",

--- a/docs/list_standalone_models.jl
+++ b/docs/list_standalone_models.jl
@@ -20,6 +20,7 @@ standalone_models = [
         ]
         "Canopy structure" => [
             "Prescribed structure" => "standalone/pages/vegetation/canopy_structure/prescribed_structure.md",
+            "Optimal LAI" => "standalone/pages/vegetation/canopy_structure/optimal_lai.md",
         ]
         "Canopy energy" => [
             "Physics" => "standalone/pages/vegetation/canopy_energy/canopy_energy.md",

--- a/docs/src/APIs/canopy/Biomass.md
+++ b/docs/src/APIs/canopy/Biomass.md
@@ -25,4 +25,5 @@ ClimaLand.Canopy.PrescribedAreaIndices{FT}(
 ) where {FT <: AbstractFloat}
 ClimaLand.Canopy.prescribed_lai_era5
 ClimaLand.Canopy.prescribed_lai_modis
+ClimaLand.Canopy.update_biomass!
 ```

--- a/docs/src/APIs/canopy/LAI.md
+++ b/docs/src/APIs/canopy/LAI.md
@@ -1,0 +1,27 @@
+# Optimal LAI
+
+```@meta
+CurrentModule = ClimaLand.Canopy
+```
+
+## Models and Parameters
+
+```@docs
+ClimaLand.Canopy.ZhouOptimalLAIModel
+ClimaLand.Canopy.OptimalLAIParameters
+ClimaLand.Canopy.OptimalLAIParameters{FT}(toml_dict::CP.ParamDict) where {FT}
+```
+
+## Methods
+
+```@docs
+ClimaLand.Canopy.update_optimal_LAI
+ClimaLand.Canopy.compute_A0_daily
+ClimaLand.Canopy.compute_LAI
+ClimaLand.Canopy.make_OptimalLAI_callback
+ClimaLand.Canopy.call_update_optimal_LAI
+ClimaLand.Canopy.compute_L_max
+ClimaLand.Canopy.compute_m
+ClimaLand.Canopy.compute_steady_state_LAI
+ClimaLand.Canopy.lambertw0
+```

--- a/docs/src/APIs/canopy/RadiativeTransfer.md
+++ b/docs/src/APIs/canopy/RadiativeTransfer.md
@@ -40,4 +40,5 @@ ClimaLand.Canopy.canopy_sw_rt_beer_lambert
 ClimaLand.Canopy.canopy_sw_rt_two_stream
 ClimaLand.Canopy.extinction_coeff
 ClimaLand.Canopy.compute_G
+ClimaLand.Canopy.compute_PPFD
 ```

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -1,3 +1,15 @@
+@article{Zhou2025,
+  author    = {Shuang Zhou and Trevor F. Keenan and Nicholas G. Smith and Colin Prentice and Henrique F. Duarte and Yao Zhang and Matteo Detto and Iain Colin Prentice and Han Wang and Benjamin D. Stocker and Kiona Ogle},
+  title     = {A General Model for the Seasonal to Decadal Dynamics of Leaf Area},
+  journal   = {Global Change Biology},
+  year      = {2025},
+  volume    = {31},
+  number    = {1},
+  pages     = {e70125},
+  doi       = {10.1111/gcb.70125},
+  url       = {https://onlinelibrary.wiley.com/doi/pdf/10.1111/gcb.70125}
+}
+
 @article{DallAmico2011,
   author       = {M.~Dall’Amico and S.~Endrizzi and S.~Gruber and R.~Rigon},
   title        = {A robust and energy-conserving model of freezing variably-saturated soil},

--- a/docs/src/standalone/pages/vegetation/canopy_structure/optimal_lai.md
+++ b/docs/src/standalone/pages/vegetation/canopy_structure/optimal_lai.md
@@ -1,0 +1,163 @@
+# Optimal LAI Model
+
+The Optimal LAI model predicts seasonal to decadal dynamics of leaf area index (LAI) based on optimality principles, balancing energy and water constraints.
+
+This model is based on [Zhou2025](@citet), which presents a general model for the seasonal to decadal dynamics of leaf area that combines predictions from both the light use efficiency (LUE) framework and optimization theory.
+
+## Key Concepts and Definitions
+
+### Potential vs Actual GPP
+
+The model distinguishes between two types of gross primary productivity (GPP):
+
+- **Potential GPP ($A_0$)**: The hypothetical GPP that would be achieved if the canopy absorbed all incoming photosynthetically active radiation (PAR). This corresponds to setting the fraction of absorbed PAR (fAPAR) to 1, which would require an infinitely dense canopy. This is computed as:
+  ```math
+  A_0 = \text{LUE} \times \text{PPFD}
+  ```
+  where LUE is the light use efficiency (mol CO₂ per mol photons) and PPFD is the photosynthetic photon flux density (mol photons m⁻² time⁻¹).
+
+- **Actual GPP ($A$)**: The GPP achieved by the actual canopy with finite LAI:
+  ```math
+  A = A_0 \times \text{fAPAR} = A_0 \times (1 - e^{-k \cdot \text{LAI}})
+  ```
+
+### fAPAR and Beer-Lambert Law
+
+The fraction of absorbed photosynthetically active radiation (fAPAR) follows Beer-Lambert's law:
+```math
+\text{fAPAR} = 1 - e^{-k \cdot \text{LAI}}
+```
+where $k$ is the light extinction coefficient. This represents the fraction of incoming PAR that is absorbed by the canopy.
+
+## Model Overview
+
+The optimal LAI model computes LAI dynamically by:
+1. Calculating the seasonal maximum LAI (LAI$_{max}$) based on energy and water limitations
+2. Computing steady-state LAI from daily meteorological conditions
+3. Updating actual LAI using an exponential moving average to represent the lag in leaf development
+
+## Seasonal Maximum LAI
+
+The seasonal maximum LAI (LAI$_{max}$) is determined by the minimum of energy-limited and water-limited constraints (Equations 11-12 in Zhou et al. 2025):
+
+```math
+\begin{align}
+\text{fAPAR}_{max} &= \min\left(\text{fAPAR}_{energy}, \text{fAPAR}_{water}\right) \\
+\text{fAPAR}_{energy} &= 1 - \frac{z}{k \cdot A_{0,annual}} \\
+\text{fAPAR}_{water} &= \frac{c_a(1-\chi)}{1.6 \cdot D_{growing}} \cdot \frac{f_0 \cdot P_{annual}}{A_{0,annual}} \\
+\text{LAI}_{max} &= -\frac{1}{k} \ln(1 - \text{fAPAR}_{max})
+\end{align}
+```
+
+**Physical interpretation:**
+- **Energy-limited fAPAR**: Represents the optimal trade-off between carbon gain from photosynthesis and the cost of building/maintaining leaves. When $z / (k \cdot A_{0,annual})$ is large (high leaf cost relative to potential carbon gain), the optimal fAPAR is reduced.
+- **Water-limited fAPAR**: Represents the constraint imposed by water availability. The numerator represents the water use efficiency (related to stomatal conductance), while the denominator relates to evaporative demand.
+
+where:
+- $A_{0,annual}$ is the annual total potential GPP (mol CO₂ m⁻² yr⁻¹) — the integrated daily $A_0$ over the year
+- $P_{annual}$ is the annual total precipitation (mol H₂O m⁻² yr⁻¹). Conversion: 1 mm precipitation ≈ 55.5 mol H₂O m⁻²
+- $D_{growing}$ is the mean vapor pressure deficit during the growing season (Pa), where growing season is defined as days with T > 0°C
+- $k$ is the light extinction coefficient (dimensionless)
+- $z$ is the unit cost of constructing and maintaining leaves (mol CO₂ m⁻² yr⁻¹)
+- $c_a$ is the ambient CO₂ partial pressure (Pa). Conversion: 400 ppm at 101325 Pa ≈ 40 Pa
+- $\chi$ is the ratio of leaf-internal to ambient CO₂ partial pressure (dimensionless), from stomatal optimization
+- $f_0$ is the fraction of annual precipitation available to plants (dimensionless), varies with aridity
+
+## Daily Steady-State LAI
+
+Given daily meteorological conditions, the steady-state LAI ($L_s$) represents the LAI that would be in equilibrium with GPP if conditions were held constant (Equations 13-15):
+
+```math
+\begin{align}
+\mu &= m \cdot A_{0,daily} \\
+L_s &= \min\left\{\mu + \frac{1}{k} W_0[-k\mu \exp(-k\mu)], \text{LAI}_{max}\right\}
+\end{align}
+```
+
+where:
+- $A_{0,daily}$ is the daily potential GPP (mol CO₂ m⁻² day⁻¹)
+- $m$ is a parameter relating steady-state LAI to steady-state GPP (Equation 20):
+
+```math
+m = \frac{\sigma \cdot \text{GSL} \cdot \text{LAI}_{max}}{A_{0,annual} \cdot \text{fAPAR}_{max}}
+```
+
+where GSL is the growing season length (days) and $\sigma$ is a dimensionless parameter representing departure from square-wave LAI dynamics (σ = 1 would mean LAI instantly reaches LAI$_{max}$ at the start of the growing season).
+
+- $W_0$ is the principal branch of the Lambert W function, which satisfies $W(x) e^{W(x)} = x$
+
+## LAI Update
+
+The actual LAI is updated using an exponential weighted moving average to represent the time lag for photosynthate allocation to leaves (Equation 16):
+
+```math
+\text{LAI}_{new} = \alpha \cdot L_s + (1-\alpha) \cdot \text{LAI}_{prev}
+```
+
+where $\alpha$ is a smoothing factor (dimensionless, 0-1). The effective memory timescale is $\tau \approx 1/\alpha$ days. Setting $\alpha = 0.067$ corresponds to approximately 15 days of memory.
+
+## Model Assumptions
+
+1. **Water limitation through soil moisture stress**: Both daily and annual potential GPP ($A_0$) include soil moisture stress (β). This allows vegetation structure (LAI$_{max}$, via $A_{0,annual}$) to adapt to water availability on annual timescales, while daily LAI dynamics respond to shorter-term moisture variability.
+2. **Beer-Lambert light extinction**: Light absorption follows an exponential decay through the canopy.
+3. **Optimal stomatal behavior**: The model assumes plants optimize their stomatal conductance following the P-model framework, giving the $\chi$ parameter.
+4. **Growing season inputs are provided, not diagnosed**: The model takes growing season length (GSL) and growing-season VPD as inputs; it does not currently diagnose season onset/offset from temperature.
+5. **Daily update at local noon**: LAI is updated once per day at local solar noon.
+
+## Parameters
+
+| Parameter | Symbol | Unit | Typical Value | Description |
+| :--- | :---: | :---: | :---: | :--- |
+| Light extinction coefficient | $k$ | - | 0.5 | Controls light attenuation through canopy |
+| Leaf construction cost | $z$ | mol CO₂ m⁻² yr⁻¹ | 12.227 | Unit cost of building and maintaining leaves |
+| LAI dynamics parameter | $\sigma$ | - | 1.1 | Departure from square-wave dynamics |
+| Smoothing factor | $\alpha$ | - | 0.067 | Controls LAI response time (~15 days) |
+| Precipitation fraction | $f_0$ | - | 0.65 | Fraction of precipitation used by plants |
+
+## Drivers
+
+| Driver | Symbol | Unit | Description |
+| :--- | :---: | :---: | :--- |
+| Daily potential GPP | $A_{0,daily}$ | mol CO₂ m⁻² day⁻¹ | GPP assuming fAPAR = 1 with actual β |
+| Annual potential GPP | $A_{0,annual}$ | mol CO₂ m⁻² yr⁻¹ | Yearly integral of daily $A_0$ with actual β |
+| Annual precipitation | $P_{annual}$ | mol H₂O m⁻² yr⁻¹ | Total yearly precipitation (1 mm ≈ 55.5 mol m⁻²) |
+| Growing season VPD | $D_{growing}$ | Pa | Mean VPD during growing season (T > 0°C) |
+| Growing season length | GSL | days | Length of continuous period with T > 0°C |
+| CO₂ partial pressure | $c_a$ | Pa | Ambient CO₂ (400 ppm ≈ 40 Pa at sea level) |
+
+## Output
+
+| Output | Symbol | Unit | Typical Range |
+| :--- | :---: | :---: | :---: |
+| Leaf Area Index | LAI | m² m⁻² | 0-10 |
+
+## Implementation Notes
+
+### Integration with Biomass Model
+
+The optimal LAI model is implemented as a `ZhouOptimalLAIModel`, a subtype of `AbstractBiomassModel`. LAI is stored in `p.canopy.biomass.area_index.leaf`, consistent with the `PrescribedBiomassModel` interface. Auxiliary variables (A0 accumulators, GSL, precip, VPD, f0) are stored under `p.canopy.biomass.*`.
+
+### Potential GPP Calculation
+
+The implementation computes potential GPP ($A_0$) directly from the P-model with fAPAR = 1 and actual β (soil moisture stress):
+
+```math
+A_0 = \text{PPFD} \times \text{LUE}
+```
+
+This differs from Zhou et al. (2025) who use β = 1 for potential GPP. Our implementation uses actual β to allow vegetation structure (LAI$_{max}$) to respond to water availability on annual timescales.
+
+### Daily and Annual A₀ Accumulation
+
+- **Daily A₀**: Accumulated every timestep by integrating instantaneous A₀. Finalized at local noon.
+- **Annual A₀**: Accumulated from daily values. Reset every 365 days.
+
+### Unit Conversions
+
+- **Precipitation**: 1 mm water = 1 kg m⁻² = 55.5 mol H₂O m⁻² (using molar mass of water = 18 g/mol)
+- **CO₂ partial pressure**: At standard pressure (101325 Pa), 400 ppm CO₂ ≈ 40.5 Pa
+- **A₀ units**: The P-model computes LUE in kg C/mol photons, so A₀ is converted to mol CO₂ using M$_c$ = 0.0120107 kg/mol
+
+## References
+
+[Zhou2025](@cite)

--- a/experiments/integrated/global/global_soil_canopy_pmodel.jl
+++ b/experiments/integrated/global/global_soil_canopy_pmodel.jl
@@ -85,21 +85,21 @@ ground = ClimaLand.PrognosticGroundConditions{FT}()
 canopy_domain = ClimaLand.obtain_surface_domain(domain)
 canopy_forcing = (; atmos, radiation, ground)
 
-LAI =
-    ClimaLand.Canopy.prescribed_lai_modis(surface_space, start_date, stop_date)
-
 # Construct the P model manually since it is not a default
 photosynthesis = PModel{FT}(canopy_domain, toml_dict)
 conductance = PModelConductance{FT}(toml_dict)
 
+# Use optimal LAI model (Zhou et al. 2025) instead of prescribed LAI
+biomass = Canopy.ZhouOptimalLAIModel{FT}(canopy_domain, toml_dict)
+
 canopy = Canopy.CanopyModel{FT}(
     canopy_domain,
     canopy_forcing,
-    LAI,
     toml_dict;
     prognostic_land_components,
     photosynthesis,
     conductance,
+    biomass,
 )
 
 # Combine the soil and canopy models into a single prognostic land model

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -198,6 +198,23 @@ function modis_lai_multiyear_paths(; start_date, stop_date, context = nothing)
 end
 
 """
+    optimal_lai_initial_conditions_path(; context = nothing)
+
+Return the path to the NetCDF file containing spatially varying initial conditions
+for the prognostic optimal LAI model:
+- GSL: Growing season length (days)
+- A0_annual: Annual potential GPP (mol CO₂ m⁻² yr⁻¹)
+- precip_annual: Mean annual precipitation (mol H₂O m⁻² yr⁻¹)
+- vpd_gs: Growing season VPD (Pa)
+- lai_init: Initial LAI from MODIS (m² m⁻²)
+"""
+function optimal_lai_initial_conditions_path(; context = nothing)
+    dir = @clima_artifact("optimal_lai_inputs", context)
+    return joinpath(dir, "optimal_lai_inputs.nc")
+end
+
+
+"""
     clm_data__folder_path(; context, lowres = false)
 
 Return the path to the folder that contains the clm data. If the lowres flag is set to true,

--- a/src/diagnostics/Diagnostics.jl
+++ b/src/diagnostics/Diagnostics.jl
@@ -25,7 +25,8 @@ import ..Canopy:
     get_Rd_leaf,
     MedlynConductanceModel,
     PModelConductance,
-    canopy_temperature
+    canopy_temperature,
+    ZhouOptimalLAIModel
 import ..Domains:
     top_center_to_surface,
     AbstractDomain,

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -439,6 +439,14 @@ function add_diagnostics!(
     append!(diagnostics, ["ws"])
     return nothing
 end
+function add_diagnostics!(
+    diagnostics,
+    model::CanopyModel,
+    subcomponent::ZhouOptimalLAIModel,
+)
+    append!(diagnostics, ["a0d", "a0a"])
+    return nothing
+end
 
 ## Possible diagnostics for standalone models
 """
@@ -516,6 +524,8 @@ function get_possible_diagnostics(model::CanopyModel)
 
     # Add conditional diagnostics based on atmosphere type
     add_diagnostics!(diagnostics, model, model.boundary_conditions.atmos)
+    # Add conditional diagnostics based on biomass model type
+    add_diagnostics!(diagnostics, model, model.biomass)
     return diagnostics
 end
 function get_possible_diagnostics(model::SnowModel)
@@ -611,7 +621,9 @@ function get_short_diagnostics(model::SoilCO2Model)
     return ["sco2"]
 end
 function get_short_diagnostics(model::CanopyModel)
-    return ["gpp", "ct", "lai", "trans", "er", "sif"]
+    diagnostics = ["gpp", "ct", "lai", "trans", "er", "sif"]
+    add_diagnostics!(diagnostics, model, model.biomass)
+    return diagnostics
 end
 function get_short_diagnostics(model::SnowModel)
     return get_possible_diagnostics(model)

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -325,6 +325,28 @@ function define_diagnostics!(land_model, possible_diags)
             compute_leaf_area_index!(out, Y, p, t, land_model),
     )
 
+    # Daily potential GPP (from optimal LAI model)
+    add_diagnostic_variable!(
+        short_name = "a0d",
+        long_name = "Daily Potential GPP",
+        standard_name = "daily_potential_gpp",
+        units = "mol CO2 m^-2 day^-1",
+        comments = "Cumulative sum of potential GPP (with fAPAR=1) over each day, used by the optimal LAI model.",
+        compute! = (out, Y, p, t) ->
+            compute_a0_daily!(out, Y, p, t, land_model),
+    )
+
+    # Annual potential GPP (from optimal LAI model)
+    add_diagnostic_variable!(
+        short_name = "a0a",
+        long_name = "Annual Potential GPP",
+        standard_name = "annual_potential_gpp",
+        units = "mol CO2 m^-2 yr^-1",
+        comments = "Cumulative sum of daily potential GPP (at local noon) over each year, used by the optimal LAI model.",
+        compute! = (out, Y, p, t) ->
+            compute_a0_annual!(out, Y, p, t, land_model),
+    )
+
     # Moisture stress factor
     conditional_add_diagnostic_variable!(
         possible_diags;

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -274,6 +274,11 @@ end
     CanopyModel,
 } p.canopy.biomass.area_index.leaf
 
+# Canopy - Optimal LAI model diagnostics
+@diagnostic_compute "a0_daily" Union{SoilCanopyModel, LandModel, CanopyModel} p.canopy.biomass.A0_daily
+
+@diagnostic_compute "a0_annual" Union{SoilCanopyModel, LandModel, CanopyModel} p.canopy.biomass.A0_annual
+
 # Canopy - Soil moisture stress
 @diagnostic_compute "moisture_stress_factor" Union{
     SoilCanopyModel,

--- a/src/standalone/Vegetation/biomass.jl
+++ b/src/standalone/Vegetation/biomass.jl
@@ -6,7 +6,10 @@ import ClimaUtilities.FileReaders: NCFileReader, read
 using DocStringExtensions
 
 export prescribed_lai_era5,
-    prescribed_lai_modis, PrescribedAreaIndices, update_biomass!
+    prescribed_lai_modis,
+    PrescribedAreaIndices,
+    update_biomass!,
+    ZhouOptimalLAIModel
 
 
 
@@ -316,4 +319,272 @@ where `rooting_depth` replaces (-1)/(100ln(β)) and z is expected to be negative
 """
 function root_distribution(z::FT, rooting_depth::FT) where {FT <: AbstractFloat}
     return (1 / rooting_depth) * exp(z / rooting_depth) # 1/m
+end
+
+#####################################################################
+# ZhouOptimalLAIModel - Optimal LAI model based on Zhou et al. (2025)
+#####################################################################
+
+"""
+    ZhouOptimalLAIModel{FT, OLPT <: OptimalLAIParameters{FT}, GD, RDTH, HTH} <: AbstractBiomassModel{FT}
+
+An implementation of the optimal LAI model from Zhou et al. (2025) as a biomass model.
+
+This model computes LAI dynamically based on optimality principles, balancing energy and
+water constraints. LAI is stored in `p.canopy.biomass.area_index.leaf`, consistent with
+`PrescribedBiomassModel`.
+
+# Fields
+- `parameters`: Required parameters for the optimal LAI model
+- `optimal_lai_inputs`: NamedTuple with spatially varying GSL (growing season length in days),
+  A0_annual (annual potential GPP in mol CO2 m^-2 yr^-1), precip_annual (mol H2O m^-2 yr^-1),
+  vpd_gs (Pa), lai_init (initial LAI from MODIS), and f0 (fraction of precip for transpiration),
+  typically created using `optimal_lai_initial_conditions`.
+- `SAI`: Prescribed stem area index (m^2 m^-2)
+- `RAI`: Prescribed root area index (m^2 m^-2)
+- `rooting_depth`: Rooting depth parameter (m) - a characteristic depth below which 1/e of the root mass lies
+- `height`: Canopy height (m) - can be scalar (uniform) or spatially-varying Field
+
+# References
+Zhou et al. (2025) "A General Model for the Seasonal to Decadal Dynamics of Leaf Area"
+Global Change Biology. https://onlinelibrary.wiley.com/doi/pdf/10.1111/gcb.70125
+"""
+struct ZhouOptimalLAIModel{
+    FT,
+    OLPT <: OptimalLAIParameters{FT},
+    GD,
+    RDTH <: Union{FT, ClimaCore.Fields.Field},
+    HTH <: Union{FT, ClimaCore.Fields.Field},
+} <: AbstractBiomassModel{FT}
+    "Required parameters for the optimal LAI model"
+    parameters::OLPT
+    "Spatially varying initial conditions (GSL, A0_annual, precip_annual, vpd_gs, lai_init, f0)"
+    optimal_lai_inputs::GD
+    "Prescribed stem area index (m^2 m^-2)"
+    SAI::FT
+    "Prescribed root area index (m^2 m^-2)"
+    RAI::FT
+    "Rooting depth parameter (m)"
+    rooting_depth::RDTH
+    "Canopy height (m) - can be scalar (uniform) or spatially-varying Field"
+    height::HTH
+end
+
+Base.eltype(::ZhouOptimalLAIModel{FT}) where {FT} = FT
+
+"""
+    ZhouOptimalLAIModel{FT}(
+        parameters::OptimalLAIParameters{FT},
+        optimal_lai_inputs;
+        SAI::FT,
+        RAI::FT,
+        rooting_depth,
+        height,
+    ) where {FT <: AbstractFloat}
+
+Outer constructor for the ZhouOptimalLAIModel struct.
+
+# Arguments
+- `parameters`: OptimalLAIParameters for the model
+- `optimal_lai_inputs`: NamedTuple with spatially varying GSL, A0_annual, precip_annual, vpd_gs, lai_init, f0 fields,
+  typically created using `optimal_lai_initial_conditions`.
+- `SAI`: Prescribed stem area index (m^2 m^-2)
+- `RAI`: Prescribed root area index (m^2 m^-2)
+- `rooting_depth`: Rooting depth parameter (m)
+- `height`: Canopy height (m) - can be scalar or spatially-varying Field
+"""
+function ZhouOptimalLAIModel{FT}(
+    parameters::OptimalLAIParameters{FT},
+    optimal_lai_inputs;
+    SAI::FT,
+    RAI::FT,
+    rooting_depth,
+    height,
+) where {FT <: AbstractFloat}
+    return ZhouOptimalLAIModel{
+        FT,
+        typeof(parameters),
+        typeof(optimal_lai_inputs),
+        typeof(rooting_depth),
+        typeof(height),
+    }(
+        parameters,
+        optimal_lai_inputs,
+        SAI,
+        RAI,
+        rooting_depth,
+        height,
+    )
+end
+
+"""
+    ClimaLand.auxiliary_vars(model::ZhouOptimalLAIModel)
+    ClimaLand.auxiliary_types(model::ZhouOptimalLAIModel)
+    ClimaLand.auxiliary_domain_names(model::ZhouOptimalLAIModel)
+
+Defines the auxiliary variables for the ZhouOptimalLAIModel:
+- `area_index`: NamedTuple{(:root, :stem, :leaf)} containing area indices (m^2 m^-2)
+- `A0_daily`: daily potential GPP from previous day (mol CO2 m^-2 day^-1), with moisture stress factor beta
+- `A0_annual`: annual potential GPP from previous year (mol CO2 m^-2 yr^-1), with actual moisture stress factor beta
+- `A0_daily_acc`: accumulator for current day's potential GPP (mol CO2 m^-2 day^-1)
+- `A0_annual_acc`: accumulator for current year's potential GPP (mol CO2 m^-2 yr^-1), sum of daily values at noon
+- `GSL`: growing season length (days), spatially varying
+- `precip_annual`: mean annual precipitation (mol H2O m^-2 yr^-1), for water limitation in LAI_max
+- `vpd_gs`: mean VPD during growing season (Pa), for water limitation WUE factor in LAI_max
+- `f0`: spatially varying fraction of precipitation for transpiration (dimensionless), from Zhou et al.
+"""
+ClimaLand.auxiliary_vars(model::ZhouOptimalLAIModel) = (
+    :area_index,
+    :A0_daily,
+    :A0_annual,
+    :A0_daily_acc,
+    :A0_annual_acc,
+    :days_since_reset,
+    :GSL,
+    :precip_annual,
+    :vpd_gs,
+    :f0,
+)
+ClimaLand.auxiliary_types(model::ZhouOptimalLAIModel{FT}) where {FT} = (
+    NamedTuple{(:root, :stem, :leaf), Tuple{FT, FT, FT}},
+    FT,
+    FT,
+    FT,
+    FT,
+    FT,
+    FT,
+    FT,
+    FT,
+    FT,
+)
+ClimaLand.auxiliary_domain_names(::ZhouOptimalLAIModel) = (
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+    :surface,
+)
+
+"""
+    update_biomass!(
+        p,
+        Y,
+        t,
+        component::ZhouOptimalLAIModel{FT},
+        canopy,
+    ) where {FT}
+
+Sets the SAI and RAI to their prescribed constant values.
+
+Note: LAI is updated via the optimal LAI callback (make_OptimalLAI_callback) at local noon,
+not in this function. This function only handles the constant area indices (SAI and RAI).
+"""
+function update_biomass!(
+    p,
+    Y,
+    t,
+    component::ZhouOptimalLAIModel{FT},
+    canopy,
+) where {FT}
+    (; SAI, RAI) = component
+    @. p.canopy.biomass.area_index.stem = SAI
+    @. p.canopy.biomass.area_index.root = RAI
+    # LAI is updated via the callback, not here
+    # Apply clipping to LAI (same as PrescribedBiomassModel)
+    p.canopy.biomass.area_index.leaf .=
+        clip.(p.canopy.biomass.area_index.leaf, FT(0.05))
+end
+
+"""
+    set_historical_cache!(p, Y0, model::ZhouOptimalLAIModel, canopy; A0_daily)
+
+The optimal LAI model requires initialization of LAI and A0 values before the simulation.
+
+GSL, A0_annual, precip_annual, vpd_gs, lai_init, and f0 are taken from `model.optimal_lai_inputs`, which
+contains spatially varying fields typically created using `optimal_lai_initial_conditions`.
+
+LAI is initialized from MODIS satellite observations (`lai_init`) rather than computing
+equilibrium from model equations. This provides a realistic starting point that reduces
+spin-up time and matches observed vegetation patterns.
+
+# Arguments
+- `A0_daily`: Initial daily potential GPP (mol CO2 m^-2 day^-1), default 0.5.
+
+# Notes
+- precip_annual is in mol H2O m^-2 yr^-1 (converted from ERA5 kg m^-2 s^-1 in optimal_lai_inputs.jl)
+  to match Zhou et al. (2025) formulation for water limitation.
+- vpd_gs is the mean VPD during growing season (Pa), used in the WUE factor for water limitation.
+- lai_init comes from MODIS first timestep, providing spatially-varying initial conditions.
+- f0 is the spatially varying fraction of precipitation for transpiration from Zhou et al.
+"""
+function set_historical_cache!(
+    p,
+    Y0,
+    model::ZhouOptimalLAIModel,
+    canopy;
+    A0_daily = zero(eltype(model.parameters)),
+)
+    parameters = model.parameters
+    optimal_lai_inputs = model.optimal_lai_inputs
+    FT = eltype(parameters)
+
+    # Get spatially varying data from optimal_lai_inputs
+    GSL = optimal_lai_inputs.GSL
+    A0_annual = optimal_lai_inputs.A0_annual
+    precip_annual = optimal_lai_inputs.precip_annual  # in mol H2O m^-2 yr^-1
+    vpd_gs = optimal_lai_inputs.vpd_gs  # in Pa
+    lai_init = optimal_lai_inputs.lai_init  # MODIS first timestep
+    f0 = optimal_lai_inputs.f0  # spatially varying f0 from Zhou et al.
+
+    L = p.canopy.biomass.area_index.leaf
+
+    # Initialize LAI from MODIS satellite observations
+    # This provides realistic spatially-varying initial conditions that reduce spin-up time
+    L .= lai_init
+
+    # Initialize A0 variables (supports both scalar and Field inputs via .=)
+    p.canopy.biomass.A0_daily .= A0_daily
+    p.canopy.biomass.A0_annual .= A0_annual
+    p.canopy.biomass.A0_daily_acc .= FT(0)
+    p.canopy.biomass.A0_annual_acc .= FT(0)
+    p.canopy.biomass.days_since_reset .= FT(0)
+
+    # Store GSL in the cache (spatially varying field)
+    p.canopy.biomass.GSL .= GSL
+
+    # Store precip_annual (already in mol H2O m^-2 yr^-1 from optimal_lai_inputs.nc)
+    p.canopy.biomass.precip_annual .= precip_annual
+
+    # Store vpd_gs (already in Pa)
+    p.canopy.biomass.vpd_gs .= vpd_gs
+
+    # Store f0 (spatially varying fraction of precipitation for transpiration)
+    p.canopy.biomass.f0 .= f0
+end
+
+"""
+    get_model_callbacks(component::ZhouOptimalLAIModel, canopy; t0, Δt)
+
+Creates the optimal LAI callback and returns it as a single element tuple of model callbacks.
+
+# Notes
+- Daily A0 is computed with moisture stress factor beta - drives L_steady
+- Annual A0 is computed with actual moisture stress factor beta - used for LAI_max
+- Water limitation enters LAI_max through the f0*P/A0 * (ca(1-chi))/(1.6*D) term (Equation 11)
+- GSL (Growing Season Length) is read from p.canopy.biomass.GSL, which supports spatially
+  varying values initialized via set_historical_cache!.
+"""
+function get_model_callbacks(
+    component::ZhouOptimalLAIModel{FT},
+    canopy;
+    t0,
+    Δt,
+) where {FT}
+    lai_cb = make_OptimalLAI_callback(FT, t0, Δt, canopy)
+    return (lai_cb,)
 end

--- a/src/standalone/Vegetation/optimal_lai.jl
+++ b/src/standalone/Vegetation/optimal_lai.jl
@@ -1,0 +1,709 @@
+export OptimalLAIParameters,
+    compute_L_max,
+    compute_m,
+    lambertw0,
+    compute_steady_state_LAI,
+    compute_LAI,
+    update_optimal_LAI,
+    call_update_optimal_LAI,
+    make_OptimalLAI_callback
+
+"""
+    OptimalLAIParameters{FT<:AbstractFloat}
+
+The required parameters for the optimal LAI model based on Zhou et al. (2025).
+
+Water limitation is handled through the f0*P/A0 term following Zhou et al. (2025) Equation 11,
+where P is annual precipitation and A0 is annual potential GPP.
+
+# References
+Zhou et al. (2025) "A General Model for the Seasonal to Decadal Dynamics of Leaf Area"
+Global Change Biology. https://onlinelibrary.wiley.com/doi/pdf/10.1111/gcb.70125
+
+$(DocStringExtensions.FIELDS)
+"""
+Base.@kwdef struct OptimalLAIParameters{FT <: AbstractFloat}
+    """Light extinction coefficient (dimensionless), typically 0.5"""
+    k::FT
+    """Unit cost of constructing and maintaining leaves (mol m^-2 yr^-1), globally fitted as 12.227 mol m^-2 yr^-1"""
+    z::FT
+    """Dimensionless parameter representing departure from square-wave LAI dynamics, globally fitted as 0.771"""
+    sigma::FT
+    """Smoothing factor for exponential moving average (dimensionless, 0-1). Set to 0.067 for ~15 days of memory"""
+    alpha::FT
+    """Fraction of annual precipitation available for transpiration (dimensionless, 0-1).
+    Following Zhou et al. (2025), f0 = 0.65 at the energy-water limitation transition.
+    In arid regions, f0 can be lower: f0 = 0.65 * exp(-0.604 * ln^2(AI/1.9)) where AI is aridity index.
+    Default value 0.65 assumes optimal water use efficiency."""
+    f0::FT
+end
+
+Base.eltype(::OptimalLAIParameters{FT}) where {FT} = FT
+
+# make these custom structs broadcastable as tuples
+Base.broadcastable(x::OptimalLAIParameters) = tuple(x)
+
+"""
+    OptimalLAIParameters{FT}(toml_dict::CP.ParamDict) where {FT}
+
+Creates an `OptimalLAIParameters` object from a TOML parameter dictionary.
+"""
+function OptimalLAIParameters{FT}(toml_dict::CP.ParamDict) where {FT}
+    return OptimalLAIParameters{FT}(
+        k = FT(toml_dict["optimal_lai_k"]),
+        z = FT(toml_dict["optimal_lai_z"]),
+        sigma = FT(toml_dict["optimal_lai_sigma"]),
+        alpha = FT(toml_dict["optimal_lai_alpha"]),
+        f0 = FT(toml_dict["optimal_lai_f0"]),
+    )
+end
+
+"""
+    compute_L_max(Ao_annual, k, z, precip_annual, f0, ca_pa, chi, vpd_gs)
+
+Compute seasonal maximum leaf area index (LAI_max) based on annual potential GPP
+and water availability, following Zhou et al. (2025) Equation 11.
+
+LAI_max is determined by the minimum of energy-limited and water-limited fAPAR:
+- Energy-limited: fAPAR_energy = 1 - z/(k*A0)
+- Water-limited: fAPAR_water = f0*P/A0 * (ca(1-chi))/(1.6*D)
+
+# Arguments
+- `Ao_annual::FT`: Annual total potential GPP (mol CO2 m^-2 yr^-1).
+- `k::FT`: Light extinction coefficient (dimensionless), typically 0.5
+- `z::FT`: Unit cost of constructing and maintaining leaves (mol m^-2 yr^-1), 12.227
+- `precip_annual::FT`: Mean annual precipitation (mol H2O m^-2 yr^-1)
+- `f0::FT`: Fraction of precipitation available for transpiration (dimensionless), 0.65
+- `ca_pa::FT`: Ambient CO2 partial pressure (Pa), typically ~40 Pa at 400 ppm
+- `chi::FT`: Optimal ratio of intercellular to ambient CO2 (dimensionless), typically 0.7-0.8
+- `vpd_gs::FT`: Mean vapor pressure deficit during growing season (Pa)
+
+# Returns
+- `LAI_max::FT`: Seasonal maximum leaf area index (m^2 m^-2)
+
+# Notes
+Following Zhou et al. (2025) Equation 11:
+```
+fAPAR_max = min{1 - z/(k*A0), f0*P/A0 * (ca(1-chi))/(1.6*D)}
+```
+The first term is energy-limited (carbon gain vs leaf cost trade-off).
+The second term is water-limited (precipitation constrains transpiration, scaled by
+intrinsic water use efficiency iWUE = ca(1-chi)/(1.6*D)).
+
+The iWUE factor converts water flux to carbon flux:
+- ca(1-chi): CO2 drawdown from ambient to intercellular (Pa)
+- 1.6*D: VPD adjusted for CO2/H2O diffusivity ratio (Pa)
+
+# References
+Zhou et al. (2025) Global Change Biology, Equation 11
+"""
+function compute_L_max(
+    Ao_annual::FT,      # mol CO2 m^-2 yr^-1
+    k::FT,              # dimensionless
+    z::FT,              # mol m^-2 yr^-1
+    precip_annual::FT,  # mol H2O m^-2 yr^-1
+    f0::FT,             # dimensionless
+    ca_pa::FT,          # Pa
+    chi::FT,            # dimensionless
+    vpd_gs::FT,         # Pa
+) where {FT}
+    # Handle edge case: very small or zero Ao_annual (e.g., polar regions)
+    # When Ao_annual ~ 0, z / (k * Ao_annual) -> Inf, causing numerical issues.
+    # Use ifelse for GPU compatibility.
+    Ao_annual_safe = max(Ao_annual, eps(FT))
+
+    # Energy-limited fAPAR (Equation 11, first term)
+    # Plants optimize leaf area to maximize carbon gain minus construction cost
+    fAPAR_energy = FT(1) - z / (k * Ao_annual_safe)
+
+    # Water-limited fAPAR (Equation 11, second term)
+    # fAPAR_water = f0 * P / A0 * (ca(1-chi)) / (1.6*D)
+    # The iWUE factor (ca(1-chi))/(1.6*D) converts water flux to carbon flux
+    # Guard against zero VPD
+    vpd_safe = max(vpd_gs, eps(FT))
+    iWUE_factor = (ca_pa * (FT(1) - chi)) / (FT(1.6) * vpd_safe)
+    fAPAR_water = f0 * precip_annual / Ao_annual_safe * iWUE_factor
+
+    # fAPAR_max is the minimum of energy and water constraints (Equation 11)
+    fAPAR_max = min(fAPAR_energy, fAPAR_water)
+
+    # Ensure fAPAR is in valid range [0, 1]
+    fAPAR_max = max(FT(0), min(FT(1), fAPAR_max))
+
+    # Convert fAPAR to LAI using Beer's law (Equation 12)
+    # fAPAR = 1 - exp(-k * LAI)  ->  LAI = -(1/k) * ln(1 - fAPAR)
+    # Guard against fAPAR_max = 1 which would give -log(0) = Inf
+    fAPAR_max_safe = min(fAPAR_max, FT(1) - eps(FT))
+    LAI_max = -(FT(1) / k) * log(FT(1) - fAPAR_max_safe)
+
+    return LAI_max
+end
+
+fAPAR_max_fun(k::FT, LAI_max::FT) where {FT} = FT(1) - exp(-k * LAI_max)
+
+"""
+    compute_m(GSL, LAI_max, Ao_annual, sigma, k)
+
+Compute the parameter m, which represents the ratio of steady-state LAI to steady-state GPP.
+
+This implements Equation 20 from Zhou et al. (2025). The parameter m quantifies the
+relationship between LAI and GPP dynamics, representing the extent to which seasonal LAI
+dynamics depart from a "square wave" (where maximum LAI would be maintained throughout
+the growing season).
+
+# Arguments
+- `GSL::FT`: Growing season length (days). Defined as the length of continuous period
+  above 0C longer than 5 days.
+- `LAI_max::FT`: Seasonal maximum leaf area index (m^2 m^-2, dimensionless)
+- `Ao_annual::FT`: Annual total potential GPP (mol m^-2 yr^-1). This is the integral of daily
+  A0 over the year.
+- `sigma::FT`: Dimensionless parameter representing departure from square-wave LAI dynamics.
+  Globally fitted as sigma = 0.771
+- `k::FT`: Light extinction coefficient (dimensionless)
+
+# Returns
+- `m::FT`: Parameter relating steady-state LAI to steady-state GPP (dimensionless, units
+  work out as: days * m^2 m^-2 / (mol m^-2 yr^-1 * dimensionless) with implicit conversion)
+
+# References
+Zhou et al. (2025) Global Change Biology, Equation 20
+"""
+function compute_m(
+    GSL::FT,        # days
+    LAI_max::FT,    # m^2 m^-2 (dimensionless)
+    Ao_annual::FT,  # mol m^-2 yr^-1
+    sigma::FT,      # dimensionless
+    k::FT,
+) where {FT}
+    # Equation 20: m = (sigma * GSL * LAI_max) / (A0_sum * fAPAR_max)
+    fAPAR_max = fAPAR_max_fun(k, LAI_max)
+
+    # Guard against division by zero: when LAI_max ~ 0, fAPAR_max ~ 0,
+    # but the numerator (sigma * GSL * LAI_max) is also ~ 0, so m ~ 0 naturally.
+    fAPAR_max_safe = max(fAPAR_max, eps(FT))
+    Ao_annual_safe = max(Ao_annual, eps(FT))
+    m = (sigma * GSL * LAI_max) / (Ao_annual_safe * fAPAR_max_safe)
+    return m
+end
+
+const MINARG = -inv(Base.MathConstants.e)
+
+"""
+    _lambertw0_initial_guess(x::T) where {T<:AbstractFloat}
+
+Provide a robust initial guess for the Lambert W0 function for use in iterative solvers.
+
+# Arguments
+- `x::T`: Input value, should be >= -1/e
+
+# Returns
+- Initial guess for W0(x)
+
+# Algorithm
+- For x > 1: uses log(x) - log(log(x)) approximation
+- For x < -0.32 (near -1/e): uses series expansion for accurate convergence near branch point
+- For -0.32 <= x <= 1: uses max(x, -0.3) as a simple starting point
+"""
+@inline function _lambertw0_initial_guess(x::T) where {T <: AbstractFloat}
+    if x > one(T)
+        return log(x) - log(max(log(x), T(1e-6)))
+    elseif x < T(-0.32)
+        # Near the branch point -1/e, use series expansion
+        # This handles the singular behavior at x = -1/e where W(x) = -1
+        p = sqrt(T(2) * (T(ℯ) * x + one(T)))
+        return -one(T) + p - p^2 / T(3) + p^3 * T(11) / T(72)
+    else
+        return max(x, T(-0.3))
+    end
+end
+
+"""
+    lambertw0(x::T; maxiter::Int = 8) where {T<:AbstractFloat}
+
+Compute the principal branch (W0) of the Lambert W function for x in [-1/e, Inf).
+
+This is a GPU-device-friendly implementation using a fixed number of Halley iterations.
+The Lambert W function satisfies W(x)*exp(W(x)) = x.
+
+# Arguments
+- `x::T`: Input value, must be >= -1/e ~ -0.36788
+- `maxiter::Int`: Maximum number of Halley iterations (default: 8; Halley's method has cubic convergence, so 8 is generous)
+
+# Returns
+- `W::T`: Lambert W0(x), the principal branch value, or NaN for invalid inputs
+
+# Algorithm
+Uses Halley's method with a fixed number of iterations for GPU compatibility:
+- No dynamic memory allocation
+- No conditional breaks (runs all iterations)
+- Broadcastable for use with CuArrays: lambertw0.(cuarray)
+
+# Device Compatibility
+This implementation is designed to work on both CPU and GPU:
+- All operations are scalar and supported on CUDA.jl
+- No array allocations or dynamic loops
+- Type-generic over AbstractFloat (Float32, Float64)
+
+# References
+Corless et al. (1996) "On the Lambert W function"
+"""
+@inline function lambertw0(x::T; maxiter::Int = 8) where {T <: AbstractFloat}
+    # In our usage, arg = -k*mu*exp(-k*mu) with k > 0, mu >= 0,
+    # so x is always in [-1/e, 0]. This check is a safety net.
+    if !(isfinite(x)) || x < T(MINARG)
+        return T(NaN)
+    end
+    w = _lambertw0_initial_guess(x)
+    for i in 1:maxiter
+        ew = exp(w)
+        f = w * ew - x
+        # Halley denominator
+        # Special case: when w ~ -1, both numerator and denominator approach 0
+        # This happens at the branch point x = -1/e, where W(-1/e) = -1
+        w_plus_1 = w + one(T)
+        if abs(w_plus_1) < eps(T)
+            # Already at or very near the solution w = -1, no update needed
+            Δ = zero(T)
+        else
+            two_w_plus_2 = T(2) * w_plus_1
+            if abs(two_w_plus_2) < eps(T)
+                # Near w = -1, use Newton's method instead of Halley
+                Δ = f / (ew * w_plus_1)
+            else
+                denom = ew * w_plus_1 - (w + T(2)) * f / two_w_plus_2
+                if abs(denom) < eps(T)
+                    Δ = f / (ew * w_plus_1)
+                else
+                    Δ = f / denom
+                end
+            end
+        end
+        w -= Δ
+    end
+    return w
+end
+
+"""
+    compute_steady_state_LAI(Ao_daily, m, k, LAI_max)
+
+Compute steady-state LAI from daily potential GPP using the Lambert W function solution.
+
+This implements Equations 13-15 from Zhou et al. (2025). The steady-state LAI (L_s) is
+the LAI that would be in equilibrium with GPP if weather conditions were held constant.
+Given daily meteorological conditions, this is computed on a daily basis.
+
+# Arguments
+- `Ao_daily::FT`: Daily potential GPP (mol m^-2 day^-1). This is the GPP that would be
+  achieved if fAPAR = 1, calculated from LUE * PPFD.
+- `m::FT`: Parameter relating steady-state LAI to steady-state GPP (dimensionless), from
+  `compute_m()`
+- `k::FT`: Light extinction coefficient (dimensionless), typically 0.5
+- `LAI_max::FT`: Seasonal maximum LAI constraint (m^2 m^-2, dimensionless)
+
+# Returns
+- `L_steady::FT`: Steady-state leaf area index (m^2 m^-2, dimensionless). Always >= 0.
+
+# Notes
+The solution uses the Lambert W0 function: L_s = min{mu + (1/k)W0[-k*mu*exp(-k*mu)], LAI_max}
+where mu = m * A0. The result is constrained to be non-negative and below LAI_max.
+
+# References
+Zhou et al. (2025) Global Change Biology, Equations 13-15
+"""
+function compute_steady_state_LAI(
+    Ao_daily::FT,  # mol m^-2 day^-1
+    m::FT,         # dimensionless
+    k::FT,         # dimensionless
+    LAI_max::FT,   # m^2 m^-2 (dimensionless)
+) where {FT}
+    # mu = m * A0 (Equation 15)
+    mu = m * Ao_daily
+
+    # Compute argument for Lambert W function
+    arg = -k * mu * exp(-k * mu)
+
+    # Check if argument is in valid range for W0 branch: [-1/e, 0]
+    # If outside this range, use boundary solution
+    if arg < -FT(1) / FT(exp(1))
+        # Beyond valid range; use maximum possible LAI
+        L_s = LAI_max
+    else
+        # Equation 15: L_s = mu + (1/k) * W0[-k mu exp(-k mu)]
+        # Using our custom lambertw0 function (W0 is the principal branch)
+        w_val = lambertw0(arg)
+        L_s = mu + (FT(1) / k) * w_val
+
+        # Take minimum with LAI_max (Equation 15)
+        L_s = min(L_s, LAI_max)
+    end
+
+    # Ensure non-negative (should be guaranteed mathematically, but enforce for numerical stability)
+    L_s = max(zero(FT), L_s)
+
+    return L_s
+end
+
+"""
+    compute_LAI(LAI_prev, L_steady, alpha, local_noon_mask)
+
+Compute updated LAI using exponential weighted moving average to represent lag between carbon
+allocation and steady-state LAI.
+
+This implements Equation 16 from Zhou et al. (2025). The exponential moving average
+represents the time lag (days to months) for photosynthate allocation to leaves and
+leaf development.
+
+# Arguments
+- `LAI_prev::FT`: LAI from previous time step (m^2 m^-2, dimensionless)
+- `L_steady::FT`: Current steady-state LAI (m^2 m^-2, dimensionless), from
+  `compute_steady_state_LAI()`
+- `alpha::FT`: Smoothing factor (dimensionless, 0-1). Set to 0.067 for ~15 days of memory,
+  meaning LAI[t] = 0.067 * L_steady[t] + 0.933 * LAI[t-1]
+- `local_noon_mask::FT`: A mask (0 or 1) indicating whether the current time is within the local noon window.
+
+# Returns
+- `LAI_new::FT`: Updated leaf area index (m^2 m^-2, dimensionless). Always >= 0.
+
+# Notes
+The parameter alpha controls the response time:
+- alpha = 0.067 ~ 15 days of memory (paper default)
+- alpha = 0.1 ~ 10 days of memory (faster response)
+- alpha = 0.033 ~ 30 days of memory (slower response)
+
+The time scale tau ~ 1/alpha days.
+
+# References
+Zhou et al. (2025) Global Change Biology, Equation 16
+"""
+function compute_LAI(
+    LAI_prev::FT,   # m^2 m^-2 (dimensionless)
+    L_steady::FT,   # m^2 m^-2 (dimensionless)
+    alpha::FT,      # dimensionless (0-1)
+    local_noon_mask::FT,
+) where {FT}
+    if local_noon_mask == FT(1.0)
+        # Equation 16: LAI_sim = alpha * L_s[t] + (1-alpha) * LAI_sim[t-1]
+        LAI_new = alpha * L_steady + (1 - alpha) * LAI_prev
+
+        # L_steady is already clipped to >= 0 in compute_steady_state_LAI,
+        # so this is a safety net for initialization edge cases only.
+        LAI_new = max(zero(FT), LAI_new)
+        return LAI_new
+    else
+        return LAI_prev
+    end
+end
+
+"""
+    update_optimal_LAI(local_noon_mask, A0_daily, L, k, A0_annual, z, GSL, sigma, alpha, precip_annual, f0, ca_pa, chi, vpd_gs)
+
+Update LAI using the optimal LAI model with precomputed daily and annual potential GPP.
+
+# Arguments
+- `local_noon_mask::FT`: Mask (0 or 1) indicating if it's local noon
+- `A0_daily::FT`: Daily potential GPP (mol CO2 m^-2 day^-1), with moisture stress factor beta
+- `L::FT`: Current LAI (m^2 m^-2)
+- `k::FT`: Light extinction coefficient
+- `A0_annual::FT`: Annual potential GPP (mol CO2 m^-2 yr^-1)
+- `z::FT`: Unit cost of constructing and maintaining leaves (mol m^-2 yr^-1)
+- `GSL::FT`: Growing season length (days)
+- `sigma::FT`: Dimensionless parameter for LAI dynamics
+- `alpha::FT`: Smoothing factor for exponential moving average (~15-day memory)
+- `precip_annual::FT`: Mean annual precipitation (mol H2O m^-2 yr^-1)
+- `f0::FT`: Fraction of precipitation available for transpiration (dimensionless)
+- `ca_pa::FT`: Ambient CO2 partial pressure (Pa)
+- `chi::FT`: Optimal ratio of intercellular to ambient CO2 (dimensionless)
+- `vpd_gs::FT`: Mean vapor pressure deficit during growing season (Pa)
+
+# Returns
+Updated LAI value.
+
+# Notes
+Following Zhou et al. (2025):
+- A0_daily uses moisture stress factor beta to drive daily LAI dynamics
+- A0_annual uses actual moisture stress factor beta for LAI_max computation
+- Water limitation enters LAI_max through the f0*P/A0 * (ca(1-chi))/(1.6*D) term (Equation 11)
+"""
+function update_optimal_LAI(
+    local_noon_mask::FT,
+    A0_daily::FT,
+    L::FT, # m2 m-2
+    k::FT,
+    A0_annual::FT, # mol CO2 m-2 y-1
+    z::FT, # mol m-2 yr-1, leaf construction cost
+    GSL::FT, # days, growing season length
+    sigma::FT, # dimensionless
+    alpha::FT, # dimensionless (~15-day memory)
+    precip_annual::FT, # mol H2O m-2 yr-1, mean annual precipitation
+    f0::FT, # dimensionless, fraction of precip for transpiration
+    ca_pa::FT, # Pa, ambient CO2 partial pressure
+    chi::FT, # dimensionless, optimal ci/ca ratio
+    vpd_gs::FT, # Pa, mean VPD during growing season
+) where {FT}
+    LAI_max =
+        compute_L_max(A0_annual, k, z, precip_annual, f0, ca_pa, chi, vpd_gs)
+    m = compute_m(GSL, LAI_max, A0_annual, sigma, k)
+    L_steady = compute_steady_state_LAI(A0_daily, m, k, LAI_max)
+    L = compute_LAI(L, L_steady, alpha, local_noon_mask)
+    return L
+end
+
+
+"""
+    call_update_optimal_LAI(p, Y, t, current_date; canopy, dt, local_noon)
+
+Updates LAI and accumulates potential GPP (A0) at each timestep.
+
+Every timestep: accumulates instantaneous potential GPP into the daily accumulator.
+At local noon: finalizes daily A0, adds it to annual accumulator, updates LAI.
+Every 365 days: finalizes annual A0 from the accumulator.
+
+Uses air temperature (not canopy temperature) for A0 computation, since canopy
+temperature includes energy balance feedbacks that should not affect potential GPP.
+
+GSL (Growing Season Length) is read from p.canopy.biomass.GSL, which supports spatially
+varying values initialized via set_historical_cache!.
+"""
+function call_update_optimal_LAI(p, Y, t, current_date; canopy, dt, local_noon)
+    FT = eltype(canopy.biomass.parameters)
+
+    # Compute local noon mask
+    local_noon_mask = @. lazy(get_local_noon_mask(t, dt, local_noon))
+
+    # Get P-model parameters and constants for computing A0
+    pmodel_parameters = canopy.photosynthesis.parameters
+    pmodel_constants = canopy.photosynthesis.constants
+    is_c3 = canopy.photosynthesis.is_c3
+
+    # Get drivers for A0 computation
+    # Use air temperature (not canopy temperature) for potential GPP computation.
+    # Canopy temperature includes energy balance feedbacks that should not affect A0.
+    T_air = p.drivers.T
+    P_air = p.drivers.P
+    ca = p.drivers.c_co2  # mol/mol
+    earth_param_set = canopy.earth_param_set
+
+    # Get soil moisture stress factor (beta)
+    βm = p.canopy.soil_moisture_stress.βm
+
+    # Compute VPD (clipped to avoid numerical issues)
+    VPD = @. lazy(
+        max(
+            Thermodynamics.vapor_pressure_deficit(
+                LP.thermodynamic_parameters(earth_param_set),
+                p.drivers.T,
+                p.drivers.P,
+                p.drivers.q,
+            ),
+            sqrt(eps(FT)),
+        ),
+    )
+
+    # Compute PPFD from PAR downwelling (total incoming, not absorbed)
+    par_d = p.canopy.radiative_transfer.par_d
+    λ_γ_PAR = canopy.radiative_transfer.parameters.λ_γ_PAR
+    PPFD = @. lazy(
+        compute_PPFD(
+            par_d,
+            λ_γ_PAR,
+            pmodel_constants.lightspeed,
+            pmodel_constants.planck_h,
+            pmodel_constants.N_a,
+        ),
+    )
+
+    # Compute instantaneous potential GPP (kg C m^-2 s^-1)
+    # A single computation serves both daily and annual accumulation
+    dt_seconds = FT(float(dt))
+    Mc = pmodel_constants.Mc
+    @. p.canopy.biomass.A0_daily_acc +=
+        compute_A0_daily(
+            is_c3,
+            pmodel_parameters,
+            pmodel_constants,
+            T_air,
+            P_air,
+            VPD,
+            ca,
+            PPFD,
+            βm,
+        ) * dt_seconds / Mc
+
+    # Get parameters from the biomass model
+    parameters = canopy.biomass.parameters
+
+    # At local noon: finalize daily A0, update annual accumulator, update LAI
+    # Snapshot the daily accumulator before any resets
+    A0_daily_final = @. p.canopy.biomass.A0_daily_acc
+
+    # Use days_since_reset to track accumulation period (365-day rolling window).
+    # This ensures the first annual update happens exactly 365 days after
+    # simulation start, and subsequent updates every 365 days thereafter.
+    days_since_reset = p.canopy.biomass.days_since_reset
+
+    # At noon: finalize annual A0 when we have accumulated 365 days
+    A0_annual_final = @. ifelse(
+        local_noon_mask == FT(1) && days_since_reset >= FT(365),
+        p.canopy.biomass.A0_annual_acc,
+        p.canopy.biomass.A0_annual,
+    )
+
+    # Compute chi for water limitation term (using growing season mean VPD)
+    chi = @. lazy(
+        compute_chi(
+            pmodel_parameters,
+            pmodel_constants,
+            T_air,
+            P_air,
+            p.canopy.biomass.vpd_gs,
+            ca,
+        ),
+    )
+
+    # Update LAI at noon using the finalized values
+    @. p.canopy.biomass.area_index.leaf = ifelse(
+        local_noon_mask == FT(1),
+        update_optimal_LAI(
+            FT(1),  # At noon, we always update
+            A0_daily_final,
+            p.canopy.biomass.area_index.leaf,
+            parameters.k,
+            A0_annual_final,
+            parameters.z,
+            p.canopy.biomass.GSL,
+            parameters.sigma,
+            parameters.alpha,
+            p.canopy.biomass.precip_annual,
+            p.canopy.biomass.f0,
+            ca * P_air,  # ca_pa: CO2 partial pressure (Pa)
+            chi,
+            p.canopy.biomass.vpd_gs,
+        ),
+        p.canopy.biomass.area_index.leaf,
+    )
+
+    # Update A0_annual when 365 days have accumulated
+    @. p.canopy.biomass.A0_annual = ifelse(
+        local_noon_mask == FT(1) && days_since_reset >= FT(365),
+        A0_annual_final,
+        p.canopy.biomass.A0_annual,
+    )
+
+    # Update A0_daily at noon (stores the daily sum for diagnostics)
+    @. p.canopy.biomass.A0_daily = ifelse(
+        local_noon_mask == FT(1),
+        A0_daily_final,
+        p.canopy.biomass.A0_daily,
+    )
+
+    # At noon: add daily sum to annual accumulator, then reset daily accumulator
+    # When 365 days reached: start fresh with today's value
+    @. p.canopy.biomass.A0_annual_acc = ifelse(
+        local_noon_mask == FT(1) && days_since_reset >= FT(365),
+        A0_daily_final,  # Reset and start with today's value
+        ifelse(
+            local_noon_mask == FT(1),
+            p.canopy.biomass.A0_annual_acc + A0_daily_final,
+            p.canopy.biomass.A0_annual_acc,
+        ),
+    )
+
+    # Update days_since_reset counter at noon
+    @. p.canopy.biomass.days_since_reset = ifelse(
+        local_noon_mask == FT(1) && days_since_reset >= FT(365),
+        FT(1),  # Reset to 1 (today's value already added)
+        ifelse(
+            local_noon_mask == FT(1),
+            days_since_reset + FT(1),
+            days_since_reset,
+        ),
+    )
+
+    # Reset daily accumulator at noon
+    @. p.canopy.biomass.A0_daily_acc =
+        ifelse(local_noon_mask == FT(1), FT(0), p.canopy.biomass.A0_daily_acc)
+end
+
+"""
+    make_OptimalLAI_callback(::Type{FT}, t0::ITime, dt, canopy; longitude) where {FT <: AbstractFloat}
+
+This constructs an IntervalBasedCallback for the optimal LAI model that:
+1. Computes and accumulates potential GPP (A0) at each timestep
+2. Updates LAI using an exponential moving average at local noon
+3. Tracks daily and annual A0 sums
+
+We check for local noon using the provided `longitude` every dt.
+The time of local noon is expressed in seconds UTC and neglects the effects of obliquity and eccentricity, so
+it is constant throughout the year.
+
+# Arguments
+- `FT`: The floating-point type used in the model (e.g., `Float32`, `Float64`).
+- `t0`: ITime, with epoch in UTC.
+- `dt`: timestep
+- `canopy`: the canopy object containing the optimal LAI model parameters.
+- `longitude`: optional longitude in degrees for local noon calculation (default is `nothing`, which means
+    that it will be inferred from the canopy domain).
+
+# Notes
+- Daily A0 is computed with fAPAR=1 and moisture stress factor beta - drives L_steady
+- Annual A0 is computed with fAPAR=1 and actual moisture stress factor beta - used for LAI_max
+- Water limitation enters LAI_max through the f0*P/A0 * (ca(1-chi))/(1.6*D) term (Equation 11)
+- Daily A0 is accumulated over each day and finalized at local noon
+- Annual A0 is accumulated and reset on January 1
+- GSL (Growing Season Length) is read from p.canopy.biomass.GSL, which supports spatially
+  varying values initialized via set_historical_cache!.
+"""
+function make_OptimalLAI_callback(
+    ::Type{FT},
+    t0,
+    dt,
+    canopy;
+    longitude = nothing,
+) where {FT <: AbstractFloat}
+    function seconds_after_midnight(d)
+        return FT(Hour(d).value * 3600 + Minute(d).value * 60 + Second(d).value)
+    end
+
+    if isnothing(longitude)
+        try
+            longitude = get_long(canopy.domain.space.surface)
+        catch e
+            error(
+                "Longitude must be provided explicitly if the domain you are working on does not \
+                  have axes that specify longitude $e",
+            )
+        end
+    end
+
+    # this computes the time of local noon in seconds UTC without considering the
+    # effects of obliquity and orbital eccentricity, so it is constant throughout the year
+    # the max error is on the order of 20 minutes
+    seconds_in_a_day = IP.day(IP.InsolationParameters(FT))
+    start_t = seconds_after_midnight(date(t0))
+    start_date = date(t0)
+    local_noon = @. seconds_in_a_day * (FT(1 / 2) - longitude / 360) # allocates, but only on init
+
+    affect! =
+        (integrator) -> begin
+            # Compute current date from t0 and elapsed time
+            elapsed_days = floor(Int, float(integrator.t) / seconds_in_a_day)
+            current_date = start_date + Dates.Day(elapsed_days)
+
+            call_update_optimal_LAI(
+                integrator.p,
+                integrator.u,
+                (float(integrator.t) + start_t) % (seconds_in_a_day), # current time in seconds UTC
+                current_date;
+                canopy = canopy,
+                dt = dt,
+                local_noon = local_noon,
+            )
+        end
+
+    return IntervalBasedCallback(
+        dt,         # period of this callback
+        t0,         # simulation start
+        dt,         # integration timestep
+        affect!;
+    )
+end

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -10,7 +10,8 @@ export BeerLambertParameters,
     canopy_sw_rt_beer_lambert,
     canopy_sw_rt_two_stream,
     extinction_coeff,
-    compute_G
+    compute_G,
+    compute_PPFD
 
 abstract type AbstractRadiationModel{FT} <: AbstractCanopyComponent{FT} end
 
@@ -818,4 +819,21 @@ function update_radiative_transfer!(
             t,
         ),
     )
+end
+
+"""
+    compute_PPFD(par_d::FT, λ_γ_PAR::FT, lightspeed::FT, planck_h::FT, N_a::FT) where {FT}
+
+Compute photosynthetic photon flux density (PPFD) from PAR downwelling flux.
+This is the total incoming PAR (not absorbed), in units of mol photons m^-2 s^-1.
+"""
+function compute_PPFD(
+    par_d::FT,
+    λ_γ_PAR::FT,
+    lightspeed::FT,
+    planck_h::FT,
+    N_a::FT,
+) where {FT}
+    energy_per_mole_photon_par = planck_h * lightspeed * N_a / λ_γ_PAR
+    return par_d / energy_per_mole_photon_par
 end

--- a/test/standalone/Vegetation/test_optimal_lai.jl
+++ b/test/standalone/Vegetation/test_optimal_lai.jl
@@ -1,0 +1,375 @@
+using Test
+using ClimaLand
+import ClimaComms
+ClimaComms.@import_required_backends
+using ClimaLand.Canopy
+using ClimaLand.Domains: Point
+import ClimaLand.Parameters as LP
+import ClimaParams
+using ClimaCore
+
+@testset "Optimal LAI Model Tests" begin
+    for FT in (Float32, Float64)
+        toml_dict = LP.create_toml_dict(FT)
+
+        @testset "OptimalLAIParameters construction for FT = $FT" begin
+            # Test parameter construction from TOML
+            params = Canopy.OptimalLAIParameters{FT}(toml_dict)
+
+            @test params.k isa FT
+            @test params.z isa FT
+            @test params.sigma isa FT
+            @test params.alpha isa FT
+
+            # Check expected values from default_parameters.toml
+            @test params.k ≈ FT(0.5)
+            @test params.z ≈ FT(12.227)
+            @test params.sigma ≈ FT(1.1)
+            @test params.alpha ≈ FT(0.067)  # ~15 days of memory
+
+            @test eltype(params) == FT
+        end
+
+        @testset "ZhouOptimalLAIModel construction for FT = $FT" begin
+            params = Canopy.OptimalLAIParameters{FT}(toml_dict)
+            # For unit tests, use scalar values for initial conditions
+            optimal_lai_inputs = (;
+                GSL = FT(240.0),
+                A0_annual = FT(258.0),
+                precip_annual = FT(1000.0),
+                vpd_gs = FT(1000.0),
+                lai_init = FT(2.0),
+                f0 = FT(0.65),
+            )
+            model = Canopy.ZhouOptimalLAIModel{FT}(
+                params,
+                optimal_lai_inputs;
+                SAI = FT(0.0),
+                RAI = FT(1.0),
+                rooting_depth = FT(1.0),
+                height = FT(10.0),
+            )
+
+            @test model.parameters === params
+            @test model.optimal_lai_inputs === optimal_lai_inputs
+            @test eltype(model) == FT
+            @test model.SAI == FT(0.0)
+            @test model.RAI == FT(1.0)
+
+            # Test auxiliary variables
+            aux_vars = Canopy.auxiliary_vars(model)
+            @test :area_index in aux_vars
+            @test :A0_daily in aux_vars
+            @test :A0_annual in aux_vars
+            @test :A0_daily_acc in aux_vars
+            @test :A0_annual_acc in aux_vars
+            @test :days_since_reset in aux_vars
+            @test :GSL in aux_vars
+            @test :precip_annual in aux_vars
+            @test :vpd_gs in aux_vars
+            @test :f0 in aux_vars
+        end
+
+        @testset "compute_L_max function (energy-limited only) for FT = $FT" begin
+            # Test with typical conditions
+            Ao_annual = FT(100.0)   # mol m^-2 yr^-1
+            k = FT(0.5)
+            z = FT(12.227)
+            # Use high precip and low VPD to ensure energy-limited
+            precip_annual = FT(100000.0)  # mol H2O m^-2 yr^-1 (very high)
+            f0 = FT(0.65)
+            ca_pa = FT(40.0)  # Pa
+            chi = FT(0.77)  # typical tropical value
+            vpd_gs = FT(1000.0)  # Pa
+
+            LAI_max = Canopy.compute_L_max(
+                Ao_annual,
+                k,
+                z,
+                precip_annual,
+                f0,
+                ca_pa,
+                chi,
+                vpd_gs,
+            )
+
+            @test LAI_max isa FT
+            @test LAI_max >= FT(0.0)  # LAI should be non-negative
+            @test LAI_max < FT(20.0)  # LAI should be reasonable (< 20)
+
+            # Test that higher A0_annual gives higher LAI_max
+            LAI_high_gpp = Canopy.compute_L_max(
+                FT(300.0),
+                k,
+                z,
+                precip_annual,
+                f0,
+                ca_pa,
+                chi,
+                vpd_gs,
+            )
+            LAI_low_gpp = Canopy.compute_L_max(
+                FT(50.0),
+                k,
+                z,
+                precip_annual,
+                f0,
+                ca_pa,
+                chi,
+                vpd_gs,
+            )
+            @test LAI_high_gpp > LAI_low_gpp
+
+            # Test energy limitation formula (with high precip, should be energy-limited)
+            fAPAR_energy = FT(1) - z / (k * Ao_annual)
+            fAPAR_max = max(FT(0), min(FT(1), fAPAR_energy))
+            LAI_max_manual = -(FT(1) / k) * log(FT(1) - fAPAR_max)
+            @test LAI_max ≈ LAI_max_manual
+        end
+
+        @testset "compute_m function for FT = $FT" begin
+            GSL = FT(180.0)         # days
+            LAI_max = FT(3.0)       # m^2 m^-2
+            Ao_annual = FT(100.0)   # mol m^-2 yr^-1
+            sigma = FT(0.771)
+            k = FT(0.5)
+
+            m = Canopy.compute_m(GSL, LAI_max, Ao_annual, sigma, k)
+
+            @test m isa FT
+            @test m > FT(0.0)  # m should be positive
+
+            # Test that m scales with GSL
+            m_short = Canopy.compute_m(FT(90.0), LAI_max, Ao_annual, sigma, k)
+            m_long = Canopy.compute_m(FT(270.0), LAI_max, Ao_annual, sigma, k)
+            @test m_long > m_short  # Longer GSL should give larger m
+        end
+
+        @testset "lambertw0 function for FT = $FT" begin
+            # Test known values of Lambert W function
+            @test Canopy.lambertw0(FT(0.0)) ≈ FT(0.0) atol = FT(1e-6)
+            @test Canopy.lambertw0(FT(1.0)) ≈ FT(0.5671432904097838) atol =
+                FT(1e-6)
+            @test Canopy.lambertw0(FT(ℯ)) ≈ FT(1.0) atol = FT(1e-6)
+
+            # Test near branch point - at x = -1/e + 1e-8, W(x) ~ -1 + sqrt(2*1e-8*e)
+            # For Float64: W(-1/e + 1e-8) ~ -0.9997668
+            # For Float32: -1/e + 1e-8 rounds to exactly -1/e, so W(-1/e) = -1
+            x_near_branch = -FT(1.0) / FT(ℯ) + FT(1e-8)
+            w_near_branch = Canopy.lambertw0(x_near_branch)
+            @test w_near_branch ≈ -FT(1.0) atol = FT(1e-3)  # Looser tolerance near branch point
+
+            # Test invalid input returns NaN (GPU-friendly behavior)
+            @test isnan(Canopy.lambertw0(-FT(1.0)))
+        end
+
+        @testset "compute_steady_state_LAI function for FT = $FT" begin
+            Ao_daily = FT(0.4)      # mol m^-2 day^-1
+            m = FT(7.0)
+            k = FT(0.5)
+            LAI_max = FT(3.0)
+
+            L_steady = Canopy.compute_steady_state_LAI(Ao_daily, m, k, LAI_max)
+
+            @test L_steady isa FT
+            @test L_steady >= FT(0.0)
+            @test L_steady <= LAI_max  # Should not exceed LAI_max
+
+            # Test with zero GPP
+            L_zero = Canopy.compute_steady_state_LAI(FT(0.0), m, k, LAI_max)
+            @test L_zero ≈ FT(0.0)
+
+            # Test that higher GPP gives higher steady-state LAI
+            L_low = Canopy.compute_steady_state_LAI(FT(0.1), m, k, LAI_max)
+            L_high = Canopy.compute_steady_state_LAI(FT(0.8), m, k, LAI_max)
+            @test L_high > L_low
+        end
+
+        @testset "compute_LAI function for FT = $FT" begin
+            LAI_prev = FT(2.0)
+            L_steady = FT(3.0)
+            alpha = FT(0.067)
+
+            # Test with local noon mask = 1 (update)
+            LAI_new = Canopy.compute_LAI(LAI_prev, L_steady, alpha, FT(1.0))
+            expected = alpha * L_steady + (1 - alpha) * LAI_prev
+            @test LAI_new ≈ expected
+            @test LAI_new > LAI_prev  # Should move toward higher steady state
+            @test LAI_new < L_steady  # But not reach it in one step
+
+            # Test with local noon mask = 0 (no update)
+            LAI_no_update =
+                Canopy.compute_LAI(LAI_prev, L_steady, alpha, FT(0.0))
+            @test LAI_no_update == LAI_prev
+
+            # Test that LAI is non-negative
+            LAI_negative_test =
+                Canopy.compute_LAI(-FT(1.0), FT(0.0), alpha, FT(1.0))
+            @test LAI_negative_test >= FT(0.0)
+        end
+
+        @testset "compute_PPFD function for FT = $FT" begin
+            # Test PPFD computation from PAR
+            par_d = FT(500.0)  # W m^-2 (typical midday)
+            λ_γ_PAR = FT(5e-7)  # 500 nm
+            lightspeed = FT(3e8)  # m s^-1
+            planck_h = FT(6.626e-34)  # J s
+            N_a = FT(6.022e23)  # mol^-1
+
+            PPFD =
+                Canopy.compute_PPFD(par_d, λ_γ_PAR, lightspeed, planck_h, N_a)
+
+            @test PPFD isa FT
+            @test PPFD > FT(0.0)
+            @test isfinite(PPFD)
+        end
+
+        @testset "get_local_noon_mask function for FT = $FT" begin
+            dt = FT(3600.0)  # 1 hour timestep
+            local_noon = FT(43200.0)  # 12:00 noon in seconds
+
+            # Test at local noon
+            mask_noon = Canopy.get_local_noon_mask(43200.0, dt, local_noon)
+            @test mask_noon == FT(1.0)
+
+            # Test within window
+            mask_before =
+                Canopy.get_local_noon_mask(43200.0 - dt / 4, dt, local_noon)
+            @test mask_before == FT(1.0)
+
+            mask_after =
+                Canopy.get_local_noon_mask(43200.0 + dt / 4, dt, local_noon)
+            @test mask_after == FT(1.0)
+
+            # Test outside window
+            mask_morning = Canopy.get_local_noon_mask(21600.0, dt, local_noon)  # 6 AM
+            @test mask_morning == FT(0.0)
+
+            mask_evening = Canopy.get_local_noon_mask(64800.0, dt, local_noon)  # 6 PM
+            @test mask_evening == FT(0.0)
+        end
+
+        @testset "update_optimal_LAI function for FT = $FT" begin
+            # Test the full LAI update function
+            A0_daily = FT(0.5)       # mol m^-2 day^-1
+            L = FT(2.0)              # current LAI
+            k = FT(0.5)
+            A0_annual = FT(100.0)    # mol m^-2 yr^-1
+            z = FT(12.227)
+            GSL = FT(180.0)          # days
+            sigma = FT(0.771)
+            alpha = FT(0.067)
+            precip_annual = FT(100000.0)  # mol H2O m^-2 yr^-1 (high, energy-limited)
+            f0 = FT(0.65)
+            ca_pa = FT(40.0)         # Pa
+            chi = FT(0.77)
+            vpd_gs = FT(1000.0)      # Pa
+
+            # Test update at noon
+            L_new = Canopy.update_optimal_LAI(
+                FT(1.0),  # local noon mask
+                A0_daily,
+                L,
+                k,
+                A0_annual,
+                z,
+                GSL,
+                sigma,
+                alpha,
+                precip_annual,
+                f0,
+                ca_pa,
+                chi,
+                vpd_gs,
+            )
+
+            @test L_new isa FT
+            @test L_new >= FT(0.0)
+            @test isfinite(L_new)
+
+            # Test no update when not at noon
+            L_no_update = Canopy.update_optimal_LAI(
+                FT(0.0),  # not local noon
+                A0_daily,
+                L,
+                k,
+                A0_annual,
+                z,
+                GSL,
+                sigma,
+                alpha,
+                precip_annual,
+                f0,
+                ca_pa,
+                chi,
+                vpd_gs,
+            )
+            @test L_no_update == L
+        end
+
+        @testset "optimal_lai_initial_conditions for single-point domains for FT = $FT" begin
+            # Test that optimal_lai_initial_conditions returns reasonable values
+            # for single-point domains at various locations (Fluxnet sites)
+
+            test_sites = [
+                # (name, longitude, latitude)
+                ("US-MOz (Ozark)", FT(-92.2000), FT(38.7441)),   # Missouri, USA - Deciduous forest
+                ("US-Ha1 (Harvard)", FT(-72.1715), FT(42.5378)), # Massachusetts, USA - Mixed forest
+                ("Amazon", FT(-60.0), FT(-3.0)),                 # Amazon rainforest
+                ("Sahel", FT(0.0), FT(15.0)),                    # Semi-arid Africa
+            ]
+
+            for (site_name, long, lat) in test_sites
+                # Create a point domain at this location
+                domain = Point(; z_sfc = FT(0.0), longlat = (long, lat))
+                surface_space = domain.space.surface
+
+                # Load initial conditions from global data file
+                optimal_lai_inputs =
+                    Canopy.optimal_lai_initial_conditions(surface_space)
+
+                # Extract scalar values from Fields
+                GSL_val = Array(parent(optimal_lai_inputs.GSL))[1]
+                A0_annual_val = Array(parent(optimal_lai_inputs.A0_annual))[1]
+                precip_annual_val =
+                    Array(parent(optimal_lai_inputs.precip_annual))[1]
+                vpd_gs_val = Array(parent(optimal_lai_inputs.vpd_gs))[1]
+                lai_init_val = Array(parent(optimal_lai_inputs.lai_init))[1]
+                f0_val = Array(parent(optimal_lai_inputs.f0))[1]
+
+                @testset "$site_name" begin
+                    # GSL should be positive and reasonable (0-365 days)
+                    @test GSL_val >= FT(0) "GSL should be non-negative at $site_name"
+                    @test GSL_val <= FT(365) "GSL should be <= 365 days at $site_name"
+                    @test GSL_val > FT(0) "GSL should be positive (non-zero) at $site_name, got $GSL_val"
+
+                    # A0_annual should be positive (mol CO2 m^-2 yr^-1)
+                    # Typical values range from ~50 (arid) to ~500 (tropical rainforest)
+                    @test A0_annual_val >= FT(0) "A0_annual should be non-negative at $site_name"
+                    @test A0_annual_val > FT(0) "A0_annual should be positive at $site_name, got $A0_annual_val"
+                    @test A0_annual_val < FT(1000) "A0_annual should be < 1000 at $site_name"
+
+                    # precip_annual should be positive (mol H2O m^-2 yr^-1)
+                    # Ranges from ~5000 (desert, ~100 mm) to ~170000+ (tropical, ~3000 mm)
+                    @test precip_annual_val >= FT(0) "precip_annual should be non-negative at $site_name"
+                    @test precip_annual_val > FT(0) "precip_annual should be positive at $site_name, got $precip_annual_val"
+
+                    # vpd_gs should be positive (Pa)
+                    # Typical growing season VPD: 500-2500 Pa
+                    @test vpd_gs_val >= FT(0) "vpd_gs should be non-negative at $site_name"
+                    @test vpd_gs_val > FT(0) "vpd_gs should be positive at $site_name, got $vpd_gs_val"
+
+                    # lai_init should be non-negative (m^2 m^-2)
+                    # Ranges from 0 (bare) to ~8 (dense forest)
+                    @test lai_init_val >= FT(0) "lai_init should be non-negative at $site_name"
+                    @test lai_init_val < FT(15) "lai_init should be < 15 at $site_name"
+
+                    # f0 should be in range [0, 1]
+                    @test f0_val >= FT(0) "f0 should be >= 0 at $site_name"
+                    @test f0_val <= FT(1) "f0 should be <= 1 at $site_name"
+                    @test f0_val > FT(0) "f0 should be positive at $site_name, got $f0_val"
+                end
+            end
+        end
+    end
+end

--- a/toml/default_parameters.toml
+++ b/toml/default_parameters.toml
@@ -86,6 +86,38 @@ type = "float"
 description = "The constant canopy height (m)"
 tag = "PrescribedBiomassModel"
 
+# Optimal LAI Model (Zhou et al. 2025)
+
+["optimal_lai_k"]
+value = 0.5
+type = "float"
+description = "Light extinction coefficient (dimensionless)"
+tag = "OptimalLAIModel"
+
+["optimal_lai_z"]
+value = 12.227
+type = "float"
+description = "Unit cost of constructing and maintaining leaves (mol m^-2 yr^-1)"
+tag = "OptimalLAIModel"
+
+["optimal_lai_sigma"]
+value = 1.1
+type = "float"
+description = "Dimensionless parameter representing departure from square-wave LAI dynamics (Zhou et al. 2025)"
+tag = "OptimalLAIModel"
+
+["optimal_lai_alpha"]
+value = 0.067
+type = "float"
+description = "Smoothing factor for exponential moving average (dimensionless, 0-1), ~15 days of memory"
+tag = "OptimalLAIModel"
+
+["optimal_lai_f0"]
+value = 0.65
+type = "float"
+description = "Fraction of annual precipitation available for transpiration (dimensionless). Following Zhou et al. (2025), f0 = 0.65 at the energy-water limitation transition."
+tag = "OptimalLAIModel"
+
 # Plant Hydraulics Parameters
 
 ["plant_nu"]


### PR DESCRIPTION
This PR implements ZhouOptimalLAIModel, a new concrete type of AbstractBiomassModel,  that computes LAI dynamically from energy and water constraints, following Zhou et al. (2025). 

- [Zhou et al., 2025 manuscript](https://onlinelibrary.wiley.com/doi/pdf/10.1111/gcb.70125) 
- [Documentation](https://clima.github.io/ClimaLand.jl/previews/PR1625/standalone/pages/vegetation/canopy_structure/optimal_lai/)
- [Dashboard (select lai)](https://dashboard.cupoftea.earth/land_longrun)

Issues for future PR:
#1634 - Storing time-integrated variables in Y 
#1636 - Dynamic C3/C4 vegetation distribution
#1637 - Calibrate GPP and LAI
#1638 - Refactor biomass model to decouple LAI from other fields 
#1639 - Use canopy temperature instead of air temperature for potential GPP (maybe it doesn't make sense though - how do we know canopy temperature if there's no canopy...)

NOTE: As discussed with Kat, this no longer has C3 C4 partitioning (will be a separate PR)

NOTE (Alexis): I believe this PR is ready to be merged. Further progress will be made in future PRs (see issues). The model works well - except LAI is overestimated in locations where GPP is overestimated - but this is related to GPP, not the LAI model. See [ILAMB GPP](https://dashboard.cupoftea.earth/ilamb/EcosystemandCarbonCycle/GrossPrimaryProductivity/FLUXCOM/FLUXCOM.html).
