### PR TITLE
Respiration update

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -56,6 +56,15 @@ git-tree-sha1 = "6ce1717bb8b7aa767380f1053b9d8d3a4e4edaa6"
     sha256 = "27d49fce7f4a5e2b81bbd29e8a7caf08f568a2df53e3af817126363decfd5a7c"
     url = "https://caltech.box.com/shared/static/99aw2gce2k65bdu0h8jkfxq4vin08gi2.gz"
 
+[soilgrids_ocd]
+git-tree-sha1 = "39b86daa8a335c7efa894b2a8c38419e98e9b228"
+[soilgrids_ocd_lowres_interp]
+git-tree-sha1 = "11d53b5e1ff9031a5e94cfe4b93322edcb1a6129"
+
+    [[soilgrids_ocd_lowres_interp.download]]
+    sha256 = "dec8ac8dfe23c088f7acdf790ce6fa8f958c6bfeb1e1d742a5904661f7facaef"
+    url = "https://caltech.box.com/shared/static/nr0bd7l18ka5fmvcmtwyj1t444vuonx8.gz"
+
 [sw_albedo]
 git-tree-sha1 = "136f1db3ed969614fb589c5250545a3ed1e8aaab"
 
@@ -237,3 +246,10 @@ git-tree-sha1 = "ea4d0f709c63d34dc2d35ce9727e3f70f67133c8"
     [[imerg_landsea_mask.download]]
     sha256 = "a931f48fcadf9c94e4162d11ae8c6d05d6d9960a01cd1a8342c7c40cf74dfd4b"
     url = "https://caltech.box.com/shared/static/kmfe3j4bg97l1y07v36gb5jntk1lru3l.gz"
+
+[ilamb_respiration_nee]
+git-tree-sha1 = "1e10a01d843f8e2a12ae7691a997c2c5c9a8c72d"
+
+    [[ilamb_respiration_nee.download]]
+    sha256 = "a7ff814d3b89fa80826670185079960b5cd3d5bf634d4d9cb502a3741d2ed437"
+    url = "https://caltech.box.com/shared/static/mb69shq9y8wnhi7hx23cf70v1b1cf1ln.gz"

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ ClimaLand.jl Release Notes
 main
 -----
 - Remove `convert_cb` function PR[#1730](https://github.com/CliMA/ClimaLand.jl/pull/1730)
+- ![breaking change][badge-💥breaking] Rewrite DAMM soil respiration in centered-Arrhenius form: `soilCO2_pre_exponential_factor` is replaced by `soilCO2_reference_rate` and `soilCO2_reference_temperature`, with retuned `Ea_sx` and `kM_sx` defaults PR[#1714](https://github.com/CliMA/ClimaLand.jl/pull/1714)
+- ![][badge-🔥behavioralΔ] Diffuse soil CO2/O2 using an effective porosity that includes Henry's-law dissolved gas; initialize prognostic SOC from SoilGrids and hold it constant; pass soil ice into the biogeochemistry PR[#1714](https://github.com/CliMA/ClimaLand.jl/pull/1714)
 - Use nearest neighbor to create higher resolution soil retention parameter data; use these by default and corresponding spun up initial condition PR[#1712](https://github.com/CliMA/ClimaLand.jl/pull/1712)
 - ![breaking change][badge-💥breaking] Refactor `PlantHydraulicsModel` to a
   single above-ground compartment; `PlantHydraulics` submodule has been

--- a/docs/src/APIs/ClimaLand.md
+++ b/docs/src/APIs/ClimaLand.md
@@ -23,13 +23,19 @@ ClimaLand.SoilCanopyModel{FT}(
     forcing,
     LAI,
     toml_dict::CP.ParamDict,
-    domain::Union{ClimaLand.Domains.Column, ClimaLand.Domains.SphericalShell};
+    domain::Union{ClimaLand.Domains.Column, ClimaLand.Domains.SphericalShell},
+    Δt;
 ) where {FT}
 ClimaLand.LandSoilBiogeochemistry
 ClimaLand.LandSoilBiogeochemistry{FT}(
     forcing,
     toml_dict::CP.ParamDict,
-    domain::Union{ClimaLand.Domains.Column, ClimaLand.Domains.SphericalShell};
+    domain::Union{
+        ClimaLand.Domains.Column,
+        ClimaLand.Domains.SphericalShell,
+        ClimaLand.Domains.HybridBox,
+    },
+    Δt;
 ) where {FT}
 ClimaLand.SoilSnowModel
 ClimaLand.SoilSnowModel{FT}(

--- a/docs/src/APIs/soil/SoilBiogeochemistry.md
+++ b/docs/src/APIs/soil/SoilBiogeochemistry.md
@@ -36,10 +36,14 @@ ClimaLand.Soil.Biogeochemistry.PrescribedMet
 ```@docs
 ClimaLand.Soil.Biogeochemistry.volumetric_air_content
 ClimaLand.Soil.Biogeochemistry.co2_diffusivity
+ClimaLand.Soil.Biogeochemistry.o2_diffusivity
 ClimaLand.Soil.Biogeochemistry.microbe_source
 ClimaLand.Soil.Biogeochemistry.o2_availability
 ClimaLand.Soil.Biogeochemistry.o2_concentration
 ClimaLand.Soil.Biogeochemistry.o2_fraction_from_concentration
+ClimaLand.Soil.Biogeochemistry.henry_constant
+ClimaLand.Soil.Biogeochemistry.beta_gas
+ClimaLand.Soil.Biogeochemistry.effective_porosity
 ```
 
 ## Extendible Functions
@@ -47,4 +51,5 @@ ClimaLand.Soil.Biogeochemistry.o2_fraction_from_concentration
 ```@docs
 ClimaLand.Soil.Biogeochemistry.soil_moisture
 ClimaLand.Soil.Biogeochemistry.soil_temperature
+ClimaLand.Soil.Biogeochemistry.soil_ice
 ```

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -365,3 +365,15 @@
   doi     = {10.5194/gmd-11-1909-2018},
   url     = {https://doi.org/10.5194/gmd-11-1909-2018}
 }
+
+@article{Sander2015,
+  author  = {Sander, R.},
+  title   = {Compilation of Henry's law constants (version 4.0) for water as solvent},
+  journal = {Atmospheric Chemistry and Physics},
+  year    = {2015},
+  volume  = {15},
+  number  = {8},
+  pages   = {4399--4981},
+  doi     = {10.5194/acp-15-4399-2015},
+  url     = {https://doi.org/10.5194/acp-15-4399-2015}
+}

--- a/docs/src/standalone/pages/soil/biogeochemistry/DAMM_model.md
+++ b/docs/src/standalone/pages/soil/biogeochemistry/DAMM_model.md
@@ -1,29 +1,46 @@
 # Soil Biogeochemistry: CO₂ Production and O₂ Consumption
 
-This section describes the coupled soil biogeochemistry model implemented in ClimaLand, which simulates the production and diffusion of CO₂, consumption of O₂, and decomposition of soil organic carbon (SOC) through microbial respiration. The model combines the Dual Arrhenius and Michaelis-Menten (DAMM) kinetics framework for microbial respiration with gas diffusion equations that account for soil structure, temperature, and moisture dependencies.
+This section describes the coupled soil biogeochemistry model implemented in ClimaLand, which simulates the production and diffusion of CO₂, consumption of O₂, and microbial respiration sourced by a fixed pool of soil organic carbon ($Y_{C_{som}}$). The model combines the Dual Arrhenius and Michaelis-Menten (DAMM) kinetics framework for microbial respiration with gas diffusion equations that account for soil structure, temperature, and moisture, and with Henry's-law partitioning of dissolved CO₂ and O₂ between the gas and aqueous phases of the pore space.
 
 ## Model Overview
 
-The biogeochemistry model tracks three prognostic variables that evolve in space (with soil depth) and time:
-- CO₂ concentration in soil air ($ρ_{CO_2}$, kg C m⁻³)
-- Volumetric O₂ fraction in soil air ($O_{2f}$, dimensionless)
-- Soil organic carbon ($C_{som}$, kg C m⁻³)
+The biogeochemistry model carries three prognostic fields that evolve in space (with soil depth) and time. The variables, listed in the units used internally, are:
 
-The model captures the fundamental processes of aerobic decomposition: microbes consume soil organic carbon and oxygen to produce carbon dioxide. These gases diffuse through the soil pore space, with diffusion rates controlled by soil structure (porosity, tortuosity), moisture content, and temperature.
+- the total CO₂ stored per unit soil volume (gas phase plus dissolved), $Y_{CO_2}$ (kg C m⁻³ soil), with $Y_{CO_2} = \theta_{\rm eff}\, c_g$ where $c_g$ is the air-phase carbon mass concentration (kg C m⁻³ air) and $\theta_{\rm eff}$ is the effective porosity, defined as the sum of the gas-filled pore volume and the dissolved-equivalent volume of the liquid pore water (see Effective Porosity below);
+- the volumetric O₂ fraction in soil air, $Y_{\theta_{O_2}}$ (dimensionless);
+- the soil organic carbon density, $Y_{C_{som}}$ (kg C m⁻³), held fixed at its initial value (no tendency, see below).
+
+The model captures the fundamental processes of aerobic decomposition: microbes consume soluble carbon and oxygen to produce carbon dioxide. CO₂ and O₂ diffuse through the soil pore space, with diffusion rates controlled by soil structure (porosity, tortuosity), moisture, temperature, and pressure.
+
+$Y_{C_{som}}$ is initialized from the SoilGrids organic carbon density product and is treated as a stationary spatial parameter: we assume that the input of organic matter (e.g., from litter and root turnover) is equal to the rate of decomposition, so the actual $Y_{C_{som}}$ is constant in time. The model thus captures geographic heterogeneity of carbon stocks but does not integrate carbon depletion on simulation timescales — a deliberate simplification appropriate for the multi-decade runs targeted by ClimaLand. In the future, we may model the rate of decomposition explicitly and track $Y_{C_{som}}$ over time; expressing $Y_{C_{som}}$ as a prognostic variable now allows that change to be made easily.
 
 ## Governing Equations
 
 ### CO₂ Transport and Production
 
-The evolution of CO₂ concentration in the soil follows a reaction-diffusion equation:
+The prognostic variable $Y_{CO_2}$ is the **total** carbon mass stored per unit soil volume, summing the gas phase (occupying the air-filled pore volume $\theta_a$ at concentration $c_g$) and the dissolved phase (held in the liquid pore water $\theta_l$ at concentration $c_{aq}$, related to $c_g$ by Henry's law as $c_{aq} = \beta\, c_g$). The total is therefore
 
 ```math
 \begin{equation}
-\frac{\partial ρ_{CO_2}}{\partial t} = -\nabla \cdot \left[-D \nabla ρ_{CO_2}\right] + S_m
+Y_{CO_2} = \theta_a\, c_g + \theta_l\, c_{aq} = (\theta_a + \beta\, \theta_l)\, c_g \equiv \theta_{\rm eff}\, c_g,
 \end{equation}
 ```
 
-where $ρ_{CO_2}$ is the CO₂ concentration (kg C m⁻³), $D$ is the effective diffusivity of CO₂ in soil (m² s⁻¹), and $S_m$ is the microbial CO₂ production rate (kg C m⁻³ s⁻¹). The diffusive flux is $-D\nabla ρ_{CO_2}$, directed from regions of high to low concentration.
+where $\theta_{\rm eff} \equiv \theta_a + \beta\, \theta_l$ is the **effective porosity** — the equivalent volume that would hold $Y_{CO_2}$ at concentration $c_g$ if all the carbon were in the gas phase. The gas-phase concentration is recovered as $c_g = Y_{CO_2} / \theta_{\rm eff}$. Storing $Y_{CO_2}$ rather than $c_g$ as the prognostic keeps the formulation well-behaved as the soil saturates ($\theta_a \to 0$): dissolved storage keeps $\theta_{\rm eff} \geq \beta\, \theta_l > 0$ as long as there is any liquid water. Diffusion is driven by gas-phase gradients:
+
+```math
+\begin{equation}
+\frac{\partial Y_{CO_2}}{\partial t} = \nabla \cdot \left[D \, \nabla c_g\right] + S_m,
+\qquad c_g = Y_{CO_2} / \theta_{\rm eff}
+\end{equation}
+```
+
+where:
+
+- the effective diffusivity of CO₂ in soil, $D$ (m² s⁻¹);
+- the microbial CO₂ production rate, $S_m$ (kg C m⁻³ s⁻¹).
+
+Here $\theta_a = \nu - \theta_l - \theta_i$ is the volumetric air content, i.e. the fraction of the soil volume occupied by the air phase. Note that we do not currently model fluxes of dissolved CO₂ due to fluxes of the soil water; only gas-phase diffusion is represented.
 
 ### O₂ Transport and Consumption
 
@@ -31,77 +48,91 @@ Oxygen transport and consumption in soil is described by:
 
 ```math
 \begin{equation}
-\frac{\partial O_{2f}}{\partial t} = \frac{R T}{\theta_a P M_{O_2}} \nabla \cdot \left[D_{O_2} \theta_a \nabla \rho_{O_2}\right] - \frac{R T}{M_C \theta_a P} S_m
+\frac{\partial Y_{\theta_{O_2}}}{\partial t}
+= \frac{R\, T}{\theta_{\rm eff,O_2}\, P\, M_{O_2}}\,
+\nabla \cdot \left[D_{O_2}\, \nabla c_{O_2}\right]
+- \frac{R\, T}{\theta_{\rm eff,O_2}\, P\, M_{C}}\, S_m
 \end{equation}
 ```
 
 where:
-- $O_{2f}$ is the volumetric O₂ fraction in air (dimensionless, ~0.21 in atmosphere)
-- $\theta_a$ is the volumetric air content (m³ air m⁻³ soil)
-- $\rho_{O_2}$ is the O₂ mass concentration in air (kg O₂ m⁻³ air)
-- $D_{O_2}$ is the effective diffusivity of O₂ in soil (m² s⁻¹)
-- $R$ is the universal gas constant (8.314 J mol⁻¹ K⁻¹)
-- $T$ is soil temperature (K)
-- $P$ is atmospheric pressure (Pa)
-- $M_{O_2}$ is the molar mass of O₂ (0.032 kg mol⁻¹)
-- $M_C$ is the molar mass of carbon (0.012 kg mol⁻¹)
 
-The second term represents O₂ consumption by microbial respiration, following the stoichiometry C + O₂ → CO₂, where each 12 g of carbon respired consumes 32 g of oxygen.
+- the effective porosity for O₂, $\theta_{\rm eff,O_2} = \theta_a + \beta_{O_2}\, \theta_l$ (m³ m⁻³ soil) — same construction as the CO₂ effective porosity defined above, but with the O₂-specific Henry's-law factor. Because O₂ is much less soluble than CO₂ ($\beta_{O_2} \approx 0.032$ vs $\beta_{CO_2} \approx 0.84$ at 298 K), the dissolved-equivalent term contributes much less for O₂;
+- the O₂ mass concentration in air, $c_{O_2}$ (kg O₂ m⁻³ air), recovered from $Y_{\theta_{O_2}}$ via the ideal gas law;
+- the effective diffusivity of O₂ in soil, $D_{O_2}$ (m² s⁻¹);
+- the universal gas constant, $R$ (8.314 J mol⁻¹ K⁻¹);
+- the soil temperature, $T$ (K);
+- the atmospheric surface pressure, $P$ (Pa);
+- the molar mass of O₂, $M_{O_2}$ (0.032 kg mol⁻¹);
+- the molar mass of carbon, $M_C$ (0.012 kg mol⁻¹).
 
-### Soil Organic Carbon Dynamics
+The second term represents O₂ consumption by microbial respiration. The stoichiometry follows C + O₂ → CO₂: each 12 g of carbon respired consumes 32 g of O₂. The conversion factor $R T / (\theta_{\rm eff,O_2}\, P\, M_C)$ translates the carbon mass source $S_m$ (kg C m⁻³ s⁻¹ soil) into a tendency on the volumetric fraction $Y_{\theta_{O_2}}$.
 
-The soil organic carbon pool is depleted by microbial decomposition:
+### Soil Organic Carbon
+
+The $Y_{C_{som}}$ pool is held fixed at its initial value:
 
 ```math
 \begin{equation}
-\frac{\partial C_{som}}{\partial t} = -S_m
+\frac{\partial Y_{C_{som}}}{\partial t} = 0
 \end{equation}
 ```
 
-where $C_{som}$ is the soil organic carbon content (kg C m⁻³). This equation enforces carbon mass conservation: the rate of SOC consumption equals the rate of CO₂ production.
+The pool $Y_{C_{som}}$ enters the DAMM substrate kinetics (below) but is not depleted by respiration. Its value is set from the SoilGrids organic carbon density at the start of the simulation, providing the spatial structure of carbon availability.
 
 ## Microbial Respiration: DAMM Model
 
-The microbial source term $S_m$ represents heterotrophic respiration and is computed using the Dual Arrhenius and Michaelis-Menten (DAMM) kinetics model [Davidson2012](@citet):
+The microbial source term $S_m$ is computed using the Dual Arrhenius and Michaelis-Menten (DAMM) kinetics model [Davidson2012](@citet):
 
 ```math
 \begin{equation}
-S_m = V_{max} \cdot MM_{sx} \cdot MM_{O_2}
-\end{equation}
-```
-
-where $V_{max}$ is the maximum potential rate of respiration (temperature-dependent), $MM_{sx}$ represents substrate availability (0-1, dimensionless), and $MM_{O_2}$ is the oxygen limitation factor (0-1, dimensionless).
-
-### Maximum Respiration Rate
-
-The maximum potential respiration rate follows Arrhenius kinetics:
-
-```math
-\begin{equation}
-V_{max} = \alpha_{sx} \exp\left(\frac{-Ea_{sx}}{RT}\right)
-\end{equation}
-```
-
-where $\alpha_{sx}$ is the pre-exponential factor (kg C m⁻³ s⁻¹), $Ea_{sx}$ is the activation energy (J mol⁻¹), $R$ is the gas constant, and $T$ is soil temperature (K). This formulation captures the exponential increase in microbial activity with temperature.
-
-### Substrate Availability
-
-The concentration of soluble carbon substrates available to microbes depends on diffusion through soil water films:
-
-```math
-\begin{equation}
-[S_x] = p_{sx} \cdot C_{som} \cdot D_{liq} \cdot \theta_l^3
+S_m = V_{\max} \cdot MM_{sx} \cdot MM_{O_2}
 \end{equation}
 ```
 
 where:
-- $[S_x]$ is the concentration of soluble substrate (kg C m⁻³)
-- $p_{sx}$ is the fraction of SOC that is soluble (dimensionless)
-- $C_{som}$ is the total soil organic carbon (kg C m⁻³)
-- $D_{liq}$ is the diffusion coefficient of soluble carbon (dimensionless)
-- $\theta_l$ is the volumetric liquid water content (m³ m⁻³)
 
-The cubic dependence on moisture ($\theta_l^3$) reflects the strong constraint that water films place on substrate diffusion to microbes.
+- the maximum potential rate of respiration (temperature-dependent), $V_{\max}$ (kg C m⁻³ s⁻¹);
+- the substrate availability factor, $MM_{sx}$ (dimensionless, 0–1);
+- the oxygen limitation factor, $MM_{O_2}$ (dimensionless, 0–1).
+
+### Maximum Respiration Rate
+
+The maximum respiration rate follows Arrhenius kinetics, written here in centered form:
+
+```math
+\begin{equation}
+V_{\max} = V_{{\rm ref},sx} \, \exp\!\left[-\frac{E_{a,sx}}{R}\!\left(\frac{1}{T} - \frac{1}{T_{{\rm ref},sx}}\right)\right]
+\end{equation}
+```
+
+where:
+
+- the maximum respiration rate at the reference temperature, $V_{{\rm ref},sx}$ (kg C m⁻³ s⁻¹);
+- the reference temperature for the centered Arrhenius form, $T_{{\rm ref},sx}$ (K);
+- the activation energy, $E_{a,sx}$ (J mol⁻¹).
+
+This is algebraically equivalent to the uncentered form $V_{\max} = \alpha_{sx}\, \exp[-E_{a,sx}/(RT)]$ with $\alpha_{sx} = V_{{\rm ref},sx}\, \exp[E_{a,sx}/(R\, T_{{\rm ref},sx})]$. The centered form is preferred for calibration because $V_{{\rm ref},sx}$ (the rate at $T_{{\rm ref},sx}$) and $E_{a,sx}$ (the temperature sensitivity) are nearly orthogonal under parameter estimation, while $\alpha_{sx}$ and $E_{a,sx}$ are strongly correlated.
+
+### Substrate Availability
+
+The concentration of soluble carbon substrate available to microbes depends on diffusion through soil water films:
+
+```math
+\begin{equation}
+[S_x] = p_{sx} \cdot Y_{C_{som}} \cdot D_{liq} \cdot \theta_l^{3}
+\end{equation}
+```
+
+where:
+
+- the concentration of soluble substrate, $[S_x]$ (kg C m⁻³);
+- the soluble fraction of $Y_{C_{som}}$, $p_{sx}$ (dimensionless);
+- the soil organic carbon density, $Y_{C_{som}}$ (kg C m⁻³);
+- the dimensionless diffusion coefficient of soluble carbon in water, $D_{liq}$;
+- the volumetric liquid water content, $\theta_l$ (m³ m⁻³).
+
+The cubic dependence on moisture reflects the strong constraint that water films place on substrate diffusion to microbial sites.
 
 The substrate limitation factor follows Michaelis-Menten kinetics:
 
@@ -111,23 +142,24 @@ MM_{sx} = \frac{[S_x]}{kM_{sx} + [S_x]}
 \end{equation}
 ```
 
-where $kM_{sx}$ is the Michaelis constant for substrate (kg C m⁻³).
+where $kM_{sx}$ is the substrate Michaelis constant (kg C m⁻³).
 
 ### Oxygen Availability
 
-The oxygen availability for microbial respiration accounts for diffusion limitations in porous media using a tortuosity model:
+The oxygen availability for microbial respiration accounts for diffusion limitations in the partially saturated pore space using a Millington–Quirk tortuosity model:
 
 ```math
 \begin{equation}
-O_{2,avail} = D_{oa} \cdot O_{2f} \cdot \theta_a^{4/3}
+O_{2,{\rm avail}} = D_{oa} \cdot Y_{\theta_{O_2}} \cdot \theta_a^{4/3}
 \end{equation}
 ```
 
 where:
-- $O_{2,avail}$ is the dimensionless O₂ availability metric
-- $D_{oa}$ is the oxygen diffusion coefficient in air (dimensionless)
-- $O_{2f}$ is the volumetric O₂ fraction in air
-- $\theta_a^{4/3}$ is the Millington-Quirk tortuosity factor
+
+- the dimensionless O₂ availability metric, $O_{2,{\rm avail}}$;
+- the dimensionless O₂ diffusion coefficient used in the availability scaling, $D_{oa}$;
+- the volumetric O₂ fraction in air, $Y_{\theta_{O_2}}$ (dimensionless);
+- the Millington–Quirk tortuosity factor, $\theta_a^{4/3}$.
 
 The exponent 4/3 captures how tortuous diffusion pathways limit gas transport in partially saturated porous media.
 
@@ -135,51 +167,105 @@ The oxygen limitation factor follows Michaelis-Menten kinetics:
 
 ```math
 \begin{equation}
-MM_{O_2} = \frac{O_{2,avail}}{kM_{O_2} + O_{2,avail}}
+MM_{O_2} = \frac{O_{2,{\rm avail}}}{kM_{O_2} + O_{2,{\rm avail}}}
 \end{equation}
 ```
 
-where $kM_{O_2}$ is the Michaelis constant for oxygen (dimensionless).
+where $kM_{O_2}$ is the dimensionless O₂ Michaelis constant.
+
+## Air–Water Partitioning of Dissolved Gases
+
+CO₂ and O₂ partition between the soil's gas phase and the aqueous phase of pore water. Treating only the gas phase becomes singular as the soil saturates ($\theta_a \to 0$); accounting for the dissolved phase keeps the equations well-posed and is physically more accurate at high water content, especially for CO₂.
+
+### Henry's Law
+
+The temperature-dependent Henry's-law solubility is computed using a van 't Hoff form [Sander2015](@citet):
+
+```math
+\begin{equation}
+K_H(T) = K_H(T_{\rm ref}^{H})\, \exp\!\left[\frac{\partial \ln K_H}{\partial T}\!\left(\frac{1}{T} - \frac{1}{T_{\rm ref}^{H}}\right)\right]
+\end{equation}
+```
+
+where:
+
+- the Henry's-law constant at the Sander reference temperature, $K_H(T_{\rm ref}^{H})$ (mol m⁻³ Pa⁻¹);
+- the temperature coefficient (a dimensional analogue of $-\Delta_{\rm sol} H/R$), $\partial \ln K_H / \partial T$ (K);
+- the Sander reference temperature, $T_{\rm ref}^{H} = 298.15$ K.
+
+The dimensionless Henry's-law factor $\beta$ is defined by:
+
+```math
+\begin{equation}
+\beta(T) = K_H(T)\, R\, T
+\end{equation}
+```
+
+and converts a gas-phase concentration to an equivalent dissolved concentration: $c_{aq} = \beta\, c_g$. At 298 K this gives $\beta_{CO_2} \approx 0.84$ (dissolved CO₂ storage is comparable to gas-phase storage) and $\beta_{O_2} \approx 0.032$ (dissolved O₂ storage is small but stabilizing).
+
+### Effective Porosity
+
+The effective porosity used to translate between $Y_{CO_2}$ and $c_g$ — and similarly for the O₂ tendency — is the sum of the gas-filled pore volume and the dissolved-equivalent volume of the liquid pore water:
+
+```math
+\begin{equation}
+\theta_{\rm eff} = \max(\theta_a + \beta\, \theta_l,\ \theta_{\rm eff,min})
+\end{equation}
+```
+
+where the gas-filled pore volume $\theta_a$ and the volumetric liquid water content $\theta_l$ are introduced below. The term $\beta\, \theta_l$ is the "air-equivalent" volume of dissolved gas held in pore water; $\theta_{\rm eff,min} = 10^{-4}$ is a numerical floor that prevents division by zero in extreme conditions where both $\theta_a$ and $\theta_l$ are vanishingly small (see Numerical Safeguards). The same construction with $\beta_{O_2}$ defines $\theta_{\rm eff,O_2}$ used in the O₂ tendency.
 
 ## Gas Diffusivity in Soil
 
 ### CO₂ and O₂ Diffusivity
 
-Both CO₂ and O₂ diffusivity in soil are computed using the same parameterization [Ryan2018](@citet), which accounts for temperature, pressure, and soil moisture effects:
+Both CO₂ and O₂ diffusivity in soil are computed using the same parameterization [Ryan2018](@citet), with separate reference diffusivities for the two gases:
 
 ```math
 \begin{equation}
-D = D_0 \cdot (2\theta_{a100}^3 + 0.04\theta_{a100}) \cdot \left(\frac{\theta_a}{\theta_{a100}}\right)^{2 + 3/b}
+D_{\rm gas} = D_{0,{\rm gas}} \cdot (2\theta_{a100}^{3} + 0.04\, \theta_{a100}) \cdot \left(\frac{\theta_a}{\theta_{a100}}\right)^{2 + 3/b}
 \end{equation}
 ```
 
 where:
-- $D$ is the effective diffusivity in soil (m² s⁻¹)
-- $\theta_a$ is the volumetric air content (m³ m⁻³)
-- $\theta_{a100}$ is the air-filled porosity at soil water potential of -100 cm H₂O (dimensionless)
-- $b$ is the pore size distribution parameter (dimensionless)
 
-The reference diffusivity $D_0$ depends on temperature and pressure:
+- the effective diffusivity of the gas in soil, $D_{\rm gas}$ (m² s⁻¹), evaluated for either CO₂ ($D$) or O₂ ($D_{O_2}$);
+- the volumetric air content, $\theta_a$ (m³ m⁻³);
+- the air-filled porosity at a soil water potential of $-100$ cm H₂O, $\theta_{a100}$ (dimensionless);
+- the pore-size distribution parameter, $b$ (dimensionless).
+
+The free-air reference diffusivity is corrected for soil temperature and pressure:
 
 ```math
 \begin{equation}
-D_0 = D_{ref} \left(\frac{T}{T_{ref}}\right)^{1.75} \left(\frac{P_{ref}}{P}\right)
+D_{0,{\rm gas}} = D_{{\rm ref},{\rm gas}} \left(\frac{T}{T_{\rm ref}}\right)^{1.75} \left(\frac{P_{\rm ref}}{P}\right)
 \end{equation}
 ```
 
-where $D_{ref}$ is the diffusion coefficient at standard conditions (m² s⁻¹), $T_{ref}$ = 273 K, $P_{ref}$ = 101325 Pa, $T$ is soil temperature (K), and $P$ is atmospheric pressure (Pa). The temperature dependence (exponent 1.75) reflects increased molecular kinetic energy, while the pressure dependence accounts for changes in gas density.
+where:
+
+- the gas-specific reference diffusivity at standard conditions, $D_{{\rm ref},{\rm gas}}$ (m² s⁻¹), evaluated as $D_{\rm ref}$ for CO₂ and $D_{{\rm ref},O_2}$ for O₂;
+- the standard reference temperature, $T_{\rm ref} = 273$ K;
+- the standard reference pressure, $P_{\rm ref} = 101325$ Pa.
+
+The temperature exponent 1.75 reflects increased molecular kinetic energy, while the pressure dependence accounts for the change in gas number density with surface pressure.
 
 ### Volumetric Air Content
 
-The volumetric air content is computed as:
+The volumetric air content uses the total water content (liquid plus ice), so frozen water displaces air space:
 
 ```math
 \begin{equation}
-\theta_a = \max(\nu - \theta_l, 0)
+\theta_a = \nu - \theta_w, \qquad \theta_w = \theta_l + \theta_i
 \end{equation}
 ```
 
-where $\nu$ is the total soil porosity (m³ m⁻³) and $\theta_l$ is the volumetric liquid water content (m³ m⁻³). This simple relationship reflects that air fills the pore space not occupied by water.
+where:
+
+- the total soil porosity, $\nu$ (m³ m⁻³);
+- the volumetric ice content, $\theta_i$ (m³ m⁻³).
+
+By contrast, the dissolved storage in $\theta_{\rm eff}$ uses only $\theta_l$ — gases dissolve in liquid water, not in ice.
 
 ## O₂ Concentration Conversions
 
@@ -189,11 +275,11 @@ The O₂ mass concentration in air is computed from the volumetric fraction usin
 
 ```math
 \begin{equation}
-\rho_{O_2} = O_{2f} \frac{P \cdot M_{O_2}}{R \cdot T}
+c_{O_2} = Y_{\theta_{O_2}}\, \frac{P\, M_{O_2}}{R\, T}
 \end{equation}
 ```
 
-where $\rho_{O_2}$ is the O₂ mass concentration in air (kg O₂ m⁻³ air), $O_{2f}$ is the volumetric O₂ fraction, $P$ is pressure (Pa), $M_{O_2}$ is the molar mass of O₂ (0.032 kg mol⁻¹), $R$ is the gas constant (8.314 J mol⁻¹ K⁻¹), and $T$ is temperature (K).
+where the O₂ mass concentration in air, $c_{O_2}$ (kg O₂ m⁻³ air), is recovered from the dimensionless volumetric fraction $Y_{\theta_{O_2}}$ together with the surface pressure $P$, the molar mass $M_{O_2} = 0.032$ kg mol⁻¹, the gas constant $R = 8.314$ J mol⁻¹ K⁻¹, and the soil temperature $T$.
 
 ### From Mass Concentration to Volumetric Fraction
 
@@ -201,84 +287,108 @@ The inverse transformation is:
 
 ```math
 \begin{equation}
-O_{2f} = \rho_{O_2} \frac{R \cdot T}{P \cdot M_{O_2}}
+Y_{\theta_{O_2}} = c_{O_2}\, \frac{R\, T}{P\, M_{O_2}}
 \end{equation}
 ```
 
-These conversions are necessary because diffusion is most naturally expressed in terms of mass concentration gradients, while the prognostic variable ($O_{2f}$) and the microbial kinetics use volumetric fractions.
+These conversions are needed because diffusion is most naturally expressed in terms of mass concentration gradients, while the prognostic variable $Y_{\theta_{O_2}}$ and the microbial kinetics use the volumetric fraction.
 
 ## Boundary Conditions
 
 ### CO₂ Boundary Conditions
 
-At the top boundary (soil-atmosphere interface), the model uses a diffusive flux condition with atmospheric CO₂ concentration:
+At the top boundary, the diffusive flux drives the soil gas-phase concentration toward the atmospheric value:
 
 ```math
 \begin{equation}
-F_{CO_2,top} = -D \frac{ρ_{CO_2,atm} - ρ_{CO_2,top}}{\Delta z_{top}}
+F_{CO_2,{\rm top}} = -D\, \frac{c_{g,{\rm atm}} - c_{g,{\rm top}}}{\Delta z_{\rm top}},
+\qquad c_{g,{\rm atm}} = \chi_{CO_2}\, P\, M_C / (R\, T_{\rm top})
 \end{equation}
 ```
 
-where $ρ_{CO_2,atm}$ is the atmospheric CO₂ concentration (kg C m⁻³), $ρ_{CO_2,top}$ is the CO₂ concentration at the top soil layer, and $\Delta z_{top}$ is the distance from the top layer center to the surface.
+where:
 
-At the bottom boundary, a no-flux condition is typically applied: $F_{CO_2,bottom} = 0$.
+- the atmospheric CO₂ mole fraction (mol mol⁻¹), $\chi_{CO_2}$, supplied as a driver;
+- the gas-phase carbon concentration in the top soil layer, $c_{g,{\rm top}}$ (kg C m⁻³ air);
+- the distance from the top layer center to the surface, $\Delta z_{\rm top}$ (m);
+- the soil temperature at the top of the column, $T_{\rm top}$ (K).
+
+At the bottom boundary, a zero-flux condition is applied: $F_{CO_2,{\rm bottom}} = 0$.
 
 ### O₂ Boundary Conditions
 
-At the top boundary, atmospheric O₂ (volumetric fraction of 0.21) is used:
+At the top boundary, the atmospheric O₂ volumetric fraction $\theta_{O_2,{\rm atm}}$ ($\approx 0.21$) is converted to a mass concentration via the ideal gas law and used as the boundary value:
 
 ```math
 \begin{equation}
-F_{O_2,top} = -D_{O_2} \theta_{a,top} \frac{\rho_{O_2,atm} - \rho_{O_2,top}}{\Delta z_{top}}
+F_{O_2,{\rm top}} = -D_{O_2}\, \frac{c_{O_2,{\rm atm}} - c_{O_2,{\rm top}}}{\Delta z_{\rm top}},
+\qquad c_{O_2,{\rm atm}} = \theta_{O_2,{\rm atm}}\, P\, M_{O_2} / (R\, T_{\rm top}).
 \end{equation}
 ```
 
-where $\rho_{O_2,atm}$ is computed from $O_{2f} = 0.21$ using the ideal gas law.
+At the bottom boundary, a zero-flux condition is applied: $F_{O_2,{\rm bottom}} = 0$.
 
-At the bottom boundary, a no-flux condition is typically applied: $F_{O_2,bottom} = 0$.
+## Numerical Safeguards
+
+The continuous PDE above is integrated with an explicit scheme. Several pragmatic safeguards keep the discrete update well-behaved in extreme regimes (e.g. very dry hot columns or saturated ice-rich columns), without changing the equations in their physical regime:
+
+- the floor on the effective porosity, $\theta_{\rm eff,min} = 10^{-4}$, prevents a singular $c_g = Y_{CO_2}/\theta_{\rm eff}$ when both $\theta_a$ and $\theta_l$ are vanishingly small (saturated, frozen soil);
+- the diffusivity ratio is capped at $\theta_a / \theta_{a100} \le 5$, preventing the Ryan/Moldrup expression from producing unphysically large $D$ in soils much drier than their reference state ($\theta_a \gg \theta_{a100}$);
+- the per-step bracket on the $Y_{\theta_{O_2}}$ tendency clamps $\partial Y_{\theta_{O_2}}/\partial t$ so that one explicit step cannot push $Y_{\theta_{O_2}}$ outside $[0,\ \theta_{O_2,{\rm atm}}]$; this kicks in only when the explicit step would otherwise violate the diffusion CFL bound, and is conservative for multi-stage Runge-Kutta integrators;
+- an extra Michaelis-Menten attenuation $Y_{\theta_{O_2}} / (Y_{\theta_{O_2}} + K_{O_2,{\rm lim}})$ with $K_{O_2,{\rm lim}} = 10^{-4}$ multiplies the O₂ consumption term, which together with the tendency bracket prevents the explicit step from driving $Y_{\theta_{O_2}}$ negative in the rare cells where $Y_{\theta_{O_2}}$ becomes very small.
 
 ## Summary Tables
 
 ### Model Outputs
 
 | Output | Symbol | Unit | Description |
-| :---         |     :---:      |    :---:      |     :---   |
-| CO₂ concentration | $ρ_{CO_2}$ | kg C m⁻³ | CO₂ in soil air |
-| O₂ volumetric fraction | $O_{2f}$ | dimensionless | O₂ fraction in soil air |
-| Soil organic carbon | $C_{som}$ | kg C m⁻³ | Total SOC pool |
+| :--- | :---: | :---: | :--- |
+| Total CO₂ | $Y_{CO_2}$ | kg C m⁻³ soil | Gas plus dissolved, $\theta_{\rm eff} c_g$ |
+| Air-phase CO₂ | $c_g$ | kg C m⁻³ air | Diagnosed as $Y_{CO_2}/\theta_{\rm eff}$ |
+| O₂ volumetric fraction | $Y_{\theta_{O_2}}$ | dimensionless | O₂ fraction in soil air |
+| Soil organic carbon | $Y_{C_{som}}$ | kg C m⁻³ | Initialized from SoilGrids, fixed |
 | Microbial respiration | $S_m$ | kg C m⁻³ s⁻¹ | CO₂ production rate |
 
 ### Drivers
 
 | Driver | Symbol | Unit | Range | Description |
-| :---         |     :---:      |    :---:      |     :---:   |    :---   |
-| Soil temperature | $T$ | K | 250-320 | Controls respiration and diffusion |
-| Volumetric liquid water | $\theta_l$ | m³ m⁻³ | 0.0-0.6 | Controls substrate diffusion |
-| Atmospheric pressure | $P$ | Pa | 80000-105000 | Affects gas diffusion |
-| Atmospheric CO₂ | $ρ_{CO_2,atm}$ | kg C m⁻³ | - | Top boundary condition |
+| :--- | :---: | :---: | :---: | :--- |
+| Soil temperature | $T$ | K | 250–320 | Controls respiration and diffusion |
+| Volumetric liquid water | $\theta_l$ | m³ m⁻³ | 0.0–0.6 | Substrate diffusion, dissolved storage |
+| Volumetric ice | $\theta_i$ | m³ m⁻³ | 0.0–0.6 | Displaces air in $\theta_a$ |
+| Atmospheric pressure | $P$ | Pa | 80000–105000 | Affects gas diffusion |
+| Atmospheric CO₂ | $\chi_{CO_2}$ | mol mol⁻¹ | $\sim 4 \times 10^{-4}$ | Top boundary condition |
 
 ### Parameters
 
-| Parameter | Symbol | Unit | Typical Range | Description |
-| :---         |     :---:      |    :---:      |     :---:   |    :---   |
-| Soil porosity | $\nu$ | m³ m⁻³ | 0.3-0.6 | Total pore space |
-| Pre-exponential factor | $\alpha_{sx}$ | kg C m⁻³ s⁻¹ | 100e3-300e3 | DAMM kinetics |
-| Activation energy | $Ea_{sx}$ | J mol⁻¹ | 50e3-70e3 | Temperature sensitivity |
-| Substrate Michaelis constant | $kM_{sx}$ | kg C m⁻³ | 1e-10-0.1 | Half-saturation for substrate |
-| O₂ Michaelis constant | $kM_{O_2}$ | dimensionless | 1e-10-0.1 | Half-saturation for O₂ |
-| Soluble SOC fraction | $p_{sx}$ | dimensionless | 0.005-0.5 | Fraction of SOC available |
-| Pore size distribution | $b$ | dimensionless | 2-12 | Soil texture parameter |
-| Air content at -100 cm H₂O | $\theta_{a100}$ | dimensionless | 0.05-0.3 | Reference air content |
+| Parameter | Symbol | Unit | Typical Value | Description |
+| :--- | :---: | :---: | :---: | :--- |
+| Soil porosity | $\nu$ | m³ m⁻³ | 0.3–0.6 | Total pore space |
+| Reference respiration rate | $V_{{\rm ref},sx}$ | kg C m⁻³ s⁻¹ | $\sim 2 \times 10^{-7}$ | DAMM, at $T_{{\rm ref},sx}$ |
+| DAMM reference temperature | $T_{{\rm ref},sx}$ | K | 288.15 | Centered Arrhenius reference |
+| Activation energy | $E_{a,sx}$ | J mol⁻¹ | $\sim 4 \times 10^{4}$ | Temperature sensitivity |
+| Substrate Michaelis constant | $kM_{sx}$ | kg C m⁻³ | 0.01–0.5 | Half-saturation for substrate |
+| O₂ Michaelis constant | $kM_{O_2}$ | dimensionless | 0.001–0.01 | Half-saturation for O₂ |
+| Soluble $Y_{C_{som}}$ fraction | $p_{sx}$ | dimensionless | 0.005–0.5 | Fraction of $Y_{C_{som}}$ available |
+| Pore size distribution | $b$ | dimensionless | 2–12 | Soil texture parameter |
+| Air content at $-100$ cm H₂O | $\theta_{a100}$ | dimensionless | 0.05–0.3 | Reference air content |
+| CO₂ Henry constant at $T_{\rm ref}^{H}$ | $K_H^{CO_2}(T_{\rm ref}^{H})$ | mol m⁻³ Pa⁻¹ | $3.4 \times 10^{-4}$ | Sander (2015) |
+| O₂ Henry constant at $T_{\rm ref}^{H}$ | $K_H^{O_2}(T_{\rm ref}^{H})$ | mol m⁻³ Pa⁻¹ | $1.3 \times 10^{-5}$ | Sander (2015) |
+| CO₂ Henry temperature coefficient | $\partial \ln K_H^{CO_2}/\partial T$ | K | 2400 | van 't Hoff slope |
+| O₂ Henry temperature coefficient | $\partial \ln K_H^{O_2}/\partial T$ | K | 1500 | van 't Hoff slope |
 
 ### Constants
 
 | Constant | Symbol | Unit | Value | Description |
-| :---         |     :---:      |    :---:      |     :---:   |    :---   |
-| CO₂ diffusion coefficient (STP) | $D_{ref}$ | m² s⁻¹ | 1.39e-5 | Reference diffusivity |
+| :--- | :---: | :---: | :---: | :--- |
+| CO₂ diffusion coefficient (STP) | $D_{\rm ref}$ | m² s⁻¹ | $1.39 \times 10^{-5}$ | Reference diffusivity, CO₂ in air |
+| O₂ diffusion coefficient (STP) | $D_{{\rm ref},O_2}$ | m² s⁻¹ | $1.67 \times 10^{-5}$ | Reference diffusivity, O₂ in air |
 | Soil C substrate diffusivity | $D_{liq}$ | dimensionless | 3.17 | Substrate diffusion |
-| O₂ diffusion coefficient | $D_{oa}$ | dimensionless | 1.67 | O₂ diffusion in air |
+| O₂ availability scaling | $D_{oa}$ | dimensionless | 1.67 | Used in O₂ availability metric |
 | Universal gas constant | $R$ | J mol⁻¹ K⁻¹ | 8.314 | Ideal gas law |
 | Molar mass of O₂ | $M_{O_2}$ | kg mol⁻¹ | 0.032 | Oxygen molecular weight |
 | Molar mass of C | $M_C$ | kg mol⁻¹ | 0.012 | Carbon atomic weight |
-| Reference temperature | $T_{ref}$ | K | 273 | Standard conditions |
-| Reference pressure | $P_{ref}$ | Pa | 101325 | Standard conditions |
+| Reference temperature (Sander) | $T_{\rm ref}^{H}$ | K | 298.15 | Henry's-law reference |
+| Reference temperature (Ryan) | $T_{\rm ref}$ | K | 273 | Diffusivity reference |
+| Reference pressure | $P_{\rm ref}$ | Pa | 101325 | Standard conditions |
+| Effective porosity floor | $\theta_{\rm eff,min}$ | m³ m⁻³ | $10^{-4}$ | Numerical floor |

--- a/docs/src/tutorials/integrated/soil_canopy_fluxnet_tutorial.jl
+++ b/docs/src/tutorials/integrated/soil_canopy_fluxnet_tutorial.jl
@@ -90,7 +90,7 @@ LAI = ClimaLand.Canopy.prescribed_lai_modis(
 # [`SoilCanopyModel`](@ref "Integrated Land Model Types and methods")
 # Here we use the highest level model constructor, which uses default parameters,
 # and parameterizations, for the soil and canopy models.
-land_model = SoilCanopyModel{FT}(forcing, LAI, toml_dict, domain);
+land_model = SoilCanopyModel{FT}(forcing, LAI, toml_dict, domain, Δt);
 set_ic! = FluxnetSimulations.make_set_fluxnet_initial_conditions(
     site_ID,
     start_date,

--- a/experiments/calibration/README.md
+++ b/experiments/calibration/README.md
@@ -25,6 +25,23 @@ latitude-weighted scalar covariance matrix.
       submission for the forward models.
     - You may want to use `tmux` to keep a persistent session on the cluster.
 
+For example, launching er.jl on Derecho
+Go into tmux:
+
+```
+tmux new -t calibration
+```
+
+(later on, attach via `tmux attach -t calibration`, and detach via `ctrl+b, release, press d`)
+Start the calibration:
+
+```
+module load climacommon/2025_02_25
+export HDF5_USE_FILE_LOCKING=FALSE
+export CALIBRATION_CONFIG=er.jl
+bash experiments/calibration/run_calibration.sh /glade/derecho/scratch/$USER/calibration_er
+```
+
 # Debugging
 
 ClimaCalibrate tries to keep `climacommon` up to date. If errors result from

--- a/experiments/calibration/configs/energy_fluxes.jl
+++ b/experiments/calibration/configs/energy_fluxes.jl
@@ -4,10 +4,11 @@
 
 """Noise scalars for the covariance matrix of each observed variable.
 
-Units follow the observational dataset:
-- `lwu`: W m^-2 (ERA5)
-- `shf`: W m^-2 (ERA5)
-- `lhf`: W m^-2 (ERA5)
+These multiply the identity in `ScalarCovariance`, so they are variances.
+Units are the square of the observational dataset units:
+- `lwu`: (W m^-2)^2 (ERA5)
+- `shf`: (W m^-2)^2 (ERA5)
+- `lhf`: (W m^-2)^2 (ERA5)
 """
 const NOISE_SCALARS = Dict("lwu" => 1.0, "shf" => 1.0, "lhf" => 1.0)
 

--- a/experiments/calibration/configs/er.jl
+++ b/experiments/calibration/configs/er.jl
@@ -1,0 +1,99 @@
+# Calibration configuration for ecosystem respiration (ER = Hr + Ra)
+#
+# This file is included by run_calibration.jl and defines:
+#   - CALIBRATE_CONFIG (CalibrateConfig)
+#   - NOISE_SCALARS (per-variable covariance scaling)
+#   - get_calibration_prior() (combined prior distribution)
+#
+# To use this config, set the CALIBRATION_CONFIG env var when invoking
+# run_calibration.sh, e.g.
+#   CALIBRATION_CONFIG=er.jl bash experiments/calibration/run_calibration.sh
+#
+# Observational target: ILAMB FLUXCOM reco (reco_FLUXCOM_reco.nc), in g C m^-2 day^-1.
+
+"""Noise scalars for the covariance matrix of each observed variable.
+
+These multiply the identity in `ScalarCovariance`, so they are variances.
+Units are the square of the observational dataset units:
+- `er`: (g C m^-2 day^-1)^2 (ILAMB FLUXCOM reco)
+"""
+const NOISE_SCALARS = Dict("er" => 3.0)
+
+"""
+    get_calibration_prior()
+
+Return the combined prior distribution for the calibration parameters.
+
+Calibrates 6 parameters: 4 heterotrophic (DAMM) + 2 autotrophic (JULES).
+Ensemble size for TransformUnscented: 6 * 2 + 1 = 13 members.
+
+DAMM uses the centered-Arrhenius form
+    Vmax = V_ref_sx * exp(-Ea_sx/R * (1/T - 1/T_ref_sx))
+with T_ref_sx = 288.15 K fixed, so V_ref_sx and Ea_sx are approximately
+orthogonal.
+"""
+function get_calibration_prior()
+    priors = [
+        EKP.constrained_gaussian(
+            "soilCO2_reference_rate",
+            2.526e-7,
+            1.0e-7,
+            5.0e-8,
+            5.0e-7,
+        ),
+        EKP.constrained_gaussian(
+            "soilCO2_activation_energy",
+            40000.0,
+            15000.0,
+            20000.0,
+            80000.0,
+        ),
+        EKP.constrained_gaussian("michaelis_constant", 0.3, 0.2, 0.01, 1.0),
+        EKP.constrained_gaussian(
+            "O2_michaelis_constant",
+            0.005,
+            0.003,
+            5.0e-4,
+            5.0e-2,
+        ),
+        # JULES autotrophic respiration (two-sided: allow Ra to increase or
+        # decrease). Priors are centered on the current defaults.
+        EKP.constrained_gaussian(
+            "root_leaf_nitrogen_ratio",
+            1.0,
+            0.5,
+            0.05,
+            3.0,
+        ),
+        EKP.constrained_gaussian(
+            "relative_contribution_factor",
+            0.25,
+            0.15,
+            0.0,
+            1.0,
+        ),
+    ]
+    return EKP.combine_distributions(priors)
+end
+
+const CALIBRATE_CONFIG = CalibrateConfig(;
+    short_names = ["er"],
+    minibatch_size = 2,
+    n_iterations = 10,
+    # 10 yearly samples: each covers DJF, MAM, JJA (Dec 1 -> Sep 1)
+    # Ending at Sep 1 avoids DJF over-representation across consecutive
+    # samples that would occur with Dec-to-Dec ranges.
+    # with extend = Month(3), simulation runs through Nov 30 of year+1
+    sample_date_ranges = [
+        ("$(year)-12-1", "$(year+1)-9-1") for year in 2001:2010
+    ],
+    extend = Dates.Month(3),
+    # Longer spinup than GPP (3 months) so that deep soil temperature and
+    # moisture profiles settle before Hr is compared to FLUXCOM reco.
+    spinup = Dates.Year(1),
+    nelements = (180, 360, 15),
+    output_dir = OUTPUT_DIR,
+    rng_seed = 42,
+    obs_vec_filepath = "experiments/calibration/land_observation_vector_er.jld2",
+    model_type = ClimaLand.LandModel,
+)

--- a/experiments/calibration/configs/gpp.jl
+++ b/experiments/calibration/configs/gpp.jl
@@ -11,8 +11,9 @@
 
 """Noise scalars for the covariance matrix of each observed variable.
 
-Units follow the observational dataset:
-- `gpp`: g C m^-2 day^-1 (ILAMB FLUXCOM)
+These multiply the identity in `ScalarCovariance`, so they are variances.
+Units are the square of the observational dataset units:
+- `gpp`: (g C m^-2 day^-1)^2 (ILAMB FLUXCOM)
 """
 const NOISE_SCALARS = Dict("gpp" => 2.0)
 

--- a/experiments/calibration/configs/gpp_er_nee_lhf.jl
+++ b/experiments/calibration/configs/gpp_er_nee_lhf.jl
@@ -1,0 +1,150 @@
+# Calibration configuration for GPP + ER + NEE + LHF
+#
+# This file is included by run_calibration.jl and defines:
+#   - CALIBRATE_CONFIG (CalibrateConfig)
+#   - NOISE_SCALARS (per-variable covariance scaling)
+#   - get_calibration_prior() (combined prior distribution)
+#
+# To use this config, set the CALIBRATION_CONFIG env var when invoking
+# run_calibration.sh, e.g.
+#   CALIBRATION_CONFIG=gpp_er_nee_lhf.jl bash experiments/calibration/run_calibration.sh
+#
+# Observational targets:
+#   - gpp: ILAMB FLUXCOM (gpp_FLUXCOM_gpp.nc),   g C m^-2 day^-1
+#   - er:  ILAMB FLUXCOM (reco_FLUXCOM_reco.nc), g C m^-2 day^-1
+#   - nee: ILAMB FLUXCOM (nee_FLUXCOM_nee.nc),   g C m^-2 day^-1
+#   - lhf: ERA5,                                 W m^-2
+#
+# Prior structure: 5 P-model/moisture-stress parameters (from gpp_lhf.jl) +
+# 4 DAMM heterotrophic-respiration parameters + 2 JULES autotrophic-
+# respiration parameters (from er.jl), for 11 parameters total.
+# Ensemble size for TransformUnscented: 11 * 2 + 1 = 23 members.
+#
+# Priors are recentered on the posterior from the previous gpp_er_nee_lhf
+# calibration (now in toml/default_parameters.toml). Standard deviations are
+# kept the same when feasible; bounds are expanded only for parameters whose
+# posterior reached or approached the previous bound:
+#   - pmodel_β_c3: lower 50 -> 10 (posterior 68.2139 with σ=40 requires lower < ~20)
+#   - pmodel_β_c4: upper 40 -> 80 (posterior 39.575 hit upper bound)
+#   - soilCO2_reference_rate: lower 1e-8 -> 1e-9 (drifted toward lower bound)
+#   - root_leaf_nitrogen_ratio: lower 0.05 -> 0.01 (posterior 0.0626 hit lower bound)
+#   - relative_contribution_factor: upper 1.0 -> 1.5 (posterior 0.844 approached upper bound)
+# Standard deviations were reduced where the original σ became infeasible after
+# recentering on a much smaller posterior mean (σ shrunk to preserve σ/μ ratio):
+#   - O2_michaelis_constant: σ 0.004 -> 0.002 (μ dropped 0.005 -> 0.00255)
+#   - root_leaf_nitrogen_ratio: σ 0.5 -> 0.04 (μ dropped 1.0 -> 0.0626)
+
+"""Noise scalars for the covariance matrix of each observed variable.
+
+These multiply the identity in `ScalarCovariance`, so they are variances.
+Units are the square of the observational dataset units:
+- `gpp`: (g C m^-2 day^-1)^2 (ILAMB FLUXCOM)
+- `er`:  (g C m^-2 day^-1)^2 (ILAMB FLUXCOM reco)
+- `nee`: (g C m^-2 day^-1)^2 (ILAMB FLUXCOM)
+- `lhf`: (W m^-2)^2 (ERA5)
+"""
+const NOISE_SCALARS =
+    Dict("gpp" => 2.5, "er" => 2.5, "nee" => 2.5, "lhf" => 100.0)
+
+"""
+    get_calibration_prior()
+
+Return the combined prior distribution for the calibration parameters.
+
+Calibrates 11 parameters: 5 P-model/moisture-stress + 4 DAMM + 2 JULES
+autotrophic respiration.
+"""
+function get_calibration_prior()
+    # Means recentered on the posterior from the previous gpp_er_nee_lhf
+    # calibration (now reflected in toml/default_parameters.toml).
+    # Standard deviations are unchanged. Bounds are expanded for parameters
+    # whose posterior reached or approached the previous bound.
+    priors = [
+        # P-model + moisture stress
+        EKP.constrained_gaussian("pmodel_cstar", 0.448094, 0.05, 0.2, 0.7),
+        # pmodel_β_c3 lower bound expanded 50 -> 10 (μ=68.2139 with σ=40 requires lower < ~20)
+        EKP.constrained_gaussian("pmodel_β_c3", 68.2139, 40.0, 10.0, 300.0),
+        # pmodel_β_c4 prior posterior 39.575 hit upper bound 40 -> expand to 80
+        EKP.constrained_gaussian("pmodel_β_c4", 39.575, 5.0, 5.0, 80.0),
+        EKP.constrained_gaussian("pmodel_α", 0.964115, 0.02, 0.85, 0.999),
+        EKP.constrained_gaussian(
+            "moisture_stress_c",
+            0.377838,
+            0.15,
+            0.05,
+            1.0,
+        ),
+        # DAMM heterotrophic respiration
+        # soilCO2_reference_rate lower bound expanded 1e-8 -> 1e-9
+        EKP.constrained_gaussian(
+            "soilCO2_reference_rate",
+            2.17564e-7,
+            2.0e-7,
+            1.0e-9,
+            2.0e-6,
+        ),
+        EKP.constrained_gaussian(
+            "soilCO2_activation_energy",
+            37357.0,
+            25000.0,
+            5000.0,
+            150000.0,
+        ),
+        EKP.constrained_gaussian(
+            "michaelis_constant",
+            0.459997,
+            0.25,
+            0.001,
+            2.0,
+        ),
+        # O2_michaelis_constant σ reduced 0.004 -> 0.002 (μ dropped 0.005 -> 0.00255 makes original σ infeasible)
+        EKP.constrained_gaussian(
+            "O2_michaelis_constant",
+            0.00255006,
+            0.002,
+            1.0e-5,
+            1.0e-1,
+        ),
+        # JULES autotrophic respiration
+        # root_leaf_nitrogen_ratio posterior 0.0626 hit lower bound 0.05 -> expand to 0.01
+        # σ reduced 0.5 -> 0.04 (μ dropped 1.0 -> 0.0626 makes original σ infeasible)
+        EKP.constrained_gaussian(
+            "root_leaf_nitrogen_ratio",
+            0.0625785,
+            0.04,
+            0.01,
+            3.0,
+        ),
+        # relative_contribution_factor posterior 0.844 approached upper bound 1.0 -> expand to 1.5
+        EKP.constrained_gaussian(
+            "relative_contribution_factor",
+            0.844417,
+            0.15,
+            0.0,
+            1.5,
+        ),
+    ]
+    return EKP.combine_distributions(priors)
+end
+
+const CALIBRATE_CONFIG = CalibrateConfig(;
+    short_names = ["gpp", "er", "nee", "lhf"],
+    minibatch_size = 2,
+    n_iterations = 10,
+    # 10 yearly samples: each covers DJF, MAM, JJA (Dec 1 -> Sep 1)
+    # Ending at Sep 1 avoids DJF over-representation across consecutive
+    # samples that would occur with Dec-to-Dec ranges.
+    # with extend = Month(3), simulation runs through Nov 30 of year+1
+    sample_date_ranges = [
+        ("$(year)-12-1", "$(year+1)-9-1") for year in 2001:2010
+    ],
+    extend = Dates.Month(3),
+    # Use the longer ER spinup (1 year) so deep soil temperature and
+    # moisture profiles settle before Hr is compared to FLUXCOM reco.
+    spinup = Dates.Year(1),
+    nelements = (180, 360, 15),
+    output_dir = OUTPUT_DIR,
+    rng_seed = 42,
+    obs_vec_filepath = "experiments/calibration/land_observation_vector_gpp_er_nee_lhf.jld2",
+    model_type = ClimaLand.LandModel,
+)

--- a/experiments/calibration/configs/gpp_lhf.jl
+++ b/experiments/calibration/configs/gpp_lhf.jl
@@ -10,9 +10,10 @@
 
 """Noise scalars for the covariance matrix of each observed variable.
 
-Units follow the observational dataset:
-- `gpp`: g C m^-2 day^-1 (ILAMB FLUXCOM)
-- `lhf`: W m^-2 (ERA5)
+These multiply the identity in `ScalarCovariance`, so they are variances.
+Units are the square of the observational dataset units:
+- `gpp`: (g C m^-2 day^-1)^2 (ILAMB FLUXCOM)
+- `lhf`: (W m^-2)^2 (ERA5)
 """
 const NOISE_SCALARS = Dict("gpp" => 2.0, "lhf" => 20.0)
 

--- a/experiments/calibration/configs/test.jl
+++ b/experiments/calibration/configs/test.jl
@@ -6,8 +6,9 @@
 
 """Noise scalars for the covariance matrix of each observed variable.
 
-Units follow the observational dataset:
-- `lwu`: W m^-2 (ERA5)
+These multiply the identity in `ScalarCovariance`, so they are variances.
+Units are the square of the observational dataset units:
+- `lwu`: (W m^-2)^2 (ERA5)
 """
 const NOISE_SCALARS = Dict("lwu" => 1.0)
 

--- a/experiments/calibration/models/snowy_land.jl
+++ b/experiments/calibration/models/snowy_land.jl
@@ -45,7 +45,7 @@ function setup_model(
         start_date,
         stop_date,
     )
-    prognostic_land_components = (:canopy, :snow, :soil)
+    prognostic_land_components = (:canopy, :snow, :soil, :soilco2)
     # Snow model setup
     # Set β = 0 in order to regain model without density dependence
     α_snow = Snow.ZenithAngleAlbedoModel(toml_dict)
@@ -153,8 +153,12 @@ function ClimaCalibrate.forward_model(
     # Need to include "lhf", "shf", "lwu", "swu" because plotting the
     # leaderboard requires these diagnostics
     short_names = CALIBRATE_CONFIG.short_names
-    short_names =
-        unique!([short_names; ["lhf", "shf", "lwu", "swu", "gpp", "et"]])
+    short_names = unique!(
+        [
+            short_names
+            ["lhf", "shf", "lwu", "swu", "gpp", "et", "hr", "ra", "er", "nee"]
+        ],
+    )
     diagnostics = ClimaLand.Diagnostics.default_diagnostics(
         model,
         start_date,

--- a/experiments/calibration/run_calibration.jl
+++ b/experiments/calibration/run_calibration.jl
@@ -89,6 +89,25 @@ function _loaded_climacommon()
 end
 
 """
+    _forwarded_env_exports()
+
+Return shell-export lines for env vars that must be propagated from the driver
+shell into each forward-model PBS/Slurm job. PBS does not inherit the submit
+environment without `-V`, so worker jobs would otherwise re-read `ENV` and see
+an empty `CALIBRATION_CONFIG`, silently falling back to the default config in
+`run_calibration.jl` and producing sims that disagree with the obs vector.
+"""
+function _forwarded_env_exports()
+    forwarded = ("CALIBRATION_CONFIG", "HDF5_USE_FILE_LOCKING")
+    lines = String[]
+    for name in forwarded
+        haskey(ENV, name) || continue
+        push!(lines, "export $name=$(ENV[name])")
+    end
+    return join(lines, "\n")
+end
+
+"""
     module_load_string(::ClimaCalibrate.ClimaGPUBackend)
     module_load_string(::ClimaCalibrate.DerechoBackend)
 
@@ -98,12 +117,14 @@ version only needs to be specified once (in `run_calibration.sh`).
 """
 function ClimaCalibrate.module_load_string(::ClimaCalibrate.ClimaGPUBackend)
     return """module purge
-    module load $(_loaded_climacommon())"""
+    module load $(_loaded_climacommon())
+    $(_forwarded_env_exports())"""
 end
 
 function ClimaCalibrate.module_load_string(::ClimaCalibrate.DerechoBackend)
     return """module purge
-    module load $(_loaded_climacommon())"""
+    module load $(_loaded_climacommon())
+    $(_forwarded_env_exports())"""
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__

--- a/experiments/integrated/fluxnet/ozark_pft.jl
+++ b/experiments/integrated/fluxnet/ozark_pft.jl
@@ -183,7 +183,8 @@ soil = Soil.EnergyHydrology{FT}(
 # Soil microbes model
 co2_prognostic_soil = Soil.Biogeochemistry.PrognosticMet(soil.parameters)
 drivers = Soil.Biogeochemistry.SoilDrivers(co2_prognostic_soil, atmos)
-soilco2 = Soil.Biogeochemistry.SoilCO2Model{FT}(soil_domain, drivers, toml_dict)
+soilco2 =
+    Soil.Biogeochemistry.SoilCO2Model{FT}(soil_domain, drivers, toml_dict, dt)
 
 # Canopy model - Set up individual Component arguments with non-default parameters
 # Set up radiative transfer

--- a/experiments/integrated/fluxnet/ozark_pmodel.jl
+++ b/experiments/integrated/fluxnet/ozark_pmodel.jl
@@ -141,7 +141,8 @@ soil = Soil.EnergyHydrology{FT}(
 # Soil microbes model
 co2_prognostic_soil = Soil.Biogeochemistry.PrognosticMet(soil.parameters)
 drivers = Soil.Biogeochemistry.SoilDrivers(co2_prognostic_soil, atmos)
-soilco2 = Soil.Biogeochemistry.SoilCO2Model{FT}(soil_domain, drivers, toml_dict)
+soilco2 =
+    Soil.Biogeochemistry.SoilCO2Model{FT}(soil_domain, drivers, toml_dict, dt)
 
 # Now we set up the canopy model, one component at a time.
 # Set up radiative transfer

--- a/experiments/integrated/fluxnet/run_fluxnet.jl
+++ b/experiments/integrated/fluxnet/run_fluxnet.jl
@@ -145,7 +145,8 @@ soil = Soil.EnergyHydrology{FT}(
 # Soil microbes model
 co2_prognostic_soil = Soil.Biogeochemistry.PrognosticMet(soil.parameters)
 drivers = Soil.Biogeochemistry.SoilDrivers(co2_prognostic_soil, atmos)
-soilco2 = Soil.Biogeochemistry.SoilCO2Model{FT}(soil_domain, drivers, toml_dict)
+soilco2 =
+    Soil.Biogeochemistry.SoilCO2Model{FT}(soil_domain, drivers, toml_dict, dt)
 
 # Now we set up the canopy model, one component at a time.
 # Set up radiative transfer

--- a/experiments/integrated/fluxnet/vaira_paper.jl
+++ b/experiments/integrated/fluxnet/vaira_paper.jl
@@ -140,7 +140,8 @@ soil = Soil.EnergyHydrology{FT}(
 # Soil microbes model
 co2_prognostic_soil = Soil.Biogeochemistry.PrognosticMet(soil.parameters)
 drivers = Soil.Biogeochemistry.SoilDrivers(co2_prognostic_soil, atmos)
-soilco2 = Soil.Biogeochemistry.SoilCO2Model{FT}(soil_domain, drivers, toml_dict)
+soilco2 =
+    Soil.Biogeochemistry.SoilCO2Model{FT}(soil_domain, drivers, toml_dict, dt)
 
 # Now we set up the canopy model, one component at a time.
 # Set up radiative transfer

--- a/experiments/integrated/global/global_soil_canopy.jl
+++ b/experiments/integrated/global/global_soil_canopy.jl
@@ -75,7 +75,7 @@ soil = Soil.EnergyHydrology{FT}(
 # Soil microbes model
 co2_prognostic_soil = Soil.Biogeochemistry.PrognosticMet(soil.parameters)
 drivers = Soil.Biogeochemistry.SoilDrivers(co2_prognostic_soil, atmos)
-soilco2 = Soil.Biogeochemistry.SoilCO2Model{FT}(domain, drivers, toml_dict)
+soilco2 = Soil.Biogeochemistry.SoilCO2Model{FT}(domain, drivers, toml_dict, dt)
 
 # Now we set up the canopy model, which mostly use defaults for:
 ground = ClimaLand.PrognosticGroundConditions{FT}()

--- a/experiments/integrated/global/global_soil_canopy_pmodel.jl
+++ b/experiments/integrated/global/global_soil_canopy_pmodel.jl
@@ -77,7 +77,7 @@ soil = Soil.EnergyHydrology{FT}(
 # Soil microbes model
 co2_prognostic_soil = Soil.Biogeochemistry.PrognosticMet(soil.parameters)
 drivers = Soil.Biogeochemistry.SoilDrivers(co2_prognostic_soil, atmos)
-soilco2 = Soil.Biogeochemistry.SoilCO2Model{FT}(domain, drivers, toml_dict)
+soilco2 = Soil.Biogeochemistry.SoilCO2Model{FT}(domain, drivers, toml_dict, dt)
 
 # Now we set up the canopy model, which mostly use defaults for:
 ground = ClimaLand.PrognosticGroundConditions{FT}()

--- a/experiments/integrated/performance/conservation/ozark_conservation.jl
+++ b/experiments/integrated/performance/conservation/ozark_conservation.jl
@@ -160,8 +160,12 @@ for float_type in (Float32, Float64)
     # Soil microbes model
     co2_prognostic_soil = Soil.Biogeochemistry.PrognosticMet(soil.parameters)
     drivers = Soil.Biogeochemistry.SoilDrivers(co2_prognostic_soil, atmos)
-    soilco2 =
-        Soil.Biogeochemistry.SoilCO2Model{FT}(land_domain, drivers, toml_dict)
+    soilco2 = Soil.Biogeochemistry.SoilCO2Model{FT}(
+        land_domain,
+        drivers,
+        toml_dict,
+        dt,
+    )
 
     # Canopy model
     # Set up radiative transfer

--- a/experiments/integrated/performance/integrated_timestep_test.jl
+++ b/experiments/integrated/performance/integrated_timestep_test.jl
@@ -214,7 +214,14 @@ soil = Soil.EnergyHydrology{FT}(
 # Soil microbes model setup
 co2_prognostic_soil = Soil.Biogeochemistry.PrognosticMet(soil.parameters)
 drivers = Soil.Biogeochemistry.SoilDrivers(co2_prognostic_soil, atmos)
-soilco2 = Soil.Biogeochemistry.SoilCO2Model{FT}(land_domain, drivers, toml_dict)
+# Δt = 0 disables the O2_f tendency limiter so this convergence test
+# measures the bare equations across the dt sweep below.
+soilco2 = Soil.Biogeochemistry.SoilCO2Model{FT}(
+    land_domain,
+    drivers,
+    toml_dict,
+    FT(0),
+)
 
 # Canopy model setup
 # Radiative transfer model

--- a/experiments/standalone/Biogeochemistry/experiment.jl
+++ b/experiments/standalone/Biogeochemistry/experiment.jl
@@ -103,7 +103,8 @@ for (FT, tf) in ((Float32, 2 * dt), (Float64, tf))
     soilco2 = SoilCO2Model{FT}(
         domain,
         drivers,
-        toml_dict;
+        toml_dict,
+        dt;
         parameters = co2_parameters,
     )
 

--- a/ext/land_sim_vis/leaderboard/data_sources.jl
+++ b/ext/land_sim_vis/leaderboard/data_sources.jl
@@ -59,6 +59,38 @@ function get_sim_var_dict(diagnostics_folder_path)
             return sim_var
         end
 
+    sim_var_dict["er"] =
+        () -> begin
+            sim_var = get(
+                ClimaAnalysis.SimDir(diagnostics_folder_path),
+                short_name = "er",
+            )
+            (ClimaAnalysis.units(sim_var) == "mol CO2 m^-2 s^-1") && (
+                sim_var = ClimaAnalysis.convert_units(
+                    sim_var,
+                    "g m-2 day-1",
+                    conversion_function = units -> units * 86400.0 * 12.011,
+                )
+            )
+            return sim_var
+        end
+
+    sim_var_dict["nee"] =
+        () -> begin
+            sim_var = get(
+                ClimaAnalysis.SimDir(diagnostics_folder_path),
+                short_name = "nee",
+            )
+            (ClimaAnalysis.units(sim_var) == "mol CO2 m^-2 s^-1") && (
+                sim_var = ClimaAnalysis.convert_units(
+                    sim_var,
+                    "g m-2 day-1",
+                    conversion_function = units -> units * 86400.0 * 12.011,
+                )
+            )
+            return sim_var
+        end
+
     sim_var_dict["lhf"] =
         () -> begin
             sim_var = get(
@@ -125,26 +157,6 @@ how to add new variables.
 function get_ilamb_obs_var_dict()
     # Dict for loading in observational data
     obs_var_dict = Dict{String, Any}()
-    obs_var_dict["et"] =
-        (start_date) -> begin
-            obs_var = ClimaAnalysis.OutputVar(
-                ClimaLand.Artifacts.ilamb_dataset_path(
-                    "evspsbl_MODIS_et_0.5x0.5.nc",
-                ),
-                "et",
-                new_start_date = start_date,
-                shift_by = Dates.firstdayofmonth,
-            )
-            (ClimaAnalysis.units(obs_var) == "kg/m2/s") && (
-                obs_var = ClimaAnalysis.convert_units(
-                    obs_var,
-                    "mm / day",
-                    conversion_function = units -> units * 86400.0,
-                )
-            )
-            obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
-            return obs_var
-        end
 
     obs_var_dict["gpp"] =
         (start_date) -> begin
@@ -162,20 +174,50 @@ function get_ilamb_obs_var_dict()
             return obs_var
         end
 
-    obs_var_dict["lwu"] =
+    obs_var_dict["er"] =
         (start_date) -> begin
             obs_var = ClimaAnalysis.OutputVar(
-                ClimaLand.Artifacts.ilamb_dataset_path(
-                    "rlus_CERESed4.2_rlus.nc",
+                ClimaLand.Artifacts.ilamb_respiration_nee_dataset_path(
+                    "reco_FLUXCOM_reco.nc",
                 ),
-                "rlus",
+                "reco",
                 new_start_date = start_date,
                 shift_by = Dates.firstdayofmonth,
             )
-            ClimaAnalysis.units(obs_var) == "W m-2" &&
-                (obs_var = ClimaAnalysis.set_units(obs_var, "W m^-2"))
+            ClimaAnalysis.dim_units(obs_var, "lon") == "degree" &&
+                (obs_var.dim_attributes["lon"]["units"] = "degrees_east")
+            ClimaAnalysis.dim_units(obs_var, "lat") == "degree" &&
+                (obs_var.dim_attributes["lat"]["units"] = "degrees_north")
+            obs_var.attributes["short_name"] = "er"
+            obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
             return obs_var
         end
+
+    obs_var_dict["nee"] =
+        (start_date) -> begin
+            obs_var = ClimaAnalysis.OutputVar(
+                ClimaLand.Artifacts.ilamb_respiration_nee_dataset_path(
+                    "nee_FLUXCOM_nee.nc",
+                ),
+                "nee",
+                new_start_date = start_date,
+                shift_by = Dates.firstdayofmonth,
+            )
+            ClimaAnalysis.dim_units(obs_var, "lon") == "degree" &&
+                (obs_var.dim_attributes["lon"]["units"] = "degrees_east")
+            ClimaAnalysis.dim_units(obs_var, "lat") == "degree" &&
+                (obs_var.dim_attributes["lat"]["units"] = "degrees_north")
+            obs_var.attributes["short_name"] = "nee"
+            obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
+            # nee_FLUXCOM_nee.nc has no _FillValue attribute, so the netCDF
+            # default fill (~9.97e36) leaks through as real data — set it to NaN.
+            obs_var = ClimaAnalysis.replace(
+                x -> (!ismissing(x) && abs(x) > 1e20) ? NaN : x,
+                obs_var,
+            )
+            return obs_var
+        end
+
     return obs_var_dict
 end
 
@@ -281,14 +323,13 @@ function get_mask_dict(data_source)
     # Dict for loading in masks
     mask_dict = Dict{String, Any}()
 
-    # LWU is found in both ERA5 and ILAMB
     mask_dict["lwu"] =
         (sim_var, obs_var) -> begin
             return ClimaAnalysis.apply_oceanmask
         end
 
     if uppercase(data_source) == "ILAMB"
-        mask_dict["et"] =
+        ilamb_nan_mask =
             (sim_var, obs_var) -> begin
                 return ClimaAnalysis.make_lonlat_mask(
                     ClimaAnalysis.slice(
@@ -298,17 +339,9 @@ function get_mask_dict(data_source)
                     set_to_val = isnan,
                 )
             end
-
-        mask_dict["gpp"] =
-            (sim_var, obs_var) -> begin
-                return ClimaAnalysis.make_lonlat_mask(
-                    ClimaAnalysis.slice(
-                        obs_var,
-                        time = ClimaAnalysis.times(obs_var) |> first,
-                    );
-                    set_to_val = isnan,
-                )
-            end
+        mask_dict["gpp"] = ilamb_nan_mask
+        mask_dict["er"] = ilamb_nan_mask
+        mask_dict["nee"] = ilamb_nan_mask
     elseif uppercase(data_source) == "ERA5"
         mask_dict["shf"] =
             (sim_var, obs_var) -> begin
@@ -344,10 +377,16 @@ function get_calibration_obs_var_dict(; short_names = nothing)
     # ERA5 energy fluxes
     era5_dict = get_era5_obs_var_dict()
     merge!(obs_var_dict, era5_dict)
-    # ILAMB GPP
+    # ILAMB GPP, ecosystem respiration (FLUXCOM reco), and NEE
     ilamb_dict = get_ilamb_obs_var_dict()
     if haskey(ilamb_dict, "gpp")
         obs_var_dict["gpp"] = ilamb_dict["gpp"]
+    end
+    if haskey(ilamb_dict, "er")
+        obs_var_dict["er"] = ilamb_dict["er"]
+    end
+    if haskey(ilamb_dict, "nee")
+        obs_var_dict["nee"] = ilamb_dict["nee"]
     end
     if !isnothing(short_names)
         filter!(p -> p.first in short_names, obs_var_dict)
@@ -374,6 +413,8 @@ function get_compare_vars_biases_plot_extrema(; annual = false)
     compare_vars_biases_plot_extrema = Dict(
         "et" => (-2.0, 2.0) .* factor,
         "gpp" => (-6.0, 6.0) .* factor,
+        "er" => (-6.0, 6.0) .* factor,
+        "nee" => (-4.0, 4.0) .* factor,
         "lwu" => (-40.0, 40.0) .* factor,
         "shf" => (-50.0, 50.0) .* factor,
         "lhf" => (-40.0, 40.0) .* factor,

--- a/ext/land_sim_vis/leaderboard/leaderboard.jl
+++ b/ext/land_sim_vis/leaderboard/leaderboard.jl
@@ -1,4 +1,58 @@
 """
+    _percentile_contour_kwargs(var; low_q = 0.05, high_q = 0.95, nlevels = 11)
+
+Build a `more_kwargs` dictionary for `ClimaAnalysis.Visualize.contour2D_on_globe!`
+that clips the colormap to `[quantile(data, low_q), quantile(data, high_q)]`
+and lets `Makie.contourf!` draw extend-arrows for values outside that range.
+
+Returns an empty `Dict` (i.e. fall back to the plotting defaults) when the
+field is all-NaN, has fewer than two finite samples, or has a degenerate
+percentile range.
+"""
+function _percentile_contour_kwargs(
+    var;
+    low_q = 0.05,
+    high_q = 0.95,
+    nlevels = 11,
+)
+    vals = filter(isfinite, vec(var.data))
+    isempty(vals) && return Dict{Symbol, Any}()
+    lo = Statistics.quantile(vals, low_q)
+    hi = Statistics.quantile(vals, high_q)
+    lo == hi && return Dict{Symbol, Any}()
+    levels = collect(range(lo, hi; length = nlevels))
+    return Dict(
+        :plot =>
+            Dict(:levels => levels, :extendhigh => :auto, :extendlow => :auto),
+    )
+end
+
+"""
+    _nee_diverging_contour_kwargs(var, q; nlevels = 21)
+
+Build `more_kwargs` for `contour2D_on_globe!` that uses a diverging
+green → white → red colormap centered at zero, so NEE ≈ 0 reads as white,
+strong sinks (NEE ≪ 0) as saturated green, and strong sources (NEE ≫ 0)
+as saturated red. The half-range is set to the `q`-th percentile of
+`|NEE|` so single-cell outliers don't dominate.
+"""
+function _nee_diverging_contour_kwargs(var, q; nlevels = 21)
+    vals = filter(isfinite, vec(var.data))
+    isempty(vals) && return Dict{Symbol, Any}()
+    bound = Statistics.quantile(abs.(vals), q)
+    bound == 0 && return Dict{Symbol, Any}()
+    levels = collect(range(-bound, bound; length = nlevels))
+    return Dict(
+        :plot => Dict(
+            :levels => levels,
+            :colormap => CairoMakie.cgrad([:darkgreen, :white, :darkred]),
+            :extendhigh => :auto,
+            :extendlow => :auto,
+        ),
+    )
+end
+
+"""
     compute_monthly_leaderboard(leaderboard_base_path,
                                 diagnostics_folder_path,
                                 data_source)
@@ -26,7 +80,11 @@ function compute_monthly_leaderboard(
     mask_dict = get_mask_dict(data_source)
 
     compare_vars_biases_plot_extrema = get_compare_vars_biases_plot_extrema()
-    short_names = intersect(keys(sim_var_dict), keys(obs_var_dict))
+    available_sim_vars = ClimaAnalysis.available_vars(
+        ClimaAnalysis.SimDir(diagnostics_folder_path),
+    )
+    short_names =
+        intersect(keys(sim_var_dict), keys(obs_var_dict), available_sim_vars)
     issubset(short_names, keys(mask_dict)) ||
         error("Not all variables ($short_names) have a mask $(keys(mask_dict))")
 
@@ -291,7 +349,11 @@ function compute_seasonal_leaderboard(
     # Get everything we need from data_sources.jl
     sim_var_dict = get_sim_var_dict(diagnostics_folder_path)
     obs_var_dict = get_obs_var_dict(data_source)
-    short_names = intersect(keys(sim_var_dict), keys(obs_var_dict))
+    available_sim_vars = ClimaAnalysis.available_vars(
+        ClimaAnalysis.SimDir(diagnostics_folder_path),
+    )
+    short_names =
+        intersect(keys(sim_var_dict), keys(obs_var_dict), available_sim_vars)
 
     # Need to intialize mask function
     mask_dict = get_mask_dict(data_source)
@@ -493,10 +555,23 @@ function compute_seasonal_leaderboard(
                 sim_var, _ = sim_obs_season_comparsion_dict[short_name]["ANN"]
                 isempty(sim_var) && break
                 layout = fig_sim_ann[row_idx, col_idx] = CairoMakie.GridLayout()
+                # Clip the colorbar to the 5th-95th percentile of the
+                # simulated field so that outliers don't flatten the map;
+                # values outside that range are drawn with the `contourf!`
+                # :auto arrow bounds (same convention as the SIM-OBS bias
+                # plot produced by `plot_bias_on_globe!`).
+                # NEE uses a diverging colormap centered at zero
+                # (green = sink, red = source) since the sign carries
+                # physical meaning.
+                more_kwargs =
+                    short_name == "nee" ?
+                    _nee_diverging_contour_kwargs(sim_var, 0.95) :
+                    _percentile_contour_kwargs(sim_var)
                 ClimaAnalysis.Visualize.contour2D_on_globe!(
                     layout,
                     sim_var,
-                    mask = mask_fn_dict[short_name],
+                    mask = mask_fn_dict[short_name];
+                    more_kwargs,
                 )
             else
                 sim_var, obs_var =

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -286,6 +286,19 @@ function soil_grids_params_artifact_path(; context = nothing, lowres = true)
 end
 
 """
+    soil_grids_ocd_artifact_path(; context = nothing)
+
+Return the path to the file that contains the soil organic carbon density
+(`ocd`, kg/m³) at six depth levels, derived from SoilGrids. This is a ~1 degree
+regridded version used for initializing the prognostic SOC in the soil
+biogeochemistry model.
+"""
+function soil_grids_ocd_artifact_path(; context = nothing)
+    dir = @clima_artifact("soilgrids_ocd_lowres_interp", context)
+    return joinpath(dir, "soil_ocd_soilgrids_lowres.nc")
+end
+
+"""
     experiment_fluxnet_data_path(
         site_ID;
         context = nothing,
@@ -526,6 +539,19 @@ There are only three datasets available which are "rlus_CERESed4.2_rlus.nc",
 """
 function ilamb_dataset_path(filename; context = nothing)
     return joinpath(@clima_artifact("ilamb_data", context), filename)
+end
+
+"""
+    ilamb_respiration_nee_dataset_path(filename; context = nothing)
+
+Triggers the download of the ILAMB respiration and NEE dataset, if not already
+downloaded, using Julia Artifacts, and returns the path to this file.
+
+Available datasets are "reco_FLUXCOM_reco.nc" (ecosystem respiration) and
+"nee_FLUXCOM_nee.nc" (net ecosystem exchange), both in g m-2 day-1.
+"""
+function ilamb_respiration_nee_dataset_path(filename; context = nothing)
+    return joinpath(@clima_artifact("ilamb_respiration_nee", context), filename)
 end
 
 """

--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -419,7 +419,7 @@ import .Soil:
     sublimation_source,
     compute_liquid_influx,
     compute_infiltration_energy_flux
-import .Soil.Biogeochemistry: soil_temperature, soil_moisture
+import .Soil.Biogeochemistry: soil_temperature, soil_moisture, soil_ice
 include("standalone/Snow/Snow.jl")
 using .Snow
 import .Snow: snow_boundary_fluxes!, maximum_snow_cover_fraction!

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -480,7 +480,7 @@ function get_possible_diagnostics(model::EnergyHydrology)
 end
 
 function get_possible_diagnostics(model::SoilCO2Model)
-    return ["sco2", "hr", "scd", "scms", "so2", "soc", "soc_int"]
+    return ["sco2", "hr", "scd", "scms", "so2", "soc", "soc_int", "sco2_ppm"]
 end
 function get_possible_diagnostics(model::CanopyModel)
     diagnostics = [
@@ -603,7 +603,8 @@ function get_possible_diagnostics(model::LandModel)
         model.canopy.boundary_conditions.radiation,
     )
 
-    additional_diagnostics = ["swa", "swu", "lwu", "tair", "precip"]
+    additional_diagnostics =
+        ["swa", "swu", "lwu", "tair", "precip", "nee", "cveg"]
 
     return unique!(append!(component_diagnostics, additional_diagnostics))
 end
@@ -617,7 +618,7 @@ function get_short_diagnostics(model::EnergyHydrology)
     return ["swc", "si", "sie", "tsoil", "et"]
 end
 function get_short_diagnostics(model::SoilCO2Model)
-    return ["sco2", "hr", "soc", "soc_int"]
+    return ["sco2", "hr", "soc", "soc_int", "sco2_ppm"]
 end
 function get_short_diagnostics(model::CanopyModel)
     diagnostics = ["gpp", "ct", "lai", "trans", "er", "sif"]

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -979,8 +979,8 @@ function define_diagnostics!(land_model, possible_diags)
         short_name = "sco2",
         long_name = "Soil CO2",
         standard_name = "soil_co2",
-        units = "kg C m^3",
-        comments = "Concentration of CO2 in the porous air space of the soil. (depth resolved)",
+        units = "kg C m^-3",
+        comments = "Soil CO2 carbon mass per soil volume (air + dissolved) (depth resolved).",
         compute! = (out, Y, p, t) -> compute_soilco2!(out, Y, p, t, land_model),
     )
 
@@ -1002,7 +1002,7 @@ function define_diagnostics!(land_model, possible_diags)
         long_name = "Soil Organic Carbon",
         standard_name = "soil_organic_carbon",
         units = "kg C m^-3",
-        comments = "Mass concentration of soil organic carbon. (depth resolved)",
+        comments = "Soil organic carbon mass per soil volume (depth resolved).",
         compute! = (out, Y, p, t) -> compute_soc!(out, Y, p, t, land_model),
     )
     conditional_add_diagnostic_variable!(
@@ -1014,6 +1014,17 @@ function define_diagnostics!(land_model, possible_diags)
         comments = "1m Integrated Mass concentration of soil organic carbon",
         compute! = (out, Y, p, t) ->
             compute_integrated_soc!(out, Y, p, t, land_model),
+    )
+
+    # Soil CO2 in ppm (for NEON comparison)
+    add_diagnostic_variable!(
+        short_name = "sco2_ppm",
+        long_name = "Soil Pore Air CO2 Concentration",
+        standard_name = "soil_pore_air_co2_concentration",
+        units = "ppm",
+        comments = "CO2 concentration in soil pore air space, in parts per million by volume. Computed from air-equivalent CO2 concentration using ideal gas law. (depth resolved)",
+        compute! = (out, Y, p, t) ->
+            compute_soilco2_ppm!(out, Y, p, t, land_model),
     )
 
     # Soil water content

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -621,6 +621,34 @@ end # Convert from kg C to mol CO2.
 # To convert from kg C to mol CO2, we need to multiply by:
 # [3.664 kg CO2/ kg C] x [10^3 g CO2/ kg CO2] x [1 mol CO2/44.009 g CO2] = 83.26 mol CO2/kg C
 
+# Soil CO2 in ppm (for comparison with NEON observations)
+# Converts air-equivalent CO2 concentration to ppm using ideal gas law:
+# ppm = (n_CO2 / n_air) × 10^6 = CO2_air_eq * R * T / (M_C * P) × 10^6
+function compute_soilco2_ppm!(
+    out,
+    Y,
+    p,
+    t,
+    land_model::Union{SoilCanopyModel{FT}, LandModel{FT}},
+) where {FT}
+    params = land_model.soilco2.parameters
+    M_C = FT(params.M_C)
+    R = FT(LP.gas_constant(params.earth_param_set))
+
+    CO2_air_eq = p.soilco2.CO2_air_eq  # kg C / m³ air-equivalent
+    T_soil = p.soilco2.T               # K
+    P_sfc = p.drivers.P                # Pa
+
+    if isnothing(out)
+        out = zeros(axes(CO2_air_eq))
+        fill!(field_values(out), NaN)
+        @. out = CO2_air_eq * R * T_soil / (M_C * P_sfc) * FT(1e6)
+        return out
+    else
+        @. out = CO2_air_eq * R * T_soil / (M_C * P_sfc) * FT(1e6)
+    end
+end
+
 ## Other ##
 @diagnostic_compute "sw_albedo" Union{SoilCanopyModel, LandModel} p.α_sfc
 @diagnostic_compute "lw_up" Union{SoilCanopyModel, LandModel} p.LW_u
@@ -721,9 +749,18 @@ function compute_total_runoff!(
         out = zeros(soil.domain.space.surface) # Allocates
         fill!(field_values(out), NaN) # fill with NaNs, even over the ocean
     end
-    out .=
-        Runoff.get_surface_runoff(soil.boundary_conditions.top.runoff, Y, p) .+
-        Runoff.get_subsurface_runoff(soil.boundary_conditions.top.runoff, Y, p)
+    runoff = soil.boundary_conditions.top.runoff
+    surface = Runoff.get_surface_runoff(runoff, Y, p)
+    subsurface = Runoff.get_subsurface_runoff(runoff, Y, p)
+    if !isnothing(surface) && !isnothing(subsurface)
+        out .= surface .+ subsurface
+    elseif !isnothing(surface)
+        out .= surface
+    elseif !isnothing(subsurface)
+        out .= subsurface
+    else
+        fill!(out, 0)
+    end
     return out
 end
 

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -166,6 +166,7 @@ end
                 forcing.atmos,
             ),
             toml_dict,
+            Δt,
         ) : nothing,
         canopy = Canopy.CanopyModel{FT}(
             Domains.obtain_surface_domain(domain),
@@ -238,6 +239,7 @@ function LandModel{FT}(
             forcing.atmos,
         ),
         toml_dict,
+        Δt,
     ) : nothing,
     canopy = Canopy.CanopyModel{FT}(
         Domains.obtain_surface_domain(domain),
@@ -297,6 +299,7 @@ end
                 forcing.atmos,
             ),
             toml_dict,
+            Δt,
         ) : nothing,
         canopy = Canopy.CanopyModel{FT}(
             Domains.obtain_surface_domain(domain),
@@ -360,6 +363,7 @@ function LandModel{FT}(
             forcing.atmos,
         ),
         toml_dict,
+        Δt,
     ) : nothing,
     canopy = Canopy.CanopyModel{FT}(
         Domains.obtain_surface_domain(domain),

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -102,7 +102,8 @@ end
         forcing,
         LAI,
         toml_dict::CP.ParamDict,
-        domain::Union{ClimaLand.Domains.Column, ClimaLand.Domains.SphericalShell};
+        domain::Union{ClimaLand.Domains.Column, ClimaLand.Domains.SphericalShell},
+        Δt;
         soil = Soil.EnergyHydrology{FT}(
             domain,
             forcing,
@@ -117,6 +118,7 @@ end
                 forcing.atmos,
             ),
             toml_dict,
+            Δt,
         ),
         canopy = Canopy.CanopyModel{FT}(
             Domains.obtain_surface_domain(domain),
@@ -138,12 +140,14 @@ correspond to `forcing` with the atmosphere, as specified by `forcing`, a NamedT
 of the form (;atmos, radiation), with `atmos` an AbstractAtmosphericDriver and `radiation`
 and AbstractRadiativeDriver. The leaf area index `LAI` must be provided (prescribed)
 as a TimeVaryingInput, and the domain must be a ClimaLand domain with a vertical extent.
+`Δt` is the model timestep in seconds, used by the SoilCO2Model O2_f tendency limiter.
 """
 function SoilCanopyModel{FT}(
     forcing,
     LAI,
     toml_dict::CP.ParamDict,
-    domain::Union{ClimaLand.Domains.Column, ClimaLand.Domains.SphericalShell};
+    domain::Union{ClimaLand.Domains.Column, ClimaLand.Domains.SphericalShell},
+    Δt;
     soil = Soil.EnergyHydrology{FT}(
         domain,
         forcing,
@@ -158,6 +162,7 @@ function SoilCanopyModel{FT}(
             forcing.atmos,
         ),
         toml_dict,
+        Δt,
     ),
     canopy = Canopy.CanopyModel{FT}(
         Domains.obtain_surface_domain(domain),

--- a/src/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/src/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -57,7 +57,8 @@ end
     LandSoilBiogeochemistry{FT}(
         forcing,
         toml_dict::CP.ParamDict,
-        domain::Union{ClimaLand.Domains.Column, ClimaLand.Domains.SphericalShell};
+        domain::Union{ClimaLand.Domains.Column, ClimaLand.Domains.SphericalShell},
+        Δt;
         soil = Soil.EnergyHydrology{FT}(
             domain,
             forcing,
@@ -70,6 +71,7 @@ end
                 forcing.atmos,
             ),
             toml_dict,
+            Δt,
         ),
     ) where {FT}
 
@@ -79,6 +81,7 @@ or passed in via the `toml_dict`. The boundary conditions of all models
 correspond to `forcing` with the atmosphere, as specified by `forcing`, a NamedTuple
 of the form `(;atmos, radiation)`, with `atmos` an `AbstractAtmosphericDriver` and `radiation`
 an `AbstractRadiativeDriver`. The domain must be a ClimaLand domain with a vertical extent.
+`Δt` is the model timestep in seconds, used by the SoilCO2Model O2_f tendency limiter.
 """
 function LandSoilBiogeochemistry{FT}(
     forcing,
@@ -87,7 +90,8 @@ function LandSoilBiogeochemistry{FT}(
         ClimaLand.Domains.Column,
         ClimaLand.Domains.SphericalShell,
         ClimaLand.Domains.HybridBox,
-    };
+    },
+    Δt;
     soil = Soil.EnergyHydrology{FT}(domain, forcing, toml_dict;),
     soilco2 = Soil.Biogeochemistry.SoilCO2Model{FT}(
         domain,
@@ -96,6 +100,7 @@ function LandSoilBiogeochemistry{FT}(
             forcing.atmos,
         ),
         toml_dict,
+        Δt,
     ),
 ) where {FT}
     return LandSoilBiogeochemistry{FT}(soil, soilco2)
@@ -154,6 +159,15 @@ model from the prognostic liquid and ice fractions.
 """
 function soil_moisture(driver::PrognosticMet, p, Y, t, z)
     return p.soil.θ_l
+end
+
+"""
+    soil_ice(driver::PrognosticMet, p, Y, t, z)
+
+Returns the prognostic ice content from coupled soil model.
+"""
+function soil_ice(driver::PrognosticMet, p, Y, t, z)
+    return Y.soil.θ_i
 end
 
 

--- a/src/simulations/initial_conditions.jl
+++ b/src/simulations/initial_conditions.jl
@@ -98,6 +98,110 @@ function set_soil_initial_conditions!(
 end
 
 """
+    set_soilco2_initial_conditions!(Y, p, land)
+
+Initialize soil CO2 state to be consistent with atmospheric CO2 and soil state.
+CO2 is stored as carbon mass per soil volume (kg C m⁻³ soil).
+
+This assumes that the soil moisture state (`Y.soil.ϑ_l` and `Y.soil.θ_i`)
+has already been set.
+"""
+function set_soilco2_initial_conditions!(Y, p, land)
+    FT = eltype(Y.soilco2.CO2)
+    soil = land.soil
+    soilco2 = land.soilco2
+    params = soilco2.parameters
+
+    θ_i = Y.soil.θ_i
+    ν = soil.parameters.ν
+    # Clip ϑ_l so total water θ_l + θ_i ≤ ν; otherwise effective_porosity
+    # is computed from unphysical θ_l.
+    θ_l = min.(Y.soil.ϑ_l, ν .- θ_i)
+    θ_w = θ_l .+ θ_i
+
+    ρc_s =
+        ClimaLand.Soil.volumetric_heat_capacity.(
+            θ_l,
+            θ_i,
+            soil.parameters.ρc_ds,
+            soil.parameters.earth_param_set,
+        )
+    T_soil =
+        ClimaLand.Soil.temperature_from_ρe_int.(
+            Y.soil.ρe_int,
+            θ_i,
+            ρc_s,
+            soil.parameters.earth_param_set,
+        )
+
+    θ_a = ClimaLand.Soil.Biogeochemistry.volumetric_air_content.(θ_w, ν)
+    R = ClimaLand.Parameters.gas_constant(params.earth_param_set)
+    M_C = params.M_C
+
+    K_H = @. ClimaLand.Soil.Biogeochemistry.henry_constant(
+        params.K_H_co2_298,
+        params.dln_K_H_co2_dT,
+        T_soil,
+        params.T_ref_henry,
+    )
+    β = @. ClimaLand.Soil.Biogeochemistry.beta_gas(K_H, R, T_soil)
+    θ_eff = @. ClimaLand.Soil.Biogeochemistry.effective_porosity(θ_a, θ_l, β)
+
+    @. Y.soilco2.CO2 =
+        θ_eff * p.drivers.c_co2 * p.drivers.P * M_C / (R * T_soil)
+    # Exponential O2 profile: 0.21 at z=0, 0.15 at z=-1 m (k = ln(0.21/0.15)).
+    # Soil O2 decreases with depth as roots and microbes consume it; the exact
+    # profile depends on porosity, biological activity, and water content, but a
+    # decaying profile is a more realistic starting point than uniform atmospheric
+    # 0.21.
+    z = soil.domain.fields.z
+    k_o2 = FT(log(0.21 / 0.15))
+    @. Y.soilco2.O2_f = FT(0.21) * exp(k_o2 * z)
+
+    set_soilco2_SOC_from_soilgrids!(Y.soilco2.SOC)
+    return nothing
+end
+
+"""
+    set_soilco2_SOC_from_soilgrids!(SOC_field)
+
+Initialize the prognostic soil organic carbon field `SOC_field` (kgC m⁻³)
+using the SoilGrids organic carbon density dataset.
+
+The data is regridded onto the 3D subsurface space of `SOC_field`. Above
+the shallowest data level (-0.025 m) values are extrapolated flat in depth,
+matching the convention used for the SoilGrids-based soil composition
+parameters. Below the deepest data level (-1.5 m) the regridder also holds
+the value flat; we then apply an exponential decay with e-folding depth
+`L_decay` to better represent the typical decline of SOC at depth (e.g.
+Jobbágy & Jackson, 2000). Ocean / missing-data grid points are zero in the
+source file and therefore come through as zero.
+"""
+function set_soilco2_SOC_from_soilgrids!(SOC_field)
+    FT = eltype(SOC_field)
+    subsurface_space = axes(SOC_field)
+    path = ClimaLand.Artifacts.soil_grids_ocd_artifact_path(;
+        context = ClimaComms.context(subsurface_space),
+    )
+    SOC_field .= SpaceVaryingInput(
+        path,
+        "ocd",
+        subsurface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc, interpolation_method),
+    )
+    z = ClimaCore.Fields.coordinate_field(subsurface_space).z
+    z_data_bottom = FT(-1.5)
+    L_decay = FT(0.5)
+    @. SOC_field = ifelse(
+        z < z_data_bottom,
+        SOC_field * exp((z - z_data_bottom) / L_decay),
+        SOC_field,
+    )
+    return nothing
+end
+
+"""
     clip_to_bounds(
     T::FT,
     lb::FT,
@@ -256,12 +360,6 @@ function make_set_initial_state_from_file(
         if atmos isa ClimaLand.PrescribedAtmosphere
             evaluate!(p.drivers.T, atmos.T, t0)
         end
-        # SoilCO2 IC
-        if !isnothing(land.soilco2)
-            Y.soilco2.CO2 .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
-            Y.soilco2.O2_f .= FT(0.21)    # atmospheric O2 volumetric fraction
-            Y.soilco2.SOC .= FT(5.0)      # default SOC concentration (kg C/m³)
-        end
         # Soil IC
         if enforce_constraints
             # get only the values over land
@@ -279,6 +377,11 @@ function make_set_initial_state_from_file(
             T_bounds,
             enforce_constraints,
         )
+
+        # SoilCO2 IC (requires soil state)
+        if !isnothing(land.soilco2)
+            set_soilco2_initial_conditions!(Y, p, land)
+        end
 
         # Snow IC
         # Use soil temperature at top to set IC
@@ -396,10 +499,6 @@ function make_set_initial_state_from_file(
             evaluate!(p.drivers.T, atmos.T, t0)
         end
 
-        Y.soilco2.CO2 .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
-        Y.soilco2.O2_f .= FT(0.21)    # atmospheric O2 volumetric fraction
-        Y.soilco2.SOC .= FT(5.0)      # default SOC concentration (kg C/m³)
-
         if enforce_constraints
             # get only the values over land
             T_atmos = Array(parent(p.drivers.T))[:]
@@ -416,6 +515,11 @@ function make_set_initial_state_from_file(
             T_bounds,
             enforce_constraints,
         )
+
+        # SoilCO2 IC (requires soil state)
+        if !isnothing(land.soilco2)
+            set_soilco2_initial_conditions!(Y, p, land)
+        end
 
         # Canopy IC
         # First determine if leaf water potential is in the file. If so, use
@@ -548,10 +652,17 @@ function make_set_subseasonal_initial_conditions(
         subsurface_space = domain.space.subsurface
         FT = eltype(Y.soil.ϑ_l)
 
-        # Set initial conditions that aren't read in from file
-        Y.soilco2.CO2 .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
-        Y.soilco2.O2_f .= FT(0.21)    # atmospheric O2 volumetric fraction
-        Y.soilco2.SOC .= FT(5.0)      # default SOC concentration (kg C/m³)
+        # Set initial conditions that aren't read in from file.
+        # Y.soilco2.CO2 stores total CO₂ as carbon mass per soil volume
+        # (kg C m⁻³ soil) = θ_eff · c_g; the value below is a representative
+        # atmospheric-equilibrium initial guess (~412 ppm at 1 atm, 283 K,
+        # θ_eff ≈ 0.3) and is rapidly replaced by the diffusive boundary
+        # condition on the first time step.
+        if !isnothing(land.soilco2)
+            Y.soilco2.CO2 .= FT(6e-5)
+            Y.soilco2.O2_f .= FT(0.21)    # atmospheric O2 volumetric fraction
+            set_soilco2_SOC_from_soilgrids!(Y.soilco2.SOC)
+        end
         Y.canopy.hydraulics.ϑ_l .= land.canopy.hydraulics.parameters.ν
 
         # Set snow T first to use in computing snow internal energy from IC file
@@ -781,12 +892,6 @@ function make_set_initial_state_from_atmos_and_parameters(
         if atmos isa ClimaLand.PrescribedAtmosphere
             evaluate!(p.drivers.T, atmos.T, t0)
         end
-        # SoilCO2 IC
-        if !isnothing(land.soilco2)
-            Y.soilco2.CO2 .= FT(0.000412) # set to atmospheric co2, mol co2 per mol air
-            Y.soilco2.O2_f .= FT(0.21)    # atmospheric O2 volumetric fraction
-            Y.soilco2.SOC .= FT(5.0)      # default SOC concentration (kg C/m³)
-        end
         (; θ_r, ν, ρc_ds) = land.soil.parameters
         @. Y.soil.ϑ_l = θ_r + (ν - θ_r) / 2
         Y.soil.θ_i .= FT(0.0)
@@ -804,6 +909,17 @@ function make_set_initial_state_from_atmos_and_parameters(
                 p.drivers.T,
                 earth_param_set,
             )
+
+        # SoilCO2 IC (requires soil state).
+        # Y.soilco2.CO2 stores total CO₂ as carbon mass per soil volume
+        # (kg C m⁻³ soil) = θ_eff · c_g; the value below is a representative
+        # atmospheric-equilibrium initial guess and is rapidly replaced by
+        # the diffusive boundary condition on the first time step.
+        if !isnothing(land.soilco2)
+            Y.soilco2.CO2 .= FT(6e-5)
+            Y.soilco2.O2_f .= FT(0.21)    # atmospheric O2 volumetric fraction
+            set_soilco2_SOC_from_soilgrids!(Y.soilco2.SOC)
+        end
 
         Y.snow.S .= FT(0)
         Y.snow.S_l .= FT(0)

--- a/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
+++ b/src/standalone/Soil/Biogeochemistry/Biogeochemistry.jl
@@ -3,6 +3,7 @@ using ClimaLand
 import ClimaParams as CP
 using DocStringExtensions
 using ClimaCore
+using LazyBroadcast: lazy
 import ...Parameters as LP
 using NVTX
 import ClimaCore: Fields, Operators, Geometry, Spaces
@@ -48,11 +49,15 @@ $(DocStringExtensions.FIELDS)
 Base.@kwdef struct SoilCO2ModelParameters{FT <: AbstractFloat, PSE}
     "Diffusion coefficient for CO₂ in air at standard temperature and pressure (m² s⁻¹)"
     D_ref::FT
+    "Diffusion coefficient for O₂ in air at standard temperature and pressure (m² s⁻¹)"
+    D_ref_o2::FT
     "Diffusivity of soil C substrate in liquid (unitless)"
     D_liq::FT
-    # DAMM
-    "Pre-exponential factor (kg C m-3 s-1)"
-    α_sx::FT
+    # DAMM — centered Arrhenius: Vmax = V_ref_sx * exp(-Ea_sx/R * (1/T - 1/T_ref_sx))
+    "Maximum respiration rate at T_ref_sx (kg C m-3 s-1)"
+    V_ref_sx::FT
+    "Reference temperature for the centered Arrhenius form (K)"
+    T_ref_sx::FT
     "Activation energy (J mol-1)"
     Ea_sx::FT
     "Michaelis constant (kg C m-3)"
@@ -69,6 +74,19 @@ Base.@kwdef struct SoilCO2ModelParameters{FT <: AbstractFloat, PSE}
     M_C::FT
     "Molar mass of oxygen (kg/mol)"
     M_O2::FT
+    # Henry's law parameters for air-water partitioning (Sander, 2015)
+    "Henry's law constant for CO2 at 298K (mol/(m³·Pa))"
+    K_H_co2_298::FT
+    "Temperature coefficient for CO2 Henry's law (K)"
+    dln_K_H_co2_dT::FT
+    "Henry's law constant for O2 at 298K (mol/(m³·Pa))"
+    K_H_o2_298::FT
+    "Temperature coefficient for O2 Henry's law (K)"
+    dln_K_H_o2_dT::FT
+    "Reference temperature for Henry's law (K), Sander (2015)"
+    T_ref_henry::FT
+    "Temperature exponent for free-air gas diffusivity correction (dimensionless), Ryan et al. (2018)"
+    T_exp_diffusivity::FT
     "Physical constants used Clima-wide"
     earth_param_set::PSE
 end
@@ -85,10 +103,12 @@ Keywords arguments can be used to directly override any parameters.
 function SoilCO2ModelParameters(
     toml_dict::CP.ParamDict;
     D_ref = toml_dict["CO2_diffusion_coefficient"],
+    D_ref_o2 = toml_dict["O2_diffusion_coefficient_air"],
 )
     name_map = (;
         :soil_C_substrate_diffusivity => :D_liq,
-        :soilCO2_pre_exponential_factor => :α_sx,
+        :soilCO2_reference_rate => :V_ref_sx,
+        :soilCO2_reference_temperature => :T_ref_sx,
         :soilCO2_activation_energy => :Ea_sx,
         :michaelis_constant => :kM_sx,
         :O2_michaelis_constant => :kM_o2,
@@ -97,6 +117,13 @@ function SoilCO2ModelParameters(
         :soluble_soil_carbon_fraction => :p_sx,
         :molar_mass_carbon => :M_C,
         :molar_mass_oxygen => :M_O2,
+        # Henry's law constants from Sander (2015), Atmos. Chem. Phys., 15, 4399-4981
+        :CO2_henry_k298 => :K_H_co2_298,
+        :CO2_henry_Tcoeff => :dln_K_H_co2_dT,
+        :O2_henry_k298 => :K_H_o2_298,
+        :O2_henry_Tcoeff => :dln_K_H_o2_dT,
+        :henry_reference_temperature => :T_ref_henry,
+        :gas_diffusivity_temperature_exponent => :T_exp_diffusivity,
     )
     parameters = CP.get_parameter_values(toml_dict, name_map, "Land")
     FT = CP.float_type(toml_dict)
@@ -104,6 +131,7 @@ function SoilCO2ModelParameters(
     return SoilCO2ModelParameters{FT, typeof(earth_param_set)}(;
         earth_param_set,
         D_ref,
+        D_ref_o2,
         parameters...,
     )
 end
@@ -140,6 +168,8 @@ struct SoilCO2Model{FT, PS, D, BC, S, DT} <:
     sources::S
     "Drivers"
     drivers::DT
+    "Model timestep in seconds (used for the O2_f tendency limiter); pass FT(0) to disable the hard cap"
+    Δt::FT
 end
 
 
@@ -147,7 +177,8 @@ end
 SoilCO2Model{FT}(
         domain::ClimaLand.AbstractDomain,
         drivers::DT,
-        toml_dict::CP.ParamDict;
+        toml_dict::CP.ParamDict,
+        Δt;
         parameters::SoilCO2ModelParameters{FT} = SoilCO2ModelParameters(toml_dict),
         sources::Tuple = (MicrobeProduction{FT}(),),
     ) where {FT, DT}
@@ -156,20 +187,24 @@ A constructor for `SoilCO2Model`.
 Defaults are provided for the parameters and sources.
 These can be overridden by providing the appropriate keyword arguments.
 
+`Δt` is the model timestep in seconds, used by the O2_f tendency limiter.
+Pass `FT(0)` to disable the limiter.
+
 Boundary conditions are set automatically:
-- Top: AtmosCO2StateBC() for CO2, AtmosO2StateBC(earth_param_set, M_O2, O2_f_atm) for O2
+- Top: AtmosCO2StateBC(earth_param_set, M_C) for CO2, AtmosO2StateBC(earth_param_set, M_O2, O2_f_atm) for O2
 - Bottom: Zero flux for both CO2 and O2
 """
 function SoilCO2Model{FT}(
     domain::ClimaLand.AbstractDomain,
     drivers::DT,
-    toml_dict::CP.ParamDict;
+    toml_dict::CP.ParamDict,
+    Δt;
     parameters::SoilCO2ModelParameters{FT} = SoilCO2ModelParameters(toml_dict),
     sources::Tuple = (MicrobeProduction{FT}(),),
 ) where {FT, DT}
     boundary_conditions = (
         top = (
-            co2 = AtmosCO2StateBC(),
+            co2 = AtmosCO2StateBC(parameters.earth_param_set, parameters.M_C),
             o2 = AtmosO2StateBC(
                 parameters.earth_param_set,
                 parameters.M_O2,
@@ -182,7 +217,7 @@ function SoilCO2Model{FT}(
         ),
     )
     args = (parameters, domain, boundary_conditions, sources, drivers)
-    SoilCO2Model{FT, typeof.(args)...}(args...)
+    SoilCO2Model{FT, typeof.(args)...}(args..., FT(Δt))
 end
 
 ClimaLand.name(model::SoilCO2Model) = :soilco2
@@ -199,6 +234,9 @@ ClimaLand.auxiliary_vars(model::SoilCO2Model) = (
     :Sm,
     :θ_a,
     :T,
+    :θ_eff,        # Effective porosity for CO2 (air + dissolved in water)
+    :θ_eff_o2,     # Effective porosity for O2 (air + dissolved in water)
+    :CO2_air_eq,   # Air-equivalent CO2 concentration for diffusion
     # CO2 boundary vars (top_bc, bottom_bc, top_bc_wvec, bottom_bc_wvec)
     ClimaLand.boundary_vars(
         model.boundary_conditions.top.co2,
@@ -224,6 +262,9 @@ ClimaLand.auxiliary_types(model::SoilCO2Model{FT}) where {FT} = (
     FT,
     FT,
     FT,
+    FT,  # θ_eff
+    FT,  # θ_eff_o2
+    FT,  # CO2_air_eq
     # CO2 boundary var types
     ClimaLand.boundary_var_types(
         model,
@@ -249,6 +290,9 @@ ClimaLand.auxiliary_domain_names(model::SoilCO2Model) = (
     :subsurface,
     :subsurface,
     :subsurface,
+    :subsurface,  # θ_eff
+    :subsurface,  # θ_eff_o2
+    :subsurface,  # CO2_air_eq
     # CO2 boundary var domain names
     ClimaLand.boundary_var_domain_names(
         model.boundary_conditions.top.co2,
@@ -352,31 +396,48 @@ function ClimaLand.make_compute_exp_tendency(model::SoilCO2Model)
             bottom = Operators.SetValue(p.soilco2.bottom_bc_o2_wvec),
         )
 
-        # CO₂ diffusion
+        # CO₂ diffusion using air-equivalent concentration for stable saturated soil behavior
+        # D from Ryan et al. already accounts for air-filled porosity via tortuosity
         @. dY.soilco2.CO2 =
-            -divf2c_C(-interpc2f(p.soilco2.D) * gradc2f_C(Y.soilco2.CO2))
+            -divf2c_C(-interpc2f(p.soilco2.D) * gradc2f_C(p.soilco2.CO2_air_eq))
 
         FT = eltype(Y.soilco2.CO2)
         T_soil = p.soilco2.T
         P_sfc = p.drivers.P
-        R = FT(LP.gas_constant(model.parameters.earth_param_set))
+        R = LP.gas_constant(model.parameters.earth_param_set)
         M_O2 = FT(model.parameters.M_O2)
 
-        # O₂ diffusion: compute ∇·[D_O2 * θ_a * ∇ρ_O2] on mass concentration,
-        # then convert to O2_f tendency by multiplying by R*T/(θ_a*P*M_O2)
+        # O₂ diffusion: compute ∇·[D_O2 * ∇ρ_O2] on mass concentration,
+        # then convert to O2_f tendency using θ_eff_o2 for stability in saturated soils
         @. dY.soilco2.O2_f =
-            -divf2c_O2(
-                -interpc2f(p.soilco2.D_o2 * p.soilco2.θ_a) *
-                gradc2f_O2(p.soilco2.O2),
-            ) *
+            -divf2c_O2(-interpc2f(p.soilco2.D_o2) * gradc2f_O2(p.soilco2.O2)) *
             R *
-            T_soil / max(p.soilco2.θ_a * P_sfc * M_O2, eps(FT))
+            T_soil / max(p.soilco2.θ_eff_o2 * P_sfc * M_O2, eps(FT))
 
         # SOC has no diffusion, only source/sink from microbial activity
         @. dY.soilco2.SOC = 0.0
 
         for src in model.sources
             source!(dY, src, Y, p, model.parameters)
+        end
+
+        # Bracket the net O2_f tendency so a single explicit step cannot drive
+        # O2_f outside [0, O2_f_atm]. With CFL-violating diffusivities (common
+        # in hot/dry columns with fine near-surface layers), the unlimited
+        # tendency oscillates wildly in both directions. The lower cap
+        # -max(Y, 0)/Δt guarantees Y_new ≥ 0; the upper cap
+        # max(O2_f_atm - Y, 0)/Δt guarantees Y_new ≤ O2_f_atm (the soil air
+        # cannot physically exceed the atmospheric O2 fraction since soil is
+        # an O2 sink). For multi-stage RK integrators the bounds are slightly
+        # conservative (per-stage step is a fraction of Δt) but still safe.
+        if model.Δt > 0
+            inv_Δt = 1 / model.Δt # model.Δt is already type FT
+            O2_f_atm = model.parameters.O2_f_atm
+            @. dY.soilco2.O2_f = clamp(
+                dY.soilco2.O2_f,
+                -max(Y.soilco2.O2_f, 0) * inv_Δt,
+                max(O2_f_atm - Y.soilco2.O2_f, 0) * inv_Δt,
+            )
         end
 
     end
@@ -407,14 +468,13 @@ struct MicrobeProduction{FT} <: AbstractCarbonSource{FT} end
                           params)
 
 A method which extends the ClimaLand source! function for the
-case of microbe production of CO2 in soil, consumption of O2_f (volumetric O2 fraction),
-and consumption of SOC.
+case of microbe production of CO2 in soil and consumption of O2_f (volumetric O2 fraction).
+SOC is held constant (initialized from data, no tendency).
 
 Physics:
 - CO2 production from microbial respiration (kg C m⁻³ s⁻¹)
 - O2 consumption with correct stoichiometry: C + O₂ → CO₂
   For every 12 kg C respired, 32 kg O₂ is consumed (ratio = 32/12 = 8/3)
-- SOC consumption equals CO2 production to conserve carbon mass
 """
 NVTX.@annotate function ClimaLand.source!(
     dY::ClimaCore.Fields.FieldVector,
@@ -425,18 +485,26 @@ NVTX.@annotate function ClimaLand.source!(
 )
     dY.soilco2.CO2 .+= p.soilco2.Sm
 
-    M_C = eltype(p.soilco2.Sm)(params.M_C)
-    R = eltype(p.soilco2.Sm)(LP.gas_constant(params.earth_param_set))
+    FT = eltype(p.soilco2.Sm)
+    M_C = FT(params.M_C)
+    R = LP.gas_constant(params.earth_param_set)
     T_soil = p.soilco2.T  # soil temperature (K)
     P_sfc = p.drivers.P   # atmospheric pressure (Pa)
 
-    θ_a = p.soilco2.θ_a
+    # Use θ_eff_o2 for stability in saturated soils
+    θ_eff_o2 = p.soilco2.θ_eff_o2
+
+    # Extra Michaelis-Menten attenuation in O2_f drives consumption to ~O2_f^2
+    # near zero (Sm already carries an MM_o2 ~O2_f factor). Combined with the
+    # tendency-level limiter in compute_exp_tendency!, this prevents the explicit
+    # step from pulling O2_f below zero.
+    K_O2_lim = FT(1e-4)
+    O2_f = Y.soilco2.O2_f
 
     @. dY.soilco2.O2_f -=
-        (R * T_soil) / max(M_C * θ_a * P_sfc, eps(eltype(p.soilco2.Sm))) *
-        p.soilco2.Sm
-
-    @. dY.soilco2.SOC -= p.soilco2.Sm
+        (R * T_soil) / max(M_C * θ_eff_o2 * P_sfc, eps(FT)) *
+        p.soilco2.Sm *
+        (O2_f / (O2_f + K_O2_lim))
 end
 
 """
@@ -552,6 +620,16 @@ function soil_moisture(driver::PrescribedMet, p, Y, t, z)
 end
 
 """
+    soil_ice(driver::PrescribedMet, p, Y, t, z)
+
+Returns zero ice content for prescribed soil case (standalone mode has no ice).
+"""
+function soil_ice(driver::PrescribedMet, p, Y, t, z)
+    FT = eltype(z)
+    return FT(0)
+end
+
+"""
     make_update_aux(model::SoilCO2Model)
 
 An extension of the function `make_update_aux`, for the soilco2 equation.
@@ -567,22 +645,78 @@ function ClimaLand.make_update_aux(model::SoilCO2Model)
         z = model.domain.fields.z
         T_soil = soil_temperature(model.drivers.met, p, Y, t, z)
         θ_l = soil_moisture(model.drivers.met, p, Y, t, z)
-        Csom = Y.soilco2.SOC  # Now using prognostic SOC
+        θ_i = soil_ice(model.drivers.met, p, Y, t, z)
+        Csom = @. lazy(max(Y.soilco2.SOC, 0))  # Clamp SOC to non-negative (lazy, no allocation)
         P_sfc = p.drivers.P
-        θ_w = θ_l
         ν = model.drivers.met.ν
         θ_a100 = model.drivers.met.θ_a100
         b = model.drivers.met.b
 
         @. p.soilco2.T = T_soil
 
-        @. p.soilco2.D =
-            co2_diffusivity.(T_soil, θ_w, P_sfc, θ_a100, b, ν, params)
-        @. p.soilco2.D_o2 .=
-            co2_diffusivity.(T_soil, θ_w, P_sfc, θ_a100, b, ν, params)
+        # Compute θ_a using total water (liquid + ice)
+        @. p.soilco2.θ_a = volumetric_air_content(θ_l + θ_i, ν)
 
-        FT = eltype(Y.soilco2.CO2)
-        @. p.soilco2.θ_a = max(ν - θ_l, FT(0))
+        @. p.soilco2.D =
+            co2_diffusivity(T_soil, θ_l + θ_i, P_sfc, θ_a100, b, ν, params)
+        @. p.soilco2.D_o2 =
+            o2_diffusivity(T_soil, θ_l + θ_i, P_sfc, θ_a100, b, ν, params)
+
+        # Compute Henry's law factors (temperature-dependent)
+        R = LP.gas_constant(params.earth_param_set)
+        K_H_co2_298 = params.K_H_co2_298
+        dln_K_H_co2_dT = params.dln_K_H_co2_dT
+        K_H_o2_298 = params.K_H_o2_298
+        dln_K_H_o2_dT = params.dln_K_H_o2_dT
+        T_ref_henry = params.T_ref_henry
+
+        # Compute effective porosities (θ_l only, not θ_i - gas dissolves in liquid water)
+        @. p.soilco2.θ_eff = effective_porosity(
+            p.soilco2.θ_a,
+            θ_l,
+            beta_gas(
+                henry_constant(
+                    K_H_co2_298,
+                    dln_K_H_co2_dT,
+                    T_soil,
+                    T_ref_henry,
+                ),
+                R,
+                T_soil,
+            ),
+        )
+        @. p.soilco2.θ_eff_o2 = effective_porosity(
+            p.soilco2.θ_a,
+            θ_l,
+            beta_gas(
+                henry_constant(K_H_o2_298, dln_K_H_o2_dT, T_soil, T_ref_henry),
+                R,
+                T_soil,
+            ),
+        )
+
+        # Compute air-equivalent CO2 concentration for diffusion.
+        # Clamp negative CO2 to zero (can occur from numerical diffusion).
+        @. Y.soilco2.CO2 = max(Y.soilco2.CO2, FT(0))
+        @. p.soilco2.CO2_air_eq = Y.soilco2.CO2 / max(p.soilco2.θ_eff, eps(FT))
+
+        # Safety guard: cap CO2_air_eq at 100 million ppm equivalent.
+        # Values above this indicate numerical blow-up, not physical conditions.
+        # 100M ppm = 100 (mol/mol) → CO2_air_eq_max = 100 * M_C * P / (R * T)
+        M_C = FT(params.M_C)
+        CO2_air_eq_max = @. FT(100) * M_C * P_sfc / (R * T_soil)
+        @. p.soilco2.CO2_air_eq = ifelse(
+            p.soilco2.CO2_air_eq > CO2_air_eq_max,
+            FT(NaN),
+            p.soilco2.CO2_air_eq,
+        )
+
+        # Clamp O2_f to physical range [0, 1]; explicit diffusion can
+        # overshoot in hot/dry columns where effective diffusivity D_o2/θ_eff_o2
+        # exceeds the CFL limit. Clamping keeps the simulation alive with
+        # physically meaningful values — the overshoot is a numerical artifact,
+        # not a real state.
+        @. Y.soilco2.O2_f = clamp(Y.soilco2.O2_f, 0, 1)
 
         @. p.soilco2.O2 =
             o2_concentration(Y.soilco2.O2_f, T_soil, P_sfc, params)
@@ -620,7 +754,7 @@ end
     )
 
 A method of ClimaLand.boundary_flux which updates the soilco2
-flux (kg CO2 /m^2/s) in the case of a prescribed flux BC at either the top
+flux (kg C m⁻² s⁻¹) in the case of a prescribed flux BC at either the top
 or bottom of the domain.
 """
 function ClimaLand.boundary_flux!(
@@ -639,7 +773,7 @@ end
 """
     SoilCO2StateBC <: ClimaLand.AbstractBC
 
-A container holding the CO2 state boundary condition (kg CO2 m−3),
+A container holding the CO2 state boundary condition (kg C m⁻³ air-equivalent),
 which is a function `f(p,t)`, where `p` is the auxiliary state
 vector.
 """
@@ -659,7 +793,10 @@ end
 
 A method of ClimaLand.boundary_flux which returns the soilco2
 flux in the case of a prescribed state BC at
- top of the domain.
+top of the domain.
+
+The prescribed state should be the air-equivalent CO2 concentration
+(kg C/m³ air), consistent with the diffused variable.
 """
 function ClimaLand.boundary_flux!(
     bc_field,
@@ -674,7 +811,7 @@ function ClimaLand.boundary_flux!(
 
     # We need to project center values onto the face space
     D_c = ClimaLand.Domains.top_center_to_surface(p.soilco2.D)
-    C_c = ClimaLand.Domains.top_center_to_surface(Y.soilco2.CO2)
+    C_c = ClimaLand.Domains.top_center_to_surface(p.soilco2.CO2_air_eq)
     C_bc = FT.(bc.bc(p, t))
     @. bc_field = ClimaLand.diffusive_flux(D_c, C_bc, C_c, Δz)
 end
@@ -692,6 +829,9 @@ end
 A method of ClimaLand.boundary_flux which returns the soilco2
 flux in the case of a prescribed state BC at
 bottom of the domain.
+
+The prescribed state should be the air-equivalent CO2 concentration
+(kg C/m³ air), consistent with the diffused variable.
 """
 function ClimaLand.boundary_flux!(
     bc_field,
@@ -704,7 +844,7 @@ function ClimaLand.boundary_flux!(
 )
     FT = eltype(Δz)
     D_c = ClimaLand.Domains.bottom_center_to_surface(p.soilco2.D)
-    C_c = ClimaLand.Domains.bottom_center_to_surface(Y.soilco2.CO2)
+    C_c = ClimaLand.Domains.bottom_center_to_surface(p.soilco2.CO2_air_eq)
     C_bc = FT.(bc.bc(p, t))
     @. bc_field = ClimaLand.diffusive_flux(D_c, C_c, C_bc, Δz)
 end
@@ -713,8 +853,26 @@ end
     AtmosCO2StateBC <: ClimaLand.AbstractBC
 
 Set the CO2 concentration to the atmospheric one.
+Stores physical constants needed for the boundary flux calculation.
+
+$(DocStringExtensions.FIELDS)
 """
-struct AtmosCO2StateBC <: ClimaLand.AbstractBC end
+struct AtmosCO2StateBC{FT <: AbstractFloat} <: ClimaLand.AbstractBC
+    "Universal gas constant (J/(mol·K))"
+    R::FT
+    "Molar mass of carbon (kg/mol)"
+    M_C::FT
+end
+
+"""
+    AtmosCO2StateBC(earth_param_set, M_C::FT) where {FT}
+
+Constructor for AtmosCO2StateBC that gets parameters from LandParameters and model parameters.
+"""
+function AtmosCO2StateBC(earth_param_set, M_C::FT) where {FT}
+    R = LP.gas_constant(earth_param_set)
+    return AtmosCO2StateBC{FT}(R, M_C)
+end
 
 """
     ClimaLand.boundary_flux!(bc_field,
@@ -727,7 +885,8 @@ struct AtmosCO2StateBC <: ClimaLand.AbstractBC end
     )
 
 A method of ClimaLand.boundary_flux which returns the soilco2 flux in the case when the
-atmospheric CO2 is ued at top of the domain.
+atmospheric CO2 is used at top of the domain. Uses air-equivalent CO2 concentration
+for stable behavior in saturated soils.
 """
 function ClimaLand.boundary_flux!(
     bc_field,
@@ -739,9 +898,17 @@ function ClimaLand.boundary_flux!(
     t,
 )
     D_c = ClimaLand.Domains.top_center_to_surface(p.soilco2.D)
-    C_c = ClimaLand.Domains.top_center_to_surface(Y.soilco2.CO2)
-    C_bc = p.drivers.c_co2
-    @. bc_field = ClimaLand.diffusive_flux(D_c, C_bc, C_c, Δz)
+    C_c = ClimaLand.Domains.top_center_to_surface(p.soilco2.CO2_air_eq)
+    T_soil_top = ClimaLand.Domains.top_center_to_surface(p.soilco2.T)
+    P_sfc = p.drivers.P
+    R = bc.R
+    M_C = bc.M_C
+    @. bc_field = ClimaLand.diffusive_flux(
+        D_c,
+        p.drivers.c_co2 * P_sfc * M_C / (R * T_soil_top),
+        C_c,
+        Δz,
+    )
 end
 
 """
@@ -767,7 +934,7 @@ end
 Constructor for AtmosO2StateBC that gets parameters from LandParameters and model parameters.
 """
 function AtmosO2StateBC(earth_param_set, M_O2::FT, O2_f_atm::FT) where {FT}
-    R = FT(LP.gas_constant(earth_param_set))
+    R = LP.gas_constant(earth_param_set)
     return AtmosO2StateBC{FT}(R, M_O2, O2_f_atm)
 end
 
@@ -794,7 +961,6 @@ function ClimaLand.boundary_flux!(
     t,
 )
     FT = eltype(Δz)
-    θ_a_top = ClimaLand.Domains.top_center_to_surface(p.soilco2.θ_a)
     D_o2 = ClimaLand.Domains.top_center_to_surface(p.soilco2.D_o2)
     O2_c = ClimaLand.Domains.top_center_to_surface(p.soilco2.O2)  # Current O2 mass concentration in air at top (kg O2/m³ air)
 
@@ -806,7 +972,7 @@ function ClimaLand.boundary_flux!(
     O2_f_atm = bc.O2_f_atm
 
     @. bc_field = ClimaLand.diffusive_flux(
-        D_o2 * θ_a_top,
+        D_o2,
         O2_f_atm * P_sfc * M_O2 / (R * T_soil_top),
         O2_c,
         Δz,

--- a/src/standalone/Soil/Biogeochemistry/co2_parameterizations.jl
+++ b/src/standalone/Soil/Biogeochemistry/co2_parameterizations.jl
@@ -1,9 +1,13 @@
 export volumetric_air_content,
     co2_diffusivity,
+    o2_diffusivity,
     microbe_source,
     o2_concentration,
     o2_fraction_from_concentration,
-    o2_availability
+    o2_availability,
+    henry_constant,
+    beta_gas,
+    effective_porosity
 
 
 """
@@ -17,6 +21,12 @@ export volumetric_air_content,
 Computes the CO₂ production in the soil by microbes, in depth and time (kg C / m^3/s), using
 the Dual Arrhenius Michaelis Menten model (Davidson et al., 2012).
 O2_avail is a dimensionless O₂ availability metric that accounts for tortuosity effects.
+
+The Arrhenius term is written in centered form,
+    Vmax = V_ref_sx * exp(-Ea_sx/R * (1/T_soil - 1/T_ref_sx)),
+so that V_ref_sx (the rate at T_ref_sx) and Ea_sx (the temperature sensitivity) are
+approximately orthogonal under calibration. This is algebraically equivalent to the
+uncentered form Vmax = α_sx * exp(-Ea_sx/(R·T_soil)) with α_sx = V_ref_sx * exp(Ea_sx/(R·T_ref_sx)).
 """
 function microbe_source(
     T_soil::FT,
@@ -25,9 +35,10 @@ function microbe_source(
     O2_avail::FT,
     params::SoilCO2ModelParameters{FT},
 ) where {FT}
-    (; α_sx, Ea_sx, kM_sx, kM_o2, D_liq, p_sx, earth_param_set) = params
-    R = FT(LP.gas_constant(earth_param_set))
-    Vmax = α_sx * exp(-Ea_sx / (R * T_soil)) # Maximum potential rate of respiration
+    (; V_ref_sx, T_ref_sx, Ea_sx, kM_sx, kM_o2, D_liq, p_sx, earth_param_set) =
+        params
+    R = LP.gas_constant(earth_param_set)
+    Vmax = V_ref_sx * exp(-Ea_sx / R * (1 / T_soil - 1 / T_ref_sx)) # Maximum potential rate of respiration
     Sx = p_sx * Csom * D_liq * max(θ_l, FT(0))^3 # All soluble substrate, kgC m⁻³
     MM_sx = Sx / (kM_sx + Sx) # Availability of substrate factor, 0-1
     # Use pre-computed O2 availability (includes tortuosity effects)
@@ -67,7 +78,7 @@ function o2_concentration(
     P_sfc::FT,
     params::SoilCO2ModelParameters{FT},
 ) where {FT}
-    R = FT(LP.gas_constant(params.earth_param_set))
+    R = LP.gas_constant(params.earth_param_set)
     M_O2 = params.M_O2
     # O2 mass concentration in air phase (kg O2/m³ air)
     ρ_O2_air = O2_f * P_sfc * M_O2 / (R * T_soil)
@@ -101,7 +112,7 @@ function o2_fraction_from_concentration(
     P_sfc::FT,
     params::SoilCO2ModelParameters{FT},
 ) where {FT}
-    R = FT(LP.gas_constant(params.earth_param_set))
+    R = LP.gas_constant(params.earth_param_set)
     M_O2 = params.M_O2
     # O2 volumetric fraction (dimensionless)
     O2_f = ρ_O2_air * R * T_soil / (P_sfc * M_O2)
@@ -137,6 +148,72 @@ end
 
 
 """
+    henry_constant(K_H_298::FT, dln_K_H_dT::FT, T::FT, T_ref::FT) where {FT}
+
+Compute temperature-dependent Henry's law constant using van 't Hoff equation.
+Returns K_H in mol/(m³·Pa).
+
+The temperature dependence follows:
+    K_H(T) = K_H(T_ref) * exp[dln_K_H_dT * (1/T - 1/T_ref)]
+
+where T_ref is the Sander reference temperature (298.15 K) and dln_K_H_dT is
+the temperature coefficient.
+
+Reference: Sander (2015), Atmos. Chem. Phys., 15, 4399-4981.
+"""
+function henry_constant(
+    K_H_298::FT,
+    dln_K_H_dT::FT,
+    T::FT,
+    T_ref::FT,
+) where {FT}
+    return K_H_298 * exp(dln_K_H_dT * (FT(1) / T - FT(1) / T_ref))
+end
+
+
+"""
+    beta_gas(K_H::FT, R::FT, T::FT) where {FT}
+
+Compute dimensionless Henry's law factor β = K_H * R * T.
+
+This converts liquid water storage to air-equivalent storage capacity.
+For CO2 at 20-25°C: β ≈ 0.7-0.9 (significant buffering)
+For O2 at 20°C: β ≈ 0.03 (less buffering, but still helps)
+
+Arguments:
+- K_H: Henry's law constant (mol/(m³·Pa))
+- R: Universal gas constant (J/(mol·K))
+- T: Temperature (K)
+"""
+function beta_gas(K_H::FT, R::FT, T::FT) where {FT}
+    return K_H * R * T
+end
+
+
+"""
+    effective_porosity(θ_a::FT, θ_l::FT, β::FT) where {FT}
+
+Compute effective porosity accounting for gas and dissolved storage.
+
+    θ_eff = max(θ_a + β * θ_l, θ_eff_min)
+
+When θ_a → 0 (saturated soil) but θ_l > 0, θ_eff remains finite,
+preventing blow-up in concentration calculations. A minimum floor
+of 1e-4 is applied for numerical stability in extreme conditions
+(e.g., very dry desert soils where both θ_a and θ_l are small).
+
+Arguments:
+- θ_a: Volumetric air content (m³/m³)
+- θ_l: Volumetric liquid water content (m³/m³)
+- β: Dimensionless Henry's law factor
+"""
+function effective_porosity(θ_a::FT, θ_l::FT, β::FT) where {FT}
+    θ_eff_min = FT(1e-4)  # Minimum effective porosity for numerical stability
+    return max(θ_a + β * θ_l, θ_eff_min)
+end
+
+
+"""
     volumetric_air_content(θ_w::FT,
                            ν::FT,
                            ) where {FT}
@@ -144,11 +221,56 @@ end
 Computes the volumetric air content (`θ_a`) in the soil,
 which is related to the total soil porosity (`ν`) and
 volumetric soil water content (`θ_w = θ_l+θ_i`).
+
+Note: The effective_porosity function provides numerical stability
+when θ_a approaches zero by accounting for dissolved gas in liquid water.
 """
 function volumetric_air_content(θ_w::FT, ν::FT) where {FT}
-    θ_a = max(ν - θ_w, FT(0))
+    θ_a = max(ν - θ_w, FT(0))  # prevents small negative θ_a from floating-point rounding when θ_w ≈ ν
     return θ_a
 end
+
+"""
+    gas_diffusivity_in_soil(T_soil::FT,
+                              θ_w::FT,
+                              P_sfc::FT,
+                              θ_a100::FT,
+                              b::FT,
+                              ν::FT,
+                              D_ref::FT,
+                              earth_param_set,
+                             ) where {FT}
+
+Effective diffusivity of a gas within partially saturated soil (m² s⁻¹).
+
+Internal helper used by [`co2_diffusivity`](@ref) and [`o2_diffusivity`](@ref).
+The reference diffusivity `D_ref` is the gas's diffusion coefficient in free
+air at standard temperature and pressure (273 K, 101325 Pa); the rest of the
+expression follows Ryan et al., GMD 11, 1909-1928, 2018,
+https://doi.org/10.5194/gmd-11-1909-2018.
+"""
+function gas_diffusivity_in_soil(
+    T_soil::FT,
+    θ_w::FT,
+    P_sfc::FT,
+    θ_a100::FT,
+    b::FT,
+    ν::FT,
+    D_ref::FT,
+    T_exp::FT,
+    earth_param_set,
+) where {FT}
+    T_ref = LP.T_0(earth_param_set)
+    P_ref = LP.P_ref(earth_param_set)
+    θ_a = volumetric_air_content(θ_w, ν)
+    D0 = D_ref * max((T_soil / T_ref), 0)^T_exp * (P_ref / P_sfc)
+    # Cap the ratio to prevent diffusivity blow-up in very dry conditions
+    # (e.g., Sahara where θ_a can greatly exceed θ_a100)
+    ratio = min(θ_a / max(θ_a100, eps(FT)), FT(5))
+    D = D0 * (FT(2)θ_a100^FT(3) + FT(0.04)θ_a100) * ratio^(FT(2) + FT(3) / b)
+    return D
+end
+
 
 """
     co2_diffusivity(
@@ -182,14 +304,54 @@ function co2_diffusivity(
     ν::FT,
     params::SoilCO2ModelParameters{FT},
 ) where {FT}
-    (; D_ref, earth_param_set) = params
-    T_ref = FT(LP.T_0(earth_param_set))
-    P_ref = FT(LP.P_ref(earth_param_set))
-    θ_a = volumetric_air_content(θ_w, ν)
-    D0 = D_ref * max((T_soil / T_ref), 0)^FT(1.75) * (P_ref / P_sfc)
-    D =
-        D0 *
-        (FT(2)θ_a100^FT(3) + FT(0.04)θ_a100) *
-        (θ_a / θ_a100)^(FT(2) + FT(3) / b)
-    return D
+    return gas_diffusivity_in_soil(
+        T_soil,
+        θ_w,
+        P_sfc,
+        θ_a100,
+        b,
+        ν,
+        params.D_ref,
+        params.T_exp_diffusivity,
+        params.earth_param_set,
+    )
+end
+
+
+"""
+    o2_diffusivity(
+                   T_soil::FT,
+                   θ_w::FT,
+                   P_sfc::FT,
+                   θ_a100::FT,
+                   b::FT,
+                   ν::FT,
+                   params::SoilCO2ModelParameters{FT},
+                  ) where {FT}
+
+Effective diffusivity of O₂ in soil (m² s⁻¹). Uses the same Ryan/Moldrup
+parameterization as [`co2_diffusivity`](@ref) but with `params.D_ref_o2`,
+the O₂ reference diffusivity in free air at standard conditions
+(≈ 1.67×10⁻⁵ m² s⁻¹, Davidson et al., 2012).
+"""
+function o2_diffusivity(
+    T_soil::FT,
+    θ_w::FT,
+    P_sfc::FT,
+    θ_a100::FT,
+    b::FT,
+    ν::FT,
+    params::SoilCO2ModelParameters{FT},
+) where {FT}
+    return gas_diffusivity_in_soil(
+        T_soil,
+        θ_w,
+        P_sfc,
+        θ_a100,
+        b,
+        ν,
+        params.D_ref_o2,
+        params.T_exp_diffusivity,
+        params.earth_param_set,
+    )
 end

--- a/test/diagnostics/diagnostics_tests.jl
+++ b/test/diagnostics/diagnostics_tests.jl
@@ -376,6 +376,7 @@ end
         LAI,
         toml_dict,
         domain,
+        dt,
     )
 
     output_writer = ClimaDiagnostics.Writers.DictWriter()
@@ -404,6 +405,7 @@ end
         LAI,
         toml_dict,
         domain,
+        dt,
     )
 
     output_writer = ClimaDiagnostics.Writers.DictWriter()

--- a/test/integrated/full_land.jl
+++ b/test/integrated/full_land.jl
@@ -25,6 +25,8 @@ for FT in (Float32, Float64)
         forcing = (; atmos, radiation)
         prognostic_land_components = (:canopy, :snow, :soil, :soilco2)
 
+        dt = FT(180)
+
         # Soil model
         soil = Soil.EnergyHydrology{FT}(
             domain,
@@ -43,6 +45,7 @@ for FT in (Float32, Float64)
             domain,
             soilco2_drivers,
             toml_dict,
+            dt,
         )
 
         # Canopy model
@@ -59,7 +62,6 @@ for FT in (Float32, Float64)
         )
 
         # Snow model
-        dt = FT(180)
         snow = SnowModel(
             FT,
             surface_domain,
@@ -357,15 +359,12 @@ end
     @test all(parent(Y.snow.S)[1, 1, 1, Array(binary_mask)] .≈ 0)
     @test all(parent(Y.snow.S_l)[1, 1, 1, Array(binary_mask)] .≈ 0)
     @test all(
-        parent(Y.soilco2.CO2)[:, 1, 1, 1, Array(binary_mask)] .- FT(0.000412) .≈
-        0,
+        parent(Y.soilco2.CO2)[:, 1, 1, 1, Array(binary_mask)] .- FT(6e-5) .≈ 0,
     )
     @test all(
         parent(Y.soilco2.O2_f)[:, 1, 1, 1, Array(binary_mask)] .- FT(0.21) .≈ 0,
     )
-    @test all(
-        parent(Y.soilco2.SOC)[:, 1, 1, 1, Array(binary_mask)] .- FT(5) .≈ 0,
-    )
+    @test all(parent(Y.soilco2.SOC)[:, 1, 1, 1, Array(binary_mask)] .>= 0)
 end
 
 

--- a/test/integrated/soil_canopy_lsm.jl
+++ b/test/integrated/soil_canopy_lsm.jl
@@ -17,7 +17,8 @@ for FT in (Float32, Float64)
         forcing = (; atmos, radiation)
         toml_dict = ClimaLand.Parameters.create_toml_dict(FT)
         LAI = TimeVaryingInput((t) -> FT(1.0))
-        model = SoilCanopyModel{FT}(forcing, LAI, toml_dict, domain)
+        Δt = FT(450)
+        model = SoilCanopyModel{FT}(forcing, LAI, toml_dict, domain, Δt)
         # The constructor has many asserts that check the model
         # components, so we don't need to check them again here.
         Y, p, cds = initialize(model)

--- a/test/integrated/soil_energy_hydrology_biogeochemistry.jl
+++ b/test/integrated/soil_energy_hydrology_biogeochemistry.jl
@@ -27,7 +27,8 @@ for FT in (Float32, Float64)
 
         (atmos, radiation) = prescribed_analytic_forcing(FT; toml_dict)
         forcing = (; atmos, radiation)
-        model = LandSoilBiogeochemistry{FT}(forcing, toml_dict, domain)
+        Δt = FT(450)
+        model = LandSoilBiogeochemistry{FT}(forcing, toml_dict, domain, Δt)
         @test ClimaComms.context(model) == ClimaComms.context()
         @test ClimaComms.device(model) == ClimaComms.device()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,6 +70,12 @@ end
 @safetestset "Soil CO2 parameterization tests" begin
     include("standalone/Soil/Biogeochemistry/co2_parameterizations.jl")
 end
+@safetestset "Soil O2_f tendency floor regression" begin
+    include("standalone/Soil/Biogeochemistry/o2_tendency_floor.jl")
+end
+@safetestset "Soil CO2 saturation stability tests" begin
+    include("standalone/Soil/Biogeochemistry/saturation_stability_test.jl")
+end
 
 @safetestset "Soil climate drivers tests" begin
     include("standalone/Soil/climate_drivers.jl")

--- a/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
+++ b/test/standalone/Soil/Biogeochemistry/biogeochemistry_module.jl
@@ -34,7 +34,7 @@ for FT in (Float32, Float64)
         atmos_p = (t) -> 100000.0
         UTC_DATETIME = Dates.now()
         atmos_h = FT(30)
-        atmos_co2 = (t) -> 1.0
+        atmos_co2 = (t) -> 4.2e-4  # atmospheric CO2 (mol/mol)
 
         atmos = ClimaLand.PrescribedAtmosphere(
             TimeVaryingInput(precipitation_function),
@@ -63,8 +63,16 @@ for FT in (Float32, Float64)
         drivers = SoilDrivers(prescribed_met, atmos)
 
         # Create model
-        model =
-            SoilCO2Model{FT}(domain, drivers, toml_dict; parameters, sources)
+        # Δt = 0 disables the O2_f tendency limiter; this test only checks
+        # tendency assembly, not multi-step time integration.
+        model = SoilCO2Model{FT}(
+            domain,
+            drivers,
+            toml_dict,
+            FT(0);
+            parameters,
+            sources,
+        )
 
         # Initialize and test
         Y, p, coords = initialize(model)
@@ -72,8 +80,9 @@ for FT in (Float32, Float64)
         exp_tendency! = make_exp_tendency(model)
         t = Float64(1)
 
-        # Set initial conditions
-        Y.soilco2.CO2 .= FT(4)
+        # Set initial conditions with physically reasonable values
+        # CO2 ~ 10,000 ppm equivalent (elevated soil CO2)
+        Y.soilco2.CO2 .= FT(0.003)  # kg C m⁻³ (well below 100k ppm threshold)
         Y.soilco2.O2_f .= FT(0.2)
         Y.soilco2.SOC .= FT(5.0)
 
@@ -85,8 +94,8 @@ for FT in (Float32, Float64)
         # Test that microbial source is positive (CO2 production)
         @test all(parent(p.soilco2.Sm) .>= FT(0))
 
-        # Test that SOC consumption equals CO2 production (mass balance)
-        @test dY.soilco2.SOC ≈ @. -p.soilco2.Sm
+        # Test that SOC tendency is zero (SOC held constant in this model)
+        @test all(parent(dY.soilco2.SOC) .== FT(0))
 
         # Test that interior cells have CO2 production (source dominates)
         # Near boundaries, diffusion may affect the tendency
@@ -97,11 +106,9 @@ for FT in (Float32, Float64)
         # (boundary diffusion may affect edge values)
         @test sum(parent(dY.soilco2.O2_f)[interior_indices]) < FT(0)
 
-        # Test boundary condition variables are set
-        @test p.soilco2.top_bc_wvec ==
-              ClimaCore.Geometry.WVector.(p.soilco2.top_bc)
-        @test p.soilco2.bottom_bc_wvec ==
-              ClimaCore.Geometry.WVector.(p.soilco2.bottom_bc)
+        # Test boundary condition variables are set (finite values)
+        @test all(isfinite.(parent(p.soilco2.top_bc)))
+        @test all(isfinite.(parent(p.soilco2.bottom_bc)))
     end
 
 
@@ -118,8 +125,8 @@ for FT in (Float32, Float64)
         # No sources for diffusion test
         sources = ()
 
-        # Set uniform CO2 concentration for testing diffusion
-        C = FT(4.0)
+        # Atmospheric CO2 concentration (mol/mol)
+        c_co2_atm = FT(4.2e-4)
 
         # Make a PrescribedAtmosphere with CO2 matching soil initial conditions
         precipitation_function = (t) -> 1.0
@@ -130,7 +137,6 @@ for FT in (Float32, Float64)
         atmos_p = (t) -> 100000.0
         UTC_DATETIME = Dates.now()
         atmos_h = FT(30)
-        atmos_co2 = (t) -> C  # Match atmospheric CO2 to soil CO2
 
         atmos = ClimaLand.PrescribedAtmosphere(
             TimeVaryingInput(precipitation_function),
@@ -142,12 +148,15 @@ for FT in (Float32, Float64)
             UTC_DATETIME,
             atmos_h,
             toml_dict;
-            c_co2 = TimeVaryingInput(atmos_co2),
+            c_co2 = TimeVaryingInput((t) -> c_co2_atm),
         )
 
         # Set up prescribed meteorology
-        T_soil = (z, t) -> eltype(z)(303)
-        θ_l = (z, t) -> eltype(z)(0.3)
+        T_soil_val = FT(303)
+        P_val = FT(100000)
+        T_soil = (z, t) -> eltype(z)(T_soil_val)
+        θ_l_val = FT(0.3)
+        θ_l = (z, t) -> eltype(z)(θ_l_val)
         ν = FT(0.6)
         θ_r = FT(0.0)
         α = FT(0.1)
@@ -159,8 +168,16 @@ for FT in (Float32, Float64)
         drivers = SoilDrivers(prescribed_met, atmos)
 
         # Create model
-        model =
-            SoilCO2Model{FT}(domain, drivers, toml_dict; parameters, sources)
+        # Δt = 0 disables the O2_f tendency limiter; this test only checks
+        # tendency assembly, not multi-step time integration.
+        model = SoilCO2Model{FT}(
+            domain,
+            drivers,
+            toml_dict,
+            FT(0);
+            parameters,
+            sources,
+        )
 
         # Initialize and test
         Y, p, coords = initialize(model)
@@ -168,8 +185,23 @@ for FT in (Float32, Float64)
         exp_tendency! = make_exp_tendency(model)
         t = Float64(1)
 
-        # Set initial conditions - uniform CO2 matching boundary conditions
-        Y.soilco2.CO2 .= C
+        # Set CO2 so that CO2_air_eq matches the atmospheric boundary condition
+        # CO2_air_eq_atm = c_co2 * P * M_C / (R * T)
+        R = FT(LP.gas_constant(parameters.earth_param_set))
+        M_C = FT(parameters.M_C)
+        θ_a = ν - θ_l_val
+        K_H = Biogeochemistry.henry_constant(
+            parameters.K_H_co2_298,
+            parameters.dln_K_H_co2_dT,
+            T_soil_val,
+            parameters.T_ref_henry,
+        )
+        β = Biogeochemistry.beta_gas(K_H, R, T_soil_val)
+        θ_eff = Biogeochemistry.effective_porosity(θ_a, θ_l_val, β)
+        CO2_air_eq_atm = c_co2_atm * P_val * M_C / (R * T_soil_val)
+        CO2_total = θ_eff * CO2_air_eq_atm
+
+        Y.soilco2.CO2 .= CO2_total
         Y.soilco2.O2_f .= FT(0.2)
         Y.soilco2.SOC .= FT(5.0)
 
@@ -182,10 +214,8 @@ for FT in (Float32, Float64)
         # net CO2 change should be ~0
         @test sum(dY.soilco2.CO2) ≈ FT(0.0) atol = FT(1e-6)
 
-        # Test boundary condition variables are set
-        @test p.soilco2.top_bc_wvec ==
-              ClimaCore.Geometry.WVector.(p.soilco2.top_bc)
-        @test p.soilco2.bottom_bc_wvec ==
-              ClimaCore.Geometry.WVector.(p.soilco2.bottom_bc)
+        # Test boundary condition variables are finite
+        @test all(isfinite.(parent(p.soilco2.top_bc)))
+        @test all(isfinite.(parent(p.soilco2.bottom_bc)))
     end
 end

--- a/test/standalone/Soil/Biogeochemistry/co2_parameterizations.jl
+++ b/test/standalone/Soil/Biogeochemistry/co2_parameterizations.jl
@@ -44,6 +44,12 @@ for FT in (Float32, Float64)
               (θ_a / θ_a100)^(FT(2) + FT(3) / b)
         @test typeof(D) == FT
 
+        # Test o2_diffusivity: same Ryan/Moldrup form as CO₂, only the reference
+        # diffusivity differs, so D_o2 / D_co2 == D_ref_o2 / D_ref.
+        D_o2 = o2_diffusivity(T_soil, θ_w, P_sfc, θ_a100, b, ν, parameters)
+        @test typeof(D_o2) == FT
+        @test D_o2 ≈ D * parameters.D_ref_o2 / parameters.D_ref
+
         # Test O2 concentration conversions
         O2_f = FT(0.21)  # Typical atmospheric value
         ρ_O2_air = o2_concentration(O2_f, T_soil, P_sfc, parameters)
@@ -65,12 +71,56 @@ for FT in (Float32, Float64)
         # Test microbe_source with O2_avail
         ms = microbe_source(T_soil, θ_l, Csom, O2_avail, parameters)
         # Check that the value is correct
-        (; p_sx, D_liq, kM_o2, kM_sx, α_sx, Ea_sx) = parameters
+        (; p_sx, D_liq, kM_o2, kM_sx, V_ref_sx, T_ref_sx, Ea_sx) = parameters
         Sx = p_sx * Csom * D_liq * max(θ_l, FT(0))^3
         MM_sx = Sx / (kM_sx + Sx)
         MM_o2 = O2_avail / (kM_o2 + O2_avail)
-        @test ms == α_sx * exp(-Ea_sx / (R * T_soil)) * MM_sx * MM_o2
+        @test ms ==
+              V_ref_sx *
+              exp(-Ea_sx / R * (1 / T_soil - 1 / T_ref_sx)) *
+              MM_sx *
+              MM_o2
         @test typeof(ms) == FT
         @test ms >= FT(0)  # Respiration should be non-negative
+
+        # Test henry_constant: at the reference temperature, returns K_H_ref
+        T_ref_henry = parameters.T_ref_henry
+        K_H_co2_ref = henry_constant(
+            parameters.K_H_co2_298,
+            parameters.dln_K_H_co2_dT,
+            T_ref_henry,
+            T_ref_henry,
+        )
+        @test K_H_co2_ref ≈ parameters.K_H_co2_298
+        @test typeof(K_H_co2_ref) == FT
+        # K_H decreases with temperature (positive dln_K_H_dT means more soluble when colder)
+        K_H_co2_warm = henry_constant(
+            parameters.K_H_co2_298,
+            parameters.dln_K_H_co2_dT,
+            T_ref_henry + FT(15),
+            T_ref_henry,
+        )
+        @test K_H_co2_warm < parameters.K_H_co2_298
+
+        # Test beta_gas: β = K_H * R * T
+        β_co2 = beta_gas(K_H_co2_ref, R, T_ref_henry)
+        @test β_co2 ≈ parameters.K_H_co2_298 * R * T_ref_henry
+        @test typeof(β_co2) == FT
+        @test β_co2 > FT(0)
+
+        # Test effective_porosity = θ_a + β·θ_l (with floor θ_eff_min = 1e-4)
+        θ_eff = effective_porosity(θ_a, θ_l, β_co2)
+        @test θ_eff ≈ θ_a + β_co2 * θ_l
+        @test typeof(θ_eff) == FT
+        # When both θ_a and θ_l vanish, the floor kicks in
+        θ_eff_floor = effective_porosity(FT(0), FT(0), β_co2)
+        @test θ_eff_floor ≈ FT(1e-4)
+        # When only θ_a vanishes (saturated soil), dissolved storage keeps θ_eff > 0
+        θ_eff_sat = effective_porosity(FT(0), FT(0.5), β_co2)
+        @test θ_eff_sat ≈ β_co2 * FT(0.5)
+        @test θ_eff_sat > FT(0)
+
+        # Test gas_diffusivity_in_soil exponent uses params.T_exp_diffusivity
+        @test parameters.T_exp_diffusivity == FT(1.75)
     end
 end

--- a/test/standalone/Soil/Biogeochemistry/o2_tendency_floor.jl
+++ b/test/standalone/Soil/Biogeochemistry/o2_tendency_floor.jl
@@ -1,0 +1,126 @@
+# Regression test for the O2_f tendency bracket. With CFL-violating explicit
+# diffusion (hot/dry column, fine near-surface layers, large Δt) and a steep
+# initial O2_f profile, the unlimited tendency drives Y_new below 0 *and*
+# above the atmospheric O2 fraction (2-cell oscillation). The bracket
+# (`SoilCO2Model.Δt > 0`) caps dY so 0 ≤ Y + Δt*dY ≤ O2_f_atm.
+
+using Test
+import ClimaComms
+ClimaComms.@import_required_backends
+using Dates
+using ClimaCore
+using ClimaUtilities
+import ClimaUtilities.TimeVaryingInputs: TimeVaryingInput
+using ClimaLand
+using ClimaLand.Domains: Column
+using ClimaLand.Soil.Biogeochemistry
+import ClimaLand
+import ClimaLand.Parameters as LP
+
+for FT in (Float32, Float64)
+    @testset "O2_f tendency bracket prevents [0, O2_f_atm] excursions, FT = $FT" begin
+        toml_dict = LP.create_toml_dict(FT)
+        parameters = SoilCO2ModelParameters(toml_dict)
+
+        # Stretched column with a very thin top layer to force CFL violation
+        # under the chosen Δt (~100 s). dz_top must be small for diffusion
+        # to dominate within one step.
+        nelems = 20
+        domain = Column(;
+            zlim = (FT(-2.0), FT(0.0)),
+            nelements = nelems,
+            dz_tuple = (FT(0.5), FT(0.005)),
+        )
+
+        # Hot, dry conditions → large D_o2, small θ_eff_o2 → CFL bound is tiny
+        T_soil = (z, t) -> eltype(z)(320)  # 47 °C
+        θ_l = (z, t) -> eltype(z)(0.05)   # very dry
+        ν = FT(0.5)
+        θ_r = FT(0.0)
+        hcm = ClimaLand.Soil.vanGenuchten{FT}(; α = FT(0.1), n = FT(2))
+        prescribed_met = PrescribedMet{FT}(T_soil, θ_l, ν, θ_r, hcm)
+
+        atmos = ClimaLand.PrescribedAtmosphere(
+            TimeVaryingInput((t) -> 1.0),
+            TimeVaryingInput((t) -> 1.0),
+            TimeVaryingInput((t) -> 1.0),
+            TimeVaryingInput((t) -> 1.0),
+            TimeVaryingInput((t) -> 1.0),
+            TimeVaryingInput((t) -> 100000.0),
+            Dates.now(),
+            FT(30),
+            toml_dict;
+            c_co2 = TimeVaryingInput((t) -> 4.2e-4),
+        )
+        drivers = SoilDrivers(prescribed_met, atmos)
+        sources = (MicrobeProduction{FT}(),)
+
+        Δt_floor = FT(100.0)
+        model_floor = SoilCO2Model{FT}(
+            domain,
+            drivers,
+            toml_dict,
+            Δt_floor;
+            parameters,
+            sources,
+        )
+        # Δt = 0 disables the O2_f tendency floor.
+        model_nofloor = SoilCO2Model{FT}(
+            domain,
+            drivers,
+            toml_dict,
+            FT(0);
+            parameters,
+            sources,
+        )
+
+        # Steep exponential O2_f IC: ~0.21 at z=0, ~0 at z=-1m. This is the
+        # initial condition used in multi_column_soilco2.jl that triggers
+        # the bug.
+        function set_o2_ic!(Y)
+            z = ClimaCore.Fields.coordinate_field(axes(Y.soilco2.O2_f)).z
+            k = FT(log(21))
+            @. Y.soilco2.O2_f = FT(0.21) * exp(k * z)
+            Y.soilco2.CO2 .= FT(1e-3)
+            Y.soilco2.SOC .= FT(5.0)
+        end
+
+        # Step manually with explicit Euler. The CFL-driven 2-cell oscillation
+        # appears within a few steps; 20 steps is enough to catch the bug
+        # without long runs in CI.
+        nsteps = 20
+        O2_f_atm = FT(parameters.O2_f_atm)
+        function run_steps(model, Δt_step)
+            Y, p, _ = initialize(model)
+            set_o2_ic!(Y)
+            set_initial_cache! = make_set_initial_cache(model)
+            set_initial_cache!(p, Y, FT(0))
+            dY = similar(Y)
+            exp_tendency! = make_exp_tendency(model)
+            min_o2 = FT(Inf)
+            max_o2 = -FT(Inf)
+            for _ in 1:nsteps
+                # update_aux! mutates Y (clamps O2_f); call before each tendency
+                set_initial_cache!(p, Y, FT(0))
+                exp_tendency!(dY, Y, p, FT(0))
+                @. Y.soilco2.O2_f += Δt_step * dY.soilco2.O2_f
+                @. Y.soilco2.CO2 += Δt_step * dY.soilco2.CO2
+                min_o2 = min(min_o2, minimum(parent(Y.soilco2.O2_f)))
+                max_o2 = max(max_o2, maximum(parent(Y.soilco2.O2_f)))
+            end
+            return min_o2, max_o2
+        end
+
+        min_o2_floor, max_o2_floor = run_steps(model_floor, Δt_floor)
+        min_o2_nofloor, max_o2_nofloor = run_steps(model_nofloor, Δt_floor)
+
+        # With the bracket on, O2_f stays inside [0, O2_f_atm] up to round-off.
+        # Without it, the CFL-driven oscillation pushes O2_f well below zero
+        # AND well above O2_f_atm at adjacent cells.
+        tol = FT(10) * eps(FT)
+        @test min_o2_floor >= -tol
+        @test max_o2_floor <= O2_f_atm + tol
+        @test min_o2_nofloor < -FT(0.01)
+        @test max_o2_nofloor > O2_f_atm + FT(0.01)
+    end
+end

--- a/test/standalone/Soil/Biogeochemistry/saturation_stability_test.jl
+++ b/test/standalone/Soil/Biogeochemistry/saturation_stability_test.jl
@@ -1,0 +1,267 @@
+"""
+Test that the SoilCO2 model remains stable under saturated/near-saturated conditions.
+
+The Henry's law air-water partitioning scheme should prevent blow-up when:
+- θ_l → ν (fully saturated soil, no air)
+- θ_l + θ_i → ν (saturated with ice)
+
+Key invariants:
+- CO2, O2_f, and their tendencies should never be NaN or Inf
+- θ_eff and θ_eff_o2 should remain positive even when θ_a = 0
+"""
+
+using Test
+import ClimaComms
+ClimaComms.@import_required_backends
+using Dates
+using ClimaCore
+using ClimaLand
+using ClimaLand.Domains: Column
+using ClimaLand.Soil.Biogeochemistry
+import ClimaLand.Parameters as LP
+
+FT = Float64
+
+@testset "Henry's law parameterizations" begin
+    # Test henry_constant
+    K_H_298 = FT(3.4e-4)  # CO2 at 298K
+    dln_K_H_dT = FT(2400)
+
+    # At reference temperature, should return K_H_298
+    T_ref = FT(298.15)
+    @test henry_constant(K_H_298, dln_K_H_dT, T_ref, T_ref) ≈ K_H_298
+
+    # At lower temperature, K_H should be higher (more soluble)
+    T_cold = FT(273.15)
+    K_H_cold = henry_constant(K_H_298, dln_K_H_dT, T_cold, T_ref)
+    @test K_H_cold > K_H_298
+
+    # At higher temperature, K_H should be lower
+    T_warm = FT(313.15)
+    K_H_warm = henry_constant(K_H_298, dln_K_H_dT, T_warm, T_ref)
+    @test K_H_warm < K_H_298
+
+    # Test beta_gas
+    R = FT(8.314)
+    T = FT(298.15)
+    K_H = FT(3.4e-4)
+    β = beta_gas(K_H, R, T)
+    @test β ≈ K_H * R * T
+    @test β > FT(0)
+
+    # Test effective_porosity
+    θ_a = FT(0.2)
+    θ_l = FT(0.3)
+    β_co2 = FT(0.8)  # typical value for CO2
+    θ_eff = effective_porosity(θ_a, θ_l, β_co2)
+    @test θ_eff ≈ θ_a + β_co2 * θ_l
+
+    # Critical test: when θ_a = 0, θ_eff should still be positive
+    θ_a_zero = FT(0)
+    θ_l_sat = FT(0.5)
+    θ_eff_sat = effective_porosity(θ_a_zero, θ_l_sat, β_co2)
+    @test θ_eff_sat > FT(0)
+    @test θ_eff_sat ≈ β_co2 * θ_l_sat
+end
+
+@testset "volumetric_air_content physical floor" begin
+    ν = FT(0.5)
+
+    # Normal case
+    θ_w_normal = FT(0.3)
+    θ_a = volumetric_air_content(θ_w_normal, ν)
+    @test θ_a ≈ ν - θ_w_normal
+
+    # Saturated case - should return 0, not 0.001
+    θ_w_sat = ν
+    θ_a_sat = volumetric_air_content(θ_w_sat, ν)
+    @test θ_a_sat == FT(0)
+
+    # Over-saturated case (shouldn't happen physically, but should be robust)
+    θ_w_over = ν + FT(0.1)
+    θ_a_over = volumetric_air_content(θ_w_over, ν)
+    @test θ_a_over == FT(0)
+end
+
+@testset "SoilCO2 model stability under saturation" begin
+    toml_dict = LP.create_toml_dict(FT)
+    parameters = SoilCO2ModelParameters(toml_dict)
+
+    # Verify Henry's law parameters are set
+    @test parameters.K_H_co2_298 > FT(0)
+    @test parameters.K_H_o2_298 > FT(0)
+    @test parameters.dln_K_H_co2_dT > FT(0)
+    @test parameters.dln_K_H_o2_dT > FT(0)
+
+    # Set up a single column domain
+    nelems = 10
+    zmin = FT(-1)
+    zmax = FT(0.0)
+    domain = Column(; zlim = (zmin, zmax), nelements = nelems)
+
+    sources = (MicrobeProduction{FT}(),)
+
+    # Set up atmosphere
+    precipitation_function = (t) -> 0.0
+    snow_precip = (t) -> 0.0
+    atmos_T = (t) -> 288.0
+    atmos_u = (t) -> 2.0
+    atmos_q = (t) -> 0.01
+    atmos_p = (t) -> 101325.0
+    UTC_DATETIME = Dates.now()
+    atmos_h = FT(2)
+    atmos_co2 = (t) -> 0.0004  # ~400 ppm as mass concentration
+
+    atmos = ClimaLand.PrescribedAtmosphere(
+        TimeVaryingInput(precipitation_function),
+        TimeVaryingInput(snow_precip),
+        TimeVaryingInput(atmos_T),
+        TimeVaryingInput(atmos_u),
+        TimeVaryingInput(atmos_q),
+        TimeVaryingInput(atmos_p),
+        UTC_DATETIME,
+        atmos_h,
+        toml_dict;
+        c_co2 = TimeVaryingInput(atmos_co2),
+    )
+
+    ν = FT(0.5)
+    θ_r = FT(0.05)
+    α = FT(0.1)
+    n = FT(2)
+    hcm = ClimaLand.Soil.vanGenuchten{FT}(; α = α, n = n)
+
+    # Test different saturation scenarios
+    test_cases = [
+        ("Normal conditions", (z, t) -> eltype(z)(0.25)),
+        ("Near-saturated", (z, t) -> eltype(z)(0.49)),
+        ("Fully saturated", (z, t) -> eltype(z)(0.5)),  # = ν
+        ("Over-saturated (edge case)", (z, t) -> eltype(z)(0.51)),  # > ν
+    ]
+
+    for (name, θ_l_func) in test_cases
+        @testset "$name" begin
+            T_soil = (z, t) -> eltype(z)(288)
+            prescribed_met = PrescribedMet{FT}(T_soil, θ_l_func, ν, θ_r, hcm)
+            drivers = SoilDrivers(prescribed_met, atmos)
+
+            model = SoilCO2Model{FT}(
+                domain,
+                drivers,
+                toml_dict,
+                FT(0);
+                parameters,
+                sources,
+            )
+
+            Y, p, coords = initialize(model)
+            dY = similar(Y)
+            exp_tendency! = make_exp_tendency(model)
+            t = Float64(0)
+
+            # Set initial conditions
+            Y.soilco2.CO2 .= FT(0.001)  # Small positive CO2
+            Y.soilco2.O2_f .= FT(0.2)   # Near-atmospheric O2 fraction
+            Y.soilco2.SOC .= FT(5.0)    # Soil organic carbon
+
+            # Update cache
+            set_initial_cache! = make_set_initial_cache(model)
+            set_initial_cache!(p, Y, t)
+
+            # Check auxiliary variables are finite
+            @test all(isfinite.(parent(p.soilco2.θ_a)))
+            @test all(isfinite.(parent(p.soilco2.θ_eff)))
+            @test all(isfinite.(parent(p.soilco2.θ_eff_o2)))
+            @test all(isfinite.(parent(p.soilco2.CO2_air_eq)))
+            @test all(isfinite.(parent(p.soilco2.D)))
+            @test all(isfinite.(parent(p.soilco2.Sm)))
+
+            # θ_eff should be positive even when θ_a = 0
+            @test all(parent(p.soilco2.θ_eff) .> FT(0))
+            @test all(parent(p.soilco2.θ_eff_o2) .> FT(0))
+
+            # Compute tendency
+            exp_tendency!(dY, Y, p, t)
+
+            # Check tendencies are finite (no blow-up)
+            @test all(isfinite.(parent(dY.soilco2.CO2)))
+            @test all(isfinite.(parent(dY.soilco2.O2_f)))
+            @test all(isfinite.(parent(dY.soilco2.SOC)))
+
+            # Check prognostic variables remain finite
+            @test all(isfinite.(parent(Y.soilco2.CO2)))
+            @test all(isfinite.(parent(Y.soilco2.O2_f)))
+        end
+    end
+end
+
+@testset "SoilCO2 stability with temperature variation" begin
+    toml_dict = LP.create_toml_dict(FT)
+    parameters = SoilCO2ModelParameters(toml_dict)
+
+    nelems = 10
+    zmin = FT(-1)
+    zmax = FT(0.0)
+    domain = Column(; zlim = (zmin, zmax), nelements = nelems)
+
+    sources = (MicrobeProduction{FT}(),)
+
+    # Set up atmosphere
+    atmos = ClimaLand.PrescribedAtmosphere(
+        TimeVaryingInput((t) -> 0.0),
+        TimeVaryingInput((t) -> 0.0),
+        TimeVaryingInput((t) -> 288.0),
+        TimeVaryingInput((t) -> 2.0),
+        TimeVaryingInput((t) -> 0.01),
+        TimeVaryingInput((t) -> 101325.0),
+        Dates.now(),
+        FT(2),
+        toml_dict;
+        c_co2 = TimeVaryingInput((t) -> 0.0004),
+    )
+
+    ν = FT(0.5)
+    θ_r = FT(0.05)
+    hcm = ClimaLand.Soil.vanGenuchten{FT}(; α = FT(0.1), n = FT(2))
+
+    # Test different temperatures
+    test_temps = [FT(263), FT(273), FT(288), FT(303), FT(313)]
+
+    for T_val in test_temps
+        @testset "Temperature = $T_val K" begin
+            T_soil = (z, t) -> eltype(z)(T_val)
+            θ_l = (z, t) -> eltype(z)(0.45)  # Near-saturated
+            prescribed_met = PrescribedMet{FT}(T_soil, θ_l, ν, θ_r, hcm)
+            drivers = SoilDrivers(prescribed_met, atmos)
+
+            model = SoilCO2Model{FT}(
+                domain,
+                drivers,
+                toml_dict,
+                FT(0);
+                parameters,
+                sources,
+            )
+
+            Y, p, coords = initialize(model)
+            dY = similar(Y)
+            exp_tendency! = make_exp_tendency(model)
+            t = Float64(0)
+
+            Y.soilco2.CO2 .= FT(0.001)
+            Y.soilco2.O2_f .= FT(0.2)
+            Y.soilco2.SOC .= FT(5.0)
+
+            set_initial_cache! = make_set_initial_cache(model)
+            set_initial_cache!(p, Y, t)
+            exp_tendency!(dY, Y, p, t)
+
+            # All values should be finite
+            @test all(isfinite.(parent(p.soilco2.θ_eff)))
+            @test all(isfinite.(parent(dY.soilco2.CO2)))
+            @test all(isfinite.(parent(dY.soilco2.O2_f)))
+        end
+    end
+end
+
+println("All saturation stability tests passed!")

--- a/toml/default_parameters.toml
+++ b/toml/default_parameters.toml
@@ -1,6 +1,6 @@
 # Moisture stress models
 [moisture_stress_c]
-value = 0.27
+value = 0.5675395275525799
 type = "float"
 description = "unitless"
 tag = "SoilMoistureStress"
@@ -223,21 +223,21 @@ tag = "ConstantResetAlbedo"
 
 # P model parameters
 ["pmodel_cstar"]
-value = 0.41
+value = 0.4126532780348918
 type = "float"
 description = "4 * dA/dJmax, assumed to be a constant marginal cost (Wang 2017, Stocker 2020)"
 tag = "PModelParameters"
 
 ["pmodel_β_c3"]
-value = 51
+value = 68.19135215644542
 type = "float"
 description = "Unit cost ratio of Vcmax to transpiration for C3 plants (Stocker 2020)"
 tag = "PModelParameters"
 
 ["pmodel_β_c4"]
-value = 51
+value = 53.92806481016041
 type = "float"
-description = "Unit cost ratio of Vcmax to transpiration for C4 plants (146/9, pyrealm)"
+description = "Unit cost ratio of Vcmax to transpiration for C4 plants"
 tag = "PModelParameters"
 
 ["pmodel_ϕ0_c3"]
@@ -289,7 +289,7 @@ description = "Second order term in quadratic intrinsic quantum yield (Cai and P
 tag = "PModelParameters"
 
 ["pmodel_α"]
-value = 0.933
+value = 0.9758442675597523
 type = "float"
 description = "1 - 1/T where T is the timescale of Vcmax, Jmax acclimation. Here T = 15 days. (Mengoli 2022)"
 tag = "PModelParameters"
@@ -570,32 +570,44 @@ type = "float"
 description = "Diffusion coefficient for CO₂ in air at standard temperature and pressure (m² s⁻¹)"
 tag = "SoilCO2Parameters"
 
+["O2_diffusion_coefficient_air"]
+value = 1.67e-5
+type = "float"
+description = "Diffusion coefficient for O₂ in air at standard temperature and pressure (m² s⁻¹)"
+tag = "SoilCO2Parameters"
+
 ["soil_C_substrate_diffusivity"]
 value = 3.17
 type = "float"
 description = "Diffusivity of soil C substrate in liquid (unitless)"
 tag = "SoilCO2Parameters"
 
-["soilCO2_pre_exponential_factor"]
-value = 194000.0
+["soilCO2_reference_rate"]
+value = 7.885402642122577e-8
 type = "float"
-description = "Pre-exponential factor for DAMM model (kg C m⁻³ s⁻¹)"
+description = "Maximum respiration rate at soilCO2_reference_temperature for DAMM model (kg C m⁻³ s⁻¹). Centered Arrhenius: Vmax = V_ref * exp(-Ea/R * (1/T - 1/T_ref))"
+tag = "SoilCO2Parameters"
+
+["soilCO2_reference_temperature"]
+value = 288.15
+type = "float"
+description = "Reference temperature for the centered Arrhenius form of the DAMM model (K)"
 tag = "SoilCO2Parameters"
 
 ["soilCO2_activation_energy"]
-value = 61000.0
+value = 65432.29096630613
 type = "float"
 description = "Activation energy for DAMM model (J mol⁻¹)"
 tag = "SoilCO2Parameters"
 
 ["michaelis_constant"]
-value = 0.005
+value = 0.3668980114900562
 type = "float"
 description = "Michaelis constant for substrate (kg C m⁻³)"
 tag = "SoilCO2Parameters"
 
 ["O2_michaelis_constant"]
-value = 0.004
+value = 0.00018610344999027417
 type = "float"
 description = "Michaelis constant for O₂ (m³ m⁻³)"
 tag = "SoilCO2Parameters"
@@ -622,6 +634,48 @@ tag = "SoilCO2Parameters"
 value = 0.032
 type = "float"
 description = "Molar mass of oxygen (kg/mol)"
+tag = "SoilCO2Parameters"
+
+["O2_volume_fraction"]
+value = 0.2095
+type = "float"
+description = "Volumetric fraction of O₂ in atmospheric air (dimensionless)"
+tag = "SoilCO2Parameters"
+
+["CO2_henry_k298"]
+value = 3.4e-4
+type = "float"
+description = "Henry's law constant for CO₂ at 298K (mol/(m³·Pa))"
+tag = "SoilCO2Parameters"
+
+["CO2_henry_Tcoeff"]
+value = 2400.0
+type = "float"
+description = "Temperature coefficient for CO₂ Henry's law (K)"
+tag = "SoilCO2Parameters"
+
+["O2_henry_k298"]
+value = 1.3e-5
+type = "float"
+description = "Henry's law constant for O₂ at 298K (mol/(m³·Pa))"
+tag = "SoilCO2Parameters"
+
+["O2_henry_Tcoeff"]
+value = 1500.0
+type = "float"
+description = "Temperature coefficient for O₂ Henry's law (K)"
+tag = "SoilCO2Parameters"
+
+["henry_reference_temperature"]
+value = 298.15
+type = "float"
+description = "Reference temperature for Henry's law constants (K), Sander (2015)"
+tag = "SoilCO2Parameters"
+
+["gas_diffusivity_temperature_exponent"]
+value = 1.75
+type = "float"
+description = "Temperature exponent for the free-air gas diffusivity correction D0 ∝ (T/T_ref)^exp (dimensionless), Ryan et al. (2018)"
 tag = "SoilCO2Parameters"
 
 # Soil Parameters
@@ -679,3 +733,16 @@ value = 0.0001
 type = "float"
 description = "Roughness length for scalars over lake water/ice (m)"
 tag = "SlabLakeParameters"
+
+# Autotrophic respiration (JULES) parameters
+["root_leaf_nitrogen_ratio"]
+value = 2.3992909128669666
+type = "float"
+description = "Ratio of root nitrogen to top leaf nitrogen (unitless)."
+tag = "AutotrophicRespirationParameters"
+
+["relative_contribution_factor"]
+value = 1.1321179749274621
+type = "float"
+description = "Factor of relative contribution for growth respiration, Rgrowth (unitless)."
+tag = "AutotrophicRespirationParameters"

--- a/toml/uncalibrated_parameters.toml
+++ b/toml/uncalibrated_parameters.toml
@@ -544,20 +544,32 @@ type = "float"
 description = "Diffusion coefficient for CO₂ in air at standard temperature and pressure (m² s⁻¹)"
 tag = "SoilCO2Parameters"
 
+["O2_diffusion_coefficient_air"]
+value = 1.67e-5
+type = "float"
+description = "Diffusion coefficient for O₂ in air at standard temperature and pressure (m² s⁻¹)"
+tag = "SoilCO2Parameters"
+
 ["soil_C_substrate_diffusivity"]
 value = 3.17
 type = "float"
 description = "Diffusivity of soil C substrate in liquid (unitless)"
 tag = "SoilCO2Parameters"
 
-["soilCO2_pre_exponential_factor"]
-value = 194000.0
+["soilCO2_reference_rate"]
+value = 4.517e-8
 type = "float"
-description = "Pre-exponential factor for DAMM model (kg C m⁻³ s⁻¹)"
+description = "Maximum respiration rate at soilCO2_reference_temperature for DAMM model (kg C m⁻³ s⁻¹). Centered Arrhenius: Vmax = V_ref * exp(-Ea/R * (1/T - 1/T_ref))"
+tag = "SoilCO2Parameters"
+
+["soilCO2_reference_temperature"]
+value = 288.15
+type = "float"
+description = "Reference temperature for the centered Arrhenius form of the DAMM model (K)"
 tag = "SoilCO2Parameters"
 
 ["soilCO2_activation_energy"]
-value = 61000.0
+value = 79000.0
 type = "float"
 description = "Activation energy for DAMM model (J mol⁻¹)"
 tag = "SoilCO2Parameters"
@@ -596,6 +608,36 @@ tag = "SoilCO2Parameters"
 value = 0.032
 type = "float"
 description = "Molar mass of oxygen (kg/mol)"
+tag = "SoilCO2Parameters"
+
+["O2_volume_fraction"]
+value = 0.2095
+type = "float"
+description = "Volumetric fraction of O₂ in atmospheric air (dimensionless)"
+tag = "SoilCO2Parameters"
+
+["CO2_henry_k298"]
+value = 3.4e-4
+type = "float"
+description = "Henry's law constant for CO₂ at 298K (mol/(m³·Pa))"
+tag = "SoilCO2Parameters"
+
+["CO2_henry_Tcoeff"]
+value = 2400.0
+type = "float"
+description = "Temperature coefficient for CO₂ Henry's law (K)"
+tag = "SoilCO2Parameters"
+
+["O2_henry_k298"]
+value = 1.3e-5
+type = "float"
+description = "Henry's law constant for O₂ at 298K (mol/(m³·Pa))"
+tag = "SoilCO2Parameters"
+
+["O2_henry_Tcoeff"]
+value = 1500.0
+type = "float"
+description = "Temperature coefficient for O₂ Henry's law (K)"
 tag = "SoilCO2Parameters"
 
 # Soil Parameters


### PR DESCRIPTION
## Summary

Overhauls the soil biogeochemistry / ecosystem-respiration pathway: fixes NaNs in global SoilCO2 runs, switches to Henry's-law air–water partitioning, initialize SOC with SoilGrids data, recalibrates against GPP + ER + NEE + LHF, and adds ER and NEE to the leaderboard.

## Highlights

- **No more NaNs** — `O2_f` clamped to [0, 0.21] each step + CFL-aware tendency limiter when `Δt > 0`. `Δt` is now a required positional arg on `SoilCO2Model{FT}` so the limiter can't be silently skipped.
- **Henry's-law air–water partitioning** (Sander 2015) for CO2 and O2: `θ_eff = max(θ_a + β·θ_l, θ_eff,min)` stays bounded as the soil saturates.
- **DAMM Arrhenius in centered form** — `V_ref` and `Ea` are orthogonal under calibration; T response reduces to a slope (~Q10) + intercept.
- **SOC from SoilGrids** instead of uniform constant; pool held fixed in time but kept prognostic for future dynamic SOC.
- **CO2 IC** in equilibrium with atmospheric `c_co2` via Henry's law; **O2 IC** exponential profile (0.21 surface → 0.15 at -1 m).
- **New calibration config** `gpp_er_nee_lhf.jl` (11 parameters). Defaults in `toml/default_parameters.toml` updated to the latest 8th-iteration posterior mean.
- **Leaderboard** now includes ILAMB FLUXCOM ER and NEE.
- **[Updated docs](https://clima.github.io/ClimaLand.jl/previews/PR1714/standalone/pages/soil/biogeochemistry/DAMM_model/)**.

## Next PR

Calibrate against a NEE dataset reproducing atmospheric CO2 (inversion dataset?), with a loss capturing (1) seasonality, (2) inter-annual variability, and (3) the decadal trend (land sink keeping up with rising emissions). Relies on human emissions and ocean sinks being known.

---

<img width="2400" height="2400" alt="cfluxes" src="https://github.com/user-attachments/assets/ce945832-1b14-4617-8293-1a3a3e9e3540" />
<img width="2400" height="3200" alt="er_energy_2" src="https://github.com/user-attachments/assets/ed8b1fac-1bf3-4d17-af8d-408addf40ed2" />
<img width="12000" height="1000" alt="cfluxes_errors" src="https://github.com/user-attachments/assets/a0b0742e-7fb9-42d6-955b-311ee5990b5c" />