### PR TITLE
fix pmodel gpp for c4

### DIFF
--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -222,7 +222,8 @@ end
         toml_dict::CP.ParamDict;
         is_c3 = clm_photosynthesis_parameters(domain.space.surface).is_c3,
         cstar = toml_dict["pmodel_cstar"],
-        β = toml_dict["pmodel_β"],
+        β_c3 = toml_dict["pmodel_β_c3"],
+        β_c4 = toml_dict["pmodel_β_c4"],
         temperature_dep_yield = true,
         ϕ0_c3 = toml_dict["pmodel_ϕ0_c3"],
         ϕ0_c4 = toml_dict["pmodel_ϕ0_c4"],
@@ -239,7 +240,8 @@ Constructs a P-model (an optimality model for photosynthesis) using default para
 
 The following default parameters (from the TOML file) are used:
 - cstar = 0.41 (unitless) - 4 * dA/dJmax, assumed to be a constant marginal cost (Wang 2017, Stocker 2020)
-- β = 146 (unitless) - Unit cost ratio of Vcmax to transpiration (Stocker 2020)
+- β_c3 = 146 (unitless) - Unit cost ratio of Vcmax to transpiration for C3 plants (Stocker 2020)
+- β_c4 = 146/9 ≈ 16.222 (unitless) - Unit cost ratio of Vcmax to transpiration for C4 plants (pyrealm)
 - ϕ0_c3 = 0.052 (unitless) - constant intrinsic quantum yield. Skillman (2008)
 - ϕ0_c4 = 0.057 (unitless) - constant intrinsic quantum yield. Skillman (2008)
 - ϕa0_c3 = 0.352*0.087 (unitless) - constant term in quadratic intrinsic quantum yield (Stocker 2020)
@@ -255,7 +257,8 @@ function PModel{FT}(
     toml_dict::CP.ParamDict;
     is_c3 = clm_photosynthesis_parameters(domain.space.surface).is_c3,
     cstar = toml_dict["pmodel_cstar"],
-    β = toml_dict["pmodel_β"],
+    β_c3 = toml_dict["pmodel_β_c3"],
+    β_c4 = toml_dict["pmodel_β_c4"],
     temperature_dep_yield = true,
     ϕ0_c3 = toml_dict["pmodel_ϕ0_c3"],
     ϕ0_c4 = toml_dict["pmodel_ϕ0_c4"],
@@ -269,7 +272,8 @@ function PModel{FT}(
 ) where {FT <: AbstractFloat}
     parameters = ClimaLand.Canopy.PModelParameters(
         cstar,
-        β,
+        β_c3,
+        β_c4,
         temperature_dep_yield,
         ϕ0_c3,
         ϕ0_c4,

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -220,7 +220,7 @@ end
     function PModel{FT}(
         domain,
         toml_dict::CP.ParamDict;
-        is_c3 = clm_photosynthesis_parameters(domain.space.surface).is_c3,
+        is_c3 = nothing,
         cstar = toml_dict["pmodel_cstar"],
         β_c3 = toml_dict["pmodel_β_c3"],
         β_c4 = toml_dict["pmodel_β_c4"],
@@ -237,6 +237,8 @@ end
     ) where {FT <: AbstractFloat}
 
 Constructs a P-model (an optimality model for photosynthesis) using default parameters.
+If `is_c3` is not provided, the constructor uses the spatial `c3_fraction` field from
+the CLM artifact when available, and otherwise falls back to the dominant-pathway flag.
 
 The following default parameters (from the TOML file) are used:
 - cstar = 0.41 (unitless) - 4 * dA/dJmax, assumed to be a constant marginal cost (Wang 2017, Stocker 2020)
@@ -244,18 +246,18 @@ The following default parameters (from the TOML file) are used:
 - β_c4 = 146/9 ≈ 16.222 (unitless) - Unit cost ratio of Vcmax to transpiration for C4 plants (pyrealm)
 - ϕ0_c3 = 0.052 (unitless) - constant intrinsic quantum yield. Skillman (2008)
 - ϕ0_c4 = 0.057 (unitless) - constant intrinsic quantum yield. Skillman (2008)
-- ϕa0_c3 = 0.352*0.087 (unitless) - constant term in quadratic intrinsic quantum yield (Stocker 2020)
-- ϕa1_c3 = 0.022*0.087 (K^-1) - first order term in quadratic intrinsic quantum yield (Stocker 2020)
-- ϕa2_c3 = -0.00034*0.087 (K^-2) - second order term in quadratic intrinsic quantum yield (Stocker 2020)
-- ϕa0_c4 = 0.352*0.087 (unitless) - constant term in quadratic intrinsic quantum yield (Scott and Smith, 2022)
-- ϕa1_c4 = 0.022*0.087 (K^-1) - first order term in quadratic intrinsic quantum yield (Scott and Smith, 2022)
-- ϕa2_c4 = -0.00034*0.087 (K^-2) - second order term in quadratic intrinsic quantum yield (Scott and Smith, 2022)
+- ϕa0_c3 = 0.044 (unitless) - constant term in quadratic intrinsic quantum yield (pyrealm/Bernacchi et al., 2003)
+- ϕa1_c3 = 0.00275 (K^-1) - first order term in quadratic intrinsic quantum yield (pyrealm/Bernacchi et al., 2003)
+- ϕa2_c3 = -0.0000425 (K^-2) - second order term in quadratic intrinsic quantum yield (pyrealm/Bernacchi et al., 2003)
+- ϕa0_c4 = -0.008 (unitless) - constant term in quadratic intrinsic quantum yield (pyrealm/Cai and Prentice, 2020)
+- ϕa1_c4 = 0.00375 (K^-1) - first order term in quadratic intrinsic quantum yield (pyrealm/Cai and Prentice, 2020)
+- ϕa2_c4 = -0.000058 (K^-2) - second order term in quadratic intrinsic quantum yield (pyrealm/Cai and Prentice, 2020)
 - α = 0.933 (unitless) - 1 - 1/T where T is the timescale of Vcmax, Jmax acclimation. Here T = 15 days. (Mengoli 2022)
 """
 function PModel{FT}(
     domain,
     toml_dict::CP.ParamDict;
-    is_c3 = clm_photosynthesis_parameters(domain.space.surface).is_c3,
+    is_c3 = nothing,
     cstar = toml_dict["pmodel_cstar"],
     β_c3 = toml_dict["pmodel_β_c3"],
     β_c4 = toml_dict["pmodel_β_c4"],
@@ -270,6 +272,17 @@ function PModel{FT}(
     ϕa2_c4 = toml_dict["pmodel_ϕa2_c4"],
     α = toml_dict["pmodel_α"],
 ) where {FT <: AbstractFloat}
+    c3_fraction = if isnothing(is_c3)
+        photosynthesis_parameters = clm_photosynthesis_parameters(domain.space.surface)
+        (
+            hasproperty(photosynthesis_parameters, :c3_fraction) ?
+            photosynthesis_parameters.c3_fraction :
+            photosynthesis_parameters.is_c3
+        )
+    else
+        is_c3
+    end
+
     parameters = ClimaLand.Canopy.PModelParameters(
         cstar,
         β_c3,
@@ -286,7 +299,7 @@ function PModel{FT}(
         α,
     )
 
-    return PModel{FT}(is_c3, toml_dict, parameters)
+    return PModel{FT}(c3_fraction, toml_dict, parameters)
 end
 
 

--- a/src/standalone/Vegetation/optimal_lai.jl
+++ b/src/standalone/Vegetation/optimal_lai.jl
@@ -557,6 +557,7 @@ function call_update_optimal_LAI(p, Y, t, current_date; canopy, dt, local_noon)
             P_air,
             p.canopy.biomass.vpd_gs,
             ca,
+            is_c3,
         ),
     )
 

--- a/src/standalone/Vegetation/pmodel.jl
+++ b/src/standalone/Vegetation/pmodel.jl
@@ -17,8 +17,10 @@ $(DocStringExtensions.FIELDS)
 Base.@kwdef struct PModelParameters{FT <: AbstractFloat}
     "Constant describing cost of maintaining electron transport (unitless)"
     cstar::FT
-    "Ratio of unit costs of transpiration and carboxylation (unitless)"
-    β::FT
+    "Ratio of unit costs of transpiration and carboxylation for C3 plants (unitless)"
+    β_c3::FT
+    "Ratio of unit costs of transpiration and carboxylation for C4 plants (unitless)"
+    β_c4::FT
     "A boolean flag indicating if the quantum yield is a function of temperature or not"
     temperature_dep_yield::Bool
     "Temp-independent intrinsic quantum yield. (unitless); C3"
@@ -111,6 +113,13 @@ Base.eltype(::PModelConstants{FT}) where {FT} = FT
 # make these custom structs broadcastable as tuples
 Base.broadcastable(x::PModelParameters) = tuple(x)
 Base.broadcastable(x::PModelConstants) = tuple(x)
+
+"""
+    get_beta(is_c3, β_c3, β_c4)
+
+Returns the appropriate β (cost ratio) based on whether the plant is C3 or C4.
+"""
+get_beta(is_c3, β_c3, β_c4) = ifelse(is_c3 == one(is_c3), β_c3, β_c4)
 
 """
     PModelConstants(toml_dict::CP.ParamDict;
@@ -336,7 +345,8 @@ function compute_full_pmodel_outputs(
     is_c3 = FT(1),
 ) where {FT}
     # Unpack parameters
-    (; cstar, β) = parameters
+    (; cstar, β_c3, β_c4) = parameters
+    β = get_beta(is_c3, β_c3, β_c4)
 
     # Unpack constants
     (;
@@ -507,7 +517,8 @@ function update_optimal_EMA(
 ) where {FT}
     if local_noon_mask == FT(1.0)
         # Unpack parameters
-        (; cstar, β, α) = parameters
+        (; cstar, β_c3, β_c4, α) = parameters
+        β = get_beta(is_c3, β_c3, β_c4)
 
         # Unpack constants
         (;
@@ -670,7 +681,8 @@ function set_historical_cache!(p, Y0, model::PModel, canopy)
 
     parameters_init = PModelParameters(
         cstar = parameters.cstar,
-        β = parameters.β,
+        β_c3 = parameters.β_c3,
+        β_c4 = parameters.β_c4,
         temperature_dep_yield = parameters.temperature_dep_yield,
         ϕ0_c4 = parameters.ϕ0_c4,
         ϕ0_c3 = parameters.ϕ0_c3,
@@ -1400,7 +1412,8 @@ function compute_A0_daily(
     PPFD::FT,
     βm::FT,
 ) where {FT}
-    (; cstar, β) = parameters
+    (; cstar, β_c3, β_c4) = parameters
+    β = get_beta(is_c3, β_c3, β_c4)
     (; R, Kc25, Ko25, To, ΔHkc, ΔHko, Drel, ΔHΓstar, Γstar25, Mc, oi, ρ_water) =
         constants
 
@@ -1429,17 +1442,18 @@ function compute_A0_daily(
 end
 
 """
-    compute_chi(pmodel_parameters, pmodel_constants, T, P_air, VPD, ca)
+    compute_chi(pmodel_parameters, pmodel_constants, T, P_air, VPD, ca, is_c3=FT(1))
 
 Compute the optimal ratio of intercellular to ambient CO2 (chi = ci/ca) using P-model.
 
 # Arguments
-- `pmodel_parameters`: P-model parameters (including beta)
+- `pmodel_parameters`: P-model parameters (including β_c3 and β_c4)
 - `pmodel_constants`: P-model constants (including Gamma_star25, Kc25, Ko25, etc.)
 - `T::FT`: Temperature (K)
 - `P_air::FT`: Atmospheric pressure (Pa)
 - `VPD::FT`: Vapor pressure deficit (Pa)
 - `ca::FT`: Ambient CO2 mixing ratio (mol/mol)
+- `is_c3::FT`: C3 (1) or C4 (0) flag (default: C3)
 
 # Returns
 - `chi::FT`: Optimal ci/ca ratio (dimensionless), typically 0.7-0.85
@@ -1451,8 +1465,10 @@ function compute_chi(
     P_air::FT,
     VPD::FT,
     ca::FT,
+    is_c3::FT = FT(1),
 ) where {FT}
-    (; β) = pmodel_parameters
+    (; β_c3, β_c4) = pmodel_parameters
+    β = get_beta(is_c3, β_c3, β_c4)
     (; R, Kc25, Ko25, To, ΔHkc, ΔHko, Drel, ΔHΓstar, Γstar25, oi, ρ_water) =
         pmodel_constants
 

--- a/src/standalone/Vegetation/pmodel.jl
+++ b/src/standalone/Vegetation/pmodel.jl
@@ -741,7 +741,7 @@ function set_historical_cache!(p, Y0, model::PModel, canopy)
     grav = LP.grav(earth_param_set)
     ρ_water = LP.ρ_cloud_liq(earth_param_set)
     βm = p.canopy.soil_moisture_stress.βm
-    T_canopy = canopy_temperature(canopy.energy, canopy, Y0, p)
+    T_canopy = p.drivers.T # use air temperature (as in pyrealm)
     # The Pmodel divides by sqrt(VPD); clip here to prevent numerical issues
     VPD = @. lazy(
         max(
@@ -837,7 +837,7 @@ function call_update_optimal_EMA(p, Y, t; canopy, dt, local_noon)
     # drivers
     FT = eltype(parameters)
     βm = p.canopy.soil_moisture_stress.βm
-    T_canopy = canopy_temperature(canopy.energy, canopy, Y, p)
+    T_canopy = p.drivers.T # use air temperature (as in pyrealm)
     # The Pmodel divides by sqrt(VPD); clip here to prevent numerical issues
     VPD = @. lazy(
         max(
@@ -992,7 +992,7 @@ function update_photosynthesis!(p, Y, model::PModel, canopy)
     P_air = p.drivers.P
     ca_pp = @. lazy(p.drivers.c_co2 * P_air) # partial pressure of co2
     c3_fraction = model.is_c3
-    T_canopy = canopy_temperature(canopy.energy, canopy, Y, p)
+    T_canopy = p.drivers.T # use air temperature (as in pyrealm)
     # The Pmodel divides by sqrt(VPD); clip here to prevent numerical issues
     VPD = @. lazy(
         max(
@@ -1176,7 +1176,7 @@ function get_J_over_Jmax(Y, p, canopy, m::PModel)
 end
 
 function compute_Jmax_canopy(Y, p, canopy, m::PModel) # used internally to pmodel photosynthesis as a helper function
-    T_canopy = canopy_temperature(canopy.energy, canopy, Y, p)
+    T_canopy = p.drivers.T # use air temperature (as in pyrealm)
     constants = m.constants
     Jmax_c3 = @. lazy(
         p.canopy.photosynthesis.OptVars.c3.Jmax25_opt * inst_temp_scaling(
@@ -1206,7 +1206,7 @@ function compute_Jmax_canopy(Y, p, canopy, m::PModel) # used internally to pmode
 end
 
 function compute_J_canopy(Y, p, canopy, m::PModel) # used internally to pmodel photosynthesis as a helper function
-    T_canopy = canopy_temperature(canopy.energy, canopy, Y, p)
+    T_canopy = p.drivers.T # use air temperature (as in pyrealm)
     FT = eltype(m.constants)
     earth_param_set = canopy.earth_param_set
     f_abs_par = p.canopy.radiative_transfer.par.abs

--- a/src/standalone/Vegetation/pmodel.jl
+++ b/src/standalone/Vegetation/pmodel.jl
@@ -114,6 +114,28 @@ Base.eltype(::PModelConstants{FT}) where {FT} = FT
 Base.broadcastable(x::PModelParameters) = tuple(x)
 Base.broadcastable(x::PModelConstants) = tuple(x)
 
+zero_optvars(::Type{FT}) where {FT} =
+    (; ξ_opt = FT(0), Vcmax25_opt = FT(0), Jmax25_opt = FT(0))
+zero_optvars_by_pathway(::Type{FT}) where {FT} =
+    (; c3 = zero_optvars(FT), c4 = zero_optvars(FT))
+
+weighted_pmodel_value(c3_fraction, c3_value, c4_value) =
+    c3_fraction * c3_value + (one(c3_fraction) - c3_fraction) * c4_value
+
+function mix_pmodel_outputs(c3_fraction, c3_outputs, c4_outputs)
+    keys = propertynames(c3_outputs)
+    values = map(
+        key ->
+            weighted_pmodel_value(
+                c3_fraction,
+                getproperty(c3_outputs, key),
+                getproperty(c4_outputs, key),
+            ),
+        keys,
+    )
+    return NamedTuple{keys}(values)
+end
+
 """
     get_beta(is_c3, β_c3, β_c4)
 
@@ -226,7 +248,7 @@ struct PModel{
     parameters::OPFT
     "Constants for the P-model"
     constants::OPCT
-    "Photosynthesis mechanism - 1 indicates C3, 0 indicates C4"
+    "Fraction of C3 vegetation - 1 indicates pure C3, 0 indicates pure C4"
     is_c3::F
 end
 
@@ -248,10 +270,8 @@ function PModel{FT}(
     parameters::PModelParameters{FT};
     constants::PModelConstants{FT} = PModelConstants(toml_dict),
 ) where {FT <: AbstractFloat}
-    # if is_c3 is a field, is_c3 may contain values between 0.0 and 1.0 after regridding
-    # this deals with that possibility by rounding to the closest int
-    is_c3 = max.(min.(is_c3, FT(1)), FT(0)) # placeholder
-    is_c3 = round.(is_c3)
+    # Preserve mixed C3/C4 pixels while keeping the valid range [0, 1].
+    is_c3 = max.(min.(is_c3, FT(1)), FT(0))
     F = typeof(is_c3)
     return PModel{FT, typeof(parameters), typeof(constants), F}(
         parameters,
@@ -269,20 +289,41 @@ Defines the auxiliary vars of the Pmode: canopy level net photosynthesis,
  canopy-level gross photosynthesis (`GPP`),
 and dark respiration at the canopy level (`Rd`), and
 
-- `OptVars`: a NamedTuple with keys `:ξ_opt`, `:Vcmax25_opt`, and `:Jmax25_opt`
-    containing the acclimated optimal values of ξ, Vcmax25, and Jmax25, respectively. These are updated
+- `OptVars`: a NamedTuple with keys `:c3` and `:c4`, each containing acclimated
+    optimal values of ξ, Vcmax25, and Jmax25 for that pathway. These are updated
     using an exponential moving average (EMA) at local noon.
 """
-ClimaLand.auxiliary_vars(model::PModel) = (:An, :GPP, :Rd, :ci, :OptVars)
+ClimaLand.auxiliary_vars(model::PModel) =
+    (:An, :GPP, :Rd, :ci, :An_c3, :An_c4, :ci_c3, :ci_c4, :OptVars)
 ClimaLand.auxiliary_types(model::PModel{FT}) where {FT} = (
     FT,
     FT,
     FT,
     FT,
-    NamedTuple{(:ξ_opt, :Vcmax25_opt, :Jmax25_opt), Tuple{FT, FT, FT}},
+    FT,
+    FT,
+    FT,
+    FT,
+    NamedTuple{
+        (:c3, :c4),
+        Tuple{
+            NamedTuple{(:ξ_opt, :Vcmax25_opt, :Jmax25_opt), Tuple{FT, FT, FT}},
+            NamedTuple{(:ξ_opt, :Vcmax25_opt, :Jmax25_opt), Tuple{FT, FT, FT}},
+        },
+    },
 )
 ClimaLand.auxiliary_domain_names(::PModel) =
-    (:surface, :surface, :surface, :surface, :surface)
+    (
+        :surface,
+        :surface,
+        :surface,
+        :surface,
+        :surface,
+        :surface,
+        :surface,
+        :surface,
+        :surface,
+    )
 
 
 """
@@ -302,7 +343,8 @@ Performs the P-model computations as defined in Stocker et al. (2020)
 and returns a dictionary of full outputs. See https://github.com/geco-bern/rpmodel
 for a code reference. This should replicate the behavior of the `rpmodel` package.
 
-This is for C3 only, since the comparison data for C3.
+When `is_c3` is between 0 and 1, the function evaluates pure C3 and pure C4
+pathways separately and returns their partition-weighted average.
 
 Args:
 - `parameters`:     PModelParameters object containing the model parameters.
@@ -333,7 +375,7 @@ Output name         Description (units)
 - "jmax25"        Jmax normalized to 25°C via modified-Arrhenius type function (mol m^-2 s^-1)
 - "Rd"            Dark respiration rate (mol m^-2 s^-1)
 """
-function compute_full_pmodel_outputs(
+function compute_full_pmodel_outputs_pathway(
     parameters::PModelParameters{FT},
     constants::PModelConstants{FT},
     T_canopy::FT,
@@ -459,6 +501,56 @@ function compute_full_pmodel_outputs(
         jmax = Jmax,
         jmax25 = Jmax25,
         rd = rd,
+    )
+end
+
+function compute_full_pmodel_outputs(
+    parameters::PModelParameters{FT},
+    constants::PModelConstants{FT},
+    T_canopy::FT,
+    P_air::FT,
+    VPD::FT,
+    ca::FT,
+    βm::FT,
+    APAR::FT;
+    is_c3 = FT(1),
+) where {FT}
+    if FT(0) < is_c3 < FT(1)
+        c3_outputs = compute_full_pmodel_outputs_pathway(
+            parameters,
+            constants,
+            T_canopy,
+            P_air,
+            VPD,
+            ca,
+            βm,
+            APAR;
+            is_c3 = FT(1),
+        )
+        c4_outputs = compute_full_pmodel_outputs_pathway(
+            parameters,
+            constants,
+            T_canopy,
+            P_air,
+            VPD,
+            ca,
+            βm,
+            APAR;
+            is_c3 = FT(0),
+        )
+        return mix_pmodel_outputs(is_c3, c3_outputs, c4_outputs)
+    end
+
+    return compute_full_pmodel_outputs_pathway(
+        parameters,
+        constants,
+        T_canopy,
+        P_air,
+        VPD,
+        ca,
+        βm,
+        APAR;
+        is_c3,
     )
 end
 
@@ -673,11 +765,8 @@ function set_historical_cache!(p, Y0, model::PModel, canopy)
         ),
     )
 
-    # Initialize OptVars with dummy values which will be overwritten
-    fill!(
-        p.canopy.photosynthesis.OptVars,
-        (; ξ_opt = FT(0), Vcmax25_opt = FT(0), Jmax25_opt = FT(0)),
-    )
+    # Initialize pathway-specific acclimated values with dummy values which will be overwritten.
+    fill!(p.canopy.photosynthesis.OptVars, zero_optvars_by_pathway(FT))
 
     parameters_init = PModelParameters(
         cstar = parameters.cstar,
@@ -697,11 +786,24 @@ function set_historical_cache!(p, Y0, model::PModel, canopy)
 
     local_noon_mask = FT(1)  # Force update for initialization
 
-    @. p.canopy.photosynthesis.OptVars = update_optimal_EMA(
-        model.is_c3,
+    @. p.canopy.photosynthesis.OptVars.c3 = update_optimal_EMA(
+        FT(1),
         parameters_init,
         constants,
-        p.canopy.photosynthesis.OptVars,
+        p.canopy.photosynthesis.OptVars.c3,
+        T_canopy,
+        p.drivers.P,
+        VPD,
+        p.drivers.c_co2,
+        βm,
+        APAR_canopy_moles,
+        local_noon_mask,
+    )
+    @. p.canopy.photosynthesis.OptVars.c4 = update_optimal_EMA(
+        FT(0),
+        parameters_init,
+        constants,
+        p.canopy.photosynthesis.OptVars.c4,
         T_canopy,
         p.drivers.P,
         VPD,
@@ -759,11 +861,24 @@ function call_update_optimal_EMA(p, Y, t; canopy, dt, local_noon)
         ),
     )
 
-    @. p.canopy.photosynthesis.OptVars = update_optimal_EMA(
-        canopy.photosynthesis.is_c3,
+    @. p.canopy.photosynthesis.OptVars.c3 = update_optimal_EMA(
+        FT(1),
         parameters,
         constants,
-        p.canopy.photosynthesis.OptVars,
+        p.canopy.photosynthesis.OptVars.c3,
+        T_canopy,
+        p.drivers.P,
+        VPD,
+        p.drivers.c_co2,
+        βm,
+        APAR_canopy_moles,
+        local_noon_mask,
+    )
+    @. p.canopy.photosynthesis.OptVars.c4 = update_optimal_EMA(
+        FT(0),
+        parameters,
+        constants,
+        p.canopy.photosynthesis.OptVars.c4,
         T_canopy,
         p.drivers.P,
         VPD,
@@ -867,11 +982,16 @@ function update_photosynthesis!(p, Y, model::PModel, canopy)
     GPP = p.canopy.photosynthesis.GPP
     Rd = p.canopy.photosynthesis.Rd
     ci = p.canopy.photosynthesis.ci
+    An_c3 = p.canopy.photosynthesis.An_c3
+    An_c4 = p.canopy.photosynthesis.An_c4
+    ci_c3 = p.canopy.photosynthesis.ci_c3
+    ci_c4 = p.canopy.photosynthesis.ci_c4
     OptVars = p.canopy.photosynthesis.OptVars
 
     # drivers
     P_air = p.drivers.P
     ca_pp = @. lazy(p.drivers.c_co2 * P_air) # partial pressure of co2
+    c3_fraction = model.is_c3
     T_canopy = canopy_temperature(canopy.energy, canopy, Y, p)
     # The Pmodel divides by sqrt(VPD); clip here to prevent numerical issues
     VPD = @. lazy(
@@ -907,7 +1027,6 @@ function update_photosynthesis!(p, Y, model::PModel, canopy)
             constants.Γstar25,
         ),
     )
-    @. ci = intercellular_co2_pmodel(OptVars.ξ_opt, ca_pp, Γstar, VPD)
     Kmm = @. lazy(
         compute_Kmm(
             T_canopy,
@@ -921,9 +1040,24 @@ function update_photosynthesis!(p, Y, model::PModel, canopy)
             constants.oi,
         ),
     )
-    # compute instantaneous max photosynthetic rates and assimilation rates
-    Jmax = @. lazy(
-        p.canopy.photosynthesis.OptVars.Jmax25_opt * inst_temp_scaling(
+    # compute instantaneous max photosynthetic rates and assimilation rates for each pathway
+    @. ci_c3 = intercellular_co2_pmodel(OptVars.c3.ξ_opt, ca_pp, Γstar, VPD)
+    @. ci_c4 = intercellular_co2_pmodel(OptVars.c4.ξ_opt, ca_pp, Γstar, VPD)
+
+    Jmax_c3 = @. lazy(
+        OptVars.c3.Jmax25_opt * inst_temp_scaling(
+            T_canopy,
+            T_canopy,
+            constants.To,
+            constants.Ha_Jmax,
+            constants.Hd_Jmax,
+            constants.aS_Jmax,
+            constants.bS_Jmax,
+            constants.R,
+        ),
+    )
+    Jmax_c4 = @. lazy(
+        OptVars.c4.Jmax25_opt * inst_temp_scaling(
             T_canopy,
             T_canopy,
             constants.To,
@@ -935,16 +1069,35 @@ function update_photosynthesis!(p, Y, model::PModel, canopy)
         ),
     )
 
-    J = @. lazy(
+    J_c3 = @. lazy(
         electron_transport_pmodel(
-            intrinsic_quantum_yield(model.is_c3, T_canopy, parameters),
+            intrinsic_quantum_yield(FT(1), T_canopy, parameters),
             APAR_canopy_moles,
-            Jmax,
+            Jmax_c3,
+        ),
+    )
+    J_c4 = @. lazy(
+        electron_transport_pmodel(
+            intrinsic_quantum_yield(FT(0), T_canopy, parameters),
+            APAR_canopy_moles,
+            Jmax_c4,
         ),
     )
 
-    Vcmax = @. lazy(
-        p.canopy.photosynthesis.OptVars.Vcmax25_opt * inst_temp_scaling(
+    Vcmax_c3 = @. lazy(
+        OptVars.c3.Vcmax25_opt * inst_temp_scaling(
+            T_canopy,
+            T_canopy,
+            constants.To,
+            constants.Ha_Vcmax,
+            constants.Hd_Vcmax,
+            constants.aS_Vcmax,
+            constants.bS_Vcmax,
+            constants.R,
+        ),
+    )
+    Vcmax_c4 = @. lazy(
+        OptVars.c4.Vcmax25_opt * inst_temp_scaling(
             T_canopy,
             T_canopy,
             constants.To,
@@ -956,35 +1109,52 @@ function update_photosynthesis!(p, Y, model::PModel, canopy)
         ),
     )
 
-    # rubisco limited assimilation rate
-    Ac = @. lazy(Vcmax * compute_mc(model.is_c3, Γstar, ca_pp, ci, VPD, Kmm)) # c3 or c4 is reflected in the value of mc
+    Ac_c3 = @. lazy(Vcmax_c3 * compute_mc(FT(1), Γstar, ca_pp, ci_c3, VPD, Kmm))
+    Ac_c4 = @. lazy(Vcmax_c4 * compute_mc(FT(0), Γstar, ca_pp, ci_c4, VPD, Kmm))
+    Aj_c3 = @. lazy(J_c3 / 4 * compute_mj(FT(1), Γstar, ca_pp, ci_c3, VPD))
+    Aj_c4 = @. lazy(J_c4 / 4 * compute_mj(FT(0), Γstar, ca_pp, ci_c4, VPD))
 
-    # light limited assimilation rate
-    Aj = @. lazy(J / 4 * compute_mj(model.is_c3, Γstar, ca_pp, ci, VPD)) # c3 or c4 is reflected in the value of mj
-
-    # dark respiration
-    # Here we make an assumption about how to relate Rd25 to Vcmax25_opt
-    # To extend to C4, defined `compute_dark_respiration_pmodel() which dispatches off of the is_c3 field
-    # This function below would become c3_dark_respiration_pmodel
-    @. Rd =
+    Rd_c3 = @. lazy(
         constants.fC3 *
-        p.canopy.photosynthesis.OptVars.Vcmax25_opt *
+        OptVars.c3.Vcmax25_opt *
         inst_temp_scaling_rd(
             T_canopy,
             constants.To,
             constants.aRd,
             constants.bRd,
         )
+    )
+    Rd_c4 = @. lazy(
+        constants.fC3 *
+        OptVars.c4.Vcmax25_opt *
+        inst_temp_scaling_rd(
+            T_canopy,
+            constants.To,
+            constants.aRd,
+            constants.bRd,
+        )
+    )
 
     # Note: net_photosynthesis applies the moisture stress to GPP, but since the P-model already applies
     # this factor to Vcmax and Jmax, we do not apply it again here
-    @. GPP = gross_photosynthesis(Ac, Aj)
-    @. An = net_photosynthesis(GPP, Rd)
+    GPP_c3 = @. lazy(gross_photosynthesis(Ac_c3, Aj_c3))
+    GPP_c4 = @. lazy(gross_photosynthesis(Ac_c4, Aj_c4))
+    @. An_c3 = net_photosynthesis(GPP_c3, Rd_c3)
+    @. An_c4 = net_photosynthesis(GPP_c4, Rd_c4)
+
+    @. ci = weighted_pmodel_value(c3_fraction, ci_c3, ci_c4)
+    @. GPP = weighted_pmodel_value(c3_fraction, GPP_c3, GPP_c4)
+    @. Rd = weighted_pmodel_value(c3_fraction, Rd_c3, Rd_c4)
+    @. An = weighted_pmodel_value(c3_fraction, An_c3, An_c4)
 
 end
 
 get_Vcmax25_leaf(p, m::PModel) = @. lazy(
-    p.canopy.photosynthesis.OptVars.Vcmax25_opt /
+    weighted_pmodel_value(
+        m.is_c3,
+        p.canopy.photosynthesis.OptVars.c3.Vcmax25_opt,
+        p.canopy.photosynthesis.OptVars.c4.Vcmax25_opt,
+    ) /
     max(p.canopy.biomass.area_index.leaf, sqrt(eps(eltype(m.constants)))),
 )
 get_Rd_leaf(p, m::PModel) = @. lazy(
@@ -1008,8 +1178,8 @@ end
 function compute_Jmax_canopy(Y, p, canopy, m::PModel) # used internally to pmodel photosynthesis as a helper function
     T_canopy = canopy_temperature(canopy.energy, canopy, Y, p)
     constants = m.constants
-    return @. lazy(
-        p.canopy.photosynthesis.OptVars.Jmax25_opt * inst_temp_scaling(
+    Jmax_c3 = @. lazy(
+        p.canopy.photosynthesis.OptVars.c3.Jmax25_opt * inst_temp_scaling(
             T_canopy,
             T_canopy,
             constants.To,
@@ -1020,10 +1190,24 @@ function compute_Jmax_canopy(Y, p, canopy, m::PModel) # used internally to pmode
             constants.R,
         ),
     )
+    Jmax_c4 = @. lazy(
+        p.canopy.photosynthesis.OptVars.c4.Jmax25_opt * inst_temp_scaling(
+            T_canopy,
+            T_canopy,
+            constants.To,
+            constants.Ha_Jmax,
+            constants.Hd_Jmax,
+            constants.aS_Jmax,
+            constants.bS_Jmax,
+            constants.R,
+        ),
+    )
+    return @. lazy(weighted_pmodel_value(m.is_c3, Jmax_c3, Jmax_c4))
 end
 
 function compute_J_canopy(Y, p, canopy, m::PModel) # used internally to pmodel photosynthesis as a helper function
     T_canopy = canopy_temperature(canopy.energy, canopy, Y, p)
+    FT = eltype(m.constants)
     earth_param_set = canopy.earth_param_set
     f_abs_par = p.canopy.radiative_transfer.par.abs
     par_d = p.canopy.radiative_transfer.par_d
@@ -1035,16 +1219,46 @@ function compute_J_canopy(Y, p, canopy, m::PModel) # used internally to pmodel p
         compute_APAR_canopy_moles(f_abs_par, par_d, λ_γ_PAR, c, planck_h, N_a),
     )
 
-    Jmax_canopy = compute_Jmax_canopy(Y, p, canopy, m)
     parameters = m.parameters
-    constants = m.constants
-    return @. lazy(
-        electron_transport_pmodel(
-            intrinsic_quantum_yield(m.is_c3, T_canopy, parameters),
-            APAR_canopy_moles,
-            Jmax_canopy,
+    Jmax_c3 = @. lazy(
+        p.canopy.photosynthesis.OptVars.c3.Jmax25_opt * inst_temp_scaling(
+            T_canopy,
+            T_canopy,
+            m.constants.To,
+            m.constants.Ha_Jmax,
+            m.constants.Hd_Jmax,
+            m.constants.aS_Jmax,
+            m.constants.bS_Jmax,
+            m.constants.R,
         ),
     )
+    Jmax_c4 = @. lazy(
+        p.canopy.photosynthesis.OptVars.c4.Jmax25_opt * inst_temp_scaling(
+            T_canopy,
+            T_canopy,
+            m.constants.To,
+            m.constants.Ha_Jmax,
+            m.constants.Hd_Jmax,
+            m.constants.aS_Jmax,
+            m.constants.bS_Jmax,
+            m.constants.R,
+        ),
+    )
+    J_c3 = @. lazy(
+        electron_transport_pmodel(
+            intrinsic_quantum_yield(FT(1), T_canopy, parameters),
+            APAR_canopy_moles,
+            Jmax_c3,
+        ),
+    )
+    J_c4 = @. lazy(
+        electron_transport_pmodel(
+            intrinsic_quantum_yield(FT(0), T_canopy, parameters),
+            APAR_canopy_moles,
+            Jmax_c4,
+        ),
+    )
+    return @. lazy(weighted_pmodel_value(m.is_c3, J_c3, J_c4))
 end
 
 """
@@ -1412,33 +1626,17 @@ function compute_A0_daily(
     PPFD::FT,
     βm::FT,
 ) where {FT}
-    (; cstar, β_c3, β_c4) = parameters
-    β = get_beta(is_c3, β_c3, β_c4)
-    (; R, Kc25, Ko25, To, ΔHkc, ΔHko, Drel, ΔHΓstar, Γstar25, Mc, oi, ρ_water) =
-        constants
-
-    # Convert ca from mol/mol to partial pressure (Pa)
-    ca_pp = ca * P_air
-
-    # Compute P-model intermediate values
-    ϕ0 = intrinsic_quantum_yield(is_c3, T_air, parameters)
-    Γstar = co2_compensation_pmodel(T_air, To, P_air, R, ΔHΓstar, Γstar25)
-    ηstar = compute_viscosity_ratio(T_air, To, ρ_water)
-    Kmm = compute_Kmm(T_air, P_air, Kc25, Ko25, ΔHkc, ΔHko, To, R, oi)
-
-    # Compute optimal ξ and intercellular CO2
-    ξ = sqrt(β * (Kmm + Γstar) / (Drel * ηstar))
-    ci = intercellular_co2_pmodel(ξ, ca_pp, Γstar, VPD)
-
-    # Compute mj and m' (with Jmax limitation)
-    mj = compute_mj(is_c3, Γstar, ca_pp, ci, VPD)
-    mprime = compute_mj_with_jmax_limitation(mj, cstar)
-
-    # Compute LUE with actual βm (soil moisture stress)
-    LUE_daily = compute_LUE(ϕ0, βm, mprime, Mc)
-
-    # Daily potential GPP = PPFD * LUE (fAPAR = 1 is implicit in using full PPFD)
-    return PPFD * LUE_daily
+    return compute_full_pmodel_outputs(
+        parameters,
+        constants,
+        T_air,
+        P_air,
+        VPD,
+        ca,
+        βm,
+        PPFD;
+        is_c3,
+    ).gpp
 end
 
 """
@@ -1458,7 +1656,7 @@ Compute the optimal ratio of intercellular to ambient CO2 (chi = ci/ca) using P-
 # Returns
 - `chi::FT`: Optimal ci/ca ratio (dimensionless), typically 0.7-0.85
 """
-function compute_chi(
+function compute_chi_pathway(
     pmodel_parameters,
     pmodel_constants,
     T::FT,
@@ -1486,6 +1684,48 @@ function compute_chi(
     VPD_safe = max(VPD, eps(FT))
     ci = intercellular_co2_pmodel(ξ, ca_pp, Γstar, VPD_safe)
     return clamp(ci / ca_pp, FT(0), FT(1))
+end
+
+function compute_chi(
+    pmodel_parameters,
+    pmodel_constants,
+    T::FT,
+    P_air::FT,
+    VPD::FT,
+    ca::FT,
+    is_c3::FT = FT(1),
+) where {FT}
+    if FT(0) < is_c3 < FT(1)
+        χ_c3 = compute_chi_pathway(
+            pmodel_parameters,
+            pmodel_constants,
+            T,
+            P_air,
+            VPD,
+            ca,
+            FT(1),
+        )
+        χ_c4 = compute_chi_pathway(
+            pmodel_parameters,
+            pmodel_constants,
+            T,
+            P_air,
+            VPD,
+            ca,
+            FT(0),
+        )
+        return weighted_pmodel_value(is_c3, χ_c3, χ_c4)
+    end
+
+    return compute_chi_pathway(
+        pmodel_parameters,
+        pmodel_constants,
+        T,
+        P_air,
+        VPD,
+        ca,
+        is_c3,
+    )
 end
 
 """

--- a/src/standalone/Vegetation/spatially_varying_parameters.jl
+++ b/src/standalone/Vegetation/spatially_varying_parameters.jl
@@ -137,6 +137,7 @@ Fields.
 
 In particular, this file returns a field for
 - C3 flag
+- C3 fraction
 - VCmax25
 
 The values correspond to the value of the dominant PFT at each point.
@@ -177,7 +178,8 @@ function clm_photosynthesis_parameters(
         regridder_kwargs = (; extrapolation_bc, interpolation_method),
         file_reader_kwargs = (; preprocess_func = (data) -> data / 1_000_000,),
     )
-    # photosynthesis mechanism is read as a float, where 1.0 indicates c3 and 0.0 c4
+    # dominant photosynthesis mechanism is read as a float, where 1.0 indicates c3
+    # and 0.0 indicates c4
     is_c3 = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "c3_dominant",
@@ -185,7 +187,14 @@ function clm_photosynthesis_parameters(
         regridder_type,
         regridder_kwargs = (; extrapolation_bc, interpolation_method),
     )
-    return (; is_c3 = is_c3, Vcmax25 = Vcmax25)
+    c3_fraction = SpaceVaryingInput(
+        joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
+        "c3_proportion",
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc, interpolation_method),
+    )
+    return (; is_c3 = is_c3, c3_fraction = c3_fraction, Vcmax25 = Vcmax25)
 end
 
 

--- a/src/standalone/Vegetation/stomatalconductance.jl
+++ b/src/standalone/Vegetation/stomatalconductance.jl
@@ -148,16 +148,27 @@ function update_canopy_conductance!(p, Y, model::PModelConductance, canopy)
     (; Drel) = canopy.conductance.parameters
     area_index = p.canopy.biomass.area_index
     LAI = area_index.leaf
-    ci = p.canopy.photosynthesis.ci             # internal CO2 partial pressure, Pa 
-    An_canopy = p.canopy.photosynthesis.An          # net assimilation rate, mol m^-2 s^-1, canopy level
+    ci_c3 = p.canopy.photosynthesis.ci_c3
+    ci_c4 = p.canopy.photosynthesis.ci_c4
+    An_c3 = p.canopy.photosynthesis.An_c3
+    An_c4 = p.canopy.photosynthesis.An_c4
+    c3_fraction = canopy.photosynthesis.is_c3
     R = LP.gas_constant(earth_param_set)
     FT = eltype(model.parameters)
 
-    χ = @. lazy(clamp(ci / (c_co2_air * P_air), FT(0), FT(1))) # ratio of intercellular to ambient CO2 concentration, unitless
+    χ_c3 = @. lazy(clamp(ci_c3 / (c_co2_air * P_air), FT(0), FT(1)))
+    χ_c4 = @. lazy(clamp(ci_c4 / (c_co2_air * P_air), FT(0), FT(1)))
+    gs_h2o_canopy = @. lazy(
+        weighted_pmodel_value(
+            c3_fraction,
+            gs_h2o_pmodel(χ_c3, c_co2_air, An_c3, Drel),
+            gs_h2o_pmodel(χ_c4, c_co2_air, An_c4, Drel),
+        ),
+    )
     @. p.canopy.conductance.r_stomata_canopy =
         1 / (
             conductance_molar_flux_to_m_per_s(
-                gs_h2o_pmodel(χ, c_co2_air, An_canopy, Drel), # canopy level conductance in mol H2O/m^2/s
+                gs_h2o_canopy, # canopy level conductance in mol H2O/m^2/s
                 T_air,
                 R,
                 P_air,

--- a/test/standalone/Vegetation/spatial_parameters.jl
+++ b/test/standalone/Vegetation/spatial_parameters.jl
@@ -49,12 +49,14 @@ const FT = Float64;
         extrapolation_bc = extrapolation_bc,
     )
     @test axes(rooting_depth) == surface_space
-    (; is_c3, Vcmax25) = ClimaLand.Canopy.clm_photosynthesis_parameters(
+    (; is_c3, c3_fraction, Vcmax25) =
+        ClimaLand.Canopy.clm_photosynthesis_parameters(
         surface_space;
         regridder_type = regridder_type,
         extrapolation_bc = extrapolation_bc,
     )
     @test axes(is_c3) == surface_space
+    @test axes(c3_fraction) == surface_space
     @test axes(Vcmax25) == surface_space
     (; Ω, G_Function, α_PAR_leaf, τ_PAR_leaf, α_NIR_leaf, τ_NIR_leaf) =
         ClimaLand.Canopy.clm_canopy_radiation_parameters(

--- a/test/standalone/Vegetation/test_pmodel.jl
+++ b/test/standalone/Vegetation/test_pmodel.jl
@@ -62,7 +62,8 @@ Constructs the parameter structure for the P-Model
 """
 function PModelParameters(inputs::Dict{String, Any}, FT)
     # these are default values used in Stocker 2020, Scott and Smith 2022
-    β = FT(inputs["beta"])
+    β_c3 = FT(inputs["beta"])
+    β_c4 = FT(inputs["beta"]) / FT(9)
     cstar = FT(0.41)
 
     # handle temperature-dependent quantum yield
@@ -82,7 +83,8 @@ function PModelParameters(inputs::Dict{String, Any}, FT)
 
     return ClimaLand.Canopy.PModelParameters(;
         cstar,
-        β,
+        β_c3,
+        β_c4,
         temperature_dep_yield,
         ϕ0_c3,
         ϕ0_c4,
@@ -271,7 +273,8 @@ end
         toml_dict = LP.create_toml_dict(FT)
         parameters = ClimaLand.Canopy.PModelParameters(
             cstar = FT(0.41),
-            β = FT(146),
+            β_c3 = FT(146),
+            β_c4 = FT(146 / 9),
             temperature_dep_yield = true,
             ϕ0_c3 = FT(0.052),
             ϕ0_c4 = FT(0.057),

--- a/test/standalone/Vegetation/test_pmodel.jl
+++ b/test/standalone/Vegetation/test_pmodel.jl
@@ -278,12 +278,12 @@ end
             temperature_dep_yield = true,
             ϕ0_c3 = FT(0.052),
             ϕ0_c4 = FT(0.057),
-            ϕa0_c3 = FT(0.352 * 0.087),
-            ϕa1_c3 = FT(0.022 * 0.087),
-            ϕa2_c3 = FT(-0.00034 * 0.087),
-            ϕa0_c4 = FT(-0.352 * 0.087),
-            ϕa1_c4 = FT(0.022 * 0.087),
-            ϕa2_c4 = FT(-0.00034 * 0.087),
+            ϕa0_c3 = FT(0.352 / 8),
+            ϕa1_c3 = FT(0.022 / 8),
+            ϕa2_c3 = FT(-0.00034 / 8),
+            ϕa0_c4 = FT(-0.008),
+            ϕa1_c4 = FT(0.00375),
+            ϕa2_c4 = FT(-0.000058),
             α = FT(0),
         )
         is_c3 = FT(1)
@@ -342,6 +342,147 @@ end
                 atol = atol,
             )
         end
+    end
+end
+
+@testset "Mixed C3/C4 P-model outputs are partition-weighted" begin
+    for FT in (Float32, Float64)
+        toml_dict = LP.create_toml_dict(FT)
+        parameters = ClimaLand.Canopy.PModelParameters(
+            cstar = FT(0.41),
+            β_c3 = FT(146),
+            β_c4 = FT(146 / 9),
+            temperature_dep_yield = true,
+            ϕ0_c3 = FT(0.052),
+            ϕ0_c4 = FT(0.057),
+            ϕa0_c3 = FT(0.352 / 8),
+            ϕa1_c3 = FT(0.022 / 8),
+            ϕa2_c3 = FT(-0.00034 / 8),
+            ϕa0_c4 = FT(-0.008),
+            ϕa1_c4 = FT(0.00375),
+            ϕa2_c4 = FT(-0.000058),
+            α = FT(0),
+        )
+        constants = PModelConstants(toml_dict)
+        T_canopy = FT(303.15)
+        APAR = FT(0.0015)
+        ca = FT(0.00041)
+        P_air = FT(101325.0)
+        VPD = FT(2000.0)
+        βm = FT(0.9)
+        c3_fraction = FT(0.35)
+
+        outputs_c3 = compute_full_pmodel_outputs(
+            parameters,
+            constants,
+            T_canopy,
+            P_air,
+            VPD,
+            ca,
+            βm,
+            APAR;
+            is_c3 = FT(1),
+        )
+        outputs_c4 = compute_full_pmodel_outputs(
+            parameters,
+            constants,
+            T_canopy,
+            P_air,
+            VPD,
+            ca,
+            βm,
+            APAR;
+            is_c3 = FT(0),
+        )
+        outputs_mixed = compute_full_pmodel_outputs(
+            parameters,
+            constants,
+            T_canopy,
+            P_air,
+            VPD,
+            ca,
+            βm,
+            APAR;
+            is_c3 = c3_fraction,
+        )
+
+        for key in propertynames(outputs_mixed)
+            mixed_value = getproperty(outputs_mixed, key)
+            weighted_value =
+                c3_fraction * getproperty(outputs_c3, key) +
+                (FT(1) - c3_fraction) * getproperty(outputs_c4, key)
+            @test isapprox(mixed_value, weighted_value; rtol = 1e-6, atol = 1e-8)
+        end
+
+        χ_mixed = ClimaLand.Canopy.compute_chi(
+            parameters,
+            constants,
+            T_canopy,
+            P_air,
+            VPD,
+            ca,
+            c3_fraction,
+        )
+        χ_weighted =
+            c3_fraction *
+            ClimaLand.Canopy.compute_chi(
+                parameters,
+                constants,
+                T_canopy,
+                P_air,
+                VPD,
+                ca,
+                FT(1),
+            ) +
+            (FT(1) - c3_fraction) *
+            ClimaLand.Canopy.compute_chi(
+                parameters,
+                constants,
+                T_canopy,
+                P_air,
+                VPD,
+                ca,
+                FT(0),
+            )
+        @test isapprox(χ_mixed, χ_weighted; rtol = 1e-6, atol = 1e-8)
+
+        A0_mixed = ClimaLand.Canopy.compute_A0_daily(
+            c3_fraction,
+            parameters,
+            constants,
+            T_canopy,
+            P_air,
+            VPD,
+            ca,
+            APAR,
+            βm,
+        )
+        A0_weighted =
+            c3_fraction *
+            ClimaLand.Canopy.compute_A0_daily(
+                FT(1),
+                parameters,
+                constants,
+                T_canopy,
+                P_air,
+                VPD,
+                ca,
+                APAR,
+                βm,
+            ) +
+            (FT(1) - c3_fraction) *
+            ClimaLand.Canopy.compute_A0_daily(
+                FT(0),
+                parameters,
+                constants,
+                T_canopy,
+                P_air,
+                VPD,
+                ca,
+                APAR,
+                βm,
+            )
+        @test isapprox(A0_mixed, A0_weighted; rtol = 1e-6, atol = 1e-8)
     end
 end
 

--- a/toml/default_parameters.toml
+++ b/toml/default_parameters.toml
@@ -223,15 +223,21 @@ tag = "ConstantResetAlbedo"
 
 # P model parameters
 ["pmodel_cstar"]
-value = 0.43
+value = 0.41
 type = "float"
 description = "4 * dA/dJmax, assumed to be a constant marginal cost (Wang 2017, Stocker 2020)"
 tag = "PModelParameters"
 
-["pmodel_β"]
-value = 51
+["pmodel_β_c3"]
+value = 146
 type = "float"
-description = "Unit cost ratio of Vcmax to transpiration (Stocker 2020)"
+description = "Unit cost ratio of Vcmax to transpiration for C3 plants (Stocker 2020)"
+tag = "PModelParameters"
+
+["pmodel_β_c4"]
+value = 16.222222222222222
+type = "float"
+description = "Unit cost ratio of Vcmax to transpiration for C4 plants (146/9, pyrealm)"
 tag = "PModelParameters"
 
 ["pmodel_ϕ0_c3"]

--- a/toml/uncalibrated_parameters.toml
+++ b/toml/uncalibrated_parameters.toml
@@ -202,10 +202,16 @@ type = "float"
 description = "4 * dA/dJmax, assumed to be a constant marginal cost (Wang 2017, Stocker 2020)"
 tag = "PModelParameters"
 
-["pmodel_β"]
+["pmodel_β_c3"]
 value = 146
 type = "float"
-description = "Unit cost ratio of Vcmax to transpiration (Stocker 2020)"
+description = "Unit cost ratio of Vcmax to transpiration for C3 plants (Stocker 2020)"
+tag = "PModelParameters"
+
+["pmodel_β_c4"]
+value = 16.222222222222222
+type = "float"
+description = "Unit cost ratio of Vcmax to transpiration for C4 plants (146/9, pyrealm)"
 tag = "PModelParameters"
 
 ["pmodel_ϕ0_c3"]


### PR DESCRIPTION
This PR makes changes to our pmodel implementation to match [pyrealm](https://github.com/ImperialCollegeLondon/pyrealm) implementation which is used, for example, by the Zhou optimal LAI model code


To do about Amazon / c4 grassland bias in south America (LHF and GPP too low in Amazon, GPP too high in c4): 
- run single column at coordinates of Amazon, South America grassland c4. Check what is suspicious: does PAR look good? APAR? Root depth? Moisture stress? LAI? Are things distinct by c3 / c4 (e.g., root depth, and therefore, moisture stress for c3 and c4...), is RAI = 1 reasonable (or should we try RAI = f*maxLAI)?  

- try calibrating GPP + LHF on the first commit of this PR (params adjusted). need to add a dataset to calibrate on (for gpp) on derecho. It seems GPP is overestimated everywhere, so possibly calibration can help (just offset globally)

