### PR TITLE
calibrate gpp

### DIFF
--- a/experiments/calibration/README.md
+++ b/experiments/calibration/README.md
@@ -7,11 +7,20 @@ latitude-weighted scalar covariance matrix.
 
 # How do I run a calibration?
 
-1. In `run_calibration.jl`, update the calibration configuration.
-    - On Derecho, you may want to set `output_dir` to a scratch directory
-      (e.g. "/glade/derecho/scratch").
-2. Run the calibration script on the cluster.
-    - Execute `bash experiments/calibration/run_calibration.sh` in the terminal.
+1. Pick (or create) a configuration file under
+   `experiments/calibration/configs/`. `run_calibration.jl` loads
+   `configs/energy_fluxes.jl` by default. To use a different config, set the
+   `CALIBRATION_CONFIG` environment variable before running the script, e.g.
+   `CALIBRATION_CONFIG=gpp.jl bash experiments/calibration/run_calibration.sh`.
+   When `TEST_CALIBRATION` is set, the single-parameter `configs/test.jl` is
+   loaded instead.
+2. Load the `climacommon` version appropriate for your cluster (for example,
+   `module load climacommon/2025_02_25` on Derecho). The loaded version is
+   forwarded to the compute jobs automatically.
+3. Run the calibration script on the cluster:
+    - Execute `bash experiments/calibration/run_calibration.sh [OUTPUT_DIR]` in
+      the terminal. `OUTPUT_DIR` is optional; on Derecho you typically want to
+      pass a scratch path (e.g. `/glade/derecho/scratch/$USER/calibration_gpp`).
     - You can start this script from the login node. Slurm/PBS will handle job
       submission for the forward models.
     - You may want to use `tmux` to keep a persistent session on the cluster.

--- a/experiments/calibration/configs/energy_fluxes.jl
+++ b/experiments/calibration/configs/energy_fluxes.jl
@@ -1,0 +1,41 @@
+# Calibration configuration for a single soil-emissivity parameter against
+# energy fluxes (lwu, shf, lhf). This matches the production default that
+# lived in run_calibration.jl on main prior to the config-split refactor.
+
+"""Noise scalars for the covariance matrix of each observed variable.
+
+Units follow the observational dataset:
+- `lwu`: W m^-2 (ERA5)
+- `shf`: W m^-2 (ERA5)
+- `lhf`: W m^-2 (ERA5)
+"""
+const NOISE_SCALARS = Dict("lwu" => 1.0, "shf" => 1.0, "lhf" => 1.0)
+
+"""
+    get_calibration_prior()
+
+Return the combined prior distribution for the calibration parameters.
+
+Calibrates one parameter: soil emissivity. True value is near 0.96.
+"""
+function get_calibration_prior()
+    priors =
+        [EKP.constrained_gaussian("emissivity_bare_soil", 0.82, 0.12, 0.0, 2.0)]
+    return EKP.combine_distributions(priors)
+end
+
+const CALIBRATE_CONFIG = CalibrateConfig(;
+    short_names = ["lwu", "shf", "lhf"],
+    minibatch_size = 1,
+    n_iterations = 10,
+    sample_date_ranges = [
+        ("$(2000 + 2*i)-12-1", "$(2002 + 2*i)-9-1") for i in 0:9
+    ], # 2000 to 2020
+    extend = Dates.Month(3),
+    spinup = Dates.Month(3),
+    nelements = (180, 360, 15),
+    output_dir = OUTPUT_DIR,
+    rng_seed = 42,
+    obs_vec_filepath = "experiments/calibration/land_observation_vector.jld2",
+    model_type = ClimaLand.LandModel,
+)

--- a/experiments/calibration/configs/gpp.jl
+++ b/experiments/calibration/configs/gpp.jl
@@ -1,0 +1,59 @@
+# Calibration configuration for GPP only
+#
+# This file is included by run_calibration.jl and defines:
+#   - CALIBRATE_CONFIG (CalibrateConfig)
+#   - NOISE_SCALARS (per-variable covariance scaling)
+#   - get_calibration_prior() (combined prior distribution)
+#
+# To use this config, set the CALIBRATION_CONFIG env var when invoking
+# run_calibration.sh, e.g.
+#   CALIBRATION_CONFIG=gpp.jl bash experiments/calibration/run_calibration.sh
+
+"""Noise scalars for the covariance matrix of each observed variable.
+
+Units follow the observational dataset:
+- `gpp`: g C m^-2 day^-1 (ILAMB FLUXCOM)
+"""
+const NOISE_SCALARS = Dict("gpp" => 2.0)
+
+"""
+    get_calibration_prior()
+
+Return the combined prior distribution for the calibration parameters.
+
+Calibrates 5 parameters: 4 P-model + 1 soil moisture stress.
+Ensemble size for TransformUnscented: 5 * 2 + 1 = 11 members.
+
+Note: ϕ0_c3/ϕ0_c4 are not calibrated because temperature_dep_yield = true
+uses the quadratic coefficients (ϕa0, ϕa1, ϕa2) instead.
+"""
+function get_calibration_prior()
+    priors = [
+        EKP.constrained_gaussian("pmodel_cstar", 0.41, 0.05, 0.2, 0.7),
+        EKP.constrained_gaussian("pmodel_β_c3", 146.0, 40.0, 50.0, 300.0),
+        EKP.constrained_gaussian("pmodel_β_c4", 16.222, 5.0, 5.0, 40.0),
+        EKP.constrained_gaussian("pmodel_α", 0.933, 0.02, 0.85, 0.999),
+        EKP.constrained_gaussian("moisture_stress_c", 0.27, 0.15, 0.05, 1.0),
+    ]
+    return EKP.combine_distributions(priors)
+end
+
+const CALIBRATE_CONFIG = CalibrateConfig(;
+    short_names = ["gpp"],
+    minibatch_size = 2,
+    n_iterations = 10,
+    # 10 yearly samples: each covers DJF, MAM, JJA (Dec 1 -> Sep 1)
+    # Ending at Sep 1 avoids DJF over-representation across consecutive
+    # samples that would occur with Dec-to-Dec ranges.
+    # with extend = Month(3), simulation runs through Nov 30 of year+1
+    sample_date_ranges = [
+        ("$(year)-12-1", "$(year+1)-9-1") for year in 2001:2010
+    ],
+    extend = Dates.Month(3),
+    spinup = Dates.Month(3),
+    nelements = (180, 360, 15),
+    output_dir = OUTPUT_DIR,
+    rng_seed = 42,
+    obs_vec_filepath = "experiments/calibration/land_observation_vector.jld2",
+    model_type = ClimaLand.LandModel,
+)

--- a/experiments/calibration/configs/gpp_lhf.jl
+++ b/experiments/calibration/configs/gpp_lhf.jl
@@ -1,0 +1,59 @@
+# Calibration configuration for GPP and LHF
+#
+# This file is included by run_calibration.jl and defines:
+#   - CALIBRATE_CONFIG (CalibrateConfig)
+#   - NOISE_SCALARS (per-variable covariance scaling)
+#   - get_calibration_prior() (combined prior distribution)
+#
+# To create a new calibration experiment, copy this file and adjust the
+# settings below.
+
+"""Noise scalars for the covariance matrix of each observed variable.
+
+Units follow the observational dataset:
+- `gpp`: g C m^-2 day^-1 (ILAMB FLUXCOM)
+- `lhf`: W m^-2 (ERA5)
+"""
+const NOISE_SCALARS = Dict("gpp" => 2.0, "lhf" => 20.0)
+
+"""
+    get_calibration_prior()
+
+Return the combined prior distribution for the calibration parameters.
+
+Calibrates 5 parameters: 4 P-model + 1 soil moisture stress.
+Ensemble size for TransformUnscented: 5 * 2 + 1 = 11 members.
+
+Note: ϕ0_c3/ϕ0_c4 are not calibrated because temperature_dep_yield = true
+uses the quadratic coefficients (ϕa0, ϕa1, ϕa2) instead.
+"""
+function get_calibration_prior()
+    priors = [
+        EKP.constrained_gaussian("pmodel_cstar", 0.41, 0.05, 0.2, 0.7),
+        EKP.constrained_gaussian("pmodel_β_c3", 146.0, 40.0, 50.0, 300.0),
+        EKP.constrained_gaussian("pmodel_β_c4", 16.222, 5.0, 5.0, 40.0),
+        EKP.constrained_gaussian("pmodel_α", 0.933, 0.02, 0.85, 0.999),
+        EKP.constrained_gaussian("moisture_stress_c", 0.27, 0.15, 0.05, 1.0),
+    ]
+    return EKP.combine_distributions(priors)
+end
+
+const CALIBRATE_CONFIG = CalibrateConfig(;
+    short_names = ["gpp", "lhf"],
+    minibatch_size = 2,
+    n_iterations = 10,
+    # 10 yearly samples: each covers DJF, MAM, JJA (Dec 1 -> Sep 1)
+    # Ending at Sep 1 avoids DJF over-representation across consecutive
+    # samples that would occur with Dec-to-Dec ranges.
+    # with extend = Month(3), simulation runs through Nov 30 of year+1
+    sample_date_ranges = [
+        ("$(year)-12-1", "$(year+1)-9-1") for year in 2001:2010
+    ],
+    extend = Dates.Month(3),
+    spinup = Dates.Month(3),
+    nelements = (180, 360, 15),
+    output_dir = OUTPUT_DIR,
+    rng_seed = 42,
+    obs_vec_filepath = "experiments/calibration/land_observation_vector.jld2",
+    model_type = ClimaLand.LandModel,
+)

--- a/experiments/calibration/configs/test.jl
+++ b/experiments/calibration/configs/test.jl
@@ -1,0 +1,39 @@
+# Calibration configuration for the end-to-end test.
+#
+# This config is loaded by run_calibration.jl when the environment variable
+# TEST_CALIBRATION is set. It calibrates a single soil parameter against lwu
+# over a single sample/iteration so the test runs quickly.
+
+"""Noise scalars for the covariance matrix of each observed variable.
+
+Units follow the observational dataset:
+- `lwu`: W m^-2 (ERA5)
+"""
+const NOISE_SCALARS = Dict("lwu" => 1.0)
+
+"""
+    get_calibration_prior()
+
+Return the combined prior for the test calibration.
+
+Calibrates one parameter (true value is 0.96).
+"""
+function get_calibration_prior()
+    priors =
+        [EKP.constrained_gaussian("emissivity_bare_soil", 0.82, 0.12, 0.0, 2.0)]
+    return EKP.combine_distributions(priors)
+end
+
+const CALIBRATE_CONFIG = CalibrateConfig(;
+    short_names = ["lwu"],
+    minibatch_size = 1,
+    n_iterations = 1,
+    sample_date_ranges = [("2007-12-1", "2007-12-1")],
+    extend = Dates.Month(3),
+    spinup = Dates.Month(0),
+    nelements = (180, 360, 15),
+    output_dir = OUTPUT_DIR,
+    rng_seed = 42,
+    obs_vec_filepath = "experiments/calibration/land_observation_vector.jld2",
+    model_type = ClimaLand.LandModel,
+)

--- a/experiments/calibration/generate_observations.jl
+++ b/experiments/calibration/generate_observations.jl
@@ -22,120 +22,155 @@ include(
 )
 
 """
-    make_era5_observation_vector(
-        covar_estimator,
+    make_observation_vector(
+        noise_scalars,
         short_names,
         sample_date_ranges,
         nelements,
     )
 
-Return a vector of `EKP.Observation` consisting of variables from ERA5 dataset
+Return a vector of `EKP.Observation` consisting of observational variables
 with `short_names`.
 
-The covariance matrix for each observation is determined by `covar_estimator`
-and the date ranges for each observation is determined by `sample_date_ranges`.
+Each variable gets its own covariance scaling from `noise_scalars`, a
+`Dict{String, Float64}` mapping short names to scalar values. Observations
+are created per-variable and combined via `EKP.combine_observations`.
+
+The date ranges for each observation are determined by `sample_date_ranges`.
 
 The ocean mask is determined by `nelements`.
 
-!!! note "Add new variable"
-    To add a new variable from the ERA5 dataset, you must add the variable to
-    `get_era5_obs_var_dict` in `data_sources.jl`. In addition, if the varaible
-    requires any further or different preprocessing than the preprocessing done
-    in `preprocess_single_era5_var`, you should also make any necessary changes
-    to that function and in `process_member_data` in `observation_map.jl`.
+Supports both ERA5 variables (lhf, shf, lwu, swu) and ILAMB variables (gpp, et)
+via `get_calibration_obs_var_dict` in `data_sources.jl`.
 """
-function make_era5_observation_vector(
-    covar_estimator,
+function make_observation_vector(
+    noise_scalars,
     short_names,
     sample_date_ranges,
     nelements,
 )
-    # TODO: The start_date argument can be removed by making data_sources.jl not
-    # dependent on a start date.
-
     # The start date doesn't matter since we never resample along the
     # time dimension, so we grab the first date in sample_date_ranges
     start_date = first(first(sample_date_ranges))
-    era5_vars = preprocess_era5_vars(short_names, start_date, nelements)
+    obs_vars = preprocess_obs_vars(short_names, start_date, nelements)
+
+    # Build per-variable covariance estimators
+    covar_estimators = Dict(
+        name => ClimaCalibrate.ObservationRecipe.ScalarCovariance(;
+            scalar = noise_scalars[name],
+            use_latitude_weights = true,
+            min_cosd_lat = 0.1,
+        ) for name in short_names
+    )
+
     observation_vector = map(sample_date_ranges) do (start_date, stop_date)
-        ClimaCalibrate.ObservationRecipe.observation(
-            covar_estimator,
-            era5_vars,
-            start_date,
-            stop_date,
+        # Create a separate observation for each variable with its own scalar
+        per_var_obs = map(zip(short_names, obs_vars)) do (name, var)
+            ClimaCalibrate.ObservationRecipe.observation(
+                covar_estimators[name],
+                [var],
+                start_date,
+                stop_date,
+            )
+        end
+        # Combine into a single observation with block-diagonal covariance.
+        # EKP.combine_observations leaves metadata as Vector{Any}; re-type it
+        # so ClimaCalibrate's GEnsembleBuilder accepts it.
+        combined = EKP.combine_observations(per_var_obs)
+        typed_md =
+            Vector{ClimaAnalysis.Var.Metadata}(EKP.get_metadata(combined))
+        EKP.Observation(
+            EKP.get_samples(combined),
+            EKP.get_covs(combined),
+            EKP.get_inv_covs(combined),
+            EKP.get_names(combined),
+            EKP.get_indices(combined),
+            typed_md,
         )
     end
     return observation_vector
 end
 
-# TODO: Add a note on how to add a new variable and what you need to do
-# Modify dict, maybe modify how they should be processed
-
 """
-    preprocess_era5_vars(short_names, start_date, nelements)
+    preprocess_obs_vars(short_names, start_date, nelements)
 
-Preprocess each variable from the ERA5 dataset with `short_names`.
+Preprocess each observational variable with `short_names`.
 """
-function preprocess_era5_vars(short_names, start_date, nelements)
-    era5_obs_vars = get_era5_obs_var_dict()
+function preprocess_obs_vars(short_names, start_date, nelements)
+    obs_var_dict = get_calibration_obs_var_dict(; short_names)
     for short_name in short_names
-        short_name ∉ keys(era5_obs_vars) && error(
-            "There is no variable with the short name $short_name. Add this variable to get_era5_obs_var_dict",
+        short_name ∉ keys(obs_var_dict) && error(
+            "There is no variable with the short name $short_name. Add this variable to get_calibration_obs_var_dict in data_sources.jl",
         )
     end
     vars = map(short_names) do short_name
-        var = era5_obs_vars[short_name](start_date)
-        preprocess_single_era5_var(var, short_name, nelements)
+        var = obs_var_dict[short_name](start_date)
+        preprocess_single_obs_var(var, short_name, nelements)
     end
     return vars
 end
 
 """
-    preprocess_single_era5_var(var::OutputVar, short_name, nelements)
+    preprocess_single_obs_var(var::OutputVar, short_name, nelements)
 
-Specifies how each individual `OutputVar` from the ERA5 dataset should be
-processed.
+Specifies how each individual `OutputVar` should be processed for calibration.
 
-The currently supported variables are `lhf`, `shf`, `lwu`, and `swu`. The
-preprocessing is
+The preprocessing is:
+- windowing to full seasons within the data's time range,
 - computing seasonal averages,
 - resampling to fit the model grid,
 - applying an ocean mask,
 - removing the last longitude point to avoid double counting,
 - and excluding the poles.
-
-Note that an `EKP.Observation` is not generated in this function.
 """
-function preprocess_single_era5_var(var::OutputVar, short_name, nelements)
+function preprocess_single_obs_var(var::OutputVar, short_name, nelements)
     lats, lons = get_lat_lon_from_resolution(nelements)
 
-    # If there are `NaN`s, then resampling cannot be performed as resampling is
-    # not `NaN` aware
-    any(isnan, var.data) && error(
-        "Cannot process OutputVar with name $short_name because `NaN`s are present in the data",
-    )
+    # NaNs are kept so that resampling propagates them rather than
+    # interpolating good observations with zeros. Some valid points near
+    # NaN regions may be lost, but this is preferred over corrupting them.
 
-    # Window to ensure that each season contains all three months
-    # The dates are found by inspecting the ERA5 data and choosing
-    # the earliest and latest dates that contain full seasons
+    # Window to ensure that each season contains all three months.
+    # Use the data's own date range, clamped to full seasons. Compute dates
+    # from (start_date + time seconds) rather than ClimaAnalysis.dates(var)
+    # to avoid relying on a `date` dim that may be stored as Float64.
+    start_date_attr = Dates.DateTime(var.attributes["start_date"])
+    time_arr = ClimaAnalysis.times(var)
+    eltype(time_arr) <: Dates.TimeType || (
+        time_arr =
+            start_date_attr .+
+            Dates.Millisecond.(round.(Int, time_arr .* 1000))
+    )
+    first_date = first(time_arr)
+    last_date = last(time_arr)
+    @info "preprocess_single_obs_var[$short_name] date range" first_date last_date eltype(
+        time_arr,
+    )
+    date_min = Dates.DateTime(Dates.year(first_date), 3)
+    date_max = Dates.DateTime(Dates.year(last_date), 8)
+    # Ensure bounds are within the data range
+    if date_max > last_date
+        date_max = Dates.DateTime(Dates.year(last_date) - 1, 8)
+    end
+    if date_min < first_date
+        date_min = Dates.DateTime(Dates.year(first_date) + 1, 3)
+    end
     var = ClimaAnalysis.window(
         var,
         "time",
-        left = Dates.DateTime(1979, 3),
-        right = Dates.DateTime(2024, 8),
+        left = date_min,
+        right = date_max,
         by = ClimaAnalysis.MatchValue(),
     )
 
-    # Take seasonal average, resample, and apply mask Resampling is an expensive
-    # operation, so it is good to do as many reductions as we can.
+    # Take seasonal average, resample, and apply mask. Resampling is an
+    # expensive operation, so it is good to do as many reductions as we can.
     var = ClimaAnalysis.average_season_across_time(var, ignore_nan = true)
 
     var = ClimaAnalysis.resampled_as(var, lon = lons, lat = lats)
 
     # Cannot apply ClimaLand.apply_oceanmask because of the small
     # differences between the ClimaLand mask and ClimaAnalysis.apply_ocean_mask
-    # For now, it is better to manually create a mask from ClimaCore and
-    # generate a mask from it using ClimaAnalysis
     ocean_mask = make_ocean_mask(nelements)
     var = ocean_mask(var)
 
@@ -158,26 +193,21 @@ function preprocess_single_era5_var(var::OutputVar, short_name, nelements)
     )
 
     var = ClimaCalibrate.ObservationRecipe.change_data_type(var, Float32)
+    var.attributes["short_name"] = short_name
     return var
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__
-    (; obs_vec_filepath) = CALIBRATE_CONFIG
-    covar_estimator = ClimaCalibrate.ObservationRecipe.ScalarCovariance(;
-        scalar = 25.0,
-        use_latitude_weights = true,
-        min_cosd_lat = 0.1,
-    )
-    nelements = CALIBRATE_CONFIG.nelements
-    sample_date_ranges = CALIBRATE_CONFIG.sample_date_ranges
-    short_names = CALIBRATE_CONFIG.short_names
+    (; obs_vec_filepath, nelements, sample_date_ranges, short_names) =
+        CALIBRATE_CONFIG
     @info "The number of samples is $(length(sample_date_ranges))"
+    @info "Noise scalars: $NOISE_SCALARS"
 
     isfile(obs_vec_filepath) &&
         @warn "Overwriting the file $obs_vec_filepath to generate the vector of observations"
 
-    observation_vector = make_era5_observation_vector(
-        covar_estimator,
+    observation_vector = make_observation_vector(
+        NOISE_SCALARS,
         short_names,
         sample_date_ranges,
         nelements,

--- a/experiments/calibration/models/snowy_land.jl
+++ b/experiments/calibration/models/snowy_land.jl
@@ -153,7 +153,8 @@ function ClimaCalibrate.forward_model(
     # Need to include "lhf", "shf", "lwu", "swu" because plotting the
     # leaderboard requires these diagnostics
     short_names = CALIBRATE_CONFIG.short_names
-    short_names = unique!([short_names; ["lhf", "shf", "lwu", "swu"]])
+    short_names =
+        unique!([short_names; ["lhf", "shf", "lwu", "swu", "gpp", "et"]])
     diagnostics = ClimaLand.Diagnostics.default_diagnostics(
         model,
         start_date,

--- a/experiments/calibration/observation_map.jl
+++ b/experiments/calibration/observation_map.jl
@@ -27,13 +27,7 @@ function ClimaCalibrate.observation_map(iteration)
     ekp = JLD2.load_object(ClimaCalibrate.ekp_path(output_dir, iteration))
     ensemble_size = EKP.get_N_ens(ekp)
 
-    # Determine which observation is used by the short names
-    # This assumes that observations do not differ in the variables that are
-    # being calibrated
-    obs_series = EKP.get_observation_series(ekp)
-    short_names = ClimaCalibrate.ObservationRecipe.short_names(
-        first(obs_series.observations),
-    )
+    short_names = CALIBRATE_CONFIG.short_names
 
     g_ens_builder = EnsembleBuilder.GEnsembleBuilder(ekp)
     for m in 1:ensemble_size
@@ -76,10 +70,10 @@ function process_member_data!(
 )
     nelements = CALIBRATE_CONFIG.nelements
     @info "Short names: $short_names"
-    era5_obs_vars = ext.get_era5_obs_var_dict()
+    calibration_obs_vars = ext.get_calibration_obs_var_dict()
     for short_name in short_names
-        short_name in keys(era5_obs_vars) || error(
-            "Variable $short_name does not appear in the observation dataset. Add the variable to get_era5_obs_var_dict",
+        short_name in keys(calibration_obs_vars) || error(
+            "Variable $short_name does not appear in the observation dataset. Add the variable to get_calibration_obs_var_dict in data_sources.jl",
         )
     end
 
@@ -178,6 +172,16 @@ function ClimaCalibrate.analyze_iteration(
         output_path,
         diagnostics_folder_path,
         "ERA5",
+    )
+    ext.compute_monthly_leaderboard(
+        output_path,
+        diagnostics_folder_path,
+        "ILAMB",
+    )
+    ext.compute_seasonal_leaderboard(
+        output_path,
+        diagnostics_folder_path,
+        "ILAMB",
     )
 end
 

--- a/experiments/calibration/run_calibration.jl
+++ b/experiments/calibration/run_calibration.jl
@@ -34,58 +34,80 @@ model_interface = joinpath(
 # Note: This has only been tested with the WorkerBackend
 const TEST_CALIBRATION = haskey(ENV, "TEST_CALIBRATION")
 
-if !TEST_CALIBRATION
-    const CALIBRATE_CONFIG = CalibrateConfig(;
-        short_names = ["lwu", "shf", "lhf"],
-        minibatch_size = 1,
-        n_iterations = 10,
-        sample_date_ranges = [
-            ("$(2000 + 2*i)-12-1", "$(2002 + 2*i)-9-1") for i in 0:9
-        ], # 2000 to 2020
-        extend = Dates.Month(3),
-        spinup = Dates.Month(3),
-        nelements = (180, 360, 15),
-        output_dir = "experiments/calibration/land_model",
-        rng_seed = 42,
-        obs_vec_filepath = "experiments/calibration/land_observation_vector.jld2",
-        model_type = ClimaLand.LandModel,
-    )
+# Optional CLI override for the calibration output directory. Pass the target
+# path as the first positional argument to run_calibration.jl /
+# generate_observations.jl (e.g. bash run_calibration.sh /scratch/foo).
+#
+# Per-member worker jobs run a generated `model_run.jl` directly, so ARGS is
+# empty there. Recover the output_dir from PROGRAM_FILE in that case — the
+# worker script always lives at $output_dir/iteration_NNN/member_MMM/model_run.jl.
+const OUTPUT_DIR = if length(ARGS) >= 1
+    ARGS[1]
+elseif basename(PROGRAM_FILE) == "model_run.jl"
+    dirname(dirname(dirname(abspath(PROGRAM_FILE))))
 else
-    @info "Using calibration config for test calibration"
-    const CALIBRATE_CONFIG = CalibrateConfig(;
-        short_names = ["lwu"],
-        minibatch_size = 1,
-        n_iterations = 1,
-        sample_date_ranges = [("2007-12-1", "2007-12-1")],
-        extend = Dates.Month(3),
-        spinup = Dates.Month(0),
-        nelements = (180, 360, 15),
-        output_dir = "experiments/calibration/land_model",
-        rng_seed = 42,
-        obs_vec_filepath = "experiments/calibration/land_observation_vector.jld2",
-        model_type = ClimaLand.LandModel,
-    )
+    "experiments/calibration/land_model"
+end
+
+# Include the calibration configuration. This defines CALIBRATE_CONFIG,
+# get_calibration_prior(), and NOISE_SCALARS. When TEST_CALIBRATION is set,
+# load the single-parameter test config; otherwise load the production config.
+# To run a different production calibration, set the CALIBRATION_CONFIG env
+# var before invoking run_calibration.sh, e.g.
+#   CALIBRATION_CONFIG=gpp.jl bash experiments/calibration/run_calibration.sh
+const CONFIG_FILE =
+    TEST_CALIBRATION ? "test.jl" :
+    get(ENV, "CALIBRATION_CONFIG", "energy_fluxes.jl")
+include(
+    joinpath(
+        pkgdir(ClimaLand),
+        "experiments",
+        "calibration",
+        "configs",
+        CONFIG_FILE,
+    ),
+)
+
+"""
+    _loaded_climacommon()
+
+Return the `climacommon/<version>` module name currently loaded in the parent
+shell, by scanning the `LOADEDMODULES` environment variable (colon-separated).
+Falls back to `"climacommon"` (default version) if none is found.
+
+This lets forward-model jobs pick up whichever `climacommon` the driver script
+loaded, instead of hardcoding a version per backend.
+"""
+function _loaded_climacommon()
+    loaded = get(ENV, "LOADEDMODULES", "")
+    # Expect entries of the form `climacommon/YYYY_MM_DD`. If multiple are
+    # loaded, the last one wins (matches `module`'s own resolution order).
+    pattern = r"^climacommon/\d{4}_\d{2}_\d{2}$"
+    matches = filter(mod -> occursin(pattern, mod), split(loaded, ':'))
+    isempty(matches) && return "climacommon"
+    return String(last(matches))
 end
 
 """
     module_load_string(::ClimaCalibrate.ClimaGPUBackend)
+    module_load_string(::ClimaCalibrate.DerechoBackend)
 
-Load the appropriate module for `clima`.
-
-This is needed to load the right `climacommon` version on `clima`. This function
-will be removed after support is added in ClimaCalibrate.jl for choosing which
-version of `climacommon` to load.
+Return the `module load` string injected into forward-model job scripts. The
+`climacommon` version is read from the driver shell's `LOADEDMODULES` so the
+version only needs to be specified once (in `run_calibration.sh`).
 """
 function ClimaCalibrate.module_load_string(::ClimaCalibrate.ClimaGPUBackend)
     return """module purge
-    module load climacommon/2026_02_18"""
+    module load $(_loaded_climacommon())"""
+end
+
+function ClimaCalibrate.module_load_string(::ClimaCalibrate.DerechoBackend)
+    return """module purge
+    module load $(_loaded_climacommon())"""
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__
-    # true solution is at 0.96
-    priors =
-        [EKP.constrained_gaussian("emissivity_bare_soil", 0.82, 0.12, 0.0, 2.0)]
-    prior = EKP.combine_distributions(priors)
+    prior = get_calibration_prior()
 
     observation_vector = JLD2.load_object(CALIBRATE_CONFIG.obs_vec_filepath)
 

--- a/experiments/calibration/run_calibration.sh
+++ b/experiments/calibration/run_calibration.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
 
-# See the README.md for more information on how to run a calibration
+# See the README.md for more information on how to run a calibration.
+#
+# Usage: bash experiments/calibration/run_calibration.sh [OUTPUT_DIR]
+#
+# If OUTPUT_DIR is omitted, the default in run_calibration.jl is used.
+#
+# Load the climacommon version appropriate for your cluster before invoking
+# this script, e.g. `module load climacommon/2025_02_25` on Derecho. The
+# loaded version is picked up automatically by ClimaCalibrate.module_load_string
+# (via LOADEDMODULES) so forward-model jobs use the same version.
 
-module load climacommon
+# Required on Derecho's Lustre scratch: HDF5 file locking is incompatible with
+# the parallel filesystem and causes NC_EHDFERR (-101) when the orchestrator
+# tries to read NetCDF files written by compute-job ensemble members.
+export HDF5_USE_FILE_LOCKING=FALSE
+
+OUTPUT_DIR="$1"
 
 julia --project=.buildkite -e 'using Pkg; Pkg.instantiate(;verbose=true)'
-julia --project=.buildkite/ experiments/calibration/generate_observations.jl
-julia --project=.buildkite/ experiments/calibration/run_calibration.jl
+julia --project=.buildkite/ experiments/calibration/generate_observations.jl $OUTPUT_DIR
+julia --project=.buildkite/ experiments/calibration/run_calibration.jl $OUTPUT_DIR

--- a/ext/land_sim_vis/leaderboard/data_sources.jl
+++ b/ext/land_sim_vis/leaderboard/data_sources.jl
@@ -331,6 +331,31 @@ function get_mask_dict(data_source)
 end
 
 """
+    get_calibration_obs_var_dict(; short_names = nothing)
+
+Return a dictionary mapping short names to `OutputVar` containing preprocessed
+observational data for calibration. This combines ERA5 energy flux variables
+(lhf, shf, lwu, swu) with ILAMB GPP (FLUXCOM) data.
+
+If `short_names` is provided, only the requested variables are returned.
+"""
+function get_calibration_obs_var_dict(; short_names = nothing)
+    obs_var_dict = Dict{String, Any}()
+    # ERA5 energy fluxes
+    era5_dict = get_era5_obs_var_dict()
+    merge!(obs_var_dict, era5_dict)
+    # ILAMB GPP
+    ilamb_dict = get_ilamb_obs_var_dict()
+    if haskey(ilamb_dict, "gpp")
+        obs_var_dict["gpp"] = ilamb_dict["gpp"]
+    end
+    if !isnothing(short_names)
+        filter!(p -> p.first in short_names, obs_var_dict)
+    end
+    return obs_var_dict
+end
+
+"""
     get_compare_vars_biases_plot_extrema(; annual = false)
 
 Return a dictionary mapping short names to ranges for the bias plots.


### PR DESCRIPTION
## Summary

Adds GPP calibration (against ILAMB FLUXCOM) to the global calibration pipeline and restructures `experiments/calibration/` so different calibration experiments can be selected without editing the driver script.

### What changed

- **Per-experiment config files** under `experiments/calibration/configs/`:
  - `energy_fluxes.jl` — prior default (1 param, `lwu`/`shf`/`lhf`)
  - `gpp.jl` — 5-param P-model + moisture-stress calibration vs `gpp`
  - `gpp_lhf.jl` — same 5 params vs `gpp` + `lhf`
  - `test.jl` — single-iteration smoke test (loaded when `TEST_CALIBRATION` is set)
  
  Each config defines `CALIBRATE_CONFIG`, `NOISE_SCALARS`, and `get_calibration_prior()`. Select one at runtime via `CALIBRATION_CONFIG=gpp_lhf.jl bash run_calibration.sh`.

- **Per-variable noise scalars**: `generate_observations.jl` now builds a separate `EKP.Observation` per variable with its own `ScalarCovariance`, then combines them block-diagonally. This lets GPP (scalar 2, g C m⁻² day⁻¹) and LHF (scalar 20, W m⁻²) coexist with appropriate weighting.

- **ILAMB support**: `make_era5_observation_vector` → `make_observation_vector`; new `get_calibration_obs_var_dict` in `ext/land_sim_vis/leaderboard/data_sources.jl` merges ERA5 energy fluxes with ILAMB GPP. Preprocessing now derives the windowing date range from the data itself (instead of the hardcoded 1979–2024 ERA5 range) and propagates NaNs through resampling rather than erroring. `analyze_iteration` now also computes ILAMB monthly/seasonal leaderboards.

- **Runtime plumbing**:
  - `run_calibration.sh` accepts an optional `OUTPUT_DIR` positional arg (useful for Derecho scratch) and sets `HDF5_USE_FILE_LOCKING=FALSE` to avoid NC_EHDFERR on Lustre.
  - `module_load_string` for both `ClimaGPUBackend` and `DerechoBackend` now reads the `climacommon/YYYY_MM_DD` version from the driver's `LOADEDMODULES`, so forward-model jobs inherit whichever version was loaded before invoking the script (no more hardcoded version in `run_calibration.jl`).
  - Forward-model diagnostics extended to include `gpp` and `et` so leaderboards render.

## Results

Calibration on GPP + LHF (noise scalars 2 and 20, respectively — see `experiments/calibration/configs/gpp_lhf.jl`):

<img width="2400" height="2400" alt="gpp_lhf_ilamb" src="https://github.com/user-attachments/assets/8a3b5ef3-33fc-4b8f-8d5f-b45ecd0f3197" />

<img width="2400" height="3200" alt="gpp_lhf_era5" src="https://github.com/user-attachments/assets/daf1506b-16cc-4eff-850c-35a1c83d7590" />

<img width="6000" height="1000" alt="gpp_lhf_errors" src="https://github.com/user-attachments/assets/3f0401e6-bab2-440c-99f1-7df96edba8cc" />

**RMSE = 0.9, Bias = 0.1**. For reference, [other ILAMB models](https://www.ilamb.org/land-hist/EcosystemandCarbonCycle/GrossPrimaryProductivity/FLUXCOM/FLUXCOM.html) land around RMSE ≈ 1.8, Bias ≈ 0.5 — so we're comfortably ahead with a simpler parameterisation (P-model rather than PFT-specific). Caveat: we prescribe LAI, and I haven't confirmed whether the ILAMB baselines do.
