### PR TITLE
re-enable MPI runs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -116,8 +116,6 @@ steps:
           slurm_ntasks_per_node: 4
           slurm_nodes: 1
           slurm_mem: 24G
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true
 
       - label: "Global Run + P Model CPU MPI"
         command: "srun julia --color=yes --project=.buildkite experiments/integrated/global/global_soil_canopy_pmodel.jl"
@@ -128,8 +126,6 @@ steps:
           slurm_ntasks_per_node: 4
           slurm_nodes: 1
           slurm_mem: 24G
-          modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-        soft_fail: true
 
       - label: "Canopy Implicit Stepping CPU"
         command: "julia --color=yes --project=.buildkite experiments/standalone/Vegetation/timestep_test.jl"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
MPI library issues are fixed on central now, so it's been added back into climacommon, and we can remove the soft fail from MPI runs in buildkite.

Reverts https://github.com/CliMA/ClimaLand.jl/pull/1674