### PR TITLE
Generic single site simulation + calibration

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -85,6 +85,32 @@ steps:
         command: "julia --color=yes --project=.buildkite experiments/integrated/fluxnet/run_fluxnet.jl US-Ha1"
         artifact_paths: "experiments/integrated/fluxnet/US-Ha1/out/*png"
 
+      # The two generic_site steps below are soft_fail while the pipeline beds
+      # in: both need the HPC-only `fluxnet2015` artifact staged on the agent.
+      #
+      # Smoke test of FluxnetSimulations.generic_site_simulation on a non-bundled
+      # FLUXNET2015 site (BE-Vie, resolved via metadata — exercises the
+      # `LOCAL=false` path). No calibration: this is the canary that ensures we
+      # can keep running generic sites at all.
+      - label: "generic_site BE-Vie run"
+        command: "julia --color=yes --project=.buildkite experiments/integrated/generic_site/run_generic_site.jl BE-Vie"
+        soft_fail: true
+
+      # Exercises the all-sites driver (calibrate_all_fluxnet.jl) on AU-Cum and
+      # BE-Vie — both hemispheres, two julia subprocesses, shared site_results.csv
+      # append path. Uses the trimmed `er_smoke.jl` config so it fits in a CI
+      # step. Once green, the same driver is what calibrate_all_fluxnet.sbatch
+      # fans out across all sites on HPC.
+      - label: "generic_site_calibrate_er_all_fluxnet (smoke, 2 sites)"
+        command: "julia --color=yes --project=.buildkite experiments/integrated/generic_site/calibrate_all_fluxnet.jl"
+        soft_fail: true
+        env:
+          SITES: "AU-Cum,BE-Vie"
+          CALIBRATION_CONFIG: "er_smoke.jl"
+        artifact_paths:
+          - "experiments/integrated/generic_site/calibration_out/*_30d/**/*"
+          - "experiments/integrated/generic_site/calibration_out/site_results.csv"
+
       - label: "ozark_pft"
         command: "julia --color=yes --project=.buildkite experiments/integrated/fluxnet/ozark_pft.jl"
         artifact_paths: "experiments/integrated/fluxnet/US-MOz/pft/out/*png"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -171,6 +171,13 @@ git-tree-sha1 = "2fc70601badf6f83dee2b84ba9c386ad041de8e2"
     sha256 = "f05b4c01b57afe9c0f59095b39cea1c0cf46b20deecd5c7afb44f474d9cd9966"
     url = "https://caltech.box.com/shared/static/otrr2y0rgjct7hqhmq214nb8qjsvqj5p.gz"
 
+# fluxnet2015: full FLUXNET2015 dataset (200+ sites + metadata). HPC-only —
+# no download URL because the bundle is too large to ship. On machines where
+# the artifact is not available, ClimaLand.Artifacts.experiment_fluxnet_data_path
+# falls back to fluxnet_sites for the 4 US- sites bundled there.
+[fluxnet2015]
+git-tree-sha1 = "94d6eb8e3bc5fc361a43597ab4fb6941bdbe2850"
+
 [topmodel]
 git-tree-sha1 = "10855ff977cc948a92c7a83915895d27650649a1"
 

--- a/experiments/integrated/generic_site/README.md
+++ b/experiments/integrated/generic_site/README.md
@@ -1,0 +1,163 @@
+# Generic Single-Site Fluxnet Calibration
+
+Per-site calibration of ClimaLand parameters against daily means of fluxnet
+observations. Each site is an independent `TransformUnscented` calibration
+with a small ensemble; sites are embarrassingly parallel and run as one
+Slurm array task each on HPC.
+
+The driver builds an `EKP.ObservationSeries` with up to `max_n_samples`
+year-long sample windows per site. EKP draws `minibatch_size` windows per
+iteration; each window is preceded by a `spinup_days` spinup so deep soil
+state has time to settle before observations are scored. Sites with only one
+year of data degenerate cleanly (single window, repeated each iteration).
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `calibrate_site.jl` | One-site driver. Loads a config, builds an ObservationSeries, runs `ClimaCalibrate.calibrate` on `JuliaBackend`. Appends a row to `calibration_out/site_results.csv` when done. |
+| `site_drivers.jl` | Aggregates fluxnet forcing + spatial soil/LAI/IGBP data at the site for the per-site CSV. |
+| `calibrate_all_fluxnet.jl` | Loops over every fluxnet site (or a subset) sequentially in one Julia process. Used by CI. |
+| `calibrate_all_fluxnet.sbatch` | Slurm array wrapper — one array task per site. **Production path on central.** |
+| `calibrate_all_fluxnet.pbs` | PBSPro array wrapper, same idea, for Derecho. Set the array range at submit time with `qsub -J 0-<N-1>`. |
+| `list_fluxnet_sites.jl` | Prints every FLUXNET2015 site ID in the `fluxnet2015` artifact, one per line. Used to size the Slurm array. |
+| `configs/default.jl` | Production GPP + LHF config: 365-day window, 5 EKP iterations, no spinup, no minibatching. |
+| `configs/smoke_test.jl` | GPP + LHF, 90-day window, 2 iterations — buildkite CI smoke. |
+| `configs/er.jl` | Production Reco/DAMM config: 4 DAMM kinetic parameters, 365-day windows, 90-day spinup, up to 5 yearly samples per site, `minibatch_size=1`. |
+| `configs/er_smoke.jl` | Reco config trimmed for buildkite CI (1 sample, 30-day window, 15-day spinup, 1 iteration). |
+
+## Configs
+
+Configs live in `configs/` and define three names that `calibrate_site.jl`
+loads via `include`:
+
+- `CALIBRATE_CONFIG` — NamedTuple with `short_names`, `n_iterations`,
+  `cal_window_days`, `spinup_days`, `minibatch_size`, `max_n_samples`, and
+  `rng_seed`. To preserve today's "single window, no spinup, no minibatching"
+  behavior, set `spinup_days = 0`, `max_n_samples = 1`, `minibatch_size = 1`.
+- `NOISE_VARIANCES` — `Dict` mapping each entry of `short_names` to a per-bin
+  scalar variance used to build the diagonal noise covariance. Variances are
+  in the obs vector's units (see calibrate_site.jl `_obs_unit_factor` for the
+  per-variable conversion — e.g. `er` is in `g C m⁻² day⁻¹`).
+- `get_calibration_prior()` — returns an `EKP.combine_distributions(...)` prior.
+
+Select a config at run time with `CALIBRATION_CONFIG=<filename> julia ...`.
+Defaults to `default.jl`. To add a new experiment, copy an existing config,
+tweak, and point `CALIBRATION_CONFIG` at the new file — no other code change.
+
+`N_ITERS` env var overrides the config's value when set; useful for one-off
+probes without editing files.
+
+## Reco / DAMM calibration
+
+`configs/er.jl` calibrates four DAMM kinetic parameters
+(`soilCO2_reference_rate`, `soilCO2_activation_energy`,
+`michaelis_constant`, `O2_michaelis_constant`) against the fluxnet
+`RECO_NT_VUT_REF` column (g C m⁻² day⁻¹). The driver compares **daily-mean**
+fluxnet RECO to **daily-mean** model `er` diagnostics on each sample window.
+
+Per-site outputs land in
+`calibration_out/<SITE_ID>_<cal_window_days>d/`. In addition, every site
+appends a row to a single shared CSV at
+`calibration_out/site_results.csv` containing the calibrated DAMM means and
+SDs alongside per-site climate / soil drivers (mean TA / VPD / SW / TS,
+annual cumulative precip, MODIS max LAI, soil porosity, IGBP class). Use it
+to study what controls parameter variation across sites.
+
+## Run all fluxnet sites for Reco (Slurm, central HPC)
+
+The `fluxnet2015` artifact is HPC-only, so this only works on a machine where
+it has been pre-staged.
+
+```bash
+tmux new -s reco_cal
+module load climacommon/2026_02_18
+
+# 1. Generate the site list once on the login node:
+julia --project=.buildkite \
+    experiments/integrated/generic_site/list_fluxnet_sites.jl \
+    > experiments/integrated/generic_site/calibration_out/site_ids.txt
+
+# 2. Submit the array job with the Reco config:
+N=$(wc -l < experiments/integrated/generic_site/calibration_out/site_ids.txt)
+sbatch --array=0-$((N-1))%50 \
+    --export=ALL,CALIBRATION_CONFIG=er.jl \
+    experiments/integrated/generic_site/calibrate_all_fluxnet.sbatch
+```
+
+Each site runs in its own array task (serial Julia process per task — no MPI
+or GPU). The shared `site_results.csv` is written under a `mkpidlock` so
+concurrent appends are safe.
+
+## Run all fluxnet sites (Slurm, default GPP+LHF config)
+
+```bash
+module load climacommon/2026_02_18
+julia --project=.buildkite \
+    experiments/integrated/generic_site/list_fluxnet_sites.jl \
+    > experiments/integrated/generic_site/calibration_out/site_ids.txt
+N=$(wc -l < experiments/integrated/generic_site/calibration_out/site_ids.txt)
+sbatch --array=0-$((N-1))%50 \
+    experiments/integrated/generic_site/calibrate_all_fluxnet.sbatch
+```
+
+To pick a different config or override the iterations, use `--export`:
+
+```bash
+sbatch --array=0-$((N-1))%50 \
+    --export=ALL,CALIBRATION_CONFIG=er.jl,N_ITERS=10 \
+    experiments/integrated/generic_site/calibrate_all_fluxnet.sbatch
+```
+
+Per-site outputs land in
+`experiments/integrated/generic_site/calibration_out/<SITE_ID>_<window>d/`,
+slurm logs in `calibration_out/slurm_logs/`, the shared per-site row in
+`calibration_out/site_results.csv`.
+
+## Run all fluxnet sites (single Julia process)
+
+For smoke tests or a small subset, run sequentially on a login node /
+workstation. Slower but simpler — no scheduler involvement.
+
+```bash
+# All sites, default config:
+julia --project=.buildkite \
+    experiments/integrated/generic_site/calibrate_all_fluxnet.jl
+
+# A 2-site subset with the smoke-test config:
+SITES="AU-Cum,BE-Vie" CALIBRATION_CONFIG=smoke_test.jl \
+    julia --project=.buildkite \
+    experiments/integrated/generic_site/calibrate_all_fluxnet.jl
+```
+
+## Run a single site
+
+```bash
+SITE_ID=US-MOz \
+    julia --color=yes --project=.buildkite \
+    experiments/integrated/generic_site/calibrate_site.jl
+```
+
+The four bundled fluxnet sites (`US-MOz`, `US-Var`, `US-NR1`, `US-Ha1`) work
+with default `LOCAL=true`. For any other FLUXNET2015 site, set `LOCAL=false` so
+coordinates are auto-resolved from the FLUXNET2015 metadata table.
+
+## CI smoke tests (buildkite)
+
+Two steps in `.buildkite/pipeline.yml` exercise this pipeline on every
+buildkite run:
+
+- `generic_site BE-Vie run` — runs `run_generic_site.jl` at BE-Vie, a
+  non-bundled site resolved through the FLUXNET2015 metadata table. No
+  calibration; this is the canary that we can still build and solve a generic
+  site at all.
+- `generic_site_calibrate_er_all_fluxnet (smoke, 2 sites)` — exercises
+  `calibrate_all_fluxnet.jl` with `SITES="AU-Cum,BE-Vie"` and the trimmed
+  `er_smoke.jl` Reco config. This is the same driver
+  `calibrate_all_fluxnet.sbatch` invokes per array task, so a green step here
+  means the all-sites HPC submission is ready to fan out. The shared
+  `site_results.csv` is published as a buildkite artifact and contains one row
+  per site, which is the form most useful for cross-site analysis.
+
+Both steps are `soft_fail: true` while the pipeline beds in — they depend on
+the HPC-only `fluxnet2015` artifact being staged on the agent.

--- a/experiments/integrated/generic_site/calibrate_all_fluxnet.jl
+++ b/experiments/integrated/generic_site/calibrate_all_fluxnet.jl
@@ -1,0 +1,69 @@
+# Run the AU-Cum-style single-site calibration (calibrate_site.jl) for every
+# FLUXNET2015 site, sequentially, in this Julia process. Each site runs as its
+# own julia subprocess so const redefinitions and intermediate state cannot
+# leak between sites. A site that errors is logged and skipped — the loop does
+# not abort.
+#
+# This is the simple path: useful for smoke tests, small subsets, or running
+# overnight on a single workstation/login node. For the central HPC, prefer
+# `calibrate_all_fluxnet.sbatch` (Slurm job array) so sites run in parallel.
+#
+# Usage:
+#   julia --project=.buildkite experiments/integrated/generic_site/calibrate_all_fluxnet.jl
+#
+# Optional ENV vars (forwarded to each calibrate_site.jl subprocess):
+#   CALIBRATION_CONFIG  default "default.jl"
+#   CAL_DURATION_DAYS   override config window
+#   N_ITERS             override config iterations
+#   SITES               comma-separated subset, e.g. "AU-Cum,US-MOz" — if unset,
+#                       runs all sites returned by list_fluxnet_sites().
+
+include(joinpath(@__DIR__, "list_fluxnet_sites.jl"))
+
+const CALIBRATE_SCRIPT = joinpath(@__DIR__, "calibrate_site.jl")
+
+function _selected_sites()
+    raw = get(ENV, "SITES", "")
+    isempty(raw) && return list_fluxnet_sites()
+    return strip.(split(raw, ','))
+end
+
+function _run_site(site)
+    env = copy(ENV)
+    env["SITE_ID"] = site
+    env["LOCAL"] = "false"
+    cmd = `$(Base.julia_cmd()) --color=yes --project=$(dirname(Base.active_project())) $CALIBRATE_SCRIPT`
+    run(setenv(cmd, env))
+end
+
+function calibrate_all()
+    sites = _selected_sites()
+    @info "Calibrating $(length(sites)) sites" first = first(sites) last =
+        last(sites)
+
+    failures = Tuple{String, String}[]
+    for (i, site) in enumerate(sites)
+        @info "[$i/$(length(sites))] === $site ==="
+        try
+            _run_site(site)
+        catch err
+            msg = sprint(showerror, err)
+            @error "Site $site failed" exception = (err, catch_backtrace())
+            push!(failures, (site, first(split(msg, '\n'))))
+        end
+    end
+
+    @info "Done. successes=$(length(sites) - length(failures)) failures=$(length(failures))"
+    if !isempty(failures)
+        @info "Failures:"
+        for (site, msg) in failures
+            println("  $site\t$msg")
+        end
+    end
+    return failures
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    failures = calibrate_all()
+    isempty(failures) || exit(1)
+end

--- a/experiments/integrated/generic_site/calibrate_all_fluxnet.pbs
+++ b/experiments/integrated/generic_site/calibrate_all_fluxnet.pbs
@@ -1,0 +1,57 @@
+#!/bin/bash
+#PBS -N calib_fluxnet
+#PBS -A UCIT0011
+#PBS -q main
+#PBS -l walltime=02:00:00
+#PBS -l select=1:ncpus=2:mem=16GB
+#PBS -j oe
+#PBS -o experiments/integrated/generic_site/calibration_out/pbs_^array_index^.out
+# Set -J at submit time so it matches the actual site count, e.g.
+#   qsub -J 0-199 experiments/integrated/generic_site/calibrate_all_fluxnet.pbs
+# PBSPro caps concurrent array tasks via queue limits — tune via
+# `qsub -W max_running=50 ...` or your project's fair-share rules.
+#
+# One array task = one fluxnet site = one full TransformUnscented calibration
+# using ClimaCalibrate.JuliaBackend. Forward models run serially inside each
+# task — no MPI, no GPU.
+#
+# Usage on Derecho:
+#   module load climacommon/2025_02_25
+#   # Generate the site list once on the login node:
+#   julia --project=.buildkite experiments/integrated/generic_site/list_fluxnet_sites.jl experiments/integrated/generic_site/calibration_out/site_ids.txt
+#   N=$(wc -l < experiments/integrated/generic_site/calibration_out/site_ids.txt)
+#   qsub -J 0-$((N-1)) -v CALIBRATION_CONFIG=er.jl \
+#       experiments/integrated/generic_site/calibrate_all_fluxnet.pbs
+
+set -euo pipefail
+
+cd "$PBS_O_WORKDIR"
+
+SITE_LIST="experiments/integrated/generic_site/calibration_out/site_ids.txt"
+
+if [[ ! -s "$SITE_LIST" ]]; then
+    echo "Site list $SITE_LIST is missing or empty. Generate it first with:"
+    echo "  julia --project=.buildkite experiments/integrated/generic_site/list_fluxnet_sites.jl > $SITE_LIST"
+    exit 1
+fi
+
+# PBS arrays are 0-based; sed wants 1-based line numbers.
+LINE_NO=$((PBS_ARRAY_INDEX + 1))
+SITE_ID=$(sed -n "${LINE_NO}p" "$SITE_LIST")
+
+if [[ -z "$SITE_ID" ]]; then
+    echo "No site ID at line $LINE_NO of $SITE_LIST"
+    exit 1
+fi
+
+echo "Array task $PBS_ARRAY_INDEX -> site $SITE_ID"
+
+# HDF5 file locking is incompatible with Lustre/GPFS on Derecho.
+export HDF5_USE_FILE_LOCKING=FALSE
+
+export SITE_ID
+export N_ITERS="${N_ITERS:-5}"
+export LOCAL="false"
+
+julia --color=yes --project=.buildkite \
+    experiments/integrated/generic_site/calibrate_site.jl

--- a/experiments/integrated/generic_site/calibrate_all_fluxnet.sbatch
+++ b/experiments/integrated/generic_site/calibrate_all_fluxnet.sbatch
@@ -1,0 +1,61 @@
+#!/bin/bash
+#SBATCH --job-name=calib_fluxnet
+#SBATCH --output=experiments/integrated/generic_site/calibration_out/slurm_logs/%x_%A_%a.out
+#SBATCH --error=experiments/integrated/generic_site/calibration_out/slurm_logs/%x_%A_%a.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=16G
+# Set --array at submit time so it matches the actual site count, e.g.
+#   sbatch --array=0-199%50 experiments/integrated/generic_site/calibrate_all_fluxnet.sbatch
+# `%50` caps concurrent tasks at 50; tune to your fair-share.
+#
+# One array task = one fluxnet site = one full TransformUnscented calibration
+# (5 ensemble members × N_ITERS iterations) using ClimaCalibrate.JuliaBackend.
+# Forward models run serially inside each task — no MPI, no GPU. Single-column
+# simulations are too small to benefit from a GPU.
+#
+# Usage:
+#   module load climacommon/2024_10_09          # central HPC
+#   # Generate the site list once on the login node:
+#   julia --project=.buildkite experiments/integrated/generic_site/list_fluxnet_sites.jl experiments/integrated/generic_site/calibration_out/site_ids.txt
+#   N=$(wc -l < experiments/integrated/generic_site/calibration_out/site_ids.txt)
+#   sbatch --array=0-$((N-1))%50 experiments/integrated/generic_site/calibrate_all_fluxnet.sbatch
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+SITE_LIST="experiments/integrated/generic_site/calibration_out/site_ids.txt"
+mkdir -p experiments/integrated/generic_site/calibration_out/slurm_logs
+
+if [[ ! -s "$SITE_LIST" ]]; then
+    echo "Site list $SITE_LIST is missing or empty. Generate it first with:"
+    echo "  julia --project=.buildkite experiments/integrated/generic_site/list_fluxnet_sites.jl > $SITE_LIST"
+    exit 1
+fi
+
+# Slurm uses 1-based line numbers; arrays are 0-based, so add 1.
+LINE_NO=$((SLURM_ARRAY_TASK_ID + 1))
+SITE_ID=$(sed -n "${LINE_NO}p" "$SITE_LIST")
+
+if [[ -z "$SITE_ID" ]]; then
+    echo "No site ID at line $LINE_NO of $SITE_LIST"
+    exit 1
+fi
+
+echo "Array task $SLURM_ARRAY_TASK_ID -> site $SITE_ID"
+
+# HDF5 file locking is incompatible with Lustre; matches run_calibration.sh.
+export HDF5_USE_FILE_LOCKING=FALSE
+
+# Match the AU-Cum buildkite settings; override per-submission with --export.
+# Window length comes from the CALIBRATION_CONFIG file (er.jl: 365 days);
+# only N_ITERS is honored as an env override in calibrate_site.jl.
+export SITE_ID
+export N_ITERS="${N_ITERS:-5}"
+export LOCAL="false"
+
+julia --color=yes --project=.buildkite \
+    experiments/integrated/generic_site/calibrate_site.jl

--- a/experiments/integrated/generic_site/calibrate_site.jl
+++ b/experiments/integrated/generic_site/calibrate_site.jl
@@ -1,0 +1,537 @@
+# Single-site calibration of ClimaLand parameters at a fluxnet site.
+#
+# Builds an `EKP.ObservationSeries` from up to `max_n_samples` 1-year windows
+# of fluxnet data. Each EKP iteration draws `minibatch_size` samples; the
+# forward model runs the corresponding window(s) preceded by a `spinup_days`
+# spinup. Daily-mean diagnostics are compared to daily-mean observations, with
+# per-variable noise variances given by the config.
+#
+# Usage:
+#   SITE_ID=US-MOz julia --project=.buildkite \
+#       experiments/integrated/generic_site/calibrate_site.jl
+#
+# Optional ENV vars:
+#   SITE_ID            (default "US-MOz")
+#   CALIBRATION_CONFIG (default "default.jl")
+#   N_ITERS            override CALIBRATE_CONFIG.n_iterations
+#   LOCAL              (default "true")  — use the per-site Val{} dispatchers
+#                                          (the four bundled sites). Anything
+#                                          else auto-resolves coordinates from
+#                                          FLUXNET2015 metadata.
+
+import ClimaComms
+ClimaComms.@import_required_backends
+using Dates
+using Random
+using Statistics
+using LinearAlgebra
+import JLD2
+import ClimaCalibrate
+import EnsembleKalmanProcesses as EKP
+import ClimaLand
+import ClimaLand.Parameters as LP
+import ClimaLand.FluxnetSimulations as FluxnetSimulations
+using ClimaLand.Simulations: solve!
+import ClimaCore
+import FileWatching.Pidfile
+
+# ── Configuration ────────────────────────────────────────────────────────────
+
+const CONFIG_FILE = get(ENV, "CALIBRATION_CONFIG", "default.jl")
+include(joinpath(@__DIR__, "configs", CONFIG_FILE))
+include(joinpath(@__DIR__, "site_drivers.jl"))
+
+const SITE_ID = get(ENV, "SITE_ID", "US-MOz")
+const N_ITERATIONS =
+    parse(Int, get(ENV, "N_ITERS", string(CALIBRATE_CONFIG.n_iterations)))
+const LOCAL_MODE = get(ENV, "LOCAL", "true") == "true"
+const FT = Float64
+const SHORT_NAMES = CALIBRATE_CONFIG.short_names
+const SPINUP_DAYS = CALIBRATE_CONFIG.spinup_days
+const CAL_WINDOW_DAYS = CALIBRATE_CONFIG.cal_window_days
+const MAX_N_SAMPLES = CALIBRATE_CONFIG.max_n_samples
+const MINIBATCH_SIZE = CALIBRATE_CONFIG.minibatch_size
+
+const OUTPUT_DIR = joinpath(
+    pkgdir(ClimaLand),
+    "experiments",
+    "integrated",
+    "generic_site",
+    "calibration_out",
+    "$(SITE_ID)_$(CAL_WINDOW_DAYS)d",
+)
+mkpath(OUTPUT_DIR)
+
+const SAMPLES_PATH = joinpath(OUTPUT_DIR, "samples.jld2")
+
+# In-process handoff for sample-window state. `generate_observation_series` and
+# the resume-from-disk path populate this; `forward_model` and the driver read
+# from it instead of round-tripping through `samples.jld2`. Reading the file we
+# just wrote was racy on Lustre (occasional InvalidDataException: Did not find
+# a Superblock) — the on-disk artifact is still written for inspection.
+const SAMPLE_STATE = Ref{NamedTuple}()
+
+const SITE_RESULTS_CSV = joinpath(
+    pkgdir(ClimaLand),
+    "experiments",
+    "integrated",
+    "generic_site",
+    "calibration_out",
+    "site_results.csv",
+)
+
+# ── Unit conversions ─────────────────────────────────────────────────────────
+# Both observation values (after the per-variable preprocess in
+# `get_comparison_data`) and model diagnostic values are converted to a common
+# "obs vector" unit before being matched. Noise variances in the config are
+# expressed in those units squared.
+
+# `er` model diag is mol CO2 m⁻² s⁻¹; obs after preprocess is mol CO2 m⁻² s⁻¹.
+# Both convert to g C m⁻² day⁻¹ via × 12.011 × 86400.
+const _GC_PER_MOLCO2_PER_DAY_PER_S = 12.011 * 86400.0
+
+function _obs_unit_factor(short_name)
+    short_name == "er" && return _GC_PER_MOLCO2_PER_DAY_PER_S
+    return 1.0
+end
+
+function _model_unit_factor(short_name)
+    short_name == "er" && return _GC_PER_MOLCO2_PER_DAY_PER_S
+    return 1.0
+end
+
+# ── Coordinate resolution ────────────────────────────────────────────────────
+
+function _resolve_coords(site_ID)
+    if LOCAL_MODE
+        site_val = FluxnetSimulations.replace_hyphen(site_ID)
+        (; time_offset, lat, long) =
+            FluxnetSimulations.get_location(FT, Val(site_val))
+        (; atmos_h) = FluxnetSimulations.get_fluxtower_height(FT, Val(site_val))
+        return (; lat, long, time_offset, atmos_h)
+    else
+        info = FluxnetSimulations.get_site_info(site_ID)
+        return (;
+            lat = FT(info.lat),
+            long = FT(info.long),
+            time_offset = Int(info.time_offset),
+            atmos_h = isempty(info.atmospheric_sensor_height) ?
+                      error("Missing atmospheric_sensor_height for $site_ID") :
+                      FT(first(info.atmospheric_sensor_height)),
+        )
+    end
+end
+
+# ── Sample windows ───────────────────────────────────────────────────────────
+
+"""
+    _sample_windows(time_offset)
+
+Enumerate up to `MAX_N_SAMPLES` non-overlapping `CAL_WINDOW_DAYS`-long sample
+windows starting at `data_start + spinup` (so the first window's spinup fits
+inside the available data). Each entry is `(window_start, window_stop)` in
+UTC. Also returns `data_start` so the forward model can compute
+`start_offset` against the actual fluxnet record start.
+"""
+function _sample_windows(time_offset)
+    (data_start, data_stop) = FluxnetSimulations.get_data_dates(
+        SITE_ID,
+        time_offset;
+        required_columns = FluxnetSimulations.FLUXNET_FORCING_COLUMNS,
+    )
+    spinup = Day(SPINUP_DAYS)
+    win = Day(CAL_WINDOW_DAYS)
+    cursor = data_start + spinup
+    samples = NTuple{2, DateTime}[]
+    # Allow a 1-day slack on the upper bound — fluxnet records typically end
+    # 30 min before the final calendar boundary (last `TIMESTAMP_END` is the
+    # start of the last half-hour), so a strict `<=` would reject an exactly
+    # 365-day record paired with a 365-day window.
+    while cursor + win - Day(1) <= data_stop && length(samples) < MAX_N_SAMPLES
+        push!(samples, (cursor, cursor + win))
+        cursor += win
+    end
+    isempty(samples) && error(
+        "$SITE_ID has no data window long enough for spinup=$(SPINUP_DAYS)d + window=$(CAL_WINDOW_DAYS)d.",
+    )
+    return samples, data_start
+end
+
+# ── Daily-mean aggregation ───────────────────────────────────────────────────
+
+"""
+    daily_means_in_window(comparison_data, varname, window_start, window_stop)
+
+Compute means of `varname` from `comparison_data` over consecutive 24-hour
+bins aligned with the simulation's `:daily` diagnostic schedule. Bin `k` covers
+`[window_start + Day(k-1), window_start + Day(k))`, so `bin_ends[k] ==
+window_start + Day(k)`. Returns `(values, bin_ends)`. Bins with no valid
+observations are filled with NaN — the caller should reject the window.
+"""
+function daily_means_in_window(
+    comparison_data,
+    varname::Symbol,
+    window_start::DateTime,
+    window_stop::DateTime,
+)
+    times = comparison_data.UTC_datetime
+    values = getproperty(comparison_data, varname)
+    valid = .!ismissing.(values)
+    times = times[valid]
+    values = Float64.(values[valid])
+
+    bin_ends = DateTime[]
+    k = 1
+    while window_start + Day(k) <= window_stop
+        push!(bin_ends, window_start + Day(k))
+        k += 1
+    end
+
+    daily = Float64[]
+    for (i, bin_end) in enumerate(bin_ends)
+        bin_start = i == 1 ? window_start : bin_ends[i - 1]
+        mask = (bin_start .<= times) .& (times .< bin_end)
+        if !any(mask)
+            push!(daily, NaN)
+        else
+            push!(daily, mean(values[mask]))
+        end
+    end
+    return daily, bin_ends
+end
+
+# ── Per-window observation builder ───────────────────────────────────────────
+
+function _build_window_observation(comparison, window_start, window_stop, name)
+    per_var = Dict{String, Vector{Float64}}()
+    bins = DateTime[]
+    for var in SHORT_NAMES
+        haskey(NOISE_VARIANCES, var) ||
+            error("NOISE_VARIANCES missing entry for short_name '$var'.")
+        vals, bin_ends = daily_means_in_window(
+            comparison,
+            Symbol(var),
+            window_start,
+            window_stop,
+        )
+        if any(isnan, vals)
+            n_missing = count(isnan, vals)
+            error(
+                "Missing $(n_missing) daily bins of '$var' at $SITE_ID in $window_start..$window_stop.",
+            )
+        end
+        per_var[var] = vals .* _obs_unit_factor(var)
+        isempty(bins) && (bins = bin_ends)
+    end
+
+    y_obs = reduce(vcat, per_var[v] for v in SHORT_NAMES)
+    n_bins = length(first(values(per_var)))
+    noise_diag =
+        reduce(vcat, fill(NOISE_VARIANCES[v], n_bins) for v in SHORT_NAMES)
+    return EKP.Observation(
+        Dict(
+            "samples" => y_obs,
+            "covariances" => Diagonal(noise_diag),
+            "names" => name,
+        ),
+    )
+end
+
+"""
+    generate_observation_series()
+
+Build an `EKP.ObservationSeries` with one `EKP.Observation` per yearly sample
+window. Persists `samples` (the list of `(window_start, window_stop)` tuples)
+to `SAMPLES_PATH` so the forward model can dispatch by minibatch index.
+"""
+function generate_observation_series()
+    coords = _resolve_coords(SITE_ID)
+    (samples, data_start) = _sample_windows(coords.time_offset)
+
+    comparison =
+        FluxnetSimulations.get_comparison_data(SITE_ID, coords.time_offset)
+
+    obs_vec = EKP.Observation[]
+    for (i, (ws, we)) in enumerate(samples)
+        push!(
+            obs_vec,
+            _build_window_observation(
+                comparison,
+                ws,
+                we,
+                "$(SITE_ID)_y$(i)_$(SHORT_NAMES |> x -> join(x, "_"))",
+            ),
+        )
+    end
+
+    minibatcher =
+        ClimaCalibrate.minibatcher_over_samples(length(obs_vec), MINIBATCH_SIZE)
+    obs_series = EKP.ObservationSeries(
+        Dict(
+            "observations" => obs_vec,
+            "minibatcher" => minibatcher,
+            "names" => ["$(SITE_ID)_y$i" for i in 1:length(obs_vec)],
+        ),
+    )
+
+    JLD2.jldsave(
+        SAMPLES_PATH;
+        samples,
+        data_start,
+        time_offset = coords.time_offset,
+        spinup_days = SPINUP_DAYS,
+        cal_window_days = CAL_WINDOW_DAYS,
+        short_names = SHORT_NAMES,
+        site_ID = SITE_ID,
+    )
+    SAMPLE_STATE[] = (; samples, data_start, time_offset = coords.time_offset)
+    @info "Built observation series" SITE_ID n_samples = length(obs_vec) MINIBATCH_SIZE
+    return obs_series
+end
+
+# ── Forward model ────────────────────────────────────────────────────────────
+
+"""
+    _extract_daily_scalar(diags_dict, short_name)
+
+Pull a vector from a DictWriter produced by daily-average diagnostics on a
+single-column simulation. The DictWriter stores keys like `"er_1D_average"`
+for `short_name="er"`; this finds the matching key and returns the
+time-sorted vector of scalar values.
+"""
+function _extract_daily_scalar(diags_dict, short_name::AbstractString)
+    matching =
+        [k for k in keys(diags_dict) if startswith(String(k), short_name * "_")]
+    isempty(matching) && error(
+        "No diagnostic key starting with '$short_name\\_' in DictWriter; available: $(collect(keys(diags_dict)))",
+    )
+    length(matching) > 1 &&
+        @warn "Multiple keys match '$short_name'; using $(matching[1])"
+    inner = diags_dict[matching[1]]
+    times = sort(collect(keys(inner)))
+    return [Float64(parent(inner[t])[1]) for t in times]
+end
+
+function _run_window(window_idx, samples, data_start, time_offset, toml_dict)
+    (window_start, _) = samples[window_idx]
+    spinup = Day(SPINUP_DAYS)
+    duration = Day(SPINUP_DAYS + CAL_WINDOW_DAYS)
+    sim_start = window_start - spinup
+    start_offset = sim_start - data_start
+    @assert start_offset >= Dates.Second(0) "Computed start_offset is negative for window $window_idx."
+
+    coords = _resolve_coords(SITE_ID)
+    result = FluxnetSimulations.generic_site_simulation(
+        SITE_ID;
+        coords...,
+        toml_dict,
+        duration,
+        start_offset,
+        diagnostic_period = :daily,
+        output_vars = SHORT_NAMES,
+    )
+    solve!(result.simulation)
+
+    writer = first(result.diags).output_writer
+    g_window = Float64[]
+    for var in SHORT_NAMES
+        full = _extract_daily_scalar(writer.dict, var)
+        # Drop the spinup prefix; the post-spinup tail must have CAL_WINDOW_DAYS bins.
+        post = full[(SPINUP_DAYS + 1):end]
+        length(post) == CAL_WINDOW_DAYS || error(
+            "Window $window_idx '$var': expected $CAL_WINDOW_DAYS daily bins after spinup, got $(length(post)) (full length $(length(full))).",
+        )
+        append!(g_window, post .* _model_unit_factor(var))
+    end
+    return g_window
+end
+
+function ClimaCalibrate.forward_model(iteration, member)
+    member_path =
+        ClimaCalibrate.path_to_ensemble_member(OUTPUT_DIR, iteration, member)
+    mkpath(member_path)
+
+    params_path = ClimaCalibrate.parameter_path(OUTPUT_DIR, iteration, member)
+    toml_dict = LP.create_toml_dict(FT, override_files = [params_path])
+
+    ekp = JLD2.load_object(ClimaCalibrate.ekp_path(OUTPUT_DIR, iteration))
+    minibatch = EKP.get_current_minibatch(ekp)
+
+    state = SAMPLE_STATE[]
+    samples = state.samples
+    data_start = state.data_start
+    time_offset = state.time_offset
+
+    @info "[iter=$iteration mem=$member] running minibatch=$minibatch ($(length(minibatch)) windows)"
+
+    g_member = Float64[]
+    for window_idx in minibatch
+        g_window =
+            _run_window(window_idx, samples, data_start, time_offset, toml_dict)
+        append!(g_member, g_window)
+    end
+
+    JLD2.jldsave(joinpath(member_path, "g.jld2"); g = g_member)
+    return nothing
+end
+
+# ── Observation map ──────────────────────────────────────────────────────────
+
+function ClimaCalibrate.observation_map(iteration)
+    ekp = JLD2.load_object(ClimaCalibrate.ekp_path(OUTPUT_DIR, iteration))
+    n_ens = EKP.get_N_ens(ekp)
+
+    first_g_path = joinpath(
+        ClimaCalibrate.path_to_ensemble_member(OUTPUT_DIR, iteration, 1),
+        "g.jld2",
+    )
+    isfile(first_g_path) ||
+        error("No g.jld2 found for iteration $iteration; forward_model failed.")
+    g_dim = length(JLD2.load_object(first_g_path))
+
+    G = fill(NaN, g_dim, n_ens)
+    for m in 1:n_ens
+        g_path = joinpath(
+            ClimaCalibrate.path_to_ensemble_member(OUTPUT_DIR, iteration, m),
+            "g.jld2",
+        )
+        if !isfile(g_path)
+            @warn "Missing g.jld2 for iteration $iteration, member $m"
+            continue
+        end
+        G[:, m] = JLD2.load_object(g_path)
+    end
+    return G
+end
+
+# ── Per-site results CSV ─────────────────────────────────────────────────────
+
+function append_site_csv(eki, prior, samples)
+    coords = _resolve_coords(SITE_ID)
+    drivers = compute_site_drivers(SITE_ID, coords, samples)
+    final_mean = EKP.get_ϕ_mean_final(prior, eki)
+    pnames = EKP.get_name(prior)
+    # Per-parameter SD across the final ensemble in constrained (ϕ) space.
+    # EKP doesn't expose a `get_ϕ_cov_final`, so we estimate the spread from
+    # the final ensemble points directly. For TransformUnscented these are
+    # the unscented sigma points; std across them is a usable posterior SD.
+    final_ens = EKP.get_ϕ_final(prior, eki)
+    final_sds = vec(std(final_ens; dims = 2))
+    final_cost = try
+        errs = EKP.get_error(eki)
+        isempty(errs) ? NaN : last(errs)
+    catch
+        NaN
+    end
+
+    mkpath(dirname(SITE_RESULTS_CSV))
+
+    Pidfile.mkpidlock(SITE_RESULTS_CSV * ".lock"; stale_age = 30) do
+        write_header = !isfile(SITE_RESULTS_CSV)
+        open(SITE_RESULTS_CSV, "a") do io
+            if write_header
+                cols = String[
+                    "site_id",
+                    "n_samples",
+                    "n_iterations",
+                    "minibatch_size",
+                    "spinup_days",
+                    "cal_window_days",
+                ]
+                append!(cols, pnames)
+                append!(cols, [n * "_sd" for n in pnames])
+                append!(
+                    cols,
+                    [
+                        "mean_TA_K",
+                        "mean_VPD_Pa",
+                        "annual_cum_P_mm",
+                        "mean_SW_in_W_m2",
+                        "mean_TS_top_K",
+                        "max_LAI",
+                        "soil_porosity",
+                        "soil_SOC_top_kgC_m3",
+                        "IGBP",
+                        "lat",
+                        "long",
+                        "final_eki_cost",
+                    ],
+                )
+                println(io, join(cols, ","))
+            end
+
+            row = Any[
+                SITE_ID,
+                length(samples),
+                N_ITERATIONS,
+                MINIBATCH_SIZE,
+                SPINUP_DAYS,
+                CAL_WINDOW_DAYS,
+            ]
+            append!(row, final_mean)
+            append!(row, final_sds)
+            push!(row, drivers.mean_TA)
+            push!(row, drivers.mean_VPD)
+            push!(row, drivers.annual_cum_P)
+            push!(row, drivers.mean_SW)
+            push!(row, drivers.mean_TS_top)
+            push!(row, drivers.max_LAI)
+            push!(row, drivers.porosity)
+            push!(row, drivers.SOC_top)
+            push!(row, drivers.IGBP)
+            push!(row, Float64(coords.lat))
+            push!(row, Float64(coords.long))
+            push!(row, final_cost)
+
+            println(io, join(row, ","))
+        end
+    end
+    @info "Appended site row to $SITE_RESULTS_CSV" SITE_ID
+    return nothing
+end
+
+# ── Driver ───────────────────────────────────────────────────────────────────
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    obs_path = joinpath(OUTPUT_DIR, "observation_series.jld2")
+    obs_series = if isfile(obs_path) && isfile(SAMPLES_PATH)
+        st = JLD2.load(SAMPLES_PATH)
+        SAMPLE_STATE[] = (;
+            samples = st["samples"],
+            data_start = st["data_start"],
+            time_offset = st["time_offset"],
+        )
+        JLD2.jldopen(obs_path, "r") do f
+            f["observation_series"]
+        end
+    else
+        os = generate_observation_series()
+        JLD2.jldsave(obs_path; observation_series = os)
+        os
+    end
+
+    prior = get_calibration_prior()
+    samples = SAMPLE_STATE[].samples
+
+    rng = Random.MersenneTwister(CALIBRATE_CONFIG.rng_seed)
+    ekp = EKP.EnsembleKalmanProcess(
+        obs_series,
+        EKP.TransformUnscented(prior; impose_prior = true);
+        verbose = true,
+        rng,
+    )
+
+    @info "Starting calibration" SITE_ID CAL_WINDOW_DAYS SPINUP_DAYS N_ITERATIONS n_samples =
+        length(samples) MINIBATCH_SIZE OUTPUT_DIR
+
+    eki = ClimaCalibrate.calibrate(
+        ClimaCalibrate.JuliaBackend(),
+        ekp,
+        N_ITERATIONS,
+        prior,
+        OUTPUT_DIR,
+    )
+
+    @info "Calibration complete." final_mean = EKP.get_ϕ_mean_final(prior, eki)
+    append_site_csv(eki, prior, samples)
+end

--- a/experiments/integrated/generic_site/configs/default.jl
+++ b/experiments/integrated/generic_site/configs/default.jl
@@ -1,0 +1,49 @@
+# Default calibration configuration for single-site fluxnet calibration.
+#
+# Loaded by experiments/integrated/generic_site/calibrate_site.jl, which
+# expects the following names to be defined:
+#
+#   - get_calibration_prior() -> EKP combined distribution
+#   - CALIBRATE_CONFIG        -> NamedTuple with keys
+#         short_names         :: Vector{String}   variables in the obs vector
+#         n_iterations        :: Int              EKP iterations
+#         cal_window_days     :: Int              length of one sample window
+#         spinup_days         :: Int              spinup before each window
+#         minibatch_size      :: Int              samples drawn per iteration
+#         max_n_samples       :: Int              cap on per-site sample count
+#         rng_seed            :: Int
+#   - NOISE_VARIANCES         -> Dict mapping each short_name to a per-bin
+#                                 scalar variance used to build the diagonal
+#                                 noise covariance.
+#
+# To create a new config, copy this file (e.g. configs/my_experiment.jl) and
+# adjust the settings below. Select it at run time with the env var
+# CALIBRATION_CONFIG, e.g. CALIBRATION_CONFIG=my_experiment.jl julia ...
+
+const CALIBRATE_CONFIG = (;
+    short_names = ["gpp", "lhf"],
+    n_iterations = 5,
+    cal_window_days = 365,
+    spinup_days = 0,
+    minibatch_size = 1,
+    max_n_samples = 1,
+    rng_seed = 42,
+)
+
+# Per-variable scalar variance applied to every diagnostic bin. GPP scale
+# ~3 µmol m⁻² s⁻¹ = 3e-6 mol m⁻² s⁻¹; LHF scale ~30 W m⁻².
+const NOISE_VARIANCES = Dict("gpp" => (3e-6)^2, "lhf" => (30.0)^2)
+
+"""
+    get_calibration_prior()
+
+Two PModel-related parameters, mirroring a subset of
+`experiments/calibration/configs/gpp_lhf.jl`. Easy to expand as the calibration
+pipeline matures.
+"""
+function get_calibration_prior()
+    return EKP.combine_distributions([
+        EKP.constrained_gaussian("pmodel_cstar", 0.41, 0.05, 0.2, 0.7),
+        EKP.constrained_gaussian("moisture_stress_c", 0.27, 0.15, 0.05, 1.0),
+    ])
+end

--- a/experiments/integrated/generic_site/configs/er.jl
+++ b/experiments/integrated/generic_site/configs/er.jl
@@ -1,0 +1,69 @@
+# Calibration of soil heterotrophic respiration (DAMM kinetics) at a single
+# fluxnet site. Targets ecosystem respiration (`er`) compared against the
+# fluxnet `RECO_NT_VUT_REF` column.
+#
+# Loaded by experiments/integrated/generic_site/calibrate_site.jl. Defines:
+#   CALIBRATE_CONFIG, NOISE_VARIANCES, get_calibration_prior()
+#
+# Loss aggregation: daily means over each yearly sample window. Each sample
+# is a 365-day window preceded by a 90-day spinup. Up to `max_n_samples`
+# windows per site (sites with ≥5 years are capped; sites with fewer fall
+# back to whatever they have). Minibatching draws `minibatch_size` samples
+# per EKP iteration; with `minibatch_size = 1`, each iteration runs one year.
+
+const CALIBRATE_CONFIG = (;
+    short_names = ["er"],
+    n_iterations = 5,
+    cal_window_days = 365,
+    spinup_days = 90,
+    minibatch_size = 1,
+    max_n_samples = 5,
+    rng_seed = 42,
+)
+
+# (g C m^-2 day^-1)^2 per daily bin. σ ≈ 2 g C m^-2 day^-1 — fluxnet RECO
+# typical range ~0–10 g C m^-2 day^-1, so this is ~20% relative.
+const NOISE_VARIANCES = Dict("er" => 4.0)
+
+"""
+    get_calibration_prior()
+
+Four DAMM kinetic parameters mirroring the DAMM block of
+`experiments/calibration/configs/gpp_er_nee_lhf.jl`, with
+`O2_michaelis_constant` widened so μ−σ stays well above zero (the reference
+prior leaves μ−σ ≈ 5e-4, near the lower bound, which makes EKI lean against
+the bound and converge poorly on single-site data).
+"""
+function get_calibration_prior()
+    return EKP.combine_distributions([
+        EKP.constrained_gaussian(
+            "soilCO2_reference_rate",
+            2.17564e-7,
+            2.0e-7,
+            1.0e-9,
+            2.0e-6,
+        ),
+        EKP.constrained_gaussian(
+            "soilCO2_activation_energy",
+            37357.0,
+            25000.0,
+            5000.0,
+            150000.0,
+        ),
+        EKP.constrained_gaussian(
+            "michaelis_constant",
+            0.459997,
+            0.25,
+            0.001,
+            2.0,
+        ),
+        # Widened relative to gpp_er_nee_lhf.jl (μ 0.00255 → 0.05, σ 0.002 → 0.02).
+        EKP.constrained_gaussian(
+            "O2_michaelis_constant",
+            0.05,
+            0.02,
+            0.005,
+            0.2,
+        ),
+    ])
+end

--- a/experiments/integrated/generic_site/configs/er_smoke.jl
+++ b/experiments/integrated/generic_site/configs/er_smoke.jl
@@ -1,0 +1,47 @@
+# CI smoke variant of `er.jl`: shorter window and fewer iterations so the
+# full ensemble run finishes inside a buildkite step.
+
+const CALIBRATE_CONFIG = (;
+    short_names = ["er"],
+    n_iterations = 1,
+    cal_window_days = 30,
+    spinup_days = 15,
+    minibatch_size = 1,
+    max_n_samples = 1,
+    rng_seed = 42,
+)
+
+const NOISE_VARIANCES = Dict("er" => 4.0)
+
+function get_calibration_prior()
+    return EKP.combine_distributions([
+        EKP.constrained_gaussian(
+            "soilCO2_reference_rate",
+            2.17564e-7,
+            2.0e-7,
+            1.0e-9,
+            2.0e-6,
+        ),
+        EKP.constrained_gaussian(
+            "soilCO2_activation_energy",
+            37357.0,
+            25000.0,
+            5000.0,
+            150000.0,
+        ),
+        EKP.constrained_gaussian(
+            "michaelis_constant",
+            0.459997,
+            0.25,
+            0.001,
+            2.0,
+        ),
+        EKP.constrained_gaussian(
+            "O2_michaelis_constant",
+            0.05,
+            0.02,
+            0.005,
+            0.2,
+        ),
+    ])
+end

--- a/experiments/integrated/generic_site/configs/smoke_test.jl
+++ b/experiments/integrated/generic_site/configs/smoke_test.jl
@@ -1,0 +1,23 @@
+# Short-window calibration config for CI smoke tests.
+#
+# Same prior and short_names as configs/default.jl but with a 90-day window
+# and 2 iterations so a full ensemble run finishes inside a CI step.
+
+const CALIBRATE_CONFIG = (;
+    short_names = ["gpp", "lhf"],
+    n_iterations = 2,
+    cal_window_days = 90,
+    spinup_days = 0,
+    minibatch_size = 1,
+    max_n_samples = 1,
+    rng_seed = 42,
+)
+
+const NOISE_VARIANCES = Dict("gpp" => (3e-6)^2, "lhf" => (30.0)^2)
+
+function get_calibration_prior()
+    return EKP.combine_distributions([
+        EKP.constrained_gaussian("pmodel_cstar", 0.41, 0.05, 0.2, 0.7),
+        EKP.constrained_gaussian("moisture_stress_c", 0.27, 0.15, 0.05, 1.0),
+    ])
+end

--- a/experiments/integrated/generic_site/list_fluxnet_sites.jl
+++ b/experiments/integrated/generic_site/list_fluxnet_sites.jl
@@ -1,0 +1,55 @@
+# Print (or write) every FLUXNET2015 site ID known to the `fluxnet2015`
+# artifact, one per line, sorted. Sized for use as a Slurm/PBS array index
+# source (see `calibrate_all_fluxnet.sbatch`, `calibrate_all_fluxnet.pbs`).
+#
+# The `fluxnet2015` artifact is HPC-only (no download URL), so this only works
+# on a machine where it has been pre-staged (central HPC, Derecho).
+#
+# Usage:
+#   # Print to stdout:
+#   julia --project=.buildkite experiments/integrated/generic_site/list_fluxnet_sites.jl
+#   # Write to a file (avoids shell redirection — useful when copy-pasting):
+#   julia --project=.buildkite experiments/integrated/generic_site/list_fluxnet_sites.jl path/to/site_ids.txt
+#
+# Or programmatically:
+#   include("list_fluxnet_sites.jl"); ids = list_fluxnet_sites()
+
+import ClimaLand
+
+"""
+    list_fluxnet_sites() -> Vector{String}
+
+Return the sorted list of FLUXNET2015 site IDs found in the `fluxnet2015`
+artifact, parsed from the per-site directory names of the form
+`FLX_<SITE_ID>_FLUXNET2015_FULLSET_<years>_<version>`.
+"""
+function list_fluxnet_sites()
+    root = ClimaLand.Artifacts.fluxnet2015_data_path()
+    site_ids = String[]
+    for d in readdir(root)
+        isdir(joinpath(root, d)) || continue
+        startswith(d, "FLX_") || continue
+        parts = split(d, '_')
+        length(parts) >= 2 || continue
+        push!(site_ids, parts[2])
+    end
+    return sort!(unique(site_ids))
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    sites = list_fluxnet_sites()
+    if length(ARGS) >= 1
+        out = ARGS[1]
+        mkpath(dirname(abspath(out)))
+        open(out, "w") do io
+            for s in sites
+                println(io, s)
+            end
+        end
+        @info "Wrote $(length(sites)) site IDs to $out"
+    else
+        for s in sites
+            println(s)
+        end
+    end
+end

--- a/experiments/integrated/generic_site/run_generic_site.jl
+++ b/experiments/integrated/generic_site/run_generic_site.jl
@@ -1,0 +1,94 @@
+# Run a single-site ClimaLand simulation using FluxnetSimulations.generic_site_simulation.
+#
+# Usage:
+#   julia --project=experiments experiments/integrated/generic_site/run_generic_site.jl US-MOz
+#   julia --project=experiments experiments/integrated/generic_site/run_generic_site.jl US-MOz --local
+#   SIM_DURATION_DAYS=14 julia --project=experiments .../run_generic_site.jl DE-Tha
+#
+# Without `--local`, coordinates are auto-resolved from the FLUXNET2015 metadata
+# CSV (requires the `fluxnet2015` artifact, HPC-only). With `--local`, we pull
+# coordinates from the per-site Val{} dispatchers — works for the four bundled
+# sites (US-MOz, US-NR1, US-Ha1, US-Var) without the FLUXNET2015 artifact.
+
+import ClimaComms
+ClimaComms.@import_required_backends
+using Dates
+using Printf
+using Statistics
+using ClimaDiagnostics
+using ClimaUtilities
+using ClimaLand
+import ClimaLand.Parameters as LP
+import ClimaLand.FluxnetSimulations as FluxnetSimulations
+using ClimaLand.Simulations: solve!
+import ClimaLand.LandSimVis as LandSimVis
+using CairoMakie
+using ClimaAnalysis
+using GeoMakie
+
+site_ID = length(ARGS) >= 1 ? ARGS[1] : "US-MOz"
+local_mode = "--local" in ARGS
+duration_days = parse(Int, get(ENV, "SIM_DURATION_DAYS", "7"))
+
+const FT = Float64
+
+if local_mode
+    site_val = FluxnetSimulations.replace_hyphen(site_ID)
+    (; time_offset, lat, long) =
+        FluxnetSimulations.get_location(FT, Val(site_val))
+    (; atmos_h) = FluxnetSimulations.get_fluxtower_height(FT, Val(site_val))
+    coord_kwargs = (; lat, long, time_offset, atmos_h)
+else
+    coord_kwargs = (;)
+end
+
+@info "Running generic_site_simulation" site_ID duration_days local_mode
+
+result = FluxnetSimulations.generic_site_simulation(
+    site_ID;
+    coord_kwargs...,
+    duration = Day(duration_days),
+)
+@time solve!(result.simulation)
+
+# `time_offset` for comparison-data fetch: reuse what we already resolved if
+# possible, otherwise look up via metadata.
+time_offset_for_comp = if local_mode
+    coord_kwargs.time_offset
+else
+    FluxnetSimulations.get_site_info(site_ID).time_offset
+end
+
+savedir = joinpath(
+    pkgdir(ClimaLand),
+    "experiments",
+    "integrated",
+    "generic_site",
+    "out",
+    site_ID,
+)
+mkpath(savedir)
+
+comparison_data =
+    FluxnetSimulations.get_comparison_data(site_ID, time_offset_for_comp)
+
+LandSimVis.make_diurnal_timeseries(
+    result.land_domain,
+    result.diags,
+    result.start_date;
+    savedir,
+    short_names = ["gpp", "lhf", "shf", "swu", "lwu"],
+    spinup_date = result.start_date + Day(1),
+    comparison_data,
+)
+LandSimVis.make_timeseries(
+    result.land_domain,
+    result.diags,
+    result.start_date;
+    savedir,
+    short_names = ["swc", "tsoil", "swe"],
+    spinup_date = result.start_date + Day(1),
+    comparison_data,
+)
+
+@info "Wrote plots to $savedir"

--- a/experiments/integrated/generic_site/site_drivers.jl
+++ b/experiments/integrated/generic_site/site_drivers.jl
@@ -1,0 +1,196 @@
+# Site-level "drivers" for the per-site calibration CSV.
+#
+# Reads the fluxnet forcing CSV directly (not via ClimaLand's TVI pipeline) so
+# the aggregation matches what one would compute by hand from the half-hourly
+# record. Spatial fields (porosity, MODIS max LAI, IGBP) are looked up at the
+# site's lat/lon from the same artifacts the forward model uses.
+#
+# Returns a NamedTuple consumed by `append_site_csv` in calibrate_site.jl.
+
+import NCDatasets: NCDataset
+import Dates: DateTime, year
+import Statistics: mean
+import DelimitedFiles: readdlm
+
+const _FLUXNET_MISSING = -9999.0
+
+"""
+    _read_fluxnet_column(site_ID, col_name) -> (utc_datetimes, values_vec)
+
+Read one column from the half-hourly fluxnet CSV (the same file ClimaLand's
+forcing pipeline reads), returning UTC timestamps and a Float64 vector with
+fluxnet missing values (-9999) replaced by `NaN`. Returns `nothing` if the
+column is absent so callers can fall back gracefully.
+"""
+function _read_fluxnet_column(site_ID, time_offset, col_name)
+    fluxnet_csv_path = ClimaLand.Artifacts.experiment_fluxnet_data_path(site_ID)
+    (data, columns) = readdlm(fluxnet_csv_path, ','; header = true)
+    col_idx = findfirst(vec(columns) .== col_name)
+    col_idx === nothing && return nothing
+    ts_idx = findfirst(vec(columns) .== "TIMESTAMP_START")
+    te_idx = findfirst(vec(columns) .== "TIMESTAMP_END")
+
+    raw = Float64.(data[:, col_idx])
+    raw[raw .== _FLUXNET_MISSING] .= NaN
+
+    function _to_utc(ts)
+        local_dt = DateTime(string(Int64(ts)), "yyyymmddHHMM")
+        return local_dt + Dates.Hour(time_offset)
+    end
+    starts = _to_utc.(data[:, ts_idx])
+    ends = _to_utc.(data[:, te_idx])
+    midpoints = starts .+ (ends .- starts) ./ 2
+    return midpoints, raw
+end
+
+"""
+    _aggregate_in_windows(times, vals, windows; reducer)
+
+Apply `reducer` (e.g. `mean`, `sum`) to `vals` over the union of `windows`
+(each `(start, stop)`), skipping NaNs. Returns the reducer's result, or NaN
+if no valid points fall inside any window.
+"""
+function _aggregate_in_windows(times, vals, windows; reducer)
+    mask = falses(length(times))
+    for (ws, we) in windows
+        @. mask = mask | ((times >= ws) & (times < we))
+    end
+    sel = vals[mask]
+    sel = sel[.!isnan.(sel)]
+    isempty(sel) && return NaN
+    return reducer(sel)
+end
+
+"""
+    _porosity_at_site(lat, long) -> Float64
+
+Look up surface (top layer) porosity at the site lat/lon from the Gupta et al.
+(2020) NetCDF used by ClimaLand's spatially-varying soil parameters. Returns
+the global default 0.47 if anything goes wrong (artifact missing, point at
+ocean mask, etc.) so the CSV always has a number.
+"""
+function _porosity_at_site(lat, long)
+    # Use the highres (0.1°) Gupta map — it's the artifact the simulation
+    # itself downloads, so we never have to fetch a second one just for the
+    # CSV row. Variable name in the NetCDF is the literal "ν".
+    try
+        soil_params_dir = ClimaLand.Artifacts.soil_params_artifact_folder_path(;
+            lowres = false,
+        )
+        nc_path = joinpath(
+            soil_params_dir,
+            "porosity_map_gupta_etal2020_0.1x0.1x4.nc",
+        )
+        return _nc_value_at_site(nc_path, "ν", lat, long; default = 0.47)
+    catch err
+        @warn "Could not read porosity at site, using default" exception = err
+        return 0.47
+    end
+end
+
+"""
+    _nc_value_at_site(nc_path, varname, lat, long; default)
+
+Open `nc_path`, find the closest grid cell to (`lat`, `long`), and return the
+value of `varname` at that cell (top layer if 3D). Returns `default` if the
+variable is missing or the value is NaN/missing.
+"""
+function _nc_value_at_site(nc_path, varname, lat, long; default = NaN)
+    NCDataset(nc_path) do ds
+        haskey(ds, varname) || return default
+        lats = ds["lat"][:]
+        lons = ds["lon"][:]
+        i = argmin(abs.(lons .- long))
+        j = argmin(abs.(lats .- lat))
+        v = ds[varname]
+        val = if ndims(v) == 2
+            v[i, j]
+        elseif ndims(v) == 3
+            v[i, j, 1]   # top layer
+        else
+            v[i, j, 1, 1]
+        end
+        (val === missing || (val isa Number && isnan(val))) && return default
+        return Float64(val)
+    end
+end
+
+"""
+    compute_site_drivers(site_ID, coords, samples; soc_default = 5.0)
+
+Aggregate fluxnet forcing variables, MODIS max LAI, soil porosity, IGBP class
+and a placeholder SOC value over the union of the calibration `samples`
+(year-long windows). All means / sums are computed by skipping NaN
+(fluxnet -9999) values. Returns a NamedTuple suitable for the per-site CSV.
+
+`soc_default` is the constant SOC initial condition the model uses
+(`Y.soilco2.SOC = 5.0 kg C m⁻³` in `src/simulations/initial_conditions.jl`).
+Reported here so the CSV has a column even though the value is currently
+constant across sites — once a spatial SOC initial-condition map lands in
+ClimaLand, swap this for a real lookup.
+"""
+function compute_site_drivers(site_ID, coords, samples; soc_default = 5.0)
+    time_offset = coords.time_offset
+    lat = Float64(coords.lat)
+    long = Float64(coords.long)
+    n_years = max(length(samples), 1)
+
+    # Fluxnet aggregations
+    function _mean_col(col, transform = identity)
+        ret = _read_fluxnet_column(site_ID, time_offset, col)
+        ret === nothing && return NaN
+        (times, vals) = ret
+        vals = transform.(vals)
+        return _aggregate_in_windows(times, vals, samples; reducer = mean)
+    end
+
+    mean_TA = _mean_col("TA_F", x -> x + 273.15)         # °C → K
+    mean_VPD = _mean_col("VPD_F", x -> x * 100.0)         # hPa → Pa
+    mean_SW = _mean_col("SW_IN_F")                        # W m⁻²
+    mean_TS_top = _mean_col("TS_F_MDS_1", x -> x + 273.15)
+
+    # Annual cumulative precip: sum(P_F mm/half-hour) divided by year count
+    annual_cum_P = let ret = _read_fluxnet_column(site_ID, time_offset, "P_F")
+        if ret === nothing
+            NaN
+        else
+            (times, vals) = ret
+            total =
+                _aggregate_in_windows(times, vals, samples; reducer = sum)
+            total / n_years
+        end
+    end
+
+    # Max LAI from MODIS at site (use first sample's mid-year as the lookup
+    # year — MODIS climatology is roughly year-agnostic via the site grid cell)
+    max_LAI = try
+        ref_date =
+            isempty(samples) ? DateTime(2010, 7, 1) :
+            samples[1][1] + (samples[1][2] - samples[1][1]) ÷ 2
+        FluxnetSimulations.get_maxLAI_at_site(ref_date, lat, long)
+    catch err
+        @warn "Could not read max LAI for $site_ID" exception = err
+        NaN
+    end
+
+    porosity = _porosity_at_site(lat, long)
+
+    igbp = try
+        FluxnetSimulations.get_site_igbp(site_ID)
+    catch err
+        @warn "Could not read IGBP for $site_ID" exception = err
+        "NA"
+    end
+
+    return (;
+        mean_TA,
+        mean_VPD,
+        annual_cum_P,
+        mean_SW,
+        mean_TS_top,
+        max_LAI,
+        porosity,
+        SOC_top = soc_default,
+        IGBP = igbp,
+    )
+end

--- a/experiments/integrated/generic_site/test_local_artifact_sites.jl
+++ b/experiments/integrated/generic_site/test_local_artifact_sites.jl
@@ -1,0 +1,61 @@
+# Smoke-test FluxnetSimulations.generic_site_simulation against the four
+# bundled (`fluxnet_sites` artifact) sites: US-MOz, US-NR1, US-Ha1, US-Var.
+#
+# Each site is run for 7 days using local-mode coordinates (from the per-site
+# Val{} dispatchers). Pass = `solve!` returns without throwing.
+#
+# Usage:
+#   julia --project=experiments experiments/integrated/generic_site/test_local_artifact_sites.jl
+
+import ClimaComms
+ClimaComms.@import_required_backends
+using Dates
+using ClimaLand
+import ClimaLand.FluxnetSimulations as FluxnetSimulations
+using ClimaLand.Simulations: solve!
+
+const FT = Float64
+const SITES = ["US-MOz", "US-NR1", "US-Ha1", "US-Var"]
+const DURATION = Day(parse(Int, get(ENV, "SIM_DURATION_DAYS", "7")))
+
+results = Dict{String, Symbol}()
+errors = Dict{String, Any}()
+
+for site_ID in SITES
+    @info "==> $site_ID"
+    try
+        site_val = FluxnetSimulations.replace_hyphen(site_ID)
+        (; time_offset, lat, long) =
+            FluxnetSimulations.get_location(FT, Val(site_val))
+        (; atmos_h) = FluxnetSimulations.get_fluxtower_height(FT, Val(site_val))
+
+        result = FluxnetSimulations.generic_site_simulation(
+            site_ID;
+            lat,
+            long,
+            time_offset,
+            atmos_h,
+            duration = DURATION,
+        )
+        @time solve!(result.simulation)
+        results[site_ID] = :ok
+    catch e
+        results[site_ID] = :failed
+        errors[site_ID] = e
+        @error "Failure at $site_ID" exception = (e, catch_backtrace())
+    end
+end
+
+println()
+println("=== Summary ===")
+for site_ID in SITES
+    println("  $site_ID: $(results[site_ID])")
+end
+
+n_failed = count(==(:failed), values(results))
+if n_failed > 0
+    println("\n$n_failed site(s) failed.")
+    exit(1)
+else
+    println("\nAll $(length(SITES)) sites passed.")
+end

--- a/ext/FluxnetSimulationsExt.jl
+++ b/ext/FluxnetSimulationsExt.jl
@@ -11,6 +11,7 @@ using Insolation
 import ClimaLand.Parameters as LP
 using ClimaLand
 using ClimaLand.Canopy
+import ClimaDiagnostics
 export prescribed_forcing_fluxnet,
     make_set_fluxnet_initial_conditions,
     get_comparison_data,
@@ -18,17 +19,23 @@ export prescribed_forcing_fluxnet,
     get_data_dt,
     replace_hyphen,
     get_parameters,
-    get_domain_info
-
-# Include site-specific configurations, as well as the default generic site.
-include("fluxnet_simulations/generic_site.jl")
-include("fluxnet_simulations/US-MOz.jl")
-include("fluxnet_simulations/US-Ha1.jl")
-include("fluxnet_simulations/US-NR1.jl")
-include("fluxnet_simulations/US-Var.jl")
+    get_domain_info,
+    generic_site_simulation,
+    get_site_info,
+    get_canopy_height
 
 # Include the data processing, forcing, and initial conditions utilities.
 include("fluxnet_simulations/data_processing.jl")
 include("fluxnet_simulations/forcing.jl")
 include("fluxnet_simulations/initial_conditions.jl")
+
+# Generic-site driver and FLUXNET2015 metadata helpers.
+include("fluxnet_simulations/get_fluxnet_metadata.jl")
+include("fluxnet_simulations/generic_site.jl")
+
+# Include site-specific configurations (hardcoded coordinates/parameters).
+include("fluxnet_simulations/US-MOz.jl")
+include("fluxnet_simulations/US-Ha1.jl")
+include("fluxnet_simulations/US-NR1.jl")
+include("fluxnet_simulations/US-Var.jl")
 end # module FluxnetSimulationsExt

--- a/ext/fluxnet_simulations/data_processing.jl
+++ b/ext/fluxnet_simulations/data_processing.jl
@@ -8,6 +8,15 @@ data. Returns true if x == -9999.
 var_missing(x; val = -9999) = x == val
 
 """
+    all_missing(v; val = -9999)
+
+True iff every entry of `v` equals the missing-data sentinel `val`. Used to
+detect FLUXNET CSV columns that are entirely unobserved at a given site —
+in which case callers must fall back rather than try to read a value.
+"""
+all_missing(v; val = -9999) = all(==(val), v)
+
+"""
     hour_offset_to_period(hour_offset_from_UTC)
 
 Convert a numerical hour offset (which may be fractional) to a
@@ -151,8 +160,13 @@ function get_data_at_start_date(
     Δ_date::Vector;
     preprocess_func = identity,
     val = -9999,
+    varname::AbstractString = "<unknown>",
 )
     Δ_date, v = mask_data(Δ_date, v; val)
+    isempty(Δ_date) && error(
+        "FLUXNET column `$(varname)` has no non-missing values; cannot read \
+         an initial condition. Caller should provide a fallback.",
+    )
     idx_start = argmin(abs.(Δ_date))
     return preprocess_func(v[idx_start])
 end

--- a/ext/fluxnet_simulations/forcing.jl
+++ b/ext/fluxnet_simulations/forcing.jl
@@ -1,6 +1,8 @@
 using NCDatasets
 import ClimaParams as CP
 
+# Bring the shared forcing-column list (defined in the stub module) into scope.
+import ClimaLand.FluxnetSimulations: FLUXNET_FORCING_COLUMNS
 
 """
      prescribed_forcing_fluxnet(site_ID,
@@ -58,18 +60,7 @@ function FluxnetSimulations.prescribed_forcing_fluxnet(
     (data, columns) = read_fluxnet_data(site_ID)
 
     # Determine which column index corresponds to which varname
-    varnames = (
-        "TIMESTAMP_START",
-        "TIMESTAMP_END",
-        "TA_F",
-        "VPD_F",
-        "PA_F",
-        "P_F",
-        "WS_F",
-        "LW_IN_F",
-        "SW_IN_F",
-        "CO2_F_MDS",
-    )
+    varnames = ("TIMESTAMP_START", "TIMESTAMP_END", FLUXNET_FORCING_COLUMNS...)
     column_name_map =
         get_column_name_map(varnames, columns; error_on_missing = false)
 
@@ -300,6 +291,7 @@ end
         hour_offset_from_UTC;
         duration::Union{Nothing, Period} = nothing,
         start_offset::Period = Second(0),
+        required_columns = nothing,
     )
 
 A helper function to get the first and last dates, in UTC, for which we have
@@ -307,6 +299,13 @@ Fluxnet data at `site_ID`, given the offset in hours of local time
 from UTC. If `duration` is provided, it is used to determine the end date,
 otherwise the end date is the last date in the data. The `start_offset` is
 added to the start date, and must be non-negative.
+
+If `required_columns` is provided, the start date is advanced past any
+leading rows in which any of those columns equals the FLUXNET missing-data
+sentinel (-9999). This is needed when the start date will be passed to
+`prescribed_forcing_fluxnet`, which masks missing rows out of each
+TimeVaryingInput; without this advance, the resulting TVIs may not cover
+simulation time 0 and `evaluate!` throws.
 
 Please note that we use date halfway between the TIMESTAMP_START
 and TIMESTAMP_END date of the Fluxnet averaging window as the timestamp of
@@ -317,6 +316,7 @@ function FluxnetSimulations.get_data_dates(
     hour_offset_from_UTC;
     duration::Union{Nothing, Period} = nothing,
     start_offset::Period = Second(0),
+    required_columns = nothing,
 )
     (data, columns) = read_fluxnet_data(site_ID)
 
@@ -342,6 +342,28 @@ function FluxnetSimulations.get_data_dates(
     UTC_datetimes =
         UTC_datetimes_start .+ (UTC_datetimes_end .- UTC_datetimes_start) ./ 2
     earliest_date, latest_date = extrema(UTC_datetimes)
+
+    # Advance earliest_date past any leading rows where a required forcing column is
+    # missing. `prescribed_forcing_fluxnet` drops those rows when building each
+    # TimeVaryingInput; if any required column is missing in the first row, that
+    # variable's TVI starts at t > 0 and evaluating at simulation t=0 throws.
+    if !isnothing(required_columns) && !isempty(required_columns)
+        req = collect(required_columns)
+        req_map = get_column_name_map(req, columns; error_on_missing = true)
+        valid = trues(size(data, 1))
+        for v in req
+            valid .&= .~var_missing.(data[:, req_map[v]])
+        end
+        any(valid) || error(
+            "No row of $site_ID has all required columns $(req) non-missing.",
+        )
+        earliest_valid = minimum(UTC_datetimes[valid])
+        if earliest_valid > earliest_date
+            @info "Advancing $site_ID start past leading missing data" earliest_date earliest_valid gap =
+                earliest_valid - earliest_date
+            earliest_date = earliest_valid
+        end
+    end
 
     # Compute the start and stop dates, applying the start_offset and duration if provided
     @assert Dates.value(start_offset) >= 0 "start_offset must be non-negative, got $start_offset"
@@ -441,6 +463,7 @@ function FluxnetSimulations.get_comparison_data(
         "TIMESTAMP_START",
         "TIMESTAMP_END",
         "GPP_DT_VUT_REF",
+        "RECO_NT_VUT_REF",
         "LE_CORR",
         "H_CORR",
         "SW_OUT",
@@ -475,6 +498,15 @@ function FluxnetSimulations.get_comparison_data(
         column_name_map,
         "gpp";
         preprocess_func = (x) -> x * 1e-6, # converts from μmol/m^2/s to mol/m^2/s
+        val,
+    )
+
+    er = FluxnetSimulations.get_comparison_data(
+        data,
+        "RECO_NT_VUT_REF",
+        column_name_map,
+        "er";
+        preprocess_func = (x) -> x * 1e-6, # converts from μmol/m^2/s to mol CO2/m^2/s
         val,
     )
 
@@ -599,6 +631,7 @@ function FluxnetSimulations.get_comparison_data(
     return merge(
         (; UTC_datetime = UTC_datetimes),
         gpp,
+        er,
         lhf,
         shf,
         swu,

--- a/ext/fluxnet_simulations/generic_site.jl
+++ b/ext/fluxnet_simulations/generic_site.jl
@@ -2,7 +2,261 @@
 #        MODULE FUNCTIONS         #
 ###################################
 
-# TODO
+"""
+    FluxnetSimulations.generic_site_simulation(site_ID; kwargs...)
+
+Build (but do not solve) a single-column ClimaLand simulation at any fluxnet
+site, using default parameters at the site coordinates and MODIS LAI
+climatology.
+
+If `lat`, `long`, `time_offset`, `atmos_h` are not provided, they are looked up
+from the FLUXNET2015 metadata CSV via [`get_site_info`](@ref) — this requires
+the `fluxnet2015` artifact, which is HPC-only by default. On machines without
+that artifact (e.g. local development with only the `fluxnet_sites` artifact),
+pass coordinates explicitly. For the four bundled sites, you can do this by
+calling `get_location(FT, Val(replace_hyphen(site_ID)))` and
+`get_fluxtower_height(FT, Val(replace_hyphen(site_ID)))`.
+
+Soil and snow components use the high-level `LandModel` defaults, which fetch
+spatially-varying parameters at the column's `(long, lat)`. The canopy is a
+PModel + PModelConductance + PiecewiseMoistureStress + PrescribedBiomass
+combination, mirroring `experiments/calibration/models/snowy_land.jl` so that
+the same calibration knobs (e.g. `pmodel_cstar`, `moisture_stress_c`) work for
+both global and single-site runs. Pass `canopy = ...` to override.
+
+# Returns
+
+A NamedTuple `(; simulation, diags, land_domain, start_date, stop_date)`. The
+caller is responsible for `solve!(simulation)`.
+
+# Example
+
+    using Dates
+    import ClimaLand
+    import ClimaLand.FluxnetSimulations as FluxnetSimulations
+    using ClimaLand.Simulations: solve!
+
+    # On HPC with fluxnet2015 staged, coordinates auto-resolve from metadata:
+    result = FluxnetSimulations.generic_site_simulation("DE-Tha"; duration = Day(7))
+    solve!(result.simulation)
+
+    # Locally, pass coordinates from the per-site dispatcher:
+    site_val = FluxnetSimulations.replace_hyphen("US-MOz")
+    (; lat, long, time_offset) = FluxnetSimulations.get_location(Float64, Val(site_val))
+    (; atmos_h) = FluxnetSimulations.get_fluxtower_height(Float64, Val(site_val))
+    result = FluxnetSimulations.generic_site_simulation(
+        "US-MOz"; lat, long, time_offset, atmos_h, duration = Day(7),
+    )
+    solve!(result.simulation)
+"""
+function FluxnetSimulations.generic_site_simulation(
+    site_ID::AbstractString;
+    FT::Type{<:AbstractFloat} = Float64,
+    kwargs...,
+)
+    # Dispatch through a type-parameterized inner function so `FT` is
+    # specialized at the type level — kwargs alone are not specialized in
+    # Julia, which produces "Unreachable reached" code-gen failures inside
+    # parametric constructors like `PModel{FT}(...)`.
+    return _generic_site_simulation(FT, site_ID; kwargs...)
+end
+
+function _generic_site_simulation(
+    ::Type{FT},
+    site_ID::AbstractString;
+    lat = nothing,
+    long = nothing,
+    time_offset = nothing,
+    atmos_h = nothing,
+    duration::Union{Nothing, Dates.Period} = nothing,
+    start_offset::Dates.Period = Dates.Second(0),
+    dt = 450.0,
+    diagnostic_period = :halfhourly,
+    output_vars = [
+        "gpp",
+        "lhf",
+        "shf",
+        "lwu",
+        "swu",
+        "swc",
+        "tsoil",
+        "swe",
+        "et",
+    ],
+    output_writer = nothing,
+    outdir = nothing,
+    domain_kwargs = (;
+        dz_bottom = 1.5,
+        dz_top = 0.1,
+        nelements = 20,
+        zmin = -10.0,
+        zmax = 0.0,
+    ),
+    toml_dict = LP.create_toml_dict(FT),
+    prognostic_land_components = (:canopy, :snow, :soil, :soilco2),
+    canopy = nothing,
+    soil = nothing,
+    snow = nothing,
+) where {FT <: AbstractFloat}
+    # 1. Resolve coordinates from FLUXNET2015 metadata if any are missing
+    if any(isnothing, (lat, long, time_offset, atmos_h))
+        info = FluxnetSimulations.get_site_info(site_ID)
+        lat = isnothing(lat) ? FT(info.lat) : FT(lat)
+        long = isnothing(long) ? FT(info.long) : FT(long)
+        time_offset =
+            isnothing(time_offset) ? Int(info.time_offset) : time_offset
+        atmos_h = if isnothing(atmos_h)
+            isempty(info.atmospheric_sensor_height) && error(
+                "No atmospheric sensor height in metadata for $site_ID; pass `atmos_h` kwarg.",
+            )
+            FT(first(info.atmospheric_sensor_height))
+        else
+            FT(atmos_h)
+        end
+    else
+        lat, long, atmos_h = FT(lat), FT(long), FT(atmos_h)
+    end
+
+    # 2. Column domain at (long, lat) — enables spatially-varying defaults
+    land_domain = ClimaLand.Domains.Column(;
+        zlim = (FT(domain_kwargs.zmin), FT(domain_kwargs.zmax)),
+        nelements = domain_kwargs.nelements,
+        dz_tuple = (FT(domain_kwargs.dz_bottom), FT(domain_kwargs.dz_top)),
+        longlat = (long, lat),
+    )
+    surface_domain = ClimaLand.Domains.obtain_surface_domain(land_domain)
+    surface_space = land_domain.space.surface
+
+    # 3. Date range from the site CSV. Pass `required_columns` so the start
+    # is advanced past any leading rows where a forcing variable is missing —
+    # otherwise the resulting TVIs in step 4 may not cover simulation t=0.
+    (start_date, stop_date) = FluxnetSimulations.get_data_dates(
+        site_ID,
+        time_offset;
+        duration,
+        start_offset,
+        required_columns = FLUXNET_FORCING_COLUMNS,
+    )
+
+    # 4. Atmospheric & radiative forcing
+    (; atmos, radiation) = FluxnetSimulations.prescribed_forcing_fluxnet(
+        site_ID,
+        lat,
+        long,
+        time_offset,
+        atmos_h,
+        start_date,
+        toml_dict,
+        FT,
+    )
+    forcing = (; atmos, radiation)
+
+    # 5. LAI from MODIS climatology (year-agnostic, periodic)
+    LAI = ClimaLand.Canopy.prescribed_climatological_lai_modis(surface_space)
+
+    # 6. Soil model. Built here rather than left to the `LandModel` default so
+    # that the canopy's moisture stress model below can be derived from the
+    # same retention parameters: `LandModel` asserts that the stress model's
+    # θ_high/θ_low equal the soil's ν/θ_r, and the soil defaults to ROSETTA
+    # parameters, which differ from the `soil_vangenuchten_parameters` the
+    # stress model would otherwise pick up on its own.
+    if isnothing(soil)
+        soil = ClimaLand.Soil.EnergyHydrology{FT}(
+            land_domain,
+            forcing,
+            toml_dict;
+            prognostic_land_components,
+            additional_sources = (ClimaLand.RootExtraction{FT}(),),
+        )
+    end
+
+    # 7. PModel canopy by default; user can pass `canopy = ...` to override
+    if isnothing(canopy)
+        photosynthesis = ClimaLand.Canopy.PModel{FT}(land_domain, toml_dict)
+        conductance = ClimaLand.Canopy.PModelConductance{FT}(toml_dict)
+        soil_moisture_stress =
+            ClimaLand.Canopy.PiecewiseMoistureStressModel{FT}(
+                land_domain,
+                toml_dict;
+                soil_params = (;
+                    ν = soil.parameters.ν,
+                    θ_r = soil.parameters.θ_r,
+                ),
+            )
+        biomass = ClimaLand.Canopy.PrescribedBiomassModel{FT}(
+            land_domain,
+            LAI,
+            toml_dict,
+        )
+        canopy_forcing = (;
+            atmos,
+            radiation,
+            ground = ClimaLand.PrognosticGroundConditions{FT}(),
+        )
+        canopy = ClimaLand.Canopy.CanopyModel{FT}(
+            surface_domain,
+            canopy_forcing,
+            LAI,
+            toml_dict;
+            prognostic_land_components,
+            photosynthesis,
+            conductance,
+            soil_moisture_stress,
+            biomass,
+        )
+    end
+
+    # 8. LandModel — uses spatial defaults at longlat for snow and soilco2
+    component_kwargs = (; canopy, soil)
+    !isnothing(snow) && (component_kwargs = merge(component_kwargs, (; snow)))
+    land = ClimaLand.LandModel{FT}(
+        forcing,
+        LAI,
+        toml_dict,
+        land_domain,
+        dt;
+        prognostic_land_components,
+        component_kwargs...,
+    )
+
+    # 9. Initial conditions from observations at start_date
+    set_ic! = FluxnetSimulations.make_set_fluxnet_initial_conditions(
+        site_ID,
+        start_date,
+        time_offset,
+        land,
+    )
+
+    # 10. Diagnostics
+    outdir_resolved = isnothing(outdir) ? mktempdir() : outdir
+    output_writer_resolved = if isnothing(output_writer)
+        ClimaDiagnostics.Writers.DictWriter()
+    else
+        output_writer
+    end
+    diags = ClimaLand.default_diagnostics(
+        land,
+        start_date,
+        outdir_resolved;
+        output_writer = output_writer_resolved,
+        output_vars,
+        reduction_period = diagnostic_period,
+    )
+
+    # 11. Build (don't solve — caller decides when)
+    simulation = ClimaLand.Simulations.LandSimulation(
+        start_date,
+        stop_date,
+        dt,
+        land;
+        outdir = outdir_resolved,
+        set_ic!,
+        updateat = dt,
+        diagnostics = diags,
+    )
+
+    return (; simulation, diags, land_domain, start_date, stop_date)
+end
 
 ###################################
 #            UTILITIES            #

--- a/ext/fluxnet_simulations/get_fluxnet_metadata.jl
+++ b/ext/fluxnet_simulations/get_fluxnet_metadata.jl
@@ -1,0 +1,184 @@
+###################################
+#       FLUXNET2015 metadata      #
+###################################
+#
+# These helpers read site metadata (lat/lon, time offset, sensor heights,
+# canopy height) from the FLUXNET2015 metadata CSV bundled with the
+# `fluxnet2015` artifact. The artifact is HPC-only by default — locally,
+# call `generic_site_simulation` with explicit coordinate kwargs instead.
+
+"""
+    parse_array_field(field) -> Vector{Float64}
+
+Parse a metadata cell that may hold a semicolon-separated list of floats
+(e.g. multiple atmospheric sensor heights). Returns an empty vector for
+empty/NaN cells.
+"""
+function parse_array_field(field)
+    if field == "" || field == "NaN"
+        return Float64[]
+    elseif field isa Float64
+        return isnan(field) ? Float64[] : [field]
+    else
+        return parse.(Float64, split(String(field), ";"))
+    end
+end
+
+"""
+    FluxnetSimulations.get_site_info(site_ID; fluxnet2015_metadata_path = nothing)
+
+Look up site metadata for `site_ID` from the FLUXNET2015 `metadata_DD_clean.csv`.
+
+Returns a NamedTuple:
+- `lat::Float64` — latitude (deg)
+- `long::Float64` — longitude (deg)
+- `time_offset::Int` — local time offset from UTC (hours), using the ClimaLand
+  convention `UTC = local_time + time_offset` (i.e. negated relative to the
+  metadata's `utc_offset` column).
+- `atmospheric_sensor_height::Vector{Float64}` — heights (m) of atmospheric
+  sensors at the site; may be empty if the metadata cell is missing.
+
+Missing fields produce a `@warn` and a `NaN`-valued entry rather than an error,
+so a partial metadata row still mostly works.
+
+The `fluxnet2015` artifact (containing the metadata CSV) is HPC-only — see
+`ClimaLand.Artifacts.fluxnet2015_data_path`.
+"""
+function FluxnetSimulations.get_site_info(
+    site_ID;
+    fluxnet2015_metadata_path = nothing,
+)
+    if fluxnet2015_metadata_path === nothing
+        fluxnet2015_metadata_path = joinpath(
+            ClimaLand.Artifacts.fluxnet2015_data_path(),
+            "metadata_DD_clean.csv",
+        )
+    end
+    raw = readdlm(fluxnet2015_metadata_path, ',', Any)
+    header = raw[1, :]
+    data = raw[2:end, :]
+
+    row_idx = findfirst(row -> row[1] == site_ID, eachrow(data))
+    isnothing(row_idx) && error("Site ID $site_ID not found in metadata.")
+    site_metadata = data[row_idx, :]
+
+    varnames =
+        ["latitude", "longitude", "utc_offset", "atmospheric_sensor_heights"]
+    column_name_map = Dict(
+        varname => findfirst(header[:] .== varname) for varname in varnames
+    )
+
+    nan_if_empty(x) =
+        (x isa AbstractString && isempty(x)) ? NaN :
+        (x isa AbstractFloat && isnan(x)) ? NaN : x
+
+    for (varname, column) in column_name_map
+        field = site_metadata[column]
+        if (field isa AbstractString && isempty(field)) ||
+           (field isa AbstractFloat && isnan(field))
+            @warn "Field $(varname) is missing for site $site_ID"
+        end
+    end
+
+    return (;
+        lat = nan_if_empty(site_metadata[column_name_map["latitude"]]),
+        long = nan_if_empty(site_metadata[column_name_map["longitude"]]),
+        time_offset = Int(
+            -1 * nan_if_empty(site_metadata[column_name_map["utc_offset"]]),
+        ),
+        atmospheric_sensor_height = parse_array_field(
+            site_metadata[column_name_map["atmospheric_sensor_heights"]],
+        ),
+    )
+end
+
+"""
+    FluxnetSimulations.get_canopy_height(site_ID; fluxnet2015_metadata_path = nothing)
+
+Return canopy height (m) for `site_ID` from the FLUXNET2015 metadata CSV.
+Same artifact requirements as `get_site_info`. Returns `NaN` (with a warning)
+if the field is missing.
+"""
+function FluxnetSimulations.get_canopy_height(
+    site_ID;
+    fluxnet2015_metadata_path = nothing,
+)
+    if fluxnet2015_metadata_path === nothing
+        fluxnet2015_metadata_path = joinpath(
+            ClimaLand.Artifacts.fluxnet2015_data_path(),
+            "metadata_DD_clean.csv",
+        )
+    end
+    raw = readdlm(fluxnet2015_metadata_path, ',', Any)
+    header = raw[1, :]
+    data = raw[2:end, :]
+
+    row_idx = findfirst(row -> row[1] == site_ID, eachrow(data))
+    isnothing(row_idx) && error("Site ID $site_ID not found in metadata.")
+    site_metadata = data[row_idx, :]
+
+    col_idx = findfirst(header[:] .== "canopy_height")
+    canopy_height = site_metadata[col_idx]
+
+    if (canopy_height isa AbstractString && isempty(canopy_height)) ||
+       (canopy_height isa AbstractFloat && isnan(canopy_height))
+        @warn "Field canopy_height is missing for site $site_ID"
+        return NaN
+    end
+    return Float64(canopy_height)
+end
+
+"""
+    FluxnetSimulations.get_site_igbp(site_ID; fluxnet2015_metadata_path = nothing)
+
+Return the IGBP land cover class string (e.g. "EBF", "DBF", "GRA", "SAV") for
+`site_ID` from the FLUXNET2015 metadata CSV. Returns `"NA"` (with a warning)
+if neither the column nor the cell is present, so callers can keep working
+on partial metadata.
+
+Tries a list of candidate column names, in order, since the column has
+historically been named differently across snapshots of the metadata CSV.
+"""
+function FluxnetSimulations.get_site_igbp(
+    site_ID;
+    fluxnet2015_metadata_path = nothing,
+)
+    if fluxnet2015_metadata_path === nothing
+        fluxnet2015_metadata_path = joinpath(
+            ClimaLand.Artifacts.fluxnet2015_data_path(),
+            "metadata_DD_clean.csv",
+        )
+    end
+    raw = readdlm(fluxnet2015_metadata_path, ',', Any)
+    header = raw[1, :]
+    data = raw[2:end, :]
+
+    row_idx = findfirst(row -> row[1] == site_ID, eachrow(data))
+    isnothing(row_idx) && error("Site ID $site_ID not found in metadata.")
+    site_metadata = data[row_idx, :]
+
+    candidates = (
+        "igbp_class",
+        "igbp_landcover_class",
+        "IGBP",
+        "biome_code",
+        "IGBP_class",
+    )
+    col_idx = nothing
+    for cand in candidates
+        col_idx = findfirst(header[:] .== cand)
+        col_idx !== nothing && break
+    end
+    if col_idx === nothing
+        @warn "No IGBP column in metadata CSV (tried $(candidates)) — returning NA for $site_ID"
+        return "NA"
+    end
+
+    igbp = site_metadata[col_idx]
+    if (igbp isa AbstractString && isempty(igbp)) ||
+       (igbp isa AbstractFloat && isnan(igbp))
+        @warn "IGBP class missing for $site_ID"
+        return "NA"
+    end
+    return String(strip(string(igbp)))
+end

--- a/ext/fluxnet_simulations/initial_conditions.jl
+++ b/ext/fluxnet_simulations/initial_conditions.jl
@@ -100,19 +100,19 @@ function set_fluxnet_ic!(
     FT = eltype(Y.soil.ρe_int)
     tmp_ic = @. model.parameters.θ_r +
        (model.parameters.ν - model.parameters.θ_r) * FT(0.95)
-    if isnothing(column_name_map["SWC_F_MDS_1"])
-        θ_l_0 = tmp_ic
-    elseif unique(data[:, column_name_map["SWC_F_MDS_1"]]) == val
+    swc_idx = column_name_map["SWC_F_MDS_1"]
+    if isnothing(swc_idx) || all_missing(data[:, swc_idx]; val)
         θ_l_0 = tmp_ic
     else
         θ_l_0 =
             min.(
                 FT(
                     get_data_at_start_date(
-                        data[:, column_name_map["SWC_F_MDS_1"]],
+                        data[:, swc_idx],
                         Δ_date;
                         preprocess_func = x -> x / 100,
                         val,
+                        varname = "SWC_F_MDS_1",
                     ),
                 ),
                 tmp_ic,
@@ -121,26 +121,23 @@ function set_fluxnet_ic!(
     Y.soil.ϑ_l .= θ_l_0
     Y.soil.θ_i .= 0
 
-    if isnothing(column_name_map["TS_F_MDS_1"])
+    ts_idx = column_name_map["TS_F_MDS_1"]
+    ta_idx = column_name_map["TA_F"]
+    if !isnothing(ts_idx) && !all_missing(data[:, ts_idx]; val)
         T_soil_0 = get_data_at_start_date(
-            data[:, column_name_map["TA_F"]],
+            data[:, ts_idx],
             Δ_date;
             preprocess_func = x -> x + 273.15,
             val,
-        )
-    elseif unique(data[:, column_name_map["TS_F_MDS_1"]]) == [val]
-        T_soil_0 = get_data_at_start_date(
-            data[:, column_name_map["TA_F"]],
-            Δ_date;
-            preprocess_func = x -> x + 273.15,
-            val,
+            varname = "TS_F_MDS_1",
         )
     else
         T_soil_0 = get_data_at_start_date(
-            data[:, column_name_map["TS_F_MDS_1"]],
+            data[:, ta_idx],
             Δ_date;
             preprocess_func = x -> x + 273.15,
             val,
+            varname = "TA_F",
         )
     end
 
@@ -184,6 +181,7 @@ function set_fluxnet_ic!(
             Δ_date;
             preprocess_func = x -> x + 273.15,
             val,
+            varname = "TA_F",
         )
         Y.canopy.energy.T .= T_air_0
     end

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -362,16 +362,27 @@ function soil_grids_ocd_artifact_path(; context = nothing)
     return joinpath(dir, "soil_ocd_soilgrids_lowres.nc")
 end
 
+const _BUNDLED_FLUXNET_SITES = ("US-MOz", "US-Var", "US-NR1", "US-Ha1")
+
 """
     experiment_fluxnet_data_path(
         site_ID;
         context = nothing,
     )
 
-Return the path to the file that contains a year of fluxnet data
-corresponding to a `site_ID` in the set (US-MOz, US-NR1, US-Ha1, US-Var).
+Return the path to the half-hourly (preferred) or hourly fluxnet CSV file for
+the given `site_ID`. Resolution order:
 
-Site publications and licenses:
+1. For the four bundled sites (US-MOz, US-NR1, US-Ha1, US-Var), always return
+   the curated single-year CSV from the `fluxnet_sites` artifact. These are
+   the date-windows the standalone fluxnet experiments are validated against;
+   using the FULLSET record here would silently change start/stop dates and
+   pull in years outside the `modis_lai` artifact's coverage.
+2. For any other `site_ID`, look up the directory in the `fluxnet2015`
+   artifact (HPC-only) by `occursin(site_ID, dir_name)` and return the
+   half-hourly (preferred) or hourly FULLSET CSV.
+
+Site publications and licenses for the bundled `fluxnet_sites` set:
 US-Ha1:
 
 Urbanski, S., Barford, C., Wofsy, S., Kucharik, C., Pyle, E., Budney, J., McKain, K., Fitzjarrald, D., Czikowsky, M., Munger, J. W. 2007. Factors Controlling CO2 Exchange On Timescales From Hourly To Decadal At Harvard Forest, Journal Of Geophysical Research, 112:G2, .
@@ -407,11 +418,47 @@ Citation: Siyan Ma, Liukang Xu, Joseph Verfaillie, Dennis Baldocchi (2023), Amer
 AmeriFlux CC-BY-4.0 License
 """
 function experiment_fluxnet_data_path(site_ID; context = nothing)
-    @assert site_ID ∈ ("US-MOz", "US-Var", "US-NR1", "US-Ha1")
+    if site_ID in _BUNDLED_FLUXNET_SITES
+        folder_path = @clima_artifact("fluxnet_sites", context)
+        return joinpath(folder_path, "$(site_ID).csv")
+    end
 
-    folder_path = @clima_artifact("fluxnet_sites", context)
-    data_path = joinpath(folder_path, "$(site_ID).csv")
-    return data_path
+    full_fluxnet_path = @clima_artifact("fluxnet2015", context)
+    dirs = filter(
+        d -> isdir(joinpath(full_fluxnet_path, d)),
+        readdir(full_fluxnet_path),
+    )
+    match_idx = findfirst(d -> occursin(site_ID, d), dirs)
+    match_idx === nothing &&
+        error("No FLUXNET2015 directory matched site ID $site_ID")
+
+    site_dir = dirs[match_idx]
+    parts = split(site_dir, "FULLSET")
+    hh_csv = string(parts[1], "FULLSET_HH", parts[2], ".csv")
+    hr_csv = string(parts[1], "FULLSET_HR", parts[2], ".csv")
+
+    if isfile(joinpath(full_fluxnet_path, site_dir, hh_csv))
+        return joinpath(full_fluxnet_path, site_dir, hh_csv)
+    elseif isfile(joinpath(full_fluxnet_path, site_dir, hr_csv))
+        return joinpath(full_fluxnet_path, site_dir, hr_csv)
+    else
+        error(
+            "Site directory $site_dir for $site_ID does not contain a half-hourly or hourly CSV.",
+        )
+    end
+end
+
+"""
+    fluxnet2015_data_path(; context = nothing)
+
+Return the directory of the full FLUXNET2015 dataset (`fluxnet2015` artifact).
+Used by `FluxnetSimulations.get_site_info` to locate `metadata_DD_clean.csv`.
+
+The `fluxnet2015` artifact is HPC-only (no download URL); calling this on a
+machine without the artifact pre-staged will throw.
+"""
+function fluxnet2015_data_path(; context = nothing)
+    return @clima_artifact("fluxnet2015", context)
 end
 
 """

--- a/src/ext/FluxnetSimulations.jl
+++ b/src/ext/FluxnetSimulations.jl
@@ -1,5 +1,13 @@
 module FluxnetSimulations
 
+# FLUXNET columns that `prescribed_forcing_fluxnet` builds TimeVaryingInputs from.
+# Exposed here (rather than only in the ext) so callers that need to keep an
+# observation/simulation window in sync — e.g. site-level calibration — can pass
+# this list to `get_data_dates(...; required_columns)` and get the same advanced
+# start_date the forward model uses internally.
+const FLUXNET_FORCING_COLUMNS =
+    ("TA_F", "VPD_F", "PA_F", "P_F", "WS_F", "LW_IN_F", "SW_IN_F", "CO2_F_MDS")
+
 function prescribed_forcing_fluxnet end
 
 function prescribed_LAI_fluxnet end
@@ -23,5 +31,14 @@ function get_fluxtower_height end
 function get_parameters end
 
 function replace_hyphen end
+
+# Generic site driver and FLUXNET2015 metadata helpers.
+function generic_site_simulation end
+
+function get_site_info end
+
+function get_canopy_height end
+
+function get_site_igbp end
 
 end


### PR DESCRIPTION
Run and calibrate ClimaLand at **any** FLUXNET2015 site, not just the four bundled ones.

- `FluxnetSimulations.generic_site_simulation(site_ID)` builds a single-column `LandModel` at an arbitrary site — coordinates and tower height resolved from FLUXNET2015 metadata, MODIS climatological LAI, PModel canopy.
- `experiments/integrated/generic_site/` — per-site calibration driver (`TransformUnscented`, yearly sample windows with spinup), plus a Slurm/PBS array wrapper to fan out over all sites. Each site appends a row to a shared `site_results.csv` for cross-site analysis.
- Calibration experiments are config files (`configs/*.jl`), selected with `CALIBRATION_CONFIG=<file>` — no code change to add one.

See `experiments/integrated/generic_site/README.md`.

## To do

- [x] test the multi-site calibration script (2 sites) via buildkite
- [x] make the script use config files
- [x] README explaining how to launch a calibration job on central
- [ ] merge

NEXT PR: add NEON.
