### PR TITLE
Fix SOC conversion for ILAMB: integrate over soil depth

### DIFF
--- a/experiments/ilamb/ilamb_conversion.jl
+++ b/experiments/ilamb/ilamb_conversion.jl
@@ -81,12 +81,12 @@ const ILAMB_VARIABLES = Dict(
         "kg m-2 s-1", # kg C
         "mol CO2 m^-2 s^-1",
     ),
-    "soc" => ILAMBMapping(
+    "soc_int" => ILAMBMapping(
         "cSoil",
-        "Soil Carbon",
+        "Depth Integrated Soil Organic Carbon",
         1.0,
         "kg m-2", # kg C
-        "kg C m^-3",
+        "kg C m^-2",
     ),
     "cveg" => ILAMBMapping(
         "cVeg",
@@ -404,6 +404,8 @@ function define_var(ilamb_ds, clima_ds, clima_short_name)
     else
         expected_dims = ["lon", "lat", "time"]
     end
+
+
     data = get_data(
         clima_ds,
         clima_short_name,

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -479,7 +479,7 @@ function get_possible_diagnostics(model::EnergyHydrology)
 end
 
 function get_possible_diagnostics(model::SoilCO2Model)
-    return ["sco2", "hr", "scd", "scms", "so2", "soc"]
+    return ["sco2", "hr", "scd", "scms", "so2", "soc", "soc_int"]
 end
 function get_possible_diagnostics(model::CanopyModel)
     diagnostics = [
@@ -618,7 +618,7 @@ function get_short_diagnostics(model::EnergyHydrology)
     return ["swc", "si", "sie", "tsoil", "et"]
 end
 function get_short_diagnostics(model::SoilCO2Model)
-    return ["sco2", "hr", "soc"]
+    return ["sco2", "hr", "soc", "soc_int"]
 end
 function get_short_diagnostics(model::CanopyModel)
     diagnostics = ["gpp", "ct", "lai", "trans", "er", "sif"]

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -600,19 +600,6 @@ function define_diagnostics!(land_model, possible_diags)
             compute_radiation_shortwave_net!(out, Y, p, t, land_model),
     )
 
-    ## Drivers Module ##
-    # Soil organic carbon
-    conditional_add_diagnostic_variable!(
-        possible_diags;
-        short_name = "soc",
-        long_name = "Soil organic carbon",
-        standard_name = "soil_organic_carbon",
-        units = "kg C m^-3",
-        comments = "Mass of organic carbon per volume of soil. (depth resolved)",
-        compute! = (out, Y, p, t) ->
-            compute_soil_organic_carbon!(out, Y, p, t, land_model),
-    )
-
     ### Canopy - Vegetation carbon (derived from prescribed biomass)
     # Vegetation carbon
     conditional_add_diagnostic_variable!(
@@ -1039,9 +1026,19 @@ function define_diagnostics!(land_model, possible_diags)
         short_name = "soc",
         long_name = "Soil Organic Carbon",
         standard_name = "soil_organic_carbon",
-        units = "kg C m^3",
-        comments = "Concentration of soil organic carbon. (depth resolved)",
+        units = "kg C m^-3",
+        comments = "Mass concentration of soil organic carbon. (depth resolved)",
         compute! = (out, Y, p, t) -> compute_soc!(out, Y, p, t, land_model),
+    )
+    conditional_add_diagnostic_variable!(
+        possible_diags;
+        short_name = "soc_int",
+        long_name = "1m Depth Integrated Soil Organic Carbon",
+        standard_name = "integrated_soc",
+        units = "kg C m^-2",
+        comments = "1m Integrated Mass concentration of soil organic carbon",
+        compute! = (out, Y, p, t) ->
+            compute_integrated_soc!(out, Y, p, t, land_model),
     )
 
     # Soil water content

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -58,6 +58,16 @@ get_canopy(m::CanopyModel) = m
 get_soil(m::Union{SoilCanopyModel, LandModel, SoilSnowModel}) = m.soil
 get_soil(m::EnergyHydrology) = m
 
+get_surface_space(m::Union{SoilCanopyModel, LandModel, SoilSnowModel}) =
+    m.soil.domain.space.surface
+get_surface_space(
+    m::Union{CanopyModel, SoilCO2Model, SnowModel, EnergyHydrology},
+) = m.domain.space.surface
+
+get_z_coordinates(m::Union{SoilCanopyModel, LandModel, SoilSnowModel}) =
+    m.soil.domain.fields.z
+get_z_coordinates(m::Union{SoilCO2Model, EnergyHydrology}) = m.domain.fields.z
+
 ### Conservation ##
 @diagnostic_compute "water_volume_per_area" EnergyHydrology p.soil.total_water
 @diagnostic_compute "energy_per_area" EnergyHydrology p.soil.total_energy
@@ -390,14 +400,6 @@ end
     CanopyModel,
 } p.canopy.radiative_transfer.SW_n
 
-## Drivers Module ##
-
-@diagnostic_compute "soil_organic_carbon" Union{
-    SoilCanopyModel,
-    LandModel,
-    SoilCO2Model,
-} Y.soilco2.SOC # SOC is now prognostic
-
 # Vegetation carbon (derived from prescribed biomass)
 function compute_vegetation_carbon!(
     out,
@@ -572,31 +574,58 @@ end
 } p.soil.turbulent_fluxes.vapor_flux_liq # should add ice here
 
 # Soil - SoilCO2
-function compute_heterotrophic_respiration!(
+@diagnostic_compute "soc" Union{SoilCanopyModel, LandModel, SoilCO2Model} Y.soilco2.SOC
+
+@diagnostic_compute "soilco2" Union{SoilCanopyModel, LandModel, SoilCO2Model} Y.soilco2.CO2
+
+@diagnostic_compute "soilo2" Union{SoilCanopyModel, LandModel, SoilCO2Model} Y.soilco2.O2_f
+@diagnostic_compute "soilco2_diffusivity" Union{
+    SoilCO2Model,
+    SoilCanopyModel,
+    LandModel,
+} p.soilco2.D
+@diagnostic_compute "soilco2_source_microbe" Union{
+    SoilCO2Model,
+    SoilCanopyModel,
+    LandModel,
+} p.soilco2.Sm
+@diagnostic_compute "soilo2_diffusivity" Union{
+    SoilCO2Model,
+    SoilCanopyModel,
+    LandModel,
+} p.soilco2.D_o2
+
+function compute_integrated_soc!(
     out,
     Y,
     p,
     t,
-    land_model::SoilCO2Model{FT},
+    land_model::Union{SoilCO2Model{FT}, SoilCanopyModel{FT}, LandModel{FT}},
 ) where {FT}
+    z = get_z_coordinates(land_model)
+    depth = FT(-1.0)
+    first_meter_SOC = @.lazy(Y.soilco2.SOC * heaviside(z, depth))
     if isnothing(out)
-        out = zeros(land_model.soil.domain.space.surface) # Allocates
+        surface_space = get_surface_space(land_model)
+        out = zeros(surface_space) # Allocates
         fill!(field_values(out), NaN) # fill with NaNs, even over the ocean
-        @. out = p.top_bc * FT(83.26)
+        column_integral_definite!(out, first_meter_SOC) # updates out in place
         return out
     else
-        out .= p.top_bc .* FT(83.26)
+        column_integral_definite!(out, first_meter_SOC) # updates out in place
     end
 end # Convert from kg C to mol CO2.
+
 function compute_heterotrophic_respiration!(
     out,
     Y,
     p,
     t,
-    land_model::Union{SoilCanopyModel{FT}, LandModel{FT}},
+    land_model::Union{SoilCO2Model{FT}, SoilCanopyModel{FT}, LandModel{FT}},
 ) where {FT}
     if isnothing(out)
-        out = zeros(land_model.soil.domain.space.surface) # Allocates
+        surface_space = get_surface_space(land_model)
+        out = zeros(surface_space) # Allocates
         fill!(field_values(out), NaN) # fill with NaNs, even over the ocean
         @. out = p.soilco2.top_bc * FT(83.26)
         return out
@@ -606,13 +635,6 @@ function compute_heterotrophic_respiration!(
 end # Convert from kg C to mol CO2.
 # To convert from kg C to mol CO2, we need to multiply by:
 # [3.664 kg CO2/ kg C] x [10^3 g CO2/ kg CO2] x [1 mol CO2/44.009 g CO2] = 83.26 mol CO2/kg C
-
-@diagnostic_compute "soilco2_diffusivity" SoilCO2Model p.soilco2.D
-@diagnostic_compute "soilco2_source_microbe" SoilCO2Model p.soilco2.Sm
-@diagnostic_compute "soilo2_diffusivity" SoilCO2Model p.soilco2.D_o2
-@diagnostic_compute "soilco2_diffusivity" Union{SoilCanopyModel, LandModel} p.soilco2.D
-@diagnostic_compute "soilco2_source_microbe" Union{SoilCanopyModel, LandModel} p.soilco2.Sm
-@diagnostic_compute "soilo2_diffusivity" Union{SoilCanopyModel, LandModel} p.soilco2.D_o2
 
 ## Other ##
 @diagnostic_compute "sw_albedo" Union{SoilCanopyModel, LandModel} p.α_sfc
@@ -1005,9 +1027,6 @@ function compute_canopy_temperature!(
     end
 end
 
-@diagnostic_compute "soilco2" Union{SoilCanopyModel, LandModel} Y.soilco2.CO2
-@diagnostic_compute "soilo2" Union{SoilCanopyModel, LandModel} Y.soilco2.O2_f
-@diagnostic_compute "soc" Union{SoilCanopyModel, LandModel} Y.soilco2.SOC
 @diagnostic_compute "soil_water_content" Union{
     SoilCanopyModel,
     LandModel,


### PR DESCRIPTION
- SOC diagnostic outputs volumetric concentration (kg C m^-3) with 15 soil layers
- ILAMB expects column-integrated carbon stock (kg C m^-2)
- Added integrated soil organic carbon diagnostic (over 1 m depth)

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
