### PR TITLE
clamp ci <=ca

### DIFF
--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -196,12 +196,20 @@ function compute_stomatal_conductance!(
     if isnothing(out)
         out = zeros(canopy.domain.space.surface) # Allocates
         fill!(field_values(out), NaN) # fill with NaNs, even over the ocean
-        @. out =
-            gs_h2o_pmodel(ci / (c_co2_air * P_air), c_co2_air, An_leaf, Drel)
+        @. out = gs_h2o_pmodel(
+            clamp(ci / (c_co2_air * P_air), 0, 1),
+            c_co2_air,
+            An_leaf,
+            Drel,
+        )
         return out
     else
-        @. out =
-            gs_h2o_pmodel(ci / (c_co2_air * P_air), c_co2_air, An_leaf, Drel)
+        @. out = gs_h2o_pmodel(
+            clamp(ci / (c_co2_air * P_air), 0, 1),
+            c_co2_air,
+            An_leaf,
+            Drel,
+        )
     end
 end
 

--- a/src/standalone/Vegetation/pmodel.jl
+++ b/src/standalone/Vegetation/pmodel.jl
@@ -419,7 +419,7 @@ function compute_full_pmodel_outputs(
 
     # intrinsic water use efficiency (iWUE) and stomatal conductance (gs)
     iWUE = (ca_pp - ci) / Drel
-    χ = ci / ca_pp
+    χ = clamp(ci / ca_pp, FT(0), FT(1))
     gs = gs_co2_pmodel(χ, ca, Ac)
 
     # dark respiration

--- a/src/standalone/Vegetation/stomatalconductance.jl
+++ b/src/standalone/Vegetation/stomatalconductance.jl
@@ -153,7 +153,7 @@ function update_canopy_conductance!(p, Y, model::PModelConductance, canopy)
     R = LP.gas_constant(earth_param_set)
     FT = eltype(model.parameters)
 
-    χ = @. lazy(ci / (c_co2_air * P_air))       # ratio of intercellular to ambient CO2 concentration, unitless
+    χ = @. lazy(clamp(ci / (c_co2_air * P_air), FT(0), FT(1))) # ratio of intercellular to ambient CO2 concentration, unitless
     @. p.canopy.conductance.r_stomata_canopy =
         1 / (
             conductance_molar_flux_to_m_per_s(


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The stomatal conductance in the pmodel depends on 1/[(ca-ci)+eps], where ca is the atmospheric co2 ppm and ci is intercellular co2 ppm. since stomatal conductance must be positive, ca >= ci. This PR clamps `chi`, the ratio of the two, so that ca >=ci


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
