### PR TITLE
change fluxnet default IC

### DIFF
--- a/ext/fluxnet_simulations/initial_conditions.jl
+++ b/ext/fluxnet_simulations/initial_conditions.jl
@@ -98,9 +98,8 @@ function set_fluxnet_ic!(
         varname => findfirst(columns[:] .== varname) for varname in varnames
     )
     FT = eltype(Y.soil.ρe_int)
-    tmp_ic =
-        model.parameters.θ_r +
-        (model.parameters.ν - model.parameters.θ_r) * FT(0.95)
+    tmp_ic = @. model.parameters.θ_r +
+       (model.parameters.ν - model.parameters.θ_r) * FT(0.95)
     if isnothing(column_name_map["SWC_F_MDS_1"])
         θ_l_0 = tmp_ic
     elseif unique(data[:, column_name_map["SWC_F_MDS_1"]]) == val


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
To reduce spinup, start from nearly saturated soil when there is no data

Note that when there is data, we just use the surface value everywhere as the IC. we might always want to start from saturated because using the surface value at depth likely is not very spun up.




## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
