### PR TITLE
Energy of subsurface runoff + alleviate issue with excess water

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -6,11 +6,11 @@ git-tree-sha1 = "cd070348ab70f5d1b165c814f70e3822c0173eed"
     url = "https://caltech.box.com/shared/static/iquk73vo9983073uxjjri2nxqevq65tk.gz"
 
 [saturated_land_15m]
-git-tree-sha1 = "0ec12ec31d1b4ba768fe5365a6e003c1d2b37a1a"
+git-tree-sha1 = "dcb51992281579a5fc183611e417e10d8ac44966"
 
     [[saturated_land_15m.download]]
-    sha256 = "ce64db1eb8296dd8f63ee06c879ac823a919883f7fbf7b4286051c7270436469"
-    url = "https://caltech.box.com/shared/static/dim37l5cjmmaldaj82r0zs6k4injzjd7.gz"
+    sha256 = "77fbc81ac5fe9188faff6aaf5428cd783fa8e87caccb62602ccc908efdfbc2ef"
+    url = "https://caltech.box.com/shared/static/cwp5w1zm1nc8dzqoer9m5blhd4h177fe.gz"
 
 [saturated_land_ic]
 git-tree-sha1 = "cc2888b590f5158113b54c75eee3e2f797be8956"

--- a/ext/LandSimulationVisualizationExt.jl
+++ b/ext/LandSimulationVisualizationExt.jl
@@ -440,6 +440,7 @@ function LandSimVis.make_timeseries(
     plot_stem_name = "timeseries",
     comparison_data = nothing,
     spinup_date = sim.start_date,
+    layer = nothing,
 )
     model = sim.model
     LandSimVis.make_timeseries(
@@ -451,6 +452,7 @@ function LandSimVis.make_timeseries(
         short_names,
         comparison_data,
         spinup_date,
+        layer,
     )
 end
 
@@ -463,6 +465,7 @@ function LandSimVis.make_timeseries(
     short_names = nothing,
     comparison_data = nothing,
     spinup_date = start_date,
+    layer = nothing,
 )
     @info "No method matching make_timeseries for $domain."
 end
@@ -471,6 +474,7 @@ function LandSimVis.make_timeseries(
     domain::Union{ClimaLand.Domains.Column, ClimaLand.Domains.Point},
     diagnostics,
     start_date;
+    layer = nothing,
     plot_stem_name = "timeseries",
     savedir = ".",
     short_names = nothing,
@@ -492,6 +496,7 @@ function LandSimVis.make_timeseries(
         plot_stem_name,
         comparison_data,
         spinup_date,
+        layer,
     )
 end
 

--- a/ext/land_sim_vis/plotting_utils.jl
+++ b/ext/land_sim_vis/plotting_utils.jl
@@ -459,6 +459,7 @@ function LandSimVis.make_timeseries(
     savedir,
     diagnostics,
     start_date;
+    layer = nothing,
     plot_stem_name = "timeseries",
     comparison_data = nothing,
     spinup_date = start_date,
@@ -472,7 +473,8 @@ function LandSimVis.make_timeseries(
         sn = short_names[i]
         model_time, model_output = ClimaLand.Diagnostics.diagnostic_as_vectors(
             diagnostics[1].output_writer,
-            dn,
+            dn;
+            layer,
         )
         save_Δt = model_time[2] - model_time[1] # in seconds
         model_dates = time_to_date.(model_time, start_date)

--- a/src/standalone/Soil/Runoff/Runoff.jl
+++ b/src/standalone/Soil/Runoff/Runoff.jl
@@ -6,7 +6,11 @@ using ClimaCore.Operators: column_integral_definite!
 using ClimaLand
 import ClimaLand: source!
 using ..ClimaLand.Soil:
-    AbstractSoilSource, AbstractSoilModel, RichardsModel, EnergyHydrology
+    AbstractSoilSource,
+    AbstractSoilModel,
+    RichardsModel,
+    EnergyHydrology,
+    volumetric_internal_energy_liq
 import ClimaLand.Parameters as LP
 import ClimaParams as CP
 export TOPMODELRunoff,
@@ -236,18 +240,15 @@ function update_infiltration_water_flux!(
     model::AbstractSoilModel,
 )
     ϑ_l = Y.soil.ϑ_l
+    ν = model.parameters.ν
+    θ_r = model.parameters.θ_r
     FT = eltype(ϑ_l)
     θ_i = model_agnostic_volumetric_ice_content(Y, FT)
-    @. p.soil.is_saturated = is_saturated(ϑ_l + θ_i, model.parameters.ν)
-    column_integral_definite!(p.soil.h∇, p.soil.is_saturated)
-    @. p.soil.R_ss = topmodel_ss_flux(
-        runoff.subsurface_source.R_sb,
-        runoff.f_over,
-        model.domain.fields.depth - p.soil.h∇,
-    )
+    # Surface runoff first
     ic = soil_infiltration_capacity(model, Y, p) # should be non-allocating
-
-    precip = p.drivers.P_liq
+    @. p.soil.is_saturated =
+        is_saturated(ϑ_l + θ_i - θ_r, ν - θ_r) * (ϑ_l + θ_i - θ_r) / (ν - θ_r) # weighted by how much above saturation, include ice!
+    column_integral_definite!(p.soil.h∇, p.soil.is_saturated) # can be bigger than the depth
     @. p.soil.infiltration = topmodel_surface_infiltration(
         runoff.f_max,
         runoff.f_over,
@@ -256,14 +257,37 @@ function update_infiltration_water_flux!(
         input,
     )
     @. p.soil.R_s = abs(input - p.soil.infiltration)
-
+    # eek! now do it again but use only liquid water for subsurface runoff
+    @. p.soil.is_saturated =
+        is_saturated(ϑ_l - θ_r, ν - θ_r) * (ϑ_l - θ_r) / (ν - θ_r) # weighted by how much above saturation
+    column_integral_definite!(p.soil.h∇, p.soil.is_saturated) # can be bigger than the depth, only includes liquid water
+    @. p.soil.R_ss = topmodel_ss_flux(
+        runoff.subsurface_source.R_sb,
+        runoff.f_over,
+        model.domain.fields.depth - p.soil.h∇,
+    )
+    update_subsurface_energy_runoff!(p, model)
 end
 
+function update_subsurface_energy_runoff!(
+    p,
+    model::EnergyHydrology{FT},
+) where {FT}
+    @. p.soil.subsfc_scratch =
+        p.soil.is_saturated * volumetric_internal_energy_liq(
+            p.soil.T,
+            model.parameters.earth_param_set,
+        )
+    column_integral_definite!(p.soil.R_ess, p.soil.subsfc_scratch) # this actuall just computes the average volumetric energy of the liquid in the saturated layers multiplied by the water table height
+    @. p.soil.R_ess *= p.soil.R_ss / max(p.soil.h∇, eps(FT)) #this divides by tthe water table height (to get average energy) and multiplies by volumetric liquid water runoff.
+end
+update_subsurface_energy_runoff!(p, model::RichardsModel) = nothing
+
 runoff_vars(::TOPMODELRunoff) =
-    (:infiltration, :is_saturated, :R_s, :R_ss, :h∇, :subsfc_scratch)
+    (:infiltration, :is_saturated, :R_s, :R_ss, :R_ess, :h∇, :subsfc_scratch)
 runoff_var_domain_names(::TOPMODELRunoff) =
-    (:surface, :subsurface, :surface, :surface, :surface, :subsurface)
-runoff_var_types(::TOPMODELRunoff, FT) = (FT, FT, FT, FT, FT, FT)
+    (:surface, :subsurface, :surface, :surface, :surface, :surface, :subsurface)
+runoff_var_types(::TOPMODELRunoff, FT) = (FT, FT, FT, FT, FT, FT, FT)
 
 """
     model_agnostic_volumetric_ice_content(Y, FT)
@@ -282,7 +306,7 @@ model_agnostic_volumetric_ice_content(Y, FT) =
         src::TOPMODELSubsurfaceRunoff,
         Y::ClimaCore.Fields.FieldVector,
         p::NamedTuple,
-        model::AbstractSoilModel{FT},
+        model::RichardsModel{FT},
     ) where {FT}
 
 Adjusts dY.soil.ϑ_l in place to account for the loss of
@@ -299,13 +323,39 @@ function ClimaLand.source!(
     src::TOPMODELSubsurfaceRunoff{FT},
     Y::ClimaCore.Fields.FieldVector,
     p::NamedTuple,
-    model::AbstractSoilModel{FT},
+    model::RichardsModel{FT},
 ) where {FT}
-    ϑ_l = Y.soil.ϑ_l
     h∇ = p.soil.h∇
     ϵ = eps(FT)
     @. dY.soil.ϑ_l -= (p.soil.R_ss / max(h∇, ϵ)) * p.soil.is_saturated # apply only to saturated layers
     @. dY.soil.∫F_vol_liq_water_dt -= p.soil.R_ss # the integral is designed to be this flux
+end
+
+"""
+    ClimaLand.source!(
+        dY::ClimaCore.Fields.FieldVector,
+        src::TOPMODELSubsurfaceRunoff,
+        Y::ClimaCore.Fields.FieldVector,
+        p::NamedTuple,
+        model::EnergyHydrology{FT},
+    ) where {FT}
+
+Adjusts dY.soil.ϑ_l and dY.soil.ρe_int in place
+ to account for the loss of water and denergy due to subsurface runoff.
+"""
+function ClimaLand.source!(
+    dY::ClimaCore.Fields.FieldVector,
+    src::TOPMODELSubsurfaceRunoff{FT},
+    Y::ClimaCore.Fields.FieldVector,
+    p::NamedTuple,
+    model::EnergyHydrology{FT},
+) where {FT}
+    h∇ = p.soil.h∇
+    ϵ = eps(FT)
+    @. dY.soil.ϑ_l -= (p.soil.R_ss / max(h∇, ϵ)) * p.soil.is_saturated # apply only to saturated layers
+    @. dY.soil.ρe_int -= (p.soil.R_ess / max(h∇, ϵ)) * p.soil.is_saturated # apply only to saturated layers
+    @. dY.soil.∫F_vol_liq_water_dt -= p.soil.R_ss # the integral is designed to be this flux
+    @. dY.soil.∫F_e_dt -= p.soil.R_ess # the integral is designed to be this flux
 end
 
 """
@@ -321,7 +371,7 @@ see: Niu et al. (2005),
 use in global climate models", Equations (8) and (11).
 """
 function topmodel_surface_infiltration(f_max, f_over, z∇, f_ic, precip)
-    f_sat = f_max * exp(-f_over / 2 * z∇)
+    f_sat = min(f_max * exp(-f_over / 2 * z∇), 1)
     return (1 - f_sat) * max(f_ic, precip)
 end
 

--- a/src/standalone/Soil/Runoff/Runoff.jl
+++ b/src/standalone/Soil/Runoff/Runoff.jl
@@ -278,8 +278,8 @@ function update_subsurface_energy_runoff!(
             p.soil.T,
             model.parameters.earth_param_set,
         )
-    column_integral_definite!(p.soil.R_ess, p.soil.subsfc_scratch) # this actuall just computes the average volumetric energy of the liquid in the saturated layers multiplied by the water table height
-    @. p.soil.R_ess *= p.soil.R_ss / max(p.soil.h∇, eps(FT)) #this divides by tthe water table height (to get average energy) and multiplies by volumetric liquid water runoff.
+    column_integral_definite!(p.soil.R_ess, p.soil.subsfc_scratch) # this actual just computes the average volumetric energy of the liquid in the saturated layers multiplied by the water table height
+    @. p.soil.R_ess *= p.soil.R_ss / max(p.soil.h∇, eps(FT)) #this divides by the water table height (to get average energy) and multiplies by volumetric liquid water runoff.
 end
 update_subsurface_energy_runoff!(p, model::RichardsModel) = nothing
 
@@ -341,7 +341,7 @@ end
     ) where {FT}
 
 Adjusts dY.soil.ϑ_l and dY.soil.ρe_int in place
- to account for the loss of water and denergy due to subsurface runoff.
+ to account for the loss of water and energy due to subsurface runoff.
 """
 function ClimaLand.source!(
     dY::ClimaCore.Fields.FieldVector,

--- a/test/standalone/Soil/runoff.jl
+++ b/test/standalone/Soil/runoff.jl
@@ -2,6 +2,9 @@ import ClimaComms
 ClimaComms.@import_required_backends
 import ClimaUtilities
 import ClimaUtilities.TimeVaryingInputs: TimeVaryingInput
+using Dates
+import ClimaParams as CP
+import ClimaLand.Parameters as LP
 using ClimaLand
 using ClimaLand.Soil.Runoff
 using Test
@@ -99,11 +102,26 @@ end
     R_sb = FT(1.484e-4 / 1000) # m/s
     runoff_model =
         Runoff.TOPMODELRunoff{FT}(; f_over = f_over, f_max = f_max, R_sb = R_sb)
-    @test Runoff.runoff_vars(runoff_model) ==
-          (:infiltration, :is_saturated, :R_s, :R_ss, :h∇, :subsfc_scratch)
-    @test Runoff.runoff_var_domain_names(runoff_model) ==
-          (:surface, :subsurface, :surface, :surface, :surface, :subsurface)
-    @test Runoff.runoff_var_types(runoff_model, FT) == (FT, FT, FT, FT, FT, FT)
+    @test Runoff.runoff_vars(runoff_model) == (
+        :infiltration,
+        :is_saturated,
+        :R_s,
+        :R_ss,
+        :R_ess,
+        :h∇,
+        :subsfc_scratch,
+    )
+    @test Runoff.runoff_var_domain_names(runoff_model) == (
+        :surface,
+        :subsurface,
+        :surface,
+        :surface,
+        :surface,
+        :surface,
+        :subsurface,
+    )
+    @test Runoff.runoff_var_types(runoff_model, FT) ==
+          (FT, FT, FT, FT, FT, FT, FT)
 
     @test runoff_model.f_over == f_over
     @test runoff_model.f_max == f_max
@@ -149,6 +167,7 @@ end
     Y, p, t = initialize(model)
     @test :R_s ∈ propertynames(p.soil)
     @test :R_ss ∈ propertynames(p.soil)
+    @test :R_ess ∈ propertynames(p.soil)
     @test :h∇ ∈ propertynames(p.soil)
     @test :infiltration ∈ propertynames(p.soil)
     @test :is_saturated ∈ propertynames(p.soil)
@@ -163,7 +182,9 @@ end
     scratch = ClimaCore.zeros(surface_space)
     ClimaCore.Operators.column_integral_definite!(
         scratch,
-        ClimaLand.heaviside.(Y.soil.ϑ_l .- model.parameters.ν),
+        ClimaLand.heaviside.(Y.soil.ϑ_l .- model.parameters.ν) .*
+        (Y.soil.ϑ_l .- model.parameters.θ_r) ./
+        (model.parameters.ν .- model.parameters.θ_r),
     )
     @test scratch == p.soil.h∇
     @test p.soil.R_ss ==
@@ -193,6 +214,100 @@ end
 
 end
 
+@testset "EnergyHydrology model, TOPMODEL runoff FT =$FT" begin
+    domain = ClimaLand.Domains.SphericalShell(;
+        radius = FT(6300e3),
+        depth = FT(50.0),
+        nelements = (101, 15),
+        dz_tuple = FT.((5.0, 0.05)),
+    )
+    toml_dict = LP.create_toml_dict(FT)
+    atmos, radiation = ClimaLand.prescribed_forcing_era5(
+        DateTime(2008),
+        DateTime(2009),
+        domain.space.surface,
+        toml_dict,
+        FT;
+        max_wind_speed = 25.0,
+        use_lowres_forcing = true,
+    )
+    forcing = (; atmos, radiation)
+    model = ClimaLand.Soil.EnergyHydrology{FT}(domain, forcing, toml_dict)
+    Y, p, t = initialize(model)
+    @test :R_s ∈ propertynames(p.soil)
+    @test :R_ss ∈ propertynames(p.soil)
+    @test :R_ess ∈ propertynames(p.soil)
+    @test :h∇ ∈ propertynames(p.soil)
+    @test :infiltration ∈ propertynames(p.soil)
+    @test :is_saturated ∈ propertynames(p.soil)
+    @test :subsfc_scratch ∈ propertynames(p.soil)
+
+    # set initial conditions
+    z = ClimaCore.Fields.coordinate_field(domain.space.subsurface).z
+    Y.soil.ϑ_l .= FT(0.6) .- FT(0.3 / 50) .* (z .+ FT(50))
+    Y.soil.θ_i .= FT(0)
+    T = FT(273.17)
+    ρc_s =
+        ClimaLand.Soil.volumetric_heat_capacity.(
+            Y.soil.ϑ_l,
+            Y.soil.θ_i,
+            model.parameters.ρc_ds,
+            model.parameters.earth_param_set,
+        )
+    Y.soil.ρe_int .=
+        ClimaLand.Soil.volumetric_internal_energy.(
+            Y.soil.θ_i,
+            ρc_s,
+            T,
+            model.parameters.earth_param_set,
+        )
+    set_initial_cache! = make_set_initial_cache(model)
+    set_initial_cache!(p, Y, FT(0))
+    surface_space = domain.space.surface
+    scratch = ClimaCore.zeros(surface_space)
+    runoff_model = model.boundary_conditions.top.runoff
+    ClimaCore.Operators.column_integral_definite!(
+        scratch,
+        ClimaLand.heaviside.(Y.soil.ϑ_l .- model.parameters.ν) .*
+        (Y.soil.ϑ_l .- model.parameters.θ_r) ./
+        (model.parameters.ν .- model.parameters.θ_r),
+    )
+    @test scratch == p.soil.h∇
+    @test p.soil.R_ss ==
+          Runoff.topmodel_ss_flux.(
+        runoff_model.subsurface_source.R_sb,
+        runoff_model.f_over,
+        model.domain.depth .- p.soil.h∇,
+    )
+    ic = Runoff.soil_infiltration_capacity(model, Y, p)
+    @test p.soil.infiltration == @. Runoff.topmodel_surface_infiltration(
+        runoff_model.f_max,
+        runoff_model.f_over,
+        model.domain.depth - p.soil.h∇,
+        ic,
+        p.drivers.P_liq,
+    )
+    @test p.soil.R_s == abs.(p.drivers.P_liq .- p.soil.infiltration)
+    scratch2 = ClimaCore.zeros(surface_space)
+    ClimaCore.Operators.column_integral_definite!(
+        scratch2,
+        ClimaLand.heaviside.(Y.soil.ϑ_l .- model.parameters.ν) .*
+        (Y.soil.ϑ_l .- model.parameters.θ_r) ./
+        (model.parameters.ν .- model.parameters.θ_r) .*
+        ClimaLand.Soil.volumetric_internal_energy_liq.(
+            p.soil.T,
+            model.parameters.earth_param_set,
+        ),
+    )
+    @test p.soil.R_ess == scratch2 .* (p.soil.R_ss ./ max.(p.soil.h∇, eps(FT)))
+    @test Runoff.get_saturated_height(runoff_model, Y, p) == p.soil.h∇
+    @test Runoff.get_subsurface_runoff(runoff_model, Y, p) == p.soil.R_ss
+    @test Runoff.get_surface_runoff(runoff_model, Y, p) == p.soil.R_s
+    tmp = p.soil.R_s
+    tmp .= Runoff.get_soil_fsat(runoff_model, Y, p, model.domain.depth)
+    @test tmp == @. runoff_model.f_max *
+             exp(-runoff_model.f_over / 2 * (model.domain.depth - p.soil.h∇))
+end
 
 @testset "Richards model, Site level runoff FT =$FT" begin
     domain = ClimaLand.Domains.SphericalShell(;


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Current main after 20 years spin up:
<img width="1200" height="900" alt="current_main" src="https://github.com/user-attachments/assets/c40f2bc9-30ed-460f-b587-d7b122144664" />
Current main with energy runoff included:
<img width="1200" height="900" alt="current_main_with_energy_runoff_included" src="https://github.com/user-attachments/assets/6719c0b1-50d3-44e2-9db4-9d5e4df53588" />
The runoff scheme included here:
<img width="1200" height="900" alt="altered_runoff_with_energy_runoff_included" src="https://github.com/user-attachments/assets/684190f1-5d1f-4554-81fb-fcad7cee1a48" />

Bottom soil moisture looks reasonable everywhere after 20 years (nanmask = ocean mask)
julia> extrema(swc_data["swc"][end, :, :, 1][nanmask])
(0.08502579603124887, 0.6976980101713615)

We still have some high levels closer to the surface - up to 1.25, but this is significantly better than the values of 7 we were getting at all levels before. 

I think this indicates we have some further work to do on surface runoff.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
