### PR TITLE
Rb/fix ilamb runoff

### DIFF
--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -411,7 +411,7 @@ function add_diagnostics!(
     model::EnergyHydrology,
     subcomponent::ClimaLand.Soil.Runoff.SurfaceRunoff,
 )
-    append!(diagnostics, ["sr"])
+    append!(diagnostics, ["sr", "tr"])
     return nothing
 end
 function add_diagnostics!(
@@ -419,7 +419,7 @@ function add_diagnostics!(
     model::EnergyHydrology,
     subcomponent::ClimaLand.Soil.Runoff.TOPMODELRunoff,
 )
-    append!(diagnostics, ["sr", "ssr", "sfsat", "sath", "infc"])
+    append!(diagnostics, ["sr", "ssr", "tr", "sfsat", "sath", "infc"])
     return nothing
 end
 function add_diagnostics!(

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -963,6 +963,18 @@ function define_diagnostics!(land_model, possible_diags)
             compute_subsurface_runoff!(out, Y, p, t, land_model),
     )
 
+    # Total runoff
+    conditional_add_diagnostic_variable!(
+        possible_diags;
+        short_name = "tr",
+        long_name = "Total Runoff",
+        standard_name = "total_runoff",
+        units = "m s^-1",
+        comments = "Total water runoff (surface + subsurface)",
+        compute! = (out, Y, p, t) ->
+            compute_total_runoff!(out, Y, p, t, land_model),
+    )
+
     ## Stored in Y (prognostic or state variables) ##
 
     # Canopy temperature

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -689,6 +689,24 @@ function compute_subsurface_runoff!(
     return out
 end
 
+function compute_total_runoff!(
+    out,
+    Y,
+    p,
+    t,
+    land_model::Union{EnergyHydrology, SoilCanopyModel, LandModel},
+)
+    soil = get_soil(land_model)
+    if isnothing(out)
+        out = zeros(soil.domain.space.surface) # Allocates
+        fill!(field_values(out), NaN) # fill with NaNs, even over the ocean
+    end
+    out .=
+        Runoff.get_surface_runoff(soil.boundary_conditions.top.runoff, Y, p) .+
+        Runoff.get_subsurface_runoff(soil.boundary_conditions.top.runoff, Y, p)
+    return out
+end
+
 function compute_saturated_height!(
     out,
     Y,


### PR DESCRIPTION
## Purpose 
Fix ILAMB variable mappings for runoff and permafrost comparison. This addresses two issues: (1) runoff variables were using swapped CF convention labels preventing proper ILAMB comparison, and (2) permafrost analysis was failing because soil temperature was not being converted to the tsl variable format that ILAMB expects.


## To-do
- Update ILAMB configuration file on server to add separate Surface Runoff (mrros) and Subsurface Runoff (ssro) comparison sections


## Content

### Runoff Variable Fixes
- Fixed CF convention labels in `experiments/ilamb/ilamb_conversion.jl`:
  - `sr` (surface runoff) now maps to `mrros` instead of `mrro`
  - `ssr` (subsurface runoff) now maps to `ssro` instead of `mrros`
  - Added new `tr` (total runoff) mapping to `mrro` as surface + subsurface
- Added `compute_total_runoff!()` function in `src/diagnostics/land_compute_methods.jl` that computes total runoff as the sum of surface and subsurface components
- Added `tr` diagnostic definition in `src/diagnostics/define_diagnostics.jl`
- Updated default diagnostics in `src/diagnostics/default_diagnostics.jl` to include `tr` for both `SurfaceRunoff` and `TOPMODELRunoff` models

### Permafrost Analysis Fixes
- Added `tsoil → tsl` mapping in `experiments/ilamb/ilamb_conversion.jl` to enable ILAMB permafrost confrontation
- Fixed depth handling for soil temperature:
  - Removed incorrect depth slicing that was extracting only top ~10cm
  - Now outputs full 4D profile (time, depth, lat, lon) needed for permafrost analysis (0-3.5m)
  - Implemented CMIP6-compliant depth coordinate conversion:
    - Maps ClimaLand's `z` coordinate (negative, depth below surface) to ILAMB/CMIP6 `depth` coordinate (positive, down)
    - Adds `depth_bnds` variable with proper dimension ordering (depth, bnds)
    - Sets dimension order to match CMIP6 convention: (time, depth, lat, lon)
  - Updated CF metadata: standard_name = "soil_temperature", long_name = "Temperature of Soil"

### Additional Notes
- ERA5 observation files were corrected separately on the server at `/net/sampo/data1/ilamb/DATA/{mrro,mrros,ssro}/ERA5/`:
  - Fixed label swap in existing mrro and mrros files
  - Created new ssro (subsurface runoff) files
  - Backups created with timestamps before modifications

----
- [ ] I have read and checked the items on the review checklist.
