### PR TITLE
Fix EnergyHydrology conservation diagnostics

### DIFF
--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -352,6 +352,7 @@ function default_diagnostics(
 
     if conservation
         additional_diags = ["epa", "epac", "wvpa", "wvpac"]
+        define_diagnostics!(land_model, additional_diags)
         additional_outputs = vcat(
             map(additional_diags) do short_name
                 output_schedule_func =


### PR DESCRIPTION
Follow up to eb886570645581e0a629c956efcfc5318ebe5dbd . After that commit, only requested diagnostics get created and added to `ALL_DIAGNOSTICS`.
When conservation diagnostics are requested, they were not getting created, leading to an error.

This commit defines the conservation
diagnostics when they are requested.



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
