### PR TITLE
new set ic methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@ ClimaLand.jl Release Notes
 
 main
 ------
-- ![breaking change][badge-💥breaking] Add CRUJRA forcing PR[#1624](https://github.com/CliMA/ClimaLand.jl/pull/1624)
+- Create set ic functions for the bucket PR[#1644](https://github.com/CliMA/ClimaLand.jl/pull/1644)
+- Add CRUJRA forcing PR[#1624](https://github.com/CliMA/ClimaLand.jl/pull/1624)
 - ![breaking change][badge-💥breaking] Unify radiation for bucket and integrated land PR[#1630](https://github.com/CliMA/ClimaLand.jl/pull/1630)
 
 v1.5.3

--- a/experiments/long_runs/bucket.jl
+++ b/experiments/long_runs/bucket.jl
@@ -93,18 +93,11 @@ toml_dict = LP.create_toml_dict(FT)
 
 # Model
 model = setup_model(FT, start_date, stop_date, domain, Δt, toml_dict, context)
-
-# IC function
-function set_ic!(Y, p, t, bucket)
-    temp_anomaly_amip(coord) = 40 * cosd(coord.lat)^4
-    # Set temperature IC including anomaly, based on atmospheric setup
-    T_sfc_0 = 271.0
-    cds = ClimaCore.Fields.coordinate_field(Y.bucket.T)
-    @. Y.bucket.T = T_sfc_0 + temp_anomaly_amip(cds)
-    Y.bucket.W .= 0.15
-    Y.bucket.Ws .= 0.0
-    Y.bucket.σS .= 0.0
-end
+# Initialize at saturated with the air temperature as bucket temperature
+set_ic! =
+    ClimaLand.Simulations.make_set_initial_state_from_atmos_and_parameters(
+        model,
+    )
 
 # Define timestepper and ODE algorithm
 timestepper = CTS.RK4()

--- a/test/shared_utilities/coupled_fluxes.jl
+++ b/test/shared_utilities/coupled_fluxes.jl
@@ -132,8 +132,11 @@ p.drivers.SW_d .= FT(500)
 p.drivers.LW_d .= FT(100)
 
 t0 = ITime(0, Second(1), start_date)
-Y.bucket.W .= FT(0.1)
-Y.bucket.T .= FT(290)
+set_bucket_ic! =
+    ClimaLand.Simulations.make_set_initial_state_from_atmos_and_parameters(
+        bucket,
+    )
+set_bucket_ic!(Y, p, t0, bucket)
 set_initial_cache! = make_set_initial_cache(bucket)
 set_initial_cache!(p, Y, t0)
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Move "set bucket ic from file" code to the Land model from Coupler repo. this streamlines coupler code between bucket and integrated land and makes NCDatasets not a dependency.

Note that the land model does not have an ic file like for the bucket. this is used in Weather quest/coupled runs only. so I dont have a test for the `maket_set_from_file` function in land.

I also created another bucket and land ic function which matches what is in the coupler. this streamlines coupler code between bucket and integrated land and offlines runs
## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
