### PR TITLE
Use MacOS runners only on PR merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: ci
 on:
   push:
+    branches: [main]
     tags: '*'
   pull_request:
 
@@ -20,8 +21,15 @@ jobs:
           - '1.12'
         os:
           - ubuntu-latest
-          - macOS-latest
           - windows-latest
+          # There is a concurrency limit for MacOS runners across the
+          # entire organization.
+          # (see https://docs.github.com/en/actions/reference/limits#job-concurrency-limits-for-github-hosted-runners)
+          # To help with this, MacOS runners are only run when PRs are merged
+          # into the main branch.
+          - ${{ github.event_name == 'push' && 'macos-latest' || '' }}
+        exclude:
+          - os: ''
     steps:
       - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v3


### PR DESCRIPTION
closes https://github.com/CliMA/ClimaLand.jl/issues/1737

This PR is identical to https://github.com/CliMA/ClimaCoupler.jl/pull/1722 and https://github.com/CliMA/ClimaAtmos.jl/pull/4287. There is a concurrency limit of 5 MacOS runners for the entire organization.