### PR TITLE
Dependabot updates

### DIFF
--- a/.github/workflows/DocCleanup.yml
+++ b/.github/workflows/DocCleanup.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
       - name: Delete preview and history + push changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,12 @@ jobs:
         exclude:
           - os: ''
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
       - name: Cache Julia depot
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # Cache Julia's depot
           path: |
@@ -57,7 +57,7 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
         with:
           file: lcov.info
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           file: lcov.info
           token: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,12 +15,12 @@ jobs:
   docbuild:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.12'
       - name: Cache Julia depot
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # Cache Julia's depot
           path: |

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -22,12 +22,12 @@ jobs:
       matrix:
         version: ['1.10', '1.12']
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
       - name: Cache Julia depot
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # Cache Julia's depot
           path: |

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -26,12 +26,12 @@ jobs:
           - '1.10'
           - '1.12'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
       - name: Cache Julia depot
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # Cache Julia's depot
           path: |
@@ -48,7 +48,7 @@ jobs:
             ubuntu-latest-julia-${{ matrix.version }}-
             ubuntu-latest-julia-
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: 'CliMA/ClimaCoupler.jl'
           path: ClimaCoupler.jl


### PR DESCRIPTION
This PR bump actions/cache from 4 to 5, codecov/codecov-action from 5 to 6, and actions/checkout from 5 to 6.