### PR TITLE
don't compute fluxes in coupled case

### DIFF
--- a/.buildkite/Manifest-v1.12.toml
+++ b/.buildkite/Manifest-v1.12.toml
@@ -489,7 +489,7 @@ weakdeps = ["CUDA"]
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "RootSolvers", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.6.5"
+version = "1.7.0"
 weakdeps = ["Adapt", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Downloads", "Flux", "GeoMakie", "InteractiveUtils", "JLD2", "Printf", "Statistics"]
 
     [deps.ClimaLand.extensions]

--- a/.buildkite/Manifest.toml
+++ b/.buildkite/Manifest.toml
@@ -486,7 +486,7 @@ weakdeps = ["CUDA"]
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "RootSolvers", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.6.5"
+version = "1.7.0"
 weakdeps = ["Adapt", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Downloads", "Flux", "GeoMakie", "InteractiveUtils", "JLD2", "Printf", "Statistics"]
 
     [deps.ClimaLand.extensions]

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ ClimaLand.jl Release Notes
 
 main
 -----
+
+v1.7.0
+-----
+- ![breaking change][badge-💥breaking] Don't compute bucket fluxes in coupled case PR[#1677](https://github.com/CliMA/ClimaLand.jl/pull/1677)
 - ![][badge-✨feature] Add slab lake model to integrated models PR[#1672](https://github.com/CliMA/ClimaLand.jl/pull/1672)
 
 v1.6.5

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ClimaLand"
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.6.5"
+version = "1.7.0"
 authors = ["Clima Land Team"]
 
 [deps]

--- a/docs/Manifest-v1.12.toml
+++ b/docs/Manifest-v1.12.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.5"
 manifest_format = "2.0"
-project_hash = "c543b0f417fa6ff1231d5c511a53364d1e1ddc19"
+project_hash = "cb1e877800c6030bdbcd9ea92b115648158d597b"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "f7304359109c768cf32dc5fa2d371565bb63b68a"
@@ -459,7 +459,7 @@ version = "0.1.1"
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "RootSolvers", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.6.5"
+version = "1.7.0"
 weakdeps = ["Adapt", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Downloads", "Flux", "GeoMakie", "InteractiveUtils", "JLD2", "Printf", "Statistics"]
 
     [deps.ClimaLand.extensions]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -456,7 +456,7 @@ version = "0.1.1"
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "RootSolvers", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.6.5"
+version = "1.7.0"
 weakdeps = ["Adapt", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Downloads", "Flux", "GeoMakie", "InteractiveUtils", "JLD2", "Printf", "Statistics"]
 
     [deps.ClimaLand.extensions]

--- a/src/shared_utilities/drivers.jl
+++ b/src/shared_utilities/drivers.jl
@@ -487,13 +487,13 @@ end
         earth_param_set)
 
 Computes turbulent surface fluxes at a point on a surface given
-(1) the prescribed atmospheric conditions, `P_atmos`, `T_atmos`, `q_tot_atmos`, 
+(1) the prescribed atmospheric conditions, `P_atmos`, `T_atmos`, `q_tot_atmos`,
     `u_atmos`, and `h_atmos` the absolute height at which these measurements are made.
     `u_atmos` is a can be a scalar if only the horizontal wind speed is known,
     otherwise a tuple can be passed with the (u,v) components of the wind.
 (2) the surface temperature (`T_sfc_guess`), specific humidity (`q_vap_sfc_guess`).
     If no `update_T_sfc` and `update_q_val_sfc` functions are passed, these ``guesses"
-    are the values used in the solve. Otherwise, the update functions are used to 
+    are the values used in the solve. Otherwise, the update functions are used to
     modify the ``guess" values to the actual surface values.
 (3) Other surface properties, such the roughness model (see SurfaceFluxes.jl
     for possible types), the surface height, relative to the same references as `h_atmos`,
@@ -549,7 +549,7 @@ function compute_turbulent_fluxes_at_a_point(
         surface_flux_params,
         T_atmos,
         q_tot_atmos,
-        FT(0),#phase_partition_atmos.liq, 
+        FT(0),#phase_partition_atmos.liq,
         FT(0),#,phase_partition_atmos.ice,
         ρ_atmos,
         T_sfc_guess,
@@ -796,8 +796,8 @@ function get_update_surface_humidity_function(model::AbstractModel, Y, p) end
     get_∂T_sfc∂T_function(model::AbstractModel, Y, p)
 
 Returns a function which computes the partial derivative of the surface temperature
-using in turbulent_fluxes! with respect to the component temperature. The expected
-arguments are (u_star, g_h, earth_param_set).
+used in `turbulent_fluxes!` with respect to the component temperature. The expected
+arguments are (`u_star`, `g_h`, `earth_param_set`).
 
 This is only required if the output of `component_temperature` does not coincide
 with the temperature that should be used to compute turbulent fluxes, and if your
@@ -818,8 +818,8 @@ end
     get_∂q_sfc∂T_function(model::AbstractModel, Y, p)
 
 Returns a function which computes the partial derivative of the surface humidity
-using in turbulent_fluxes! with respect to the component temperature. The expected
-arguments are (u_star, g_h, T_sfc, P_sfc, earth_param_set).
+used in `turbulent_fluxes!` with respect to the component temperature. The expected
+arguments are (`u_star`, `g_h`, `T_sfc`, `P_sfc`, `earth_param_set`).
 
 This is only required if the output of `component_specific_humidity` does not coincide
 with the humidity that should be used to compute turbulent fluxes, and if your
@@ -1635,7 +1635,7 @@ See Appendix A of Braghiere, "Evaluation of turbulent fluxes of CO2, sensible he
 and latent heat as a function of aerosol optical depth over the course of deforestation
 in the Brazilian Amazon" 2013.
 
-Note that cosθs is a coefficient of k₀, which we divide by in this expression. 
+Note that cosθs is a coefficient of k₀, which we divide by in this expression.
 This can amplify small errors when cosθs is near 0.
 
 This formula is empirical and can yield negative numbers depending on the

--- a/src/standalone/Bucket/Bucket.jl
+++ b/src/standalone/Bucket/Bucket.jl
@@ -631,6 +631,33 @@ function make_update_aux(model::BucketModel{FT}) where {FT}
 end
 
 """
+    turbulent_fluxes!(dest,
+                    atmos::CoupledAtmosphere,
+                    model::BucketModel,
+                    Y,
+                    p,
+                    t)
+
+Computes the turbulent surface fluxes terms at the ground for a coupled bucket.
+In this case, the coupler has already computed turbulent fluxes and updated
+them in each of the component models, so this function does nothing.
+
+Note that this function is not used for the full land model; in that case,
+the turbulent fluxes are computed by the full land model during each step.
+"""
+function ClimaLand.turbulent_fluxes!(
+    dest,
+    atmos::CoupledAtmosphere,
+    model::BucketModel,
+    Y,
+    p,
+    t,
+)
+    # coupler has done its thing behind the scenes already
+    return nothing
+end
+
+"""
     next_albedo!(next_α_sfc,
                  model_albedo::PrescribedBaregroundAlbedo{FT},
                  parameters, Y, p, t)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Reverts this change from #1591. Requires also reverting bucket changes from https://github.com/CliMA/ClimaCoupler.jl/commit/288987875b84413fc01e5de6a8826f11abab9261#diff-a2880400c2145db122968b23c23a980c061601611b3bfe9e2cce55c10f147c73

Tested in this ClimaCoupler PR and works fine https://github.com/CliMA/ClimaCoupler.jl/pull/1865

## To-do
- [x] add a method of `turbulent_fluxes!` which does nothing in `CoupledAtmosphere` case
- [x] add a function `helper_update_surface_humidity_function` so we can remap `W` and `σS` onto the boundary space and call it on those in the coupler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v1.7.0

* **New Features**
  * Updated bucket model flux handling in coupled atmospheric scenarios.

* **Documentation**
  * Improved formatting and clarity in driver documentation.

* **Chores**
  * Updated package dependencies to latest stable versions.
  * Released version 1.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->