### PR TITLE
Tr/bench

### DIFF
--- a/.buildkite/short_perf/pipeline.yml
+++ b/.buildkite/short_perf/pipeline.yml
@@ -67,7 +67,8 @@ steps:
                     command: "julia --color=yes --project=.buildkite experiments/benchmarks/bucket.jl"
                     agents:
                       slurm_mem: 8GB
-                      slurm_gpus: 1
+                      # a bug in this plugin ignores non-strings properties
+                      slurm_gpus: "1"
                     concurrency: 1
                     concurrency_group: "depot/climaland-perf-regression-tests"
                     artifact_paths:
@@ -84,7 +85,8 @@ steps:
                     concurrency_group: "depot/climaland-perf-regression-tests"
                     agents:
                       slurm_mem: 24GB
-                      slurm_gpus: 1
+                      # a bug in this plugin ignores non-strings properties
+                      slurm_gpus: "1"
                     artifact_paths:
                       - "snowy_land_benchmark_gpu/*"
                 - path:
@@ -101,6 +103,7 @@ steps:
                     concurrency_group: "depot/climaland-perf-regression-tests"
                     agents:
                       slurm_mem: 16GB
-                      slurm_gpus: 1
+                      # a bug in this plugin ignores non-strings properties
+                      slurm_gpus: "1"
                     artifact_paths:
                       - "soil_benchmark_gpu/*"

--- a/experiments/benchmarks/benchmark_utils.jl
+++ b/experiments/benchmarks/benchmark_utils.jl
@@ -47,7 +47,9 @@ function profile_and_benchmark(
         GC.gc()
         # if the profiler is run before the benchmarks, the timing seems less consistent
         run_profiler(setup_simulation, device, outdir)
-        if get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing) == "climaland-benchmark"
+        buildkite_slug = get(ENV, "BUILDKITE_PIPELINE_SLUG", nothing)
+        if buildkite_slug == "climaland-benchmark" ||
+           buildkite_slug == "climaland-dot-jl-short-benchmarks"
             if average_timing_s > reference_time + std_timing_s
                 @info "Possible performance regression, previous average time was $(reference_time)"
                 extra_note_string = "If this is unexpected, it may be caused by someone "


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
- make the short-perf pipeline actually test for regressions
- change the way a gpu is requested so the plugin will pass it to slurm-buildkite

## To-do
- re-enable the pipeline after merging this



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
