### PR TITLE
GPU vs CPU differences in snow

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,7 +51,7 @@ steps:
 
       - label: "Snow Col de Porte"
         command: "julia --color=yes --project=.buildkite experiments/standalone/Snow/snowmip_simulation.jl cdp"
-        artifact_paths: "experiments/standalone/Snow/cpu/cdp/output_active/*png"
+        artifact_paths: "experiments/standalone/Snow/cpu/cdp_default_gradtemp/output_active/*png"
 
       - label: "Varying LAI, no stem compartment"
         command: "julia --color=yes --project=.buildkite experiments/standalone/Vegetation/varying_lai.jl"
@@ -233,7 +233,7 @@ steps:
 
       - label: "Snow Col de Porte GPU"
         command: "julia --color=yes --project=.buildkite experiments/standalone/Snow/snowmip_simulation.jl cdp"
-        artifact_paths: "experiments/standalone/Snow/gpu/cdp/output_active/*png"
+        artifact_paths: "experiments/standalone/Snow/gpu/cdp_default_gradtemp/output_active/*png"
         agents:
           slurm_ntasks: 1
           slurm_gpus: 1

--- a/experiments/standalone/Snow/snowmip_simulation.jl
+++ b/experiments/standalone/Snow/snowmip_simulation.jl
@@ -36,7 +36,7 @@ else
 end
 climaland_dir = pkgdir(ClimaLand)
 
-USE_NEURAL_MODELS = true
+USE_NEURAL_MODELS = false
 USE_BULK_SFC_TEMP = false
 
 FT = Float32
@@ -71,7 +71,7 @@ density =
     Snow.ConstantAlbedoModel(α)
 
 temp_tag = USE_BULK_SFC_TEMP ? "surftemp" : "gradtemp"
-neural_tag = USE_NEURAL_MODELS ? "default" : "neural"
+neural_tag = USE_NEURAL_MODELS ? "neural" : "default"
 
 savedir = generate_output_path(
     "experiments/standalone/Snow/$(device_suffix)/$(SITE_NAME)_$(neural_tag)_$(temp_tag)",

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -445,22 +445,24 @@ function phase_change_flux(
     ΔS::FT,
     earth_param_set,
 ) where {FT}
-    S_safe = max(S, FT(0))
-
+    S = max(S, FT(0))
+    T = snow_bulk_temperature(U,S,q_l,ΔS,earth_param_set)
     _LH_f0 = LP.LH_f0(earth_param_set)
     _ρ_liq = LP.ρ_cloud_liq(earth_param_set)
     _cp_i = LP.cp_i(earth_param_set)
     _cp_l = LP.cp_l(earth_param_set)
     _T_ref = LP.T_0(earth_param_set)
     _T_freeze = LP.T_freeze(earth_param_set)
-    Upred = U - energy_flux * Δt # predicted U
-    # difference in energy per unit volume between ice and water
-    Δenergy_per_unit_volume =
-        _ρ_liq * ((_cp_l - _cp_i) * (_T_freeze - _T_ref) + _LH_f0)
-    # change in energy required to bring the snow pack back to a physical state (same q but T = _T_freeze)
-    ΔU = Upred - energy_from_q_l_and_swe(S, q_l, ΔS, earth_param_set)
-    if ΔU > 0 || ΔU * heaviside(q_l, sqrt(eps(FT))) < 0
-        return -ΔU / Δt / Δenergy_per_unit_volume # units of ΔS/Δt
+    # difference in energy per unit volume between ice and water at Tfreeze
+    Δenergy_per_unit_volume(T) = _ρ_liq * ((_cp_l - _cp_i) * (T - _T_ref)*(S+ΔS) + _LH_f0*S)
+    numerator(T) = (U - _ρ_liq*(S+ΔS)*(T - _T_ref)*_cp_i + _ρ_liq *S*_LH_f0)
+    qls = numerator(_T_freeze)/Δenergy_per_unit_volume(_T_freeze)
+    if T >= _T_freeze # we need to melt some snow
+        qls = clamp(qls, q_l, FT(1))
+        return (q_l - qls)/Δt#(_ρ_liq * _cp_l * (S+ΔS)^2)
+    elseif T < _T_freeze && q_l > eps(FT)
+        qls = FT(0)
+        return (q_l - qls)/Δt#(_ρ_liq * _cp_l * (S+ΔS)^2)
     else
         return FT(0)
     end

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -447,20 +447,20 @@ function phase_change_flux(
 ) where {FT}
     S_safe = max(S, FT(0))
 
-    energy_at_T_freeze =
-        energy_from_q_l_and_swe(S_safe, q_l, ΔS, earth_param_set)
-    Upred = U - energy_flux * Δt
-    energy_excess = Upred - energy_at_T_freeze
-
     _LH_f0 = LP.LH_f0(earth_param_set)
     _ρ_liq = LP.ρ_cloud_liq(earth_param_set)
     _cp_i = LP.cp_i(earth_param_set)
     _cp_l = LP.cp_l(earth_param_set)
     _T_ref = LP.T_0(earth_param_set)
     _T_freeze = LP.T_freeze(earth_param_set)
-    if energy_excess > 0 || (energy_excess < 0 && q_l > 0)
-        return -energy_excess / Δt / _ρ_liq /
-               ((_cp_l - _cp_i) * (_T_freeze - _T_ref) + _LH_f0)
+    Upred = U - energy_flux * Δt # predicted U
+    # difference in energy per unit volume between ice and water
+    Δenergy_per_unit_volume =
+        _ρ_liq * ((_cp_l - _cp_i) * (_T_freeze - _T_ref) + _LH_f0)
+    # change in energy required to bring the snow pack back to a physical state (same q but T = _T_freeze)
+    ΔU = Upred - energy_from_q_l_and_swe(S, q_l, ΔS, earth_param_set)
+    if ΔU > 0 || ΔU * heaviside(q_l, sqrt(eps(FT))) < 0
+        return -ΔU / Δt / Δenergy_per_unit_volume # units of ΔS/Δt
     else
         return FT(0)
     end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Previously we saw that the GPU and CPU col de porte simulations looked very similar in all outputs except the phase change flux. See linked issue. This flux converts ice to liquid and vice versa in the snow, but does not change the overall snow water content.

On GPU, the flux cumulatively grew to large (positive) numbers. On CPU we saw it cumulatively grow to negative numbers, but with a much smaller magnitude overall. For context, a positive number corresponds to refreezing, so this indicates that there was much more proposed "refreezing" on the GPU. 

The if statement for refreezing compared q_l to 0. I noticed on a run between CPU and GPU that q_l could be e.g. 1e-40 and the snow would "refreeze", but on CPU this was q_l=0. Not sure if 1e-40 is considered "roundoff" or why errors like this might be more frequent on GPU.

I think that roundoff differences in the flux near q_l = 0 are only "felt" if they are positive, because we clip S_l (or the liquid mass fraction q_l) to be positive - so roundoff errors leading to q_l< 0 are masked, but q_l>0 are not. And somehow on GPU this roundoff or whatever occurs more often, leading to more refreezing. Since the flux is clipped in the tendency, the downstream behavior looks the same in the prognostic state Y between the two.

This PR "fixes" this by using a larger threshold on q_l to indicate refreezing..


@imreddyTeja does this make sense?
## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
