### PR TITLE
Change plot limits on annual leaderboard

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ ClimaLand.jl Release Notes
 
 main
 -----
+- change limits on leaderboard annual plots PR[#1698](https://github.com/CliMA/ClimaLand.jl/pull/1698)
 - add standalone lake model PR[#1695](https://github.com/CliMA/ClimaLand.jl/pull/1695)
 
 v1.6.4

--- a/ext/land_sim_vis/leaderboard/data_sources.jl
+++ b/ext/land_sim_vis/leaderboard/data_sources.jl
@@ -345,7 +345,7 @@ the value is a tuple, where the first element is the lower bound and the last
 element is the upper bound for the bias plots.
 """
 function get_compare_vars_biases_plot_extrema(; annual = false)
-    factor = annual ? 1/sqrt(2) : 1.0 # treats each season as ~ independent
+    factor = annual ? 1 / sqrt(2) : 1.0 # treats each season as ~ independent
     compare_vars_biases_plot_extrema = Dict(
         "et" => (-2.0, 2.0) .* factor,
         "gpp" => (-6.0, 6.0) .* factor,

--- a/ext/land_sim_vis/leaderboard/leaderboard.jl
+++ b/ext/land_sim_vis/leaderboard/leaderboard.jl
@@ -448,7 +448,8 @@ function compute_seasonal_leaderboard(
     # Add plot of time average for simulation and bias data excluding spin up
     # Rows correspond to short names
     # Cols correspond to "SIM" and "ANN"
-    annual_compare_vars_biases_plot_extrema = get_compare_vars_biases_plot_extrema(; annual = true)
+    annual_compare_vars_biases_plot_extrema =
+        get_compare_vars_biases_plot_extrema(; annual = true)
     groups = ["SIM", "ANN"]
     fig_sim_ann = CairoMakie.Figure(;
         size = (600 * length(groups), 400 * length(short_names)),


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This changes the plot limits for the annual average leaderboard. 


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
