### PR TITLE
Fix hr diagnostic units to match ILAMB conversion expectations

### DIFF
--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -872,7 +872,7 @@ function define_diagnostics!(land_model, possible_diags)
         short_name = "hr",
         long_name = "Heterotrophic Respiration",
         standard_name = "heterotrophic_respiration",
-        units = "mol m^-2 s^-1",
+        units = "mol CO2 m^-2 s^-1",
         comments = "The CO2 efflux at the soil surface due to microbial decomposition of soil organic matter. This is not necessarily equal to CO2 production by microbes, as co2 diffusion through the soil pores takes time.",
         compute! = (out, Y, p, t) ->
             compute_heterotrophic_respiration!(out, Y, p, t, land_model),


### PR DESCRIPTION
The heterotrophic respiration (hr) diagnostic had units `mol m^-2 s^-1` while the ILAMB conversion mapping expected `mol CO2 m^-2 s^-1`. All other CO2 flux diagnostics (gpp, nee, er, ra) already use `mol CO2 m^-2 s^-1`.

This mismatch caused the ILAMB conversion to fail with: `Units in the simulation-output NetCDF do not match the expected CliMA units for hr.`

Fixes: https://buildkite.com/clima/climaland-long-runs/builds/4575

<!--- THESE LINES ARE COMMENTED -->
## Purpose 

Fix the `hr` diagnostic units from `mol m^-2 s^-1` to `mol CO2 m^-2 s^-1` to match the ILAMB conversion expectations and be consistent with all other CO2 flux diagnostics.

## To-do

## Content
- Fixed `hr` diagnostic units in `src/diagnostics/define_diagnostics.jl` from `"mol m^-2 s^-1"` to `"mol CO2 m^-2 s^-1"`

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.