### PR TITLE
add plots to CI

### DIFF
--- a/docs/Manifest-v1.12.toml
+++ b/docs/Manifest-v1.12.toml
@@ -2780,9 +2780,9 @@ version = "1.0.2"
 
 [[deps.Qt6Base_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Fontconfig_jll", "Glib_jll", "JLLWrappers", "Libdl", "Libglvnd_jll", "OpenSSL_jll", "Vulkan_Loader_jll", "Xorg_libSM_jll", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Xorg_libxcb_jll", "Xorg_xcb_util_cursor_jll", "Xorg_xcb_util_image_jll", "Xorg_xcb_util_keysyms_jll", "Xorg_xcb_util_renderutil_jll", "Xorg_xcb_util_wm_jll", "Zlib_jll", "libinput_jll", "xkbcommon_jll"]
-git-tree-sha1 = "d7a4bff94f42208ce3cf6bc8e4e7d1d663e7ee8b"
+git-tree-sha1 = "144895f6166994730ee7ff8113b981fc360638f1"
 uuid = "c0090381-4147-56d7-9ebc-da0b1113ec56"
-version = "6.10.2+1"
+version = "6.10.2+2"
 
 [[deps.Qt6Declarative_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Qt6Base_jll", "Qt6ShaderTools_jll", "Qt6Svg_jll"]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -2756,9 +2756,9 @@ version = "1.0.2"
 
 [[deps.Qt6Base_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Fontconfig_jll", "Glib_jll", "JLLWrappers", "Libdl", "Libglvnd_jll", "OpenSSL_jll", "Vulkan_Loader_jll", "Xorg_libSM_jll", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Xorg_libxcb_jll", "Xorg_xcb_util_cursor_jll", "Xorg_xcb_util_image_jll", "Xorg_xcb_util_keysyms_jll", "Xorg_xcb_util_renderutil_jll", "Xorg_xcb_util_wm_jll", "Zlib_jll", "libinput_jll", "xkbcommon_jll"]
-git-tree-sha1 = "d7a4bff94f42208ce3cf6bc8e4e7d1d663e7ee8b"
+git-tree-sha1 = "144895f6166994730ee7ff8113b981fc360638f1"
 uuid = "c0090381-4147-56d7-9ebc-da0b1113ec56"
-version = "6.10.2+1"
+version = "6.10.2+2"
 
 [[deps.Qt6Declarative_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Qt6Base_jll", "Qt6ShaderTools_jll", "Qt6Svg_jll"]

--- a/ext/LandSimulationVisualizationExt.jl
+++ b/ext/LandSimulationVisualizationExt.jl
@@ -16,6 +16,7 @@ using Printf
 include("land_sim_vis/plotting_utils.jl")
 include("land_sim_vis/leaderboard/data_sources.jl")
 include("land_sim_vis/leaderboard/leaderboard.jl")
+include("land_sim_vis/leaderboard/rmse_boxplots.jl")
 
 """
     make_leaderboard_plots(sim::ClimaLand.Simulations.LandSimulation; savedir = ".",  leaderboard_data_sources = ["ERA5", "ILAMB"])
@@ -91,6 +92,7 @@ function LandSimVis.make_leaderboard_plots(
             data_source,
         )
     end
+    compute_rmse_boxplots(leaderboard_base_path, diagnostics_folder_path)
 end
 
 function LandSimVis.make_leaderboard_plots(

--- a/ext/land_sim_vis/leaderboard/leaderboard.jl
+++ b/ext/land_sim_vis/leaderboard/leaderboard.jl
@@ -28,6 +28,43 @@ function _percentile_contour_kwargs(
 end
 
 """
+    _monthly_climatology_global_mean(var, mask_fn = ClimaAnalysis.apply_oceanmask)
+
+Return a 12-element vector of global, lonlat-weighted monthly climatology
+means for `var`. Index `i` corresponds to month `i` (1=Jan ... 12=Dec).
+Months that have no valid samples are filled with `NaN`.
+
+`mask_fn` is the same per-variable mask used by `global_bias` /  `global_rmse`
+elsewhere in this module (e.g. `apply_oceanmask` for ERA5 vars, the FLUXCOM
+NaN mask for ILAMB vars). Applying it to sim and obs identically guarantees
+that both lines are averaged over the same set of valid pixels, so the gap
+between the lines matches the global bias shown in the ANN column.
+"""
+function _monthly_climatology_global_mean(
+    var,
+    mask_fn = ClimaAnalysis.apply_oceanmask,
+)
+    times = ClimaAnalysis.times(var)
+    isempty(times) && return fill(NaN, 12)
+    start_date = Dates.DateTime(var.attributes["start_date"])
+    months =
+        [Dates.month(start_date + Dates.Second(round(Int, t))) for t in times]
+    global_means = [
+        ClimaAnalysis.weighted_average_lonlat(
+            mask_fn(ClimaAnalysis.slice(var, time = t)),
+        ).data[] for t in times
+    ]
+    out = fill(NaN, 12)
+    for m in 1:12
+        idxs = findall(==(m), months)
+        isempty(idxs) && continue
+        vals = filter(isfinite, global_means[idxs])
+        isempty(vals) || (out[m] = sum(vals) / length(vals))
+    end
+    return out
+end
+
+"""
     _nee_diverging_contour_kwargs(var, q; nlevels = 21)
 
 Build `more_kwargs` for `contour2D_on_globe!` that uses a diverging
@@ -369,6 +406,9 @@ function compute_seasonal_leaderboard(
     sim_obs_season_comparsion_dict = Dict()
     # Map short name to time series of time averages for each season
     sim_obs_time_avg_over_seasons_comparsion_dict = Dict()
+    # Map short name to (sim_var, obs_var) full windowed time series, used by
+    # the MON column to compute a monthly climatology.
+    sim_obs_full_dict = Dict()
     seasons = ["ANN", "MAM", "JJA", "SON", "DJF"]
 
     spin_up_months = 12
@@ -413,6 +453,9 @@ function compute_seasonal_leaderboard(
         # Resample
         obs_var = ClimaAnalysis.shift_longitude(obs_var, -180.0, 180.0)
         obs_var = ClimaAnalysis.resampled_as(obs_var, sim_var)
+        # Stash the full windowed time series so the MON column can compute a
+        # monthly climatology before we collapse along time below.
+        sim_obs_full_dict[short_name] = (sim_var, obs_var)
         sim_var_seasons = (sim_var, ClimaAnalysis.split_by_season(sim_var)...)
         obs_var_seasons = (obs_var, ClimaAnalysis.split_by_season(obs_var)...)
 
@@ -512,7 +555,7 @@ function compute_seasonal_leaderboard(
     # Cols correspond to "SIM" and "ANN"
     annual_compare_vars_biases_plot_extrema =
         get_compare_vars_biases_plot_extrema(; annual = true)
-    groups = ["SIM", "ANN"]
+    groups = ["SIM", "ANN", "MON"]
     fig_sim_ann = CairoMakie.Figure(;
         size = (600 * length(groups), 400 * length(short_names)),
     )
@@ -567,11 +610,104 @@ function compute_seasonal_leaderboard(
                     short_name == "nee" ?
                     _nee_diverging_contour_kwargs(sim_var, 0.95) :
                     _percentile_contour_kwargs(sim_var)
+                # Replace the auto-generated panel title (which leaks raw
+                # seconds-since-start_date) with a clean summary that names
+                # the variable, the year range averaged over, and the actual
+                # min/max of the field shown — the colorbar is clipped to
+                # [5%, 95%] so the data range is otherwise invisible.
+                sim_var_full, _ = sim_obs_full_dict[short_name]
+                start_date =
+                    Dates.DateTime(sim_var_full.attributes["start_date"])
+                ts = ClimaAnalysis.times(sim_var_full)
+                y0 =
+                    Dates.year(start_date + Dates.Second(round(Int, first(ts))))
+                y1 = Dates.year(start_date + Dates.Second(round(Int, last(ts))))
+                year_str = y0 == y1 ? "$(y0)" : "$(y0)–$(y1)"
+                # Use the un-averaged var's `long_name` and strip the
+                # `, average within …` annotation that ClimaAnalysis appends
+                # for monthly diagnostics — otherwise it leaks into the title
+                # alongside our explicit "mean over <years>" phrase.
+                long_name =
+                    get(sim_var_full.attributes, "long_name", short_name)
+                long_name = String(split(long_name, ", average")[1])
+                units_str = ClimaAnalysis.units(sim_var)
+                masked_data = mask_fn_dict[short_name](sim_var).data
+                finite = filter(isfinite, vec(masked_data))
+                panel_title = if isempty(finite)
+                    "$long_name, mean over $year_str [$units_str]"
+                else
+                    lo, hi = extrema(finite)
+                    Printf.@sprintf(
+                        "%s, mean over %s, range %.3g to %.3g [%s]",
+                        long_name,
+                        year_str,
+                        lo,
+                        hi,
+                        units_str,
+                    )
+                end
+                more_kwargs[:axis] = Dict(:title => panel_title)
                 ClimaAnalysis.Visualize.contour2D_on_globe!(
                     layout,
                     sim_var,
                     mask = mask_fn_dict[short_name];
                     more_kwargs,
+                )
+            elseif group == "MON"
+                sim_var_full, obs_var_full = sim_obs_full_dict[short_name]
+                isempty(sim_var_full) && break
+                mask_fn = mask_fn_dict[short_name]
+                sim_monthly =
+                    _monthly_climatology_global_mean(sim_var_full, mask_fn)
+                obs_monthly =
+                    _monthly_climatology_global_mean(obs_var_full, mask_fn)
+                units_str = ClimaAnalysis.units(sim_var_full)
+                ax = CairoMakie.Axis(
+                    fig_sim_ann[row_idx, col_idx],
+                    xlabel = "Month",
+                    ylabel = "$short_name ($units_str)",
+                    xticks = (
+                        1:12,
+                        [
+                            "J",
+                            "F",
+                            "M",
+                            "A",
+                            "M",
+                            "J",
+                            "J",
+                            "A",
+                            "S",
+                            "O",
+                            "N",
+                            "D",
+                        ],
+                    ),
+                )
+                CairoMakie.lines!(
+                    ax,
+                    1:12,
+                    obs_monthly;
+                    color = :black,
+                    linewidth = 4,
+                    label = "OBS",
+                )
+                CairoMakie.lines!(
+                    ax,
+                    1:12,
+                    sim_monthly;
+                    color = :firebrick,
+                    linewidth = 4,
+                    label = "SIM",
+                )
+                # Show the legend only on the top-right panel (first row of
+                # MON); per review feedback (kmdeck/AlexisRenchon), repeating
+                # it on every row clutters the figure and on some variables
+                # (e.g. SWU, NEE) the curves intersect the :rt anchor.
+                row_idx == 1 && CairoMakie.axislegend(
+                    ax,
+                    position = :rt,
+                    framevisible = false,
                 )
             else
                 sim_var, obs_var =

--- a/ext/land_sim_vis/leaderboard/rmse_boxplots.jl
+++ b/ext/land_sim_vis/leaderboard/rmse_boxplots.jl
@@ -1,0 +1,514 @@
+# Energy and carbon RMSE boxplots: compare ClimaLand against an ILAMB land-hist
+# cohort. "Other-model" RMSE values are inlined from the ILAMB land-hist
+# dashboards (https://www.ilamb.org/land-hist/) and from the LE intercomparison
+# in the CliMA-Land RMSE tracker. ClimaLand RMSE is computed at runtime from
+# the diagnostics directory using the same workflow as
+# `compute_seasonal_leaderboard`.
+
+# Convert ET in mm/day to LE in W/m^2 using the latent heat of vaporization
+# (2.45e6 J/kg) and seconds per day.
+const _ET_TO_LE = 2.45e6 / 86400
+
+# Panel definitions (sim short_name + benchmark used by the cohort + cohort RMSEs).
+const _ENERGY_PANELS = (
+    (
+        title = "H",
+        sim_short_name = "shf",
+        data_source = "ERA5",
+        bench = "vs FLUXCOM",
+        others = [
+            19.1,
+            18.0,
+            15.3,
+            17.9,
+            18.9,
+            15.8,
+            22.9,
+            24.0,
+            22.6,
+            16.8,
+            17.8,
+            14.8,
+        ],
+    ),
+    (
+        title = "LE",
+        sim_short_name = "lhf",
+        data_source = "ERA5",
+        bench = "vs ERA5",
+        others = [
+            0.529,
+            0.789,
+            0.600,
+            0.491,
+            0.657,
+            0.621,
+            0.756,
+            0.618,
+            0.779,
+            0.805,
+            0.569,
+            0.702,
+            0.494,
+            0.563,
+            0.622,
+            0.671,
+            0.566,
+            0.561,
+            0.650,
+            0.620,
+            0.616,
+        ] .* _ET_TO_LE,
+    ),
+    (
+        title = "SWup",
+        sim_short_name = "swu",
+        data_source = "ERA5",
+        bench = "vs CERESed4.1",
+        others = [
+            12.7,
+            12.3,
+            13.4,
+            15.1,
+            13.7,
+            14.8,
+            17.5,
+            15.4,
+            17.5,
+            12.9,
+            12.0,
+            13.7,
+        ],
+    ),
+    (
+        title = "LWup",
+        sim_short_name = "lwu",
+        data_source = "ERA5",
+        bench = "vs CERESed4.1",
+        others = [12.1, 12.6, 12.3, 13.3, 10.8, 11.3, 11.5, 10.3, 11.0],
+    ),
+)
+
+const _CARBON_PANELS = (
+    (
+        title = "GPP",
+        sim_short_name = "gpp",
+        data_source = "ILAMB",
+        bench = "vs FLUXCOM",
+        others = [
+            1.39,
+            1.08,
+            1.97,
+            1.01,
+            1.04,
+            1.13,
+            0.950,
+            0.828,
+            0.907,
+            1.42,
+            1.19,
+            1.67,
+        ],
+    ),
+    (
+        title = "ER",
+        sim_short_name = "er",
+        data_source = "ILAMB",
+        bench = "vs FLUXCOM",
+        others = [
+            1.78,
+            1.38,
+            2.01,
+            4.07,
+            3.03,
+            3.87,
+            4.87,
+            2.98,
+            4.12,
+            2.01,
+            2.19,
+            2.07,
+        ],
+    ),
+)
+
+"""
+    _annual_global_rmse(diagnostics_folder_path, short_name, data_source;
+                        spin_up_months = 12)
+
+Compute the global, annual-mean RMSE of ClimaLand `short_name` against the
+benchmark indicated by `data_source` (`"ILAMB"` or `"ERA5"`). The pipeline
+mirrors `compute_seasonal_leaderboard`: spinup removed, windowed to overlap,
+resampled, time-averaged, then `ClimaAnalysis.global_rmse` with the same mask.
+
+Returns `NaN` if the variable is not in the simulation directory or in the
+benchmark.
+"""
+function _annual_global_rmse(
+    diagnostics_folder_path,
+    short_name,
+    data_source;
+    spin_up_months = 12,
+)
+    sim_var_dict = get_sim_var_dict(diagnostics_folder_path)
+    obs_var_dict = get_obs_var_dict(data_source)
+    mask_dict = get_mask_dict(data_source)
+    available = ClimaAnalysis.available_vars(
+        ClimaAnalysis.SimDir(diagnostics_folder_path),
+    )
+    (
+        short_name in keys(sim_var_dict) &&
+        short_name in keys(obs_var_dict) &&
+        short_name in available
+    ) || return NaN
+
+    sim_var = sim_var_dict[short_name]()
+    obs_var = obs_var_dict[short_name](sim_var.attributes["start_date"])
+
+    spinup_cutoff = spin_up_months * 31 * 86400.0
+    if ClimaAnalysis.times(sim_var)[end] >= spinup_cutoff
+        sim_var = ClimaAnalysis.window(sim_var, "time", left = spinup_cutoff)
+    end
+
+    sim_times = ClimaAnalysis.times(sim_var)
+    obs_times = ClimaAnalysis.times(obs_var)
+    min_time = maximum(first.((sim_times, obs_times)))
+    max_time = minimum(last.((sim_times, obs_times)))
+    sim_var =
+        ClimaAnalysis.window(sim_var, "time", left = min_time, right = max_time)
+    obs_var =
+        ClimaAnalysis.window(obs_var, "time", left = min_time, right = max_time)
+
+    obs_var = ClimaAnalysis.shift_longitude(obs_var, -180.0, 180.0)
+    obs_var = ClimaAnalysis.resampled_as(obs_var, sim_var)
+
+    mask_fn = mask_dict[short_name](sim_var, obs_var)
+    sim_avg = ClimaAnalysis.average_time(sim_var)
+    obs_avg = ClimaAnalysis.average_time(obs_var)
+    return ClimaAnalysis.global_rmse(sim_avg, obs_avg; mask = mask_fn)
+end
+
+# Box-and-whisker statistics with Tukey-style 1.5*IQR fences clipped to data
+# extrema.
+function _bstats(vals)
+    s = sort(collect(filter(isfinite, vals)))
+    length(s) < 2 && return nothing
+    q1 = Statistics.quantile(s, 0.25)
+    med = Statistics.quantile(s, 0.50)
+    q3 = Statistics.quantile(s, 0.75)
+    iqr = q3 - q1
+    lo = max(minimum(s), q1 - 1.5 * iqr)
+    hi = min(maximum(s), q3 + 1.5 * iqr)
+    return (; q1, med, q3, lo, hi)
+end
+
+# Draw one panel: cohort box + jittered model dots + ClimaLand current/prev dots.
+function _draw_boxplot_panel!(
+    fig,
+    col,
+    panel,
+    rmse_current,
+    rmse_prev,
+    y_max,
+    ylabel,
+)
+    ax = CairoMakie.Axis(
+        fig[1, col],
+        title = panel.title,
+        titlesize = 18,
+        ylabel = ylabel,
+        xlabel = "$(panel.bench)\nn=$(length(panel.others))",
+        xlabelsize = 12,
+        xlabelcolor = :gray,
+        xticks = (Float64[], String[]),
+        xgridvisible = false,
+        limits = (0, 1, 0, y_max),
+    )
+    CairoMakie.hidexdecorations!(
+        ax;
+        ticks = true,
+        ticklabels = true,
+        label = false,
+        grid = true,
+    )
+
+    cx = 0.40
+    box_half = 0.085
+
+    s = _bstats(panel.others)
+    if !isnothing(s)
+        # IQR box
+        CairoMakie.poly!(
+            ax,
+            CairoMakie.Rect(cx - box_half, s.q1, 2 * box_half, s.q3 - s.q1);
+            color = (:dodgerblue, 0.10),
+            strokecolor = :dodgerblue,
+            strokewidth = 1.5,
+        )
+        # Median
+        CairoMakie.lines!(
+            ax,
+            [cx - box_half, cx + box_half],
+            [s.med, s.med];
+            color = :darkorange,
+            linewidth = 3,
+        )
+        # Whiskers
+        CairoMakie.lines!(
+            ax,
+            [cx, cx],
+            [s.lo, s.q1];
+            color = :dodgerblue,
+            linewidth = 1.5,
+        )
+        CairoMakie.lines!(
+            ax,
+            [cx, cx],
+            [s.q3, s.hi];
+            color = :dodgerblue,
+            linewidth = 1.5,
+        )
+        CairoMakie.lines!(
+            ax,
+            [cx - 0.04, cx + 0.04],
+            [s.lo, s.lo];
+            color = :dodgerblue,
+            linewidth = 1.5,
+        )
+        CairoMakie.lines!(
+            ax,
+            [cx - 0.04, cx + 0.04],
+            [s.hi, s.hi];
+            color = :dodgerblue,
+            linewidth = 1.5,
+        )
+    end
+
+    # Jittered model dots (deterministic golden-ratio jitter for stable layout)
+    for (i, v) in enumerate(panel.others)
+        jx = cx + ((i * 0.618033) % 1) * 0.16 - 0.08
+        CairoMakie.scatter!(
+            ax,
+            [jx],
+            [v];
+            color = (:dodgerblue, 0.4),
+            strokecolor = :white,
+            strokewidth = 0.7,
+            markersize = 11,
+        )
+    end
+
+    # ClimaLand dots offset to the right of the box
+    dx = cx + box_half + 0.18
+
+    if isfinite(rmse_prev) && isfinite(rmse_current)
+        CairoMakie.lines!(
+            ax,
+            [dx, dx],
+            [rmse_prev, rmse_current];
+            color = :gray,
+            linewidth = 1.5,
+        )
+    end
+    if isfinite(rmse_prev)
+        CairoMakie.scatter!(
+            ax,
+            [dx],
+            [rmse_prev];
+            color = :gray,
+            strokecolor = :white,
+            strokewidth = 2,
+            markersize = 16,
+        )
+    end
+    if isfinite(rmse_current)
+        CairoMakie.scatter!(
+            ax,
+            [dx],
+            [rmse_current];
+            color = :firebrick,
+            strokecolor = :white,
+            strokewidth = 2,
+            markersize = 16,
+        )
+    end
+    if isfinite(rmse_prev) && isfinite(rmse_current) && rmse_prev > 0
+        pct = round(Int, (rmse_prev - rmse_current) / rmse_prev * 100)
+        sign = pct >= 0 ? "−" : "+"
+        CairoMakie.text!(
+            ax,
+            dx + 0.04,
+            (rmse_prev + rmse_current) / 2;
+            text = "$(sign)$(abs(pct))%",
+            color = pct >= 0 ? :forestgreen : :firebrick,
+            fontsize = 14,
+            font = :bold,
+            align = (:left, :center),
+        )
+    end
+
+    return ax
+end
+
+"""
+    compute_rmse_boxplots(leaderboard_base_path,
+                          diagnostics_folder_path;
+                          prev_diagnostics_folder_path = nothing)
+
+Generate `boxplot_rmse.png` in `leaderboard_base_path`: a single figure with
+four energy panels (H, LE, SWup, LWup) and two carbon panels (GPP, ER) side
+by side, separated by a slightly wider column gap because the two groups use
+different units.
+
+Each panel shows a boxplot of "other-model" RMSE values from the ILAMB
+land-hist dashboards alongside the ClimaLand RMSE computed from the simulation
+in `diagnostics_folder_path` (red dot). If `prev_diagnostics_folder_path` is
+given, the equivalent RMSE from that earlier run is plotted as a gray dot,
+with a percent-change label drawn between the two.
+
+Energy panels are RMSE in W m⁻² (ClimaLand vs ERA5); the cohort benchmark
+differs per panel — see the per-panel label. Carbon panels are RMSE in
+g m⁻² day⁻¹ (ClimaLand and cohort both vs ILAMB FLUXCOM).
+"""
+function compute_rmse_boxplots(
+    leaderboard_base_path,
+    diagnostics_folder_path;
+    prev_diagnostics_folder_path = nothing,
+)
+    @info "Computing ClimaLand RMSE for energy/carbon boxplots"
+
+    energy_panels = collect(_ENERGY_PANELS)
+    carbon_panels = collect(_CARBON_PANELS)
+    all_panels = vcat(energy_panels, carbon_panels)
+    n_energy = length(energy_panels)
+
+    rmse_current = Dict{String, Float64}()
+    rmse_prev = Dict{String, Float64}()
+    for p in all_panels
+        rmse_current[p.sim_short_name] = _annual_global_rmse(
+            diagnostics_folder_path,
+            p.sim_short_name,
+            p.data_source,
+        )
+        rmse_prev[p.sim_short_name] =
+            isnothing(prev_diagnostics_folder_path) ? NaN :
+            _annual_global_rmse(
+                prev_diagnostics_folder_path,
+                p.sim_short_name,
+                p.data_source,
+            )
+    end
+
+    function _group_y_max(panels)
+        vals = Float64[]
+        for p in panels
+            append!(vals, p.others)
+            push!(vals, rmse_current[p.sim_short_name])
+            push!(vals, rmse_prev[p.sim_short_name])
+        end
+        finite = filter(isfinite, vals)
+        return isempty(finite) ? 1.0 : maximum(finite) * 1.18
+    end
+    y_max_energy = _group_y_max(energy_panels)
+    y_max_carbon = _group_y_max(carbon_panels)
+
+    fig = CairoMakie.Figure(size = (260 * length(all_panels) + 280, 560))
+    for (col, p) in enumerate(all_panels)
+        is_energy = col <= n_energy
+        y_max = is_energy ? y_max_energy : y_max_carbon
+        ylabel = if col == 1
+            "RMSE [W m⁻²]"
+        elseif col == n_energy + 1
+            "RMSE [g m⁻² day⁻¹]"
+        else
+            ""
+        end
+        _draw_boxplot_panel!(
+            fig,
+            col,
+            p,
+            rmse_current[p.sim_short_name],
+            rmse_prev[p.sim_short_name],
+            y_max,
+            ylabel,
+        )
+    end
+    # Widen the gap between the last energy panel and the first carbon panel
+    # so the unit change reads as a deliberate split rather than another panel.
+    CairoMakie.colgap!(fig.layout, n_energy, 50)
+
+    CairoMakie.Label(
+        fig[0, :],
+        "ClimaLand RMSE — Global energy and carbon fluxes";
+        fontsize = 18,
+        font = :bold,
+    )
+
+    legend_elems = [
+        CairoMakie.MarkerElement(
+            color = (:dodgerblue, 0.4),
+            marker = :circle,
+            markersize = 11,
+        ),
+        CairoMakie.LineElement(color = :darkorange, linewidth = 3),
+        CairoMakie.PolyElement(
+            color = (:dodgerblue, 0.10),
+            strokecolor = :dodgerblue,
+            strokewidth = 1.5,
+        ),
+        CairoMakie.MarkerElement(
+            color = :firebrick,
+            marker = :circle,
+            markersize = 14,
+        ),
+    ]
+    legend_labels = [
+        "Other models (ILAMB land-hist)",
+        "Ensemble median",
+        "IQR box",
+        "ClimaLand · current",
+    ]
+    if !isnothing(prev_diagnostics_folder_path)
+        push!(
+            legend_elems,
+            CairoMakie.MarkerElement(
+                color = :gray,
+                marker = :circle,
+                markersize = 14,
+            ),
+        )
+        push!(legend_labels, "ClimaLand · previous")
+    end
+    CairoMakie.Legend(
+        fig[2, :],
+        legend_elems,
+        legend_labels;
+        orientation = :horizontal,
+        tellheight = true,
+        framevisible = false,
+        labelsize = 12,
+    )
+
+    disclaimer =
+        "Disclaimer: For internal use only. A proper Model Intercomparison " *
+        "Project (MIP) is beyond scope here, so this comparison is not " *
+        "strictly fair: reference datasets and forcings differ across " *
+        "models, tuning targets differ, and some variables are prescribed " *
+        "rather than predicted (e.g., LAI in ClimaLand). Only a MIP would " *
+        "enable a fair comparison."
+    CairoMakie.Label(
+        fig[3, :],
+        disclaimer;
+        fontsize = 11,
+        color = :gray30,
+        word_wrap = true,
+        justification = :left,
+        halign = :left,
+        tellheight = true,
+        tellwidth = false,
+        padding = (10, 10, 6, 0),
+    )
+
+    CairoMakie.save(joinpath(leaderboard_base_path, "boxplot_rmse.png"), fig)
+    return nothing
+end


### PR DESCRIPTION
This PR adds global seasonality to ilamb energy and carbon annual figures, as well as a boxplot comparing to other model

<img width="3680" height="1120" alt="boxplot_rmse" src="https://github.com/user-attachments/assets/f8999331-f00f-4794-9a3e-5bd998986e92" />

Note the "Disclaimer: For internal use only. A proper Model Intercomparison Project (MIP) is beyond scope here, so this comparison is not strictly fair: reference datasets and forcings differ across models, tuning targets differ, and some variables are prescribed rather than predicted (e.g., LAI in ClimaLand). Only a MIP would enable a fair comparison."

<img width="3600" height="3200" alt="ERA5_sim_annual_time_avg_over_all_years" src="https://github.com/user-attachments/assets/6b0e353c-931f-45f5-af5b-599c219cbf91" />
<img width="3600" height="2400" alt="ILAMB_sim_annual_time_avg_over_all_years" src="https://github.com/user-attachments/assets/30eb6e86-a02c-43b3-a415-53702bb7e6ad" />

you can optionally pass two climaland output (e.g., may 2026, november 2025) to see how it has evolved in the boxplot figure

<img width="3680" height="1120" alt="boxplot_rmse" src="https://github.com/user-attachments/assets/6adf8e4f-2fa9-4f08-b1a7-cd64dec15b98" />