### PR TITLE
update ClimaCoupler env in downstream test

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -54,6 +54,6 @@ jobs:
           path: ClimaCoupler.jl
 
       - run: |
-          julia -O0 --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ -e 'using Pkg; Pkg.instantiate()'
-          julia -O0 --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ -e 'using Pkg; Pkg.develop(; path = ".")'
-          julia -O0 --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth/ ClimaCoupler.jl/experiments/ClimaEarth/test/runtests.jl
+          julia -O0 --color=yes --project=ClimaCoupler.jl/experiments/AMIP/ -e 'using Pkg; Pkg.instantiate()'
+          julia -O0 --color=yes --project=ClimaCoupler.jl/experiments/AMIP/ -e 'using Pkg; Pkg.develop(; path = ".")'
+          julia -O0 --color=yes --project=ClimaCoupler.jl/experiments/AMIP/ ClimaCoupler.jl/experiments/test/runtests.jl


### PR DESCRIPTION
To update for the AMIP/CMIP environment split in https://github.com/CliMA/ClimaCoupler.jl/pull/1775. For now I left in the experiments/ClimaEarth/ environment in ClimaCoupler.jl so downstream tests don't break, but it will be removed soon.

## Content
- [x] `experiments/ClimaEarth/` --> `experiments/AMIP/`
- [x] `experiments/AMIP/test/runtests.jl` --> `experiments/test/runtests.jl`