### PR TITLE
Calibration of carbon and energy (inversion nee, sif-based gpp)

### DIFF
--- a/experiments/calibration/README.md
+++ b/experiments/calibration/README.md
@@ -14,10 +14,7 @@ latitude-weighted scalar covariance matrix.
    `CALIBRATION_CONFIG=gpp.jl bash experiments/calibration/run_calibration.sh`.
    When `TEST_CALIBRATION` is set, the single-parameter `configs/test.jl` is
    loaded instead.
-2. Load the `climacommon` version appropriate for your cluster (for example,
-   `module load climacommon/2025_02_25` on Derecho). The loaded version is
-   forwarded to the compute jobs automatically.
-3. Run the calibration script on the cluster:
+2. Run the calibration script on the cluster:
     - Execute `bash experiments/calibration/run_calibration.sh [OUTPUT_DIR]` in
       the terminal. `OUTPUT_DIR` is optional; on Derecho you typically want to
       pass a scratch path (e.g. `/glade/derecho/scratch/$USER/calibration_gpp`).
@@ -25,30 +22,29 @@ latitude-weighted scalar covariance matrix.
       submission for the forward models.
     - You may want to use `tmux` to keep a persistent session on the cluster.
 
-For example, launching er.jl on Derecho
-Go into tmux:
+Before invoking the script you still need to `module load climacommon/<version>`
+to put Julia on the orchestrator's PATH. The version forward-model PBS jobs
+load is pinned separately in `run_calibration.jl` via the `modules` keyword on
+the backend constructor — edit that line directly to change it.
+
+For example, launching er.jl on Derecho.
+
+Note Derecho has multiple login nodes (`derecho1`–`derecho7`); tmux sessions are
+per-node, so SSH to a specific one (e.g. `ssh derecho7.hpc.ucar.edu`) so you can
+reattach later from the same node.
+
+Go into tmux (`-s` sets the session name; `-t` is for target-session groups and
+won't do what you want here):
 
 ```
-tmux new -t calibration
+tmux new -s calibration
 ```
 
 (later on, attach via `tmux attach -t calibration`, and detach via `ctrl+b, release, press d`)
-Start the calibration:
+Start the calibration *inside* the tmux session:
 
 ```
 module load climacommon/2025_02_25
-export HDF5_USE_FILE_LOCKING=FALSE
 export CALIBRATION_CONFIG=er.jl
 bash experiments/calibration/run_calibration.sh /glade/derecho/scratch/$USER/calibration_er
 ```
-
-# Debugging
-
-ClimaCalibrate tries to keep `climacommon` up to date. If errors result from
-Julia version mismatches, use the `climacommon` versions below. These versions
-are compatible with ClimaCalibrate v0.2.2.
-
-- `ClimaGPUBackend`: `climacommon/2026_02_18`
-- `DerechoBackend`: `climacommon/2025_02_25`
-- `CaltechHPCBackend`: `climacommon/2024_10_09`
-- `GCPBackend`: `climacommon` is not supported

--- a/experiments/calibration/api.jl
+++ b/experiments/calibration/api.jl
@@ -59,8 +59,9 @@ struct CalibrateConfig{SPINUP <: Dates.Period, EXTEND <: Dates.Period, MODEL}
     model_type::MODEL
 
     "Whether the soil model should use the Rosetta (Montzka et al. 2017) van
-    Genuchten retention parameters instead of the default Gupta et al. (2020)
-    product. Only affects `ClimaLand.LandModel` runs."
+    Genuchten retention parameters (and the matching spun-up Rosetta initial
+    conditions) instead of the Gupta et al. (2020) product. Only affects
+    `ClimaLand.LandModel` runs."
     use_rosetta::Bool
 end
 
@@ -123,9 +124,11 @@ Keyword arguments
 - `model_type`: A type indicating which model to use. The only supported
   models are "ClimaLand.LandModel" and "ClimaLand.Bucket.BucketModel".
 
-- `use_rosetta`: If `true`, the `ClimaLand.LandModel` soil model uses the Rosetta
-  (Montzka et al. 2017) van Genuchten retention parameters instead of the default
-  Gupta et al. (2020) product. Defaults to `false`. Ignored for the bucket model.
+- `use_rosetta`: If `true` (the default), the `ClimaLand.LandModel` soil model
+  uses the Rosetta (Montzka et al. 2017) van Genuchten retention parameters and
+  the matching spun-up Rosetta initial conditions; if `false`, it uses the Gupta
+  et al. (2020) product with the Gupta-based saturated initial conditions.
+  Ignored for the bucket model.
 """
 function CalibrateConfig(;
     short_names,
@@ -143,7 +146,7 @@ function CalibrateConfig(;
         "land_observation_vector.jld2",
     ),
     model_type = ClimaLand.LandModel,
-    use_rosetta = false,
+    use_rosetta = true,
 )
     isempty(short_names) && error("Cannot run calibration with no short names")
 

--- a/experiments/calibration/api.jl
+++ b/experiments/calibration/api.jl
@@ -63,6 +63,12 @@ struct CalibrateConfig{SPINUP <: Dates.Period, EXTEND <: Dates.Period, MODEL}
     conditions) instead of the Gupta et al. (2020) product. Only affects
     `ClimaLand.LandModel` runs."
     use_rosetta::Bool
+
+    "Whether the canopy should compute LAI prognostically with the optimal-LAI
+    model (Zhou et al. 2025, `ZhouOptimalLAIModel`) instead of prescribing it
+    from MODIS. Set `true` to calibrate the optimal-LAI parameters against the
+    MODIS `lai` target. Only affects `ClimaLand.LandModel` runs."
+    prognostic_lai::Bool
 end
 
 """
@@ -129,6 +135,12 @@ Keyword arguments
   the matching spun-up Rosetta initial conditions; if `false`, it uses the Gupta
   et al. (2020) product with the Gupta-based saturated initial conditions.
   Ignored for the bucket model.
+
+- `prognostic_lai`: If `true`, the canopy computes LAI prognostically with the
+  optimal-LAI model (`ZhouOptimalLAIModel`, Zhou et al. 2025) instead of
+  prescribing it from MODIS. Use this when calibrating the optimal-LAI
+  parameters against the MODIS `lai` target. Defaults to `false` (prescribed
+  MODIS LAI). Ignored for the bucket model.
 """
 function CalibrateConfig(;
     short_names,
@@ -147,6 +159,7 @@ function CalibrateConfig(;
     ),
     model_type = ClimaLand.LandModel,
     use_rosetta = true,
+    prognostic_lai = false,
 )
     isempty(short_names) && error("Cannot run calibration with no short names")
 
@@ -200,6 +213,7 @@ function CalibrateConfig(;
         obs_vec_filepath,
         model_type,
         use_rosetta,
+        prognostic_lai,
     )
 
 end

--- a/experiments/calibration/api.jl
+++ b/experiments/calibration/api.jl
@@ -57,6 +57,11 @@ struct CalibrateConfig{SPINUP <: Dates.Period, EXTEND <: Dates.Period, MODEL}
 
     """Type of model to use"""
     model_type::MODEL
+
+    "Whether the soil model should use the Rosetta (Montzka et al. 2017) van
+    Genuchten retention parameters instead of the default Gupta et al. (2020)
+    product. Only affects `ClimaLand.LandModel` runs."
+    use_rosetta::Bool
 end
 
 """
@@ -117,6 +122,10 @@ Keyword arguments
 
 - `model_type`: A type indicating which model to use. The only supported
   models are "ClimaLand.LandModel" and "ClimaLand.Bucket.BucketModel".
+
+- `use_rosetta`: If `true`, the `ClimaLand.LandModel` soil model uses the Rosetta
+  (Montzka et al. 2017) van Genuchten retention parameters instead of the default
+  Gupta et al. (2020) product. Defaults to `false`. Ignored for the bucket model.
 """
 function CalibrateConfig(;
     short_names,
@@ -134,6 +143,7 @@ function CalibrateConfig(;
         "land_observation_vector.jld2",
     ),
     model_type = ClimaLand.LandModel,
+    use_rosetta = false,
 )
     isempty(short_names) && error("Cannot run calibration with no short names")
 
@@ -186,6 +196,7 @@ function CalibrateConfig(;
         rng_seed,
         obs_vec_filepath,
         model_type,
+        use_rosetta,
     )
 
 end

--- a/experiments/calibration/build_model_lai_validity_mask.jl
+++ b/experiments/calibration/build_model_lai_validity_mask.jl
@@ -1,0 +1,109 @@
+# Build the model-LAI validity mask used to align the MODIS-LAI observation with
+# the simulated-LAI footprint (see preprocess_single_obs_var in
+# generate_observations.jl).
+#
+# Why this exists: the ClimaLand `lai` diagnostic is NaN over a broader set of
+# grid cells than the observation's `make_ocean_mask` removes (interpolated
+# diagnostics are not mask-aware, so coastline / partially-ocean cells the mask
+# keeps still come back NaN from the simulation). Those cells stay finite in the
+# MODIS obs, so the forward-model G ensemble ends up with NaNs at obs-valid
+# cells. With TransformUnscented (UKI) the innovation `y - mean(G)` then goes
+# NaN and every parameter update collapses to NaN. Masking the observation by
+# the simulated-LAI validity footprint removes the mismatch at the source.
+#
+# The footprint is structural (identical across ensemble members with valid
+# parameters), so it is derived once from a reference forward-model run and
+# saved. Regenerate it whenever `nelements` (the model grid) changes.
+#
+# Usage:
+#   julia --project=.buildkite experiments/calibration/build_model_lai_validity_mask.jl \
+#       <reference_simdir> [<output_path>]
+#
+# <reference_simdir> is a global_diagnostics output directory from a valid
+# forward-model run, e.g.
+#   <cal_output>/iteration_001/member_001/global_diagnostics/output_active
+
+import ClimaAnalysis
+import ClimaLand
+import JLD2
+
+include(
+    joinpath(
+        pkgdir(ClimaLand),
+        "experiments",
+        "calibration",
+        "observation_utils.jl",
+    ),
+)
+include(
+    joinpath(
+        pkgdir(ClimaLand),
+        "ext",
+        "land_sim_vis",
+        "leaderboard",
+        "data_sources.jl",
+    ),
+)
+
+const DEFAULT_MASK_PATH = joinpath(
+    pkgdir(ClimaLand),
+    "experiments",
+    "calibration",
+    "model_lai_validity_mask.jld2",
+)
+
+"""
+    build_model_lai_validity_mask(reference_simdir)
+
+Return an `OutputVar` on the diagnostics grid that is `1.0` where the simulated
+`lai` diagnostic is finite and `0.0` where it is NaN, taking the union of NaN
+locations across all seasons (the structural footprint). The variable is
+preprocessed with the same steps used for the simulation side of the
+observation map (`preprocess_sim_var` + `average_season_across_time`) so its
+grid matches the resampled observation before windowing.
+"""
+function build_model_lai_validity_mask(reference_simdir)
+    simdir = ClimaAnalysis.SimDir(reference_simdir)
+    var = get(simdir, "lai")
+    var = preprocess_sim_var(var)
+    var = ClimaAnalysis.average_season_across_time(var, ignore_nan = false)
+
+    tname = ClimaAnalysis.time_name(var)
+    tidx = var.dim2index[tname]
+    nan_union =
+        reduce((a, b) -> a .| b, eachslice(isnan.(var.data); dims = tidx))
+
+    lats = ClimaAnalysis.latitudes(var)
+    lons = ClimaAnalysis.longitudes(var)
+    # nan_union follows `var`'s spatial axis order (lon, lat); OutputVar expects
+    # the data laid out as (latitude, longitude), so permute to match the dims.
+    lat_idx = var.dim2index[ClimaAnalysis.latitude_name(var)]
+    lon_idx = var.dim2index[ClimaAnalysis.longitude_name(var)]
+    spatial_nan = lat_idx < lon_idx ? nan_union : permutedims(nan_union, (2, 1))
+    validity = map(isnan_cell -> isnan_cell ? 0.0 : 1.0, spatial_nan)
+
+    attribs = Dict(
+        "short_name" => "model_lai_validity",
+        "long_name" => "Simulated LAI validity mask (1 where sim LAI is finite)",
+    )
+    dim_attribs = Dict(
+        "latitude" => Dict("units" => "degrees_north"),
+        "longitude" => Dict("units" => "degrees_east"),
+    )
+    dims = Dict("latitude" => lats, "longitude" => lons)
+    return ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, validity)
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    length(ARGS) >= 1 || error(
+        "Usage: julia --project=.buildkite build_model_lai_validity_mask.jl <reference_simdir> [<output_path>]",
+    )
+    reference_simdir = ARGS[1]
+    output_path = length(ARGS) >= 2 ? ARGS[2] : DEFAULT_MASK_PATH
+    maskvar = build_model_lai_validity_mask(reference_simdir)
+    n_valid = count(==(1.0), maskvar.data)
+    n_total = length(maskvar.data)
+    @info "Built model LAI validity mask" reference_simdir n_valid n_total
+    JLD2.save_object(output_path, maskvar)
+    @info "Saved mask" output_path
+end

--- a/experiments/calibration/configs/ar_res_er.jl
+++ b/experiments/calibration/configs/ar_res_er.jl
@@ -1,0 +1,88 @@
+# Calibration config: autotrophic respiration vs inversion residual ER.
+# Included by run_calibration.jl; defines CALIBRATE_CONFIG, NOISE_SCALARS, and
+# get_calibration_prior(). Run with:
+#   CALIBRATION_CONFIG=ar_res_er.jl \
+#     bash experiments/calibration/run_calibration.sh
+#
+# Goal: pull total ecosystem respiration ER = Ra + Rh onto the inversion
+# residual ER (res_er = CT2022 NEE + GOSIF GPP) by moving ONLY autotrophic
+# respiration. GPP and the DAMM/Rh params are already baked into
+# toml/default_parameters.toml (GOSIF/energy + Hashimoto calibrations), so Rh is
+# held fixed here and ER is shifted entirely through Ra.
+#
+# The two free parameters live solely in autotrophic_respiration.jl and never
+# enter the photosynthesis / stomatal-conductance / GPP path, so GPP is
+# unchanged by this calibration (autotrophic respiration is computed strictly
+# downstream of photosynthesis: it reads An_canopy/Rd_canopy and returns Ra,
+# and nothing reads Ra back; GPP is reported as gross assimilation):
+#   - autotrophic_respiration_Rd_ref      base root/stem maintenance
+#                                          (R_root = Rd_ref*RAI, R_stem = Rd_ref*μs*SAI)
+#   - relative_contribution_factor (Rel)  growth respiration (Rg = Rel*max(An-Rpm,0))
+# The leaf maintenance term R_leaf = Rd_canopy is inherited from the (fixed)
+# photosynthesis Rd, so it is not a lever here.
+#
+# Target (from the `inversion_nee` artifact, g C m^-2 day^-1, + = source):
+#   res_er  ER residual = NEE + GPP. observation_map.jl reads the model `er`
+#           diagnostic and retags it to res_er.
+
+"""Per-variable observation variance; multiplies the identity in `ScalarCovariance`.
+Units are (dataset units)^2: res_er in (g C m^-2 day^-1)^2.
+
+Matches the res_er weight used in inversionnee_sifgpp_er_lhf_shf_lwu.jl; res_er
+is a residual (NEE + GPP) so it carries real structural noise.
+"""
+const NOISE_SCALARS = Dict("res_er" => 0.5)
+
+"""
+    get_calibration_prior()
+
+Prior over the two autotrophic-respiration parameters;
+TransformUnscented ensemble = 2*2+1 = 5 members.
+
+Both priors are centered on the current `toml/default_parameters.toml` defaults.
+autotrophic_respiration_Rd_ref uses a [0, Inf] lognormal transform (a finite
+upper bound makes constrained_gaussian silently fall back to the bound midpoint
+for these small-magnitude rates; see calibration_soilco2_prior_misspecified) and
+is given a broad σ so EKI can lower Ra (the model over-respires) without hitting
+a bound. relative_contribution_factor is two-sided on [0, 1].
+"""
+function get_calibration_prior()
+    priors = [
+        EKP.constrained_gaussian(
+            "autotrophic_respiration_Rd_ref",
+            7.83e-7,
+            5.0e-7,
+            0.0,
+            Inf,
+        ),
+        EKP.constrained_gaussian(
+            "relative_contribution_factor",
+            0.3,
+            0.15,
+            0.0,
+            1.0,
+        ),
+    ]
+    return EKP.combine_distributions(priors)
+end
+
+const CALIBRATE_CONFIG = CalibrateConfig(;
+    short_names = ["res_er"],
+    minibatch_size = 2,
+    n_iterations = 10,
+    # Yearly DJF-MAM-JJA samples (Dec 1 -> Sep 1). With spinup = Year(1) and
+    # extend = Month(3), all 16 samples stay within the artifact's 2002-2020
+    # coverage; 16 is divisible by minibatch_size so none is dropped per epoch.
+    sample_date_ranges = [
+        ("$(year)-12-1", "$(year+1)-9-1") for year in 2003:2018
+    ],
+    extend = Dates.Month(3),
+    # 1-year spinup so deep soil temperature/moisture settle before ER vs obs.
+    spinup = Dates.Year(1),
+    nelements = (180, 360, 15),
+    output_dir = OUTPUT_DIR,
+    rng_seed = 42,
+    obs_vec_filepath = "experiments/calibration/land_observation_vector_ar_res_er.jld2",
+    model_type = ClimaLand.LandModel,
+    use_rosetta = true,
+)

--- a/experiments/calibration/configs/inv_hr_damm.jl
+++ b/experiments/calibration/configs/inv_hr_damm.jl
@@ -1,0 +1,97 @@
+# Calibration config: DAMM heterotrophic respiration only.
+# Included by run_calibration.jl; defines CALIBRATE_CONFIG, NOISE_SCALARS, and
+# get_calibration_prior(). Run with:
+#   CALIBRATION_CONFIG=inv_hr_damm.jl \
+#     bash experiments/calibration/run_calibration.sh
+#
+# This isolates the soil-CO2 (DAMM) heterotrophic-respiration parameters: it
+# calibrates the four DAMM parameters against a single Rh target and nothing
+# else. The autotrophic-respiration and P-model/canopy parameters that the
+# larger inversionnee_sifgpp_er_lhf_shf_lwu.jl config also moves are excluded,
+# since Rh alone cannot constrain them.
+#
+# Target (from the `inversion_nee` artifact, g C m^-2 day^-1, + = source):
+#   inv_hr  Rh, Hashimoto 2015 (2013-2020 filled with 2002-2012 climatology).
+# observation_map.jl reads the model `hr` diagnostic and retags it to inv_hr.
+# Rh is already a daily rate, so it is not rescaled from monthly totals.
+
+"""Per-variable observation variance; multiplies the identity in `ScalarCovariance`.
+Units are (dataset units)^2: Rh in (g C m^-2 day^-1)^2.
+
+inv_hr is kept tight (0.05, matching inversionnee_sifgpp_er_lhf_shf_lwu.jl) so
+the DAMM rate is pulled to the Hashimoto magnitude rather than drifting.
+"""
+const NOISE_SCALARS = Dict("inv_hr" => 0.05)
+
+"""
+    get_calibration_prior()
+
+Prior over the four DAMM heterotrophic-respiration parameters;
+TransformUnscented ensemble = 4*2+1 = 9 members.
+
+Means, σ and bounds are inherited from the DAMM block of
+inversionnee_sifgpp_er_lhf_shf_lwu.jl. soilCO2_reference_rate and
+O2_michaelis_constant use a [0, Inf] lognormal transform: a finite upper bound
+makes constrained_gaussian silently fall back to the bound midpoint for these
+small-magnitude rates (see calibration_soilco2_prior_misspecified). Rh depends
+chiefly on soilCO2_reference_rate; soilCO2_activation_energy refines the spatial
+spread, and the two Michaelis constants shape the moisture/oxygen limitation.
+"""
+function get_calibration_prior()
+    priors = [
+        # soilCO2_reference_rate ([0, Inf] lognormal): 6e-8 gives 4-site summer
+        # Rh 1.84 vs obs 1.80 in the single-column sweep (priormean_sweep.jl).
+        EKP.constrained_gaussian(
+            "soilCO2_reference_rate",
+            6.0e-8,
+            4.0e-8,
+            0.0,
+            Inf,
+        ),
+        EKP.constrained_gaussian(
+            "soilCO2_activation_energy",
+            36897.373510987745,
+            20000.0,
+            5000.0,
+            150000.0,
+        ),
+        # σ reduced to 0.03 so μ-σ stays above the lower bound 0.001.
+        EKP.constrained_gaussian(
+            "michaelis_constant",
+            0.05113112510036322,
+            0.03,
+            0.001,
+            2.0,
+        ),
+        # [0, Inf] lognormal (same fallback issue as soilCO2_reference_rate).
+        EKP.constrained_gaussian(
+            "O2_michaelis_constant",
+            1.9e-4,
+            1.5e-4,
+            0.0,
+            Inf,
+        ),
+    ]
+    return EKP.combine_distributions(priors)
+end
+
+const CALIBRATE_CONFIG = CalibrateConfig(;
+    short_names = ["inv_hr"],
+    minibatch_size = 2,
+    n_iterations = 10,
+    # Yearly DJF-MAM-JJA samples (Dec 1 -> Sep 1). With spinup = Year(1) and
+    # extend = Month(3), all 16 samples stay within the artifact's 2002-2020
+    # coverage; 16 is divisible by minibatch_size so none is dropped per epoch.
+    sample_date_ranges = [
+        ("$(year)-12-1", "$(year+1)-9-1") for year in 2003:2018
+    ],
+    extend = Dates.Month(3),
+    # 1-year spinup so deep soil temperature/moisture settle before Hr vs obs.
+    spinup = Dates.Year(1),
+    nelements = (180, 360, 15),
+    output_dir = OUTPUT_DIR,
+    rng_seed = 42,
+    obs_vec_filepath = "experiments/calibration/land_observation_vector_inv_hr_damm.jld2",
+    model_type = ClimaLand.LandModel,
+    use_rosetta = true,
+)

--- a/experiments/calibration/configs/inversionnee_sifgpp_er_lhf_shf_lwu.jl
+++ b/experiments/calibration/configs/inversionnee_sifgpp_er_lhf_shf_lwu.jl
@@ -1,0 +1,144 @@
+# Calibration config: inversion NEE/GPP/ER/Rh + ERA5 LHF/SHF/LWU.
+# Included by run_calibration.jl; defines CALIBRATE_CONFIG, NOISE_SCALARS, and
+# get_calibration_prior(). Run with:
+#   CALIBRATION_CONFIG=inversionnee_sifgpp_er_lhf_shf_lwu.jl \
+#     bash experiments/calibration/run_calibration.sh
+#
+# Targets use distinct short_names so they don't collide with the FLUXCOM
+# gpp/er/nee keys. Carbon targets come from the `inversion_nee` artifact in
+# g C m^-2 day^-1 (sign: + = source, except GPP + = uptake):
+#   inv_nee  NEE, CarbonTracker CT2022
+#   sif_gpp  GPP, GOSIF-GPP v2
+#   res_er   ER residual = NEE + GPP
+#   inv_hr   Rh, Hashimoto 2015 (2013-2020 filled with 2002-2012 climatology)
+# plus ERA5 lhf/shf/lwu in W m^-2 (+ = upward). Sign conventions match the
+# model, which computes NEE = ER - GPP. data_sources.jl converts nee/gpp/er
+# from monthly totals to daily rates using actual days-in-month (not
+# 365.25/12); Rh is already daily and not rescaled.
+
+"""Per-variable observation variances; multiply the identity in `ScalarCovariance`.
+Units are (dataset units)^2: carbon in (g C m^-2 day^-1)^2, energy in (W m^-2)^2.
+
+inv_hr is the tightest carbon target (0.05) so soilCO2 params are pulled to the
+Hashimoto magnitude instead of collapsing. inv_nee is loose (0.2) so EKI fits
+NEE's spatial structure without buying amplitude via an unphysical AR/Rh split
+(the two errors cancel in NEE). res_er ≡ inv_nee + sif_gpp, so it carries no
+independent info; kept moderate (0.5). GPP stays loose (2.0) to absorb the
+P-model high-latitude bias. Energy variances sit at the RMSE floor (LWU 25,
+SHF/LHF 144) and act as background constraints.
+"""
+const NOISE_SCALARS = Dict(
+    "inv_nee" => 0.2,
+    "sif_gpp" => 2.0,
+    "res_er" => 0.5,
+    "inv_hr" => 0.05,
+    "lwu" => 25.0,
+    "shf" => 144.0,
+    "lhf" => 144.0,
+)
+
+"""
+    get_calibration_prior()
+
+Combined prior over 15 parameters (5 P-model/moisture-stress + 4 DAMM Rh + 1
+JULES AR Rd_ref + 5 canopy transfer); TransformUnscented ensemble = 15*2+1 = 31.
+
+relative_contribution_factor, autotrophic_respiration_Q10 and
+root_leaf_nitrogen_ratio (μr) are no longer calibrated (fixed in TOML): they
+were the AR-inflation / partition-degeneracy levers — with them free, EKI bought
+NEE amplitude by inflating AR and collapsing Rh. Means are recentered on the
+eki_file.jld2 iter-3 ensemble mean, except the canopy-transfer params (whose
+iter trajectory thrashed) which keep physical defaults. soilCO2_reference_rate,
+O2_michaelis_constant and Rd_ref use a [0, Inf] lognormal transform; finite-bound
+constrained_gaussian silently fell back to the bound midpoint for these.
+"""
+function get_calibration_prior()
+    priors = [
+        # P-model + moisture stress (means = eki_file iter-3 ensemble mean)
+        EKP.constrained_gaussian("pmodel_cstar", 0.4335786422686187, 0.05, 0.2, 0.7),
+        EKP.constrained_gaussian("pmodel_β_c3", 85.06089150945417, 40.0, 10.0, 300.0),
+        EKP.constrained_gaussian("pmodel_β_c4", 28.65798918466436, 12.0, 5.0, 100.0),
+        # σ kept tight so μ+σ stays clear of the upper bound 0.999.
+        EKP.constrained_gaussian("pmodel_α", 0.9543827460568335, 0.012, 0.85, 0.999),
+        EKP.constrained_gaussian(
+            "moisture_stress_c",
+            0.505925674083973,
+            0.15,
+            0.05,
+            1.0,
+        ),
+        # DAMM heterotrophic respiration.
+        # soilCO2_reference_rate ([0, Inf] lognormal): 6e-8 gives 4-site summer
+        # Rh 1.84 vs obs 1.80 in the single-column sweep (priormean_sweep.jl).
+        # Rh depends only on this rate; activation_energy refines its spatial spread.
+        EKP.constrained_gaussian(
+            "soilCO2_reference_rate",
+            6.0e-8,
+            4.0e-8,
+            0.0,
+            Inf,
+        ),
+        EKP.constrained_gaussian(
+            "soilCO2_activation_energy",
+            36897.373510987745,
+            20000.0,
+            5000.0,
+            150000.0,
+        ),
+        # σ reduced to 0.03 so μ-σ stays above the lower bound 0.001.
+        EKP.constrained_gaussian(
+            "michaelis_constant",
+            0.05113112510036322,
+            0.03,
+            0.001,
+            2.0,
+        ),
+        # [0, Inf] lognormal (same fallback issue as soilCO2_reference_rate).
+        EKP.constrained_gaussian(
+            "O2_michaelis_constant",
+            1.9e-4,
+            1.5e-4,
+            0.0,
+            Inf,
+        ),
+        # autotrophic_respiration_Rd_ref ([0, Inf] lognormal): base rate for the
+        # LAI-independent root/stem maintenance (R_root = Rd_ref*μr*RAI*β,
+        # R_stem = Rd_ref*μs*(ηsl*h/σl)*SAI). 2e-7 gives the best summer AR in the
+        # single-column sweep with μr fixed at 1.0 (grassland 2.86 vs obs 2.74).
+        EKP.constrained_gaussian(
+            "autotrophic_respiration_Rd_ref",
+            2.0e-7,
+            1.5e-7,
+            0.0,
+            Inf,
+        ),
+        # Canopy turbulent / radiative transfer. Kept at physical means (iter-3
+        # is a poor center: e.g. canopy_d_coeff thrashed to ~0.01).
+        EKP.constrained_gaussian("leaf_Cd", 0.08, 0.03, 0, Inf),
+        EKP.constrained_gaussian("canopy_z_0m_coeff", 0.13, 0.05, 0.0, 0.5),
+        EKP.constrained_gaussian("canopy_z_0b_coeff", 0.013, 0.005, 0.0, 0.05),
+        EKP.constrained_gaussian("canopy_d_coeff", 0.67, 0.2, 0.0, 1.0),
+        EKP.constrained_gaussian("canopy_K_lw", 1.0, 0.2, 0.0, 2.0),
+    ]
+    return EKP.combine_distributions(priors)
+end
+
+const CALIBRATE_CONFIG = CalibrateConfig(;
+    short_names = ["inv_nee", "sif_gpp", "res_er", "inv_hr", "lhf", "shf", "lwu"],
+    minibatch_size = 2,
+    n_iterations = 10,
+    # Yearly DJF-MAM-JJA samples (Dec 1 -> Sep 1). With spinup = Year(1) and
+    # extend = Month(3), all 16 samples stay within the artifact's 2002-2020
+    # coverage; 16 is divisible by minibatch_size so none is dropped per epoch.
+    sample_date_ranges = [
+        ("$(year)-12-1", "$(year+1)-9-1") for year in 2003:2018
+    ],
+    extend = Dates.Month(3),
+    # 1-year spinup so deep soil temperature/moisture settle before Hr vs ER.
+    spinup = Dates.Year(1),
+    nelements = (180, 360, 15),
+    output_dir = OUTPUT_DIR,
+    rng_seed = 42,
+    obs_vec_filepath = "experiments/calibration/land_observation_vector_inversionnee_sifgpp_er_lhf_shf_lwu.jld2",
+    model_type = ClimaLand.LandModel,
+)

--- a/experiments/calibration/configs/lai.jl
+++ b/experiments/calibration/configs/lai.jl
@@ -1,0 +1,81 @@
+# Calibration config: optimal-LAI parameters against MODIS LAI.
+# Included by run_calibration.jl; defines CALIBRATE_CONFIG, NOISE_SCALARS, and
+# get_calibration_prior(). Run with:
+#   CALIBRATION_CONFIG=lai.jl bash experiments/calibration/run_calibration.sh
+#
+# This calibrates the prognostic optimal-LAI model (Zhou et al. 2025,
+# `ZhouOptimalLAIModel`) so the forward model is run with `prognostic_lai = true`
+# (canopy computes LAI from P-model potential GPP instead of prescribing MODIS).
+# The single target is the model `lai` diagnostic (m^2 m^-2) compared against the
+# MODIS LAI observation (`get_modis_lai_obs_var` in data_sources.jl), as seasonal
+# averages.
+#
+# Ensemble size = 4 params * 2 + 1 = 9 (TransformUnscented); set the number of
+# tasks in run_calibration.sh / the batch script to 9.
+
+"""Per-variable observation variance; multiplies the identity in `ScalarCovariance`.
+Units are (m^2 m^-2)^2.
+
+A scalar of 0.5 corresponds to an observation σ ≈ 0.7 m^2 m^-2, which is a
+reasonable combined MODIS-retrieval + model-structural error for seasonal LAI
+(typical LAI ranges 0–6). Loosen it (→ 1.0+) if EKI overfits the seasonal
+amplitude at the expense of timing; tighten it (→ 0.25) to pull harder on the
+peak-LAI magnitude.
+"""
+const NOISE_SCALARS = Dict("lai" => 0.5)
+
+"""
+    get_calibration_prior()
+
+Prior over the 4 optimal-LAI parameters that shape the simulated LAI seasonal
+cycle and magnitude. Means are the TOML defaults; `optimal_lai_k` (light
+extinction, 0.5) is left fixed because it is strongly correlated with
+`optimal_lai_z` (both enter the energy-limited fAPAR = 1 - z/(k*A0)) and would
+otherwise make the inversion degenerate.
+
+TransformUnscented ensemble = 4*2+1 = 9.
+
+  - optimal_lai_z     leaf construction/maintenance cost (mol m^-2 yr^-1). Sets
+                      the energy-limited LAI_max via 1 - z/(k*A0): larger z ->
+                      lower peak LAI.
+  - optimal_lai_sigma departure from square-wave LAI dynamics (dimensionless).
+                      Controls the m ratio (Eq. 20) and hence how sharply LAI
+                      tracks the growing season.
+  - optimal_lai_alpha EMA smoothing factor (dimensionless). Sets the
+                      green-up/senescence lag (alpha ~ 0.067 ≈ 15-day memory).
+  - optimal_lai_f0    fraction of precipitation available for transpiration
+                      (dimensionless). Sets the water-limited LAI_max in
+                      moisture-limited regions.
+"""
+function get_calibration_prior()
+    priors = [
+        EKP.constrained_gaussian("optimal_lai_z", 12.227, 4.0, 1.0, 40.0),
+        EKP.constrained_gaussian("optimal_lai_sigma", 1.1, 0.3, 0.1, 3.0),
+        # alpha and f0 are bounded fractions; σ kept clear of the bounds.
+        EKP.constrained_gaussian("optimal_lai_alpha", 0.067, 0.03, 0.01, 0.3),
+        EKP.constrained_gaussian("optimal_lai_f0", 0.65, 0.2, 0.05, 1.0),
+    ]
+    return EKP.combine_distributions(priors)
+end
+
+const CALIBRATE_CONFIG = CalibrateConfig(;
+    short_names = ["lai"],
+    minibatch_size = 1,
+    n_iterations = 10,
+    # One annual cycle to calibrate on (DJF-MAM-JJA from Dec 1 -> Sep 1, plus
+    # SON via extend = Month(3)). With spinup = Year(2), the simulation runs
+    # 2015-12-01 -> 2018-12-01: two years of spin-up so the optimal-LAI annual
+    # potential GPP (A0_annual) self-corrects off its stale file value, then one
+    # year scored against MODIS. All dates stay within MODIS (2000-2020) and the
+    # high-res ERA5 forcing coverage. Add more (year) tuples here (and raise
+    # minibatch_size) to calibrate across multiple years.
+    sample_date_ranges = [("2017-12-1", "2018-9-1")],
+    extend = Dates.Month(3),
+    spinup = Dates.Year(2),
+    nelements = (180, 360, 15),
+    output_dir = OUTPUT_DIR,
+    rng_seed = 42,
+    obs_vec_filepath = "experiments/calibration/land_observation_vector_lai.jld2",
+    model_type = ClimaLand.LandModel,
+    prognostic_lai = true,
+)

--- a/experiments/calibration/configs/lai.jl
+++ b/experiments/calibration/configs/lai.jl
@@ -10,8 +10,8 @@
 # MODIS LAI observation (`get_modis_lai_obs_var` in data_sources.jl), as seasonal
 # averages.
 #
-# Ensemble size = 4 params * 2 + 1 = 9 (TransformUnscented); set the number of
-# tasks in run_calibration.sh / the batch script to 9.
+# Ensemble size = 3 params * 2 + 1 = 7 (TransformUnscented); set the number of
+# tasks in run_calibration.sh / the batch script to 7.
 
 """Per-variable observation variance; multiplies the identity in `ScalarCovariance`.
 Units are (m^2 m^-2)^2.
@@ -27,13 +27,16 @@ const NOISE_SCALARS = Dict("lai" => 0.5)
 """
     get_calibration_prior()
 
-Prior over the 4 optimal-LAI parameters that shape the simulated LAI seasonal
-cycle and magnitude. Means are the TOML defaults; `optimal_lai_k` (light
+Prior over the 3 optimal-LAI parameters that shape the simulated LAI seasonal
+cycle and magnitude. Means are the TOML defaults. `optimal_lai_k` (light
 extinction, 0.5) is left fixed because it is strongly correlated with
 `optimal_lai_z` (both enter the energy-limited fAPAR = 1 - z/(k*A0)) and would
-otherwise make the inversion degenerate.
+otherwise make the inversion degenerate. `optimal_lai_f0` is excluded because
+the prognostic LAI reads f0 from the spatially-varying `optimal_lai_inputs`
+artifact (`p.canopy.biomass.f0`), so the TOML `optimal_lai_f0` parameter is
+inert and calibrating it does nothing.
 
-TransformUnscented ensemble = 4*2+1 = 9.
+TransformUnscented ensemble = 3*2+1 = 7.
 
   - optimal_lai_z     leaf construction/maintenance cost (mol m^-2 yr^-1). Sets
                       the energy-limited LAI_max via 1 - z/(k*A0): larger z ->
@@ -43,17 +46,13 @@ TransformUnscented ensemble = 4*2+1 = 9.
                       tracks the growing season.
   - optimal_lai_alpha EMA smoothing factor (dimensionless). Sets the
                       green-up/senescence lag (alpha ~ 0.067 ≈ 15-day memory).
-  - optimal_lai_f0    fraction of precipitation available for transpiration
-                      (dimensionless). Sets the water-limited LAI_max in
-                      moisture-limited regions.
 """
 function get_calibration_prior()
     priors = [
         EKP.constrained_gaussian("optimal_lai_z", 12.227, 4.0, 1.0, 40.0),
         EKP.constrained_gaussian("optimal_lai_sigma", 1.1, 0.3, 0.1, 3.0),
-        # alpha and f0 are bounded fractions; σ kept clear of the bounds.
+        # alpha is a bounded fraction; σ kept clear of the bounds.
         EKP.constrained_gaussian("optimal_lai_alpha", 0.067, 0.03, 0.01, 0.3),
-        EKP.constrained_gaussian("optimal_lai_f0", 0.65, 0.2, 0.05, 1.0),
     ]
     return EKP.combine_distributions(priors)
 end

--- a/experiments/calibration/configs/sifgpp_lhf_shf_lwu_rosetta.jl
+++ b/experiments/calibration/configs/sifgpp_lhf_shf_lwu_rosetta.jl
@@ -15,7 +15,9 @@
 #   lhf/shf/lwu  ERA5 turbulent + upwelling longwave fluxes in W m^-2 (+ = upward)
 #
 # The model uses the Rosetta (Montzka et al. 2017) van Genuchten soil retention
-# parameters via `use_rosetta = true` (PR #1763, kd/add_rosetta_option).
+# parameters via `use_rosetta = true` (the default), which also selects the
+# matching spun-up Rosetta initial conditions (`rosetta_spunup_ic`, PR #1772) so
+# the soil state is consistent with the retention curve.
 
 """Per-variable observation variances; multiply the identity in `ScalarCovariance`.
 Units are (dataset units)^2: GPP in (g C m^-2 day^-1)^2, energy in (W m^-2)^2.

--- a/experiments/calibration/configs/sifgpp_lhf_shf_lwu_rosetta.jl
+++ b/experiments/calibration/configs/sifgpp_lhf_shf_lwu_rosetta.jl
@@ -1,0 +1,98 @@
+# Calibration config: GOSIF GPP + ERA5 LHF/SHF/LWU, with a Rosetta soil.
+# Included by run_calibration.jl; defines CALIBRATE_CONFIG, NOISE_SCALARS, and
+# get_calibration_prior(). Run with:
+#   CALIBRATION_CONFIG=sifgpp_lhf_shf_lwu_rosetta.jl \
+#     bash experiments/calibration/run_calibration.sh
+#
+# This is the energy/carbon-uptake subset of inversionnee_sifgpp_er_lhf_shf_lwu.jl:
+# the carbon-source targets (inv_nee/res_er/inv_hr) are dropped, so only the
+# parameters that GPP/LHF/SHF/LWU can actually constrain are calibrated. The
+# soilCO2/DAMM-Rh params and autotrophic_respiration_Rd_ref are therefore not
+# included (they only move Rh/AR, which have no target here).
+#
+# Targets:
+#   sif_gpp  GPP, GOSIF-GPP v2 (from the `inversion_nee` artifact, + = uptake)
+#   lhf/shf/lwu  ERA5 turbulent + upwelling longwave fluxes in W m^-2 (+ = upward)
+#
+# The model uses the Rosetta (Montzka et al. 2017) van Genuchten soil retention
+# parameters via `use_rosetta = true` (PR #1763, kd/add_rosetta_option).
+
+"""Per-variable observation variances; multiply the identity in `ScalarCovariance`.
+Units are (dataset units)^2: GPP in (g C m^-2 day^-1)^2, energy in (W m^-2)^2.
+
+GPP is tightened to 0.6 (vs the inversion config's 2.0) since it is the only
+carbon target and we want the P-model params pulled to GOSIF. Energy variances
+sit near the RMSE floor (LWU 25, SHF/LHF 100) and act as background constraints.
+"""
+const NOISE_SCALARS = Dict(
+    "sif_gpp" => 0.6,
+    "lhf" => 100.0,
+    "shf" => 100.0,
+    "lwu" => 25.0,
+)
+
+"""
+    get_calibration_prior()
+
+Prior over the 10 parameters relevant to GPP/LHF/SHF/LWU (5 P-model/moisture
+stress + 5 canopy turbulent/radiative transfer); TransformUnscented ensemble =
+10*2+1 = 21.
+
+Each prior mean equals the corresponding value in `toml/default_parameters.toml`
+(synced to the `ar/calibrated_C_energy_together` branch), so the prior is
+centered on the model defaults. The σ and bounds are inherited from the relevant
+subset of `inversionnee_sifgpp_er_lhf_shf_lwu.jl`, except where the calibrated
+default sat at a former bound — there the bound is relaxed and σ shrunk so the
+constrained_gaussian can actually center on the default (EKP errors when
+μ ± σ crosses a bound):
+  - pmodel_β_c4:      σ 12 -> 2,    lower 5 -> 1     (default 5.36 was at lower=5)
+  - canopy_z_0b_coeff: σ 0.005 -> 0.01, upper 0.05 -> 0.1 (default 0.044 near upper=0.05)
+  - canopy_d_coeff:    σ 0.2 -> 0.025                 (default 0.057 near lower=0)
+"""
+function get_calibration_prior()
+    priors = [
+        # P-model + moisture stress. Constrain GPP and, via stomatal
+        # conductance, transpiration (LHF).
+        EKP.constrained_gaussian("pmodel_cstar", 0.42890384025557793, 0.05, 0.2, 0.7),
+        EKP.constrained_gaussian("pmodel_β_c3", 91.09351405009605, 40.0, 10.0, 300.0),
+        EKP.constrained_gaussian("pmodel_β_c4", 5.356145477815346, 2.0, 1.0, 100.0),
+        # σ kept tight so μ+σ stays clear of the upper bound 0.999.
+        EKP.constrained_gaussian("pmodel_α", 0.9723018635387689, 0.012, 0.85, 0.999),
+        EKP.constrained_gaussian(
+            "moisture_stress_c",
+            0.591401756353606,
+            0.15,
+            0.05,
+            1.0,
+        ),
+        # Canopy turbulent / radiative transfer. These constrain SHF/LHF
+        # (roughness/drag) and LWU (longwave extinction).
+        EKP.constrained_gaussian("leaf_Cd", 0.07257315811847019, 0.03, 0, Inf),
+        EKP.constrained_gaussian("canopy_z_0m_coeff", 0.3494203357014585, 0.05, 0.0, 0.5),
+        EKP.constrained_gaussian("canopy_z_0b_coeff", 0.04435103776675633, 0.01, 0.0, 0.1),
+        EKP.constrained_gaussian("canopy_d_coeff", 0.05725798250714986, 0.025, 0.0, 1.0),
+        EKP.constrained_gaussian("canopy_K_lw", 0.9191833718378635, 0.2, 0.0, 2.0),
+    ]
+    return EKP.combine_distributions(priors)
+end
+
+const CALIBRATE_CONFIG = CalibrateConfig(;
+    short_names = ["sif_gpp", "lhf", "shf", "lwu"],
+    minibatch_size = 2,
+    n_iterations = 10,
+    # Yearly DJF-MAM-JJA samples (Dec 1 -> Sep 1). With spinup = Year(1) and
+    # extend = Month(3), all 16 samples stay within the artifact's 2002-2020
+    # coverage; 16 is divisible by minibatch_size so none is dropped per epoch.
+    sample_date_ranges = [
+        ("$(year)-12-1", "$(year+1)-9-1") for year in 2003:2018
+    ],
+    extend = Dates.Month(3),
+    # 1-year spinup so soil moisture/temperature settle before the flux average.
+    spinup = Dates.Year(1),
+    nelements = (180, 360, 15),
+    output_dir = OUTPUT_DIR,
+    rng_seed = 42,
+    obs_vec_filepath = "experiments/calibration/land_observation_vector_sifgpp_lhf_shf_lwu.jld2",
+    model_type = ClimaLand.LandModel,
+    use_rosetta = true,
+)

--- a/experiments/calibration/generate_observations.jl
+++ b/experiments/calibration/generate_observations.jl
@@ -204,6 +204,20 @@ function preprocess_single_obs_var(var::OutputVar, short_name, nelements)
         by = ClimaAnalysis.Index(),
     )
 
+    # Force all time slices to share one NaN mask (the union of NaN locations
+    # across every season/year). The inversion obs have year/season-varying NaN
+    # coverage, so otherwise each yearly Observation flattens to a different
+    # length; EKP's minibatch update-group indexing assumes equal sample lengths
+    # and overruns get_obs (BoundsError in succ_gauss_analysis!, seen at iter 4).
+    time_idx = var.dim2index[ClimaAnalysis.time_name(var)]
+    common_nan_mask =
+        reduce((a, b) -> a .| b, eachslice(isnan.(var.data); dims = time_idx))
+    masked_data = copy(var.data)
+    for time_slice in eachslice(masked_data; dims = time_idx)
+        time_slice[common_nan_mask] .= eltype(masked_data)(NaN)
+    end
+    var = ClimaAnalysis.remake(var; data = masked_data)
+
     var = ClimaCalibrate.ObservationRecipe.change_data_type(var, Float32)
     var.attributes["short_name"] = short_name
     return var

--- a/experiments/calibration/generate_observations.jl
+++ b/experiments/calibration/generate_observations.jl
@@ -8,17 +8,54 @@ import ClimaCore
 import EnsembleKalmanProcesses as EKP
 import JLD2
 
-# Access CalibrateConfig
-include(
-    joinpath(
-        pkgdir(ClimaLand),
-        "experiments",
-        "calibration",
-        "run_calibration.jl",
-    ),
-)
+# Access CalibrateConfig, the config's CALIBRATE_CONFIG / NOISE_SCALARS, and
+# OUTPUT_DIR. Deliberately avoid include(run_calibration.jl): it pulls in
+# model_interface.jl -> observation_map.jl -> `using CairoMakie, GeoMakie`,
+# which is only needed for the calibration's plotting and (on Derecho) does not
+# reliably precompile. Generating the observation vector needs none of it, so we
+# include just api.jl (CalibrateConfig) and the config file directly, mirroring
+# run_calibration.jl's OUTPUT_DIR / config-file selection.
+include(joinpath(@__DIR__, "api.jl"))
+const TEST_CALIBRATION = haskey(ENV, "TEST_CALIBRATION")
+const OUTPUT_DIR =
+    length(ARGS) >= 1 ? ARGS[1] : "experiments/calibration/land_model"
+const CONFIG_FILE =
+    TEST_CALIBRATION ? "test.jl" :
+    get(ENV, "CALIBRATION_CONFIG", "energy_fluxes.jl")
+include(joinpath(@__DIR__, "configs", CONFIG_FILE))
 
 include("observation_utils.jl")
+
+# Path to the simulated-LAI validity mask produced by
+# build_model_lai_validity_mask.jl. The ClimaLand `lai` diagnostic is NaN over a
+# broader footprint than `make_ocean_mask` removes (interpolated diagnostics are
+# not mask-aware). Masking the `lai` observation by this footprint prevents obs
+# cells from surviving where the model returns NaN, which would otherwise leak
+# NaNs into the G ensemble and, via TransformUnscented (UKI), collapse every
+# parameter update to NaN. Regenerate the mask whenever `nelements` changes.
+const MODEL_LAI_VALIDITY_MASK_PATH =
+    joinpath(@__DIR__, "model_lai_validity_mask.jld2")
+
+"""
+    apply_model_validity_mask(var, short_name)
+
+For the `lai` target, mask `var` by the simulated-LAI validity footprint so the
+observation is NaN wherever the model returns NaN. No-op for other variables.
+Errors if the mask file is missing so a stale/absent mask cannot silently
+reintroduce the NaN leak.
+"""
+function apply_model_validity_mask(var, short_name)
+    short_name == "lai" || return var
+    isfile(MODEL_LAI_VALIDITY_MASK_PATH) || error(
+        "Model LAI validity mask not found at $MODEL_LAI_VALIDITY_MASK_PATH. " *
+        "Generate it first with:\n" *
+        "  julia --project=.buildkite experiments/calibration/build_model_lai_validity_mask.jl <reference_simdir>",
+    )
+    mask_var = JLD2.load_object(MODEL_LAI_VALIDITY_MASK_PATH)
+    mask_fn =
+        ClimaAnalysis.generate_lonlat_mask(mask_var, NaN, 1.0; threshold = 0.5)
+    return mask_fn(var)
+end
 
 # For now, we will reuse `data_sources.jl` that is used for making the
 # leaderboard, since it is the easiest option.
@@ -185,6 +222,12 @@ function preprocess_single_obs_var(var::OutputVar, short_name, nelements)
     # differences between the ClimaLand mask and ClimaAnalysis.apply_ocean_mask
     ocean_mask = make_ocean_mask(nelements)
     var = ocean_mask(var)
+
+    # Additionally drop cells where the simulated LAI diagnostic is NaN (a
+    # broader footprint than the ocean mask). Without this, obs-valid cells that
+    # the model returns as NaN leak NaNs into the G ensemble and the UKI update
+    # (see MODEL_LAI_VALIDITY_MASK_PATH above). No-op for non-lai targets.
+    var = apply_model_validity_mask(var, short_name)
 
     # To prevent double counting along the longitudes since -180 and 180 degrees
     # are the same point

--- a/experiments/calibration/models/snowy_land.jl
+++ b/experiments/calibration/models/snowy_land.jl
@@ -24,7 +24,7 @@ function setup_model(
     domain,
     toml_dict,
     ::Type{ClimaLand.LandModel};
-    use_rosetta = false,
+    use_rosetta = true,
 ) where {FT}
     surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
     surface_space = domain.space.surface
@@ -48,9 +48,11 @@ function setup_model(
     )
     prognostic_land_components = (:canopy, :lake, :snow, :soil, :soilco2)
 
-    # Build the soil model explicitly so we can optionally swap in the Rosetta
-    # (Montzka et al. 2017) van Genuchten retention parameters. When use_rosetta
-    # is false, this reproduces LandModel's default Gupta et al. (2020) soil.
+    # Build the soil model explicitly so we can choose the van Genuchten
+    # retention parameters. use_rosetta = true (the default) uses the Rosetta
+    # (Montzka et al. 2017) product, matching LandModel's default soil; false
+    # uses the Gupta et al. (2020) product. The chosen parameters must be paired
+    # with the matching spun-up initial conditions in `forward_model`.
     retention_parameters =
         use_rosetta ?
         ClimaLand.Soil.rosetta_soil_vangenuchten_parameters(
@@ -191,12 +193,25 @@ function ClimaCalibrate.forward_model(
         reduction_type = :average,
     )
 
+    # Initial conditions must match the soil retention parameters: the spun-up
+    # Rosetta ICs go with the Rosetta soil, the Gupta-based saturated ICs with
+    # the Gupta soil. LandSimulation defaults to the Rosetta IC, but we set it
+    # explicitly so soil and IC stay paired regardless of use_rosetta.
+    ic_path =
+        use_rosetta ?
+        ClimaLand.Artifacts.rosetta_spunup_ic_path(; context) :
+        ClimaLand.Artifacts.saturated_land_ic_path(; context)
+
     simulation = LandSimulation(
         t0,
         tf,
         Δt,
         model;
         outdir,
+        set_ic! = ClimaLand.Simulations.make_set_initial_state_from_file(
+            ic_path,
+            model,
+        ),
         user_callbacks = (ClimaLand.ReportCallback(div((tf - t0), 10), t0),),
         diagnostics = diagnostics,
     )

--- a/experiments/calibration/models/snowy_land.jl
+++ b/experiments/calibration/models/snowy_land.jl
@@ -25,6 +25,7 @@ function setup_model(
     toml_dict,
     ::Type{ClimaLand.LandModel};
     use_rosetta = true,
+    prognostic_lai = false,
 ) where {FT}
     surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
     surface_space = domain.space.surface
@@ -39,13 +40,6 @@ function setup_model(
         context,
     )
     forcing = (; atmos, radiation)
-
-    # Read in LAI from MODIS data
-    LAI = ClimaLand.Canopy.prescribed_lai_modis(
-        surface_space,
-        start_date,
-        stop_date,
-    )
     prognostic_land_components = (:canopy, :lake, :snow, :soil, :soilco2)
 
     # Build the soil model explicitly so we can choose the van Genuchten
@@ -59,10 +53,7 @@ function setup_model(
             domain.space.subsurface,
             FT,
         ) :
-        ClimaLand.Soil.soil_vangenuchten_parameters(
-            domain.space.subsurface,
-            FT,
-        )
+        ClimaLand.Soil.soil_vangenuchten_parameters(domain.space.subsurface, FT)
     soil = ClimaLand.Soil.EnergyHydrology{FT}(
         domain,
         forcing,
@@ -72,44 +63,86 @@ function setup_model(
         retention_parameters,
     )
 
-    # Build the canopy explicitly so SAI/RAI track spatially-varying max LAI
-    # (MODIS 2000-2020), which sets the AR winter maintenance baseline, instead
-    # of LandModel's default constant SAI/RAI. Other canopy defaults are unchanged.
     # Feed the soil's ν/θ_r into the moisture-stress thresholds so they stay
     # consistent with the (possibly Rosetta) retention parameters.
-    maxLAI = ClimaLand.Canopy.modis_max_lai(surface_space)
-    canopy = ClimaLand.Canopy.CanopyModel{FT}(
-        surface_domain,
-        (;
-            atmos,
-            radiation,
-            ground = ClimaLand.PrognosticGroundConditions{FT}(),
-        ),
-        LAI,
-        toml_dict;
-        prognostic_land_components,
-        soil_moisture_stress = ClimaLand.Canopy.PiecewiseMoistureStressModel{FT}(
-            domain,
-            toml_dict;
-            soil_params = (; ν = soil.parameters.ν, θ_r = soil.parameters.θ_r),
-        ),
-        biomass = ClimaLand.Canopy.PrescribedBiomassModel{FT}(
-            surface_domain,
-            LAI,
-            maxLAI,
-            toml_dict,
-        ),
-    )
-    land = LandModel{FT}(
-        forcing,
-        LAI,
-        toml_dict,
+    soil_moisture_stress = ClimaLand.Canopy.PiecewiseMoistureStressModel{FT}(
         domain,
-        Δt;
-        prognostic_land_components,
-        soil,
-        canopy,
+        toml_dict;
+        soil_params = (; ν = soil.parameters.ν, θ_r = soil.parameters.θ_r),
     )
+
+    if prognostic_lai
+        # Prognostic LAI: the canopy computes LAI with the optimal-LAI model
+        # (Zhou et al. 2025), driven by the P-model potential GPP (PModel is the
+        # CanopyModel default photosynthesis). The optimal-LAI callback that
+        # advances LAI at local noon is added automatically by LandSimulation
+        # via get_model_callbacks. This is what makes the optimal-LAI parameters
+        # (optimal_lai_z/sigma/alpha/f0/k) affect the simulated `lai`.
+        canopy = ClimaLand.Canopy.CanopyModel{FT}(
+            surface_domain,
+            (;
+                atmos,
+                radiation,
+                ground = ClimaLand.PrognosticGroundConditions{FT}(),
+            ),
+            toml_dict;
+            prognostic_land_components,
+            soil_moisture_stress,
+            biomass = ClimaLand.Canopy.ZhouOptimalLAIModel{FT}(
+                surface_domain,
+                toml_dict,
+            ),
+        )
+        land = LandModel{FT}(
+            forcing,
+            toml_dict,
+            domain,
+            Δt;
+            prognostic_land_components,
+            soil,
+            canopy,
+        )
+    else
+        # Prescribed LAI (default): read LAI from MODIS data.
+        LAI = ClimaLand.Canopy.prescribed_lai_modis(
+            surface_space,
+            start_date,
+            stop_date,
+        )
+        # Build the canopy explicitly so SAI/RAI track spatially-varying max LAI
+        # (MODIS 2000-2020), which sets the AR winter maintenance baseline,
+        # instead of LandModel's default constant SAI/RAI. Other canopy defaults
+        # are unchanged.
+        maxLAI = ClimaLand.Canopy.modis_max_lai(surface_space)
+        canopy = ClimaLand.Canopy.CanopyModel{FT}(
+            surface_domain,
+            (;
+                atmos,
+                radiation,
+                ground = ClimaLand.PrognosticGroundConditions{FT}(),
+            ),
+            LAI,
+            toml_dict;
+            prognostic_land_components,
+            soil_moisture_stress,
+            biomass = ClimaLand.Canopy.PrescribedBiomassModel{FT}(
+                surface_domain,
+                LAI,
+                maxLAI,
+                toml_dict,
+            ),
+        )
+        land = LandModel{FT}(
+            forcing,
+            LAI,
+            toml_dict,
+            domain,
+            Δt;
+            prognostic_land_components,
+            soil,
+            canopy,
+        )
+    end
     return land
 end
 
@@ -120,8 +153,15 @@ function ClimaCalibrate.forward_model(
     ::Type{ClimaLand.LandModel},
 )
     (; config) = model_interface
-    (; output_dir, sample_date_ranges, nelements, spinup, extend, use_rosetta) =
-        config
+    (;
+        output_dir,
+        sample_date_ranges,
+        nelements,
+        spinup,
+        extend,
+        use_rosetta,
+        prognostic_lai,
+    ) = config
     ensemble_member_path =
         ClimaCalibrate.path_to_ensemble_member(output_dir, iteration, member)
 
@@ -166,6 +206,7 @@ function ClimaCalibrate.forward_model(
         toml_dict,
         ClimaLand.LandModel;
         use_rosetta,
+        prognostic_lai,
     )
 
     # Set up diagnostics. lhf/shf/lwu/swu are needed for the leaderboard.
@@ -184,6 +225,11 @@ function ClimaCalibrate.forward_model(
             ["lhf", "shf", "lwu", "swu", "gpp", "et", "hr", "ra", "er", "nee"]
         ],
     )
+    # With prognostic LAI, also write the optimal-LAI annual potential GPP
+    # (a0a_1M_average.nc, mol CO2 m^-2 yr^-1). This is the model-derived
+    # A0_annual used to refresh the `optimal_lai_inputs` artifact; it only exists
+    # for the ZhouOptimalLAIModel biomass. (a0d is the daily potential GPP.)
+    prognostic_lai && push!(short_names, "a0a")
     diagnostics = ClimaLand.Diagnostics.default_diagnostics(
         model,
         start_date,
@@ -198,8 +244,7 @@ function ClimaCalibrate.forward_model(
     # the Gupta soil. LandSimulation defaults to the Rosetta IC, but we set it
     # explicitly so soil and IC stay paired regardless of use_rosetta.
     ic_path =
-        use_rosetta ?
-        ClimaLand.Artifacts.rosetta_spunup_ic_path(; context) :
+        use_rosetta ? ClimaLand.Artifacts.rosetta_spunup_ic_path(; context) :
         ClimaLand.Artifacts.saturated_land_ic_path(; context)
 
     simulation = LandSimulation(

--- a/experiments/calibration/models/snowy_land.jl
+++ b/experiments/calibration/models/snowy_land.jl
@@ -46,6 +46,32 @@ function setup_model(
         stop_date,
     )
     prognostic_land_components = (:canopy, :lake, :snow, :soil, :soilco2)
+
+    # Build the canopy explicitly so SAI/RAI track spatially-varying max LAI
+    # (MODIS 2000-2020), which sets the AR winter maintenance baseline, instead
+    # of LandModel's default constant SAI/RAI. Other canopy defaults are unchanged.
+    maxLAI = ClimaLand.Canopy.modis_max_lai(surface_space)
+    canopy = ClimaLand.Canopy.CanopyModel{FT}(
+        surface_domain,
+        (;
+            atmos,
+            radiation,
+            ground = ClimaLand.PrognosticGroundConditions{FT}(),
+        ),
+        LAI,
+        toml_dict;
+        prognostic_land_components,
+        soil_moisture_stress = ClimaLand.Canopy.PiecewiseMoistureStressModel{FT}(
+            domain,
+            toml_dict,
+        ),
+        biomass = ClimaLand.Canopy.PrescribedBiomassModel{FT}(
+            surface_domain,
+            LAI,
+            maxLAI,
+            toml_dict,
+        ),
+    )
     land = LandModel{FT}(
         forcing,
         LAI,
@@ -53,6 +79,7 @@ function setup_model(
         domain,
         Δt;
         prognostic_land_components,
+        canopy,
     )
     return land
 end
@@ -110,13 +137,19 @@ function ClimaCalibrate.forward_model(
         ClimaLand.LandModel,
     )
 
-    # Set up diagnostics
-    # Need to include "lhf", "shf", "lwu", "swu" because plotting the
-    # leaderboard requires these diagnostics
+    # Set up diagnostics. lhf/shf/lwu/swu are needed for the leaderboard.
+    # Observation-alias short_names (inv_nee, ...) map to their model diagnostic
+    # names here; the aliases are reconstructed in data_sources.jl.
+    obs_alias_to_diag = Dict(
+        "inv_nee" => "nee",
+        "sif_gpp" => "gpp",
+        "res_er" => "er",
+        "inv_hr" => "hr",
+    )
     (; short_names) = config
     short_names = unique!(
         [
-            short_names
+            [get(obs_alias_to_diag, sn, sn) for sn in short_names]
             ["lhf", "shf", "lwu", "swu", "gpp", "et", "hr", "ra", "er", "nee"]
         ],
     )

--- a/experiments/calibration/models/snowy_land.jl
+++ b/experiments/calibration/models/snowy_land.jl
@@ -23,7 +23,8 @@ function setup_model(
     Δt,
     domain,
     toml_dict,
-    ::Type{ClimaLand.LandModel},
+    ::Type{ClimaLand.LandModel};
+    use_rosetta = false,
 ) where {FT}
     surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
     surface_space = domain.space.surface
@@ -47,9 +48,33 @@ function setup_model(
     )
     prognostic_land_components = (:canopy, :lake, :snow, :soil, :soilco2)
 
+    # Build the soil model explicitly so we can optionally swap in the Rosetta
+    # (Montzka et al. 2017) van Genuchten retention parameters. When use_rosetta
+    # is false, this reproduces LandModel's default Gupta et al. (2020) soil.
+    retention_parameters =
+        use_rosetta ?
+        ClimaLand.Soil.rosetta_soil_vangenuchten_parameters(
+            domain.space.subsurface,
+            FT,
+        ) :
+        ClimaLand.Soil.soil_vangenuchten_parameters(
+            domain.space.subsurface,
+            FT,
+        )
+    soil = ClimaLand.Soil.EnergyHydrology{FT}(
+        domain,
+        forcing,
+        toml_dict;
+        prognostic_land_components,
+        additional_sources = (ClimaLand.RootExtraction{FT}(),),
+        retention_parameters,
+    )
+
     # Build the canopy explicitly so SAI/RAI track spatially-varying max LAI
     # (MODIS 2000-2020), which sets the AR winter maintenance baseline, instead
     # of LandModel's default constant SAI/RAI. Other canopy defaults are unchanged.
+    # Feed the soil's ν/θ_r into the moisture-stress thresholds so they stay
+    # consistent with the (possibly Rosetta) retention parameters.
     maxLAI = ClimaLand.Canopy.modis_max_lai(surface_space)
     canopy = ClimaLand.Canopy.CanopyModel{FT}(
         surface_domain,
@@ -63,7 +88,8 @@ function setup_model(
         prognostic_land_components,
         soil_moisture_stress = ClimaLand.Canopy.PiecewiseMoistureStressModel{FT}(
             domain,
-            toml_dict,
+            toml_dict;
+            soil_params = (; ν = soil.parameters.ν, θ_r = soil.parameters.θ_r),
         ),
         biomass = ClimaLand.Canopy.PrescribedBiomassModel{FT}(
             surface_domain,
@@ -79,6 +105,7 @@ function setup_model(
         domain,
         Δt;
         prognostic_land_components,
+        soil,
         canopy,
     )
     return land
@@ -91,7 +118,8 @@ function ClimaCalibrate.forward_model(
     ::Type{ClimaLand.LandModel},
 )
     (; config) = model_interface
-    (; output_dir, sample_date_ranges, nelements, spinup, extend) = config
+    (; output_dir, sample_date_ranges, nelements, spinup, extend, use_rosetta) =
+        config
     ensemble_member_path =
         ClimaCalibrate.path_to_ensemble_member(output_dir, iteration, member)
 
@@ -134,7 +162,8 @@ function ClimaCalibrate.forward_model(
         Δt,
         domain,
         toml_dict,
-        ClimaLand.LandModel,
+        ClimaLand.LandModel;
+        use_rosetta,
     )
 
     # Set up diagnostics. lhf/shf/lwu/swu are needed for the leaderboard.

--- a/experiments/calibration/observation_map.jl
+++ b/experiments/calibration/observation_map.jl
@@ -94,7 +94,10 @@ function process_member_data!(
     short_names,
 )
     @info "Short names: $short_names"
-    calibration_obs_vars = ext.get_calibration_obs_var_dict()
+    # Only build the requested observation variables (some, e.g. MODIS `lai`,
+    # are expensive to load); this validates that each requested short name has
+    # a corresponding observation.
+    calibration_obs_vars = ext.get_calibration_obs_var_dict(; short_names)
     for short_name in short_names
         short_name in keys(calibration_obs_vars) || error(
             "Variable $short_name does not appear in the observation dataset. Add the variable to get_calibration_obs_var_dict in data_sources.jl",
@@ -117,7 +120,8 @@ function process_member_data!(
         # preprocess_sim_var dispatches on the diagnostic name (e.g. :nee),
         # so unit conversion happens before we retag to the obs alias.
         var = preprocess_sim_var(var)
-        diag_name == short_name || (var.attributes["short_name"] = short_name)
+        diag_name == short_name ||
+            (var.attributes["short_name"] = short_name)
         var = ClimaAnalysis.average_season_across_time(var, ignore_nan = false)
 
         # To prevent double counting along the longitudes since -180 and 180

--- a/experiments/calibration/observation_map.jl
+++ b/experiments/calibration/observation_map.jl
@@ -101,10 +101,23 @@ function process_member_data!(
         )
     end
 
+    # Inversion calibration targets read the underlying model diagnostic
+    # (nee/gpp/er/hr) but are retagged to the obs alias so fill_g_ens_col!
+    # matches the inversion observations (see get_inversion_obs_var_dict).
+    sim_alias = Dict(
+        "inv_nee" => "nee",
+        "sif_gpp" => "gpp",
+        "res_er" => "er",
+        "inv_hr" => "hr",
+    )
     simdir = ClimaAnalysis.SimDir(diagnostics_folder_path)
     vars = map(short_names) do short_name
-        var = get(simdir, short_name)
+        diag_name = get(sim_alias, short_name, short_name)
+        var = get(simdir, diag_name)
+        # preprocess_sim_var dispatches on the diagnostic name (e.g. :nee),
+        # so unit conversion happens before we retag to the obs alias.
         var = preprocess_sim_var(var)
+        diag_name == short_name || (var.attributes["short_name"] = short_name)
         var = ClimaAnalysis.average_season_across_time(var, ignore_nan = false)
 
         # To prevent double counting along the longitudes since -180 and 180
@@ -178,37 +191,10 @@ function ClimaCalibrate.analyze_iteration(
     plot_output_path = ClimaCalibrate.path_to_iteration(output_dir, iteration)
     plot_constrained_params_and_errors(plot_output_path, ekp, prior)
 
-    # Leaderboard plots can only be plotted when the model saves swu, lwu, shf, lhf diagnostics
-    # Plot ERA5 bias plots for only the first ensemble member
-    # This can take a while to plot, so we plot only one of the members.
-    # We choose the first ensemble member because the parameters for the first
-    # ensemble member are supposed to be the mean of the parameters of the
-    # ensemble members if it is EKP.TransformUnscented
-    output_path =
-        ClimaCalibrate.path_to_ensemble_member(output_dir, iteration, 1)
-
-    diagnostics_folder_path =
-        joinpath(output_path, "global_diagnostics", "output_active")
-    ext.compute_monthly_leaderboard(
-        output_path,
-        diagnostics_folder_path,
-        "ERA5",
-    )
-    ext.compute_seasonal_leaderboard(
-        output_path,
-        diagnostics_folder_path,
-        "ERA5",
-    )
-    ext.compute_monthly_leaderboard(
-        output_path,
-        diagnostics_folder_path,
-        "ILAMB",
-    )
-    ext.compute_seasonal_leaderboard(
-        output_path,
-        diagnostics_folder_path,
-        "ILAMB",
-    )
+    # Inter-iteration leaderboards are disabled: they reproducibly SEGV the
+    # orchestrator on Derecho. Regenerate them offline from each iteration's
+    # member_001/global_diagnostics/output_active/ NetCDFs after calibration.
+    return nothing
 end
 
 """

--- a/experiments/calibration/plot_energy_leaderboard.jl
+++ b/experiments/calibration/plot_energy_leaderboard.jl
@@ -1,0 +1,34 @@
+# ERA5 energy-flux leaderboard for a calibrated-model diagnostics directory.
+# Compares the model's turbulent + radiative fluxes (lhf, shf, lwu, swu) against
+# the ERA5 monthly product (era5_monthly_averages_surface_single_level_1979_2024)
+# via the standard ERA5DataLoader — the energy-side analogue of the inversion
+# carbon leaderboard (experiments/calibration/plot_inversion_leaderboard.jl).
+#
+# Usage (julia 1.10, .buildkite env has the CairoMakie/GeoMakie/ClimaAnalysis stack):
+#   julia +1.10 --startup-file=no --project=.buildkite \
+#     experiments/calibration/plot_energy_leaderboard.jl \
+#     /home/alexisr/GitHub/climaland_out_invcal_iter0 [/path/to/savedir]
+
+using CairoMakie, GeoMakie, ClimaAnalysis
+using ClimaLand
+
+const ext = Base.get_extension(ClimaLand, :LandSimulationVisualizationExt)
+ext === nothing && error(
+    "LandSimulationVisualizationExt is not loaded. Load CairoMakie, GeoMakie, ClimaAnalysis first.",
+)
+
+const diag_dir =
+    length(ARGS) >= 1 ? ARGS[1] : "/home/alexisr/GitHub/climaland_out_invcal_iter0"
+const savedir =
+    length(ARGS) >= 2 ? ARGS[2] : mktempdir(; prefix = "energy_leaderboard_")
+isdir(savedir) || mkpath(savedir)
+
+@info "Diagnostics dir: $diag_dir"
+@info "Save dir:        $savedir"
+
+ext.compute_seasonal_leaderboard(savedir, diag_dir, "ERA5")
+
+@info "Done. ERA5 energy leaderboard PNGs:"
+for f in sort(readdir(savedir))
+    endswith(f, ".png") && println("  ", joinpath(savedir, f))
+end

--- a/experiments/calibration/plot_inversion_leaderboard.jl
+++ b/experiments/calibration/plot_inversion_leaderboard.jl
@@ -1,0 +1,36 @@
+# Seasonal leaderboard comparing the calibrated model diagnostics against the
+# inversion-derived carbon obs (inversion NEE [CT2022], GOSIF GPP, residual ER)
+# from the `inversion_nee` artifact plus the MODIS LAI target (Yuan et al. 2017).
+# LAI replaces the earlier Hashimoto Rh panel, so the four panels are NEE / GPP /
+# ER / LAI — the calibrated carbon + LAI targets. This is the inversion analogue
+# of the ILAMB (FLUXCOM) leaderboard (uses InversionDataLoader; see
+# ext/.../leaderboard/data_sources.jl).
+#
+# Usage (julia 1.10, .buildkite env has the CairoMakie/GeoMakie/ClimaAnalysis stack):
+#   julia +1.10 --startup-file=no --project=.buildkite \
+#     experiments/calibration/plot_inversion_leaderboard.jl \
+#     /home/alexisr/GitHub/climaland_out_invcal_2 [/path/to/savedir]
+
+using CairoMakie, GeoMakie, ClimaAnalysis
+using ClimaLand
+
+const ext = Base.get_extension(ClimaLand, :LandSimulationVisualizationExt)
+ext === nothing && error(
+    "LandSimulationVisualizationExt is not loaded. Load CairoMakie, GeoMakie, ClimaAnalysis first.",
+)
+
+const diag_dir =
+    length(ARGS) >= 1 ? ARGS[1] : "/home/alexisr/GitHub/climaland_out_invcal_2"
+const savedir =
+    length(ARGS) >= 2 ? ARGS[2] : mktempdir(; prefix = "inversion_leaderboard_")
+isdir(savedir) || mkpath(savedir)
+
+@info "Diagnostics dir: $diag_dir"
+@info "Save dir:        $savedir"
+
+ext.compute_seasonal_leaderboard(savedir, diag_dir, "INVERSION")
+
+@info "Done. Inversion leaderboard PNGs:"
+for f in sort(readdir(savedir))
+    endswith(f, ".png") && println("  ", joinpath(savedir, f))
+end

--- a/experiments/calibration/run_calibration.jl
+++ b/experiments/calibration/run_calibration.jl
@@ -60,24 +60,43 @@ include(
     ),
 )
 
-"""
-    _loaded_climacommon()
+# Workaround for ClimaCalibrate v0.3.0: its job script inlines a multi-line
+# program into `julia -e`, which Derecho's set_gpu_rank wrapper word-splits on
+# newlines so julia only parses `import`. Restore v0.2.2's behavior of writing
+# model_run.jl to disk and passing the path. Remove once fixed upstream.
+function ClimaCalibrate.Calibration.generate_job_script_for_ensemble_member(
+    backend::ClimaCalibrate.Backend.HPCBackend,
+    iter,
+    member,
+    output_dir,
+    model_interface_filepath,
+    experiment_dir,
+    exeflags,
+)
+    job_body = """
+    import ClimaCalibrate
+    iteration = $iter; member = $member
+    model_interface_filepath = "$model_interface_filepath"
+    include(model_interface_filepath)
+    interface = ClimaCalibrate._load(joinpath("$output_dir", "interface.jld2"))
+    ClimaCalibrate.forward_model(interface, iteration, member)
+    ClimaCalibrate.write_model_completed("$output_dir", iteration, member)
+    """
+    member_path =
+        ClimaCalibrate.Calibration.path_to_ensemble_member(output_dir, iter, member)
+    mkpath(member_path)
+    julia_filepath = joinpath(member_path, "model_run.jl")
+    write(julia_filepath, job_body)
 
-Return the `climacommon/<version>` module name currently loaded in the parent
-shell, by scanning the `LOADEDMODULES` environment variable (colon-separated).
-Falls back to `"climacommon"` (default version) if none is found.
+    julia_command = "julia --project=$experiment_dir $exeflags $julia_filepath"
 
-This lets forward-model jobs pick up whichever `climacommon` the driver script
-loaded, instead of hardcoding a version per backend.
-"""
-function _loaded_climacommon()
-    loaded = get(ENV, "LOADEDMODULES", "")
-    # Expect entries of the form `climacommon/YYYY_MM_DD`. If multiple are
-    # loaded, the last one wins (matches `module`'s own resolution order).
-    pattern = r"^climacommon/\d{4}_\d{2}_\d{2}$"
-    matches = filter(mod -> occursin(pattern, mod), split(loaded, ':'))
-    isempty(matches) && return "climacommon"
-    return String(last(matches))
+    member_log = ClimaCalibrate.Calibration.path_to_model_log(output_dir, iter, member)
+    return ClimaCalibrate.Backend.make_job_script(
+        backend,
+        julia_command;
+        job_name = "run_$(iter)_$(member)",
+        output = member_log,
+    )
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__
@@ -154,11 +173,15 @@ if abspath(PROGRAM_FILE) == @__FILE__
         # 180 minutes is 3 hours
         :time => 180,
     ]
-    # Modules to load with `module load`
-    modules = [_loaded_climacommon()]
-    # Environment variables to set for each job
-    env_vars =
-        ["CLIMACOMMS_CONTEXT" => "SINGLETON", "CLIMACOMMS_DEVICE" => "CUDA"]
+    # Pin the module version so forward-model jobs match the project Manifests;
+    # unversioned `climacommon` resolves to whatever is current.
+    modules = ["climacommon/2025_02_25"]
+    # HDF5_USE_FILE_LOCKING=FALSE is required on Derecho's Lustre scratch.
+    env_vars = [
+        "CLIMACOMMS_CONTEXT" => "SINGLETON",
+        "CLIMACOMMS_DEVICE" => "CUDA",
+        "HDF5_USE_FILE_LOCKING" => "FALSE",
+    ]
 
     # Determine which backend to submit job scripts to
     if curr_backend == ClimaCalibrate.DerechoBackend

--- a/experiments/calibration/run_calibration.sh
+++ b/experiments/calibration/run_calibration.sh
@@ -6,10 +6,10 @@
 #
 # If OUTPUT_DIR is omitted, the default in run_calibration.jl is used.
 #
-# Load the climacommon version appropriate for your cluster before invoking
-# this script, e.g. `module load climacommon/2025_02_25` on Derecho. The
-# loaded version is picked up automatically by ClimaCalibrate.module_load_string
-# (via LOADEDMODULES) so forward-model jobs use the same version.
+# Before invoking this script, load climacommon to put Julia on PATH for the
+# orchestrator process, e.g. `module load climacommon/2025_02_25` on Derecho.
+# The version that forward-model PBS jobs load is pinned separately in
+# run_calibration.jl via the `modules` kwarg on the backend constructor.
 
 # Required on Derecho's Lustre scratch: HDF5 file locking is incompatible with
 # the parallel filesystem and causes NC_EHDFERR (-101) when the orchestrator
@@ -18,6 +18,6 @@ export HDF5_USE_FILE_LOCKING=FALSE
 
 OUTPUT_DIR="$1"
 
-julia --project=.buildkite -e 'using Pkg; Pkg.instantiate(;verbose=true)'
+julia --project=.buildkite -e 'using Pkg; Pkg.update(); Pkg.instantiate()'
 julia --project=.buildkite/ experiments/calibration/generate_observations.jl $OUTPUT_DIR
 julia --project=.buildkite/ experiments/calibration/run_calibration.jl $OUTPUT_DIR

--- a/experiments/long_runs/snowy_land_pmodel.jl
+++ b/experiments/long_runs/snowy_land_pmodel.jl
@@ -134,7 +134,11 @@ ClimaLand.Simulations.solve!(simulation)
 
 LandSimVis.make_annual_timeseries(simulation; savedir = root_path)
 LandSimVis.make_heatmaps(simulation; savedir = root_path, date = stop_date)
-LandSimVis.make_leaderboard_plots(simulation; savedir = root_path)
+LandSimVis.make_leaderboard_plots(
+    simulation;
+    savedir = root_path,
+    leaderboard_data_sources = ["ERA5", "ILAMB", "INVERSION"],
+)
 
 if LONGER_RUN
     include("../ilamb/ilamb_conversion.jl")

--- a/ext/land_sim_vis/leaderboard/data_sources.jl
+++ b/ext/land_sim_vis/leaderboard/data_sources.jl
@@ -61,6 +61,19 @@ function _preprocess_sim_var(var, ::Val{:nee})
     return var
 end
 
+function _preprocess_sim_var(var, ::Val{:hr})
+    # heterotrophic respiration: convert `mol CO2 m^-2 s^-1` in sim to
+    # `g C m-2 day-1` in obs (used for the inv_hr inversion target).
+    (ClimaAnalysis.units(var) == "mol CO2 m^-2 s^-1") && (
+        var = ClimaAnalysis.convert_units(
+            var,
+            "g m-2 day-1",
+            conversion_function = units -> units * 86400.0 * 12.011,
+        )
+    )
+    return var
+end
+
 _preprocess_sim_var(var, ::Val{:lwu}) = var
 _preprocess_sim_var(var, ::Val{:lhf}) = var
 _preprocess_sim_var(var, ::Val{:shf}) = var
@@ -439,6 +452,7 @@ function get_compare_vars_biases_plot_extrema(; annual = false)
         "gpp" => (-6.0, 6.0) .* factor,
         "er" => (-6.0, 6.0) .* factor,
         "nee" => (-4.0, 4.0) .* factor,
+        "hr" => (-4.0, 4.0) .* factor,
         "lwu" => (-40.0, 40.0) .* factor,
         "shf" => (-50.0, 50.0) .* factor,
         "lhf" => (-40.0, 40.0) .* factor,
@@ -448,11 +462,180 @@ function get_compare_vars_biases_plot_extrema(; annual = false)
 end
 
 """
+    _monthly_total_to_daily_rate!(obs_var)
+
+In-place: convert `obs_var.data` from `g C m⁻² month⁻¹` to `g C m⁻² day⁻¹` by
+dividing each time slice by its real days-in-month (28–31), rather than the
+constant 365.25/12 ≈ 30.4375. Avoids a ±5% spurious seasonality the constant
+would introduce. Updates the `units` attribute.
+"""
+function _monthly_total_to_daily_rate!(obs_var)
+    dates_vec = ClimaAnalysis.dates(obs_var)
+    factors = 1.0 ./ Float64.(Dates.daysinmonth.(dates_vec))
+    t_idx = obs_var.dim2index[ClimaAnalysis.time_name(obs_var)]
+    shape = ntuple(d -> d == t_idx ? length(factors) : 1, ndims(obs_var.data))
+    obs_var.data .*= reshape(factors, shape)
+    obs_var.attributes["units"] = "g m-2 day-1"
+    return obs_var
+end
+
+"""
+    get_inversion_obs_var_dict()
+
+Inversion-derived NEE/GPP/ER/Rh observations from the `inversion_nee` artifact
+(`derived_nee_gpp_er_rh_2002_2020.nc`, monthly 1°×1°, 2002–2020), returned as
+full-timeseries `OutputVar`s (the framework sets the per-sample reference date
+and windows by season in `generate_observations.jl`).
+
+Variables (all positive = source except gpp = uptake):
+  - `nee` from CarbonTracker CT2022, g C m⁻² month⁻¹
+  - `gpp` from GOSIF-GPP v2,        g C m⁻² month⁻¹
+  - `er`  residual = nee + gpp,     g C m⁻² month⁻¹
+  - `rh`  from Hashimoto 2015,      **g C m⁻² day⁻¹** (native units)
+
+All four are returned in g C m⁻² day⁻¹ (nee/gpp/er divided by actual
+days-in-month; rh already daily), with the units *string* set to `"g m-2 day-1"`
+to match the model diagnostics — ClimaCalibrate's `UnitsChecker` does a raw
+string compare. Short_names are retagged to `inv_nee`/`sif_gpp`/`res_er`/`inv_hr`
+so they don't collide with the FLUXCOM `gpp`/`er`/`nee` keys.
+"""
+function get_inversion_obs_var_dict()
+    inversion_path = ClimaLand.Artifacts.inversion_nee_dataset_path()
+
+    _load(varname) = begin
+        obs_var = ClimaAnalysis.OutputVar(inversion_path, varname)
+        ClimaAnalysis.dim_units(obs_var, "lon") == "degree" &&
+            ClimaAnalysis.set_dim_units!(obs_var, "lon", "degrees_east")
+        ClimaAnalysis.dim_units(obs_var, "lat") == "degree" &&
+            ClimaAnalysis.set_dim_units!(obs_var, "lat", "degrees_north")
+        ClimaAnalysis.transform_dates!(obs_var, Dates.firstdayofmonth)
+        return ClimaAnalysis.replace(obs_var, missing => NaN)
+    end
+
+    obs_var_dict = Dict{String, Any}()
+    for (alias, varname, monthly) in (
+        ("inv_nee", "nee", true),
+        ("sif_gpp", "gpp", true),
+        ("res_er", "er", true),
+        ("inv_hr", "rh", false), # rh already a daily rate; relabeled below
+    )
+        obs_var = _load(varname)
+        if monthly
+            # Convert to a daily rate and set units to "g m-2 day-1".
+            _monthly_total_to_daily_rate!(obs_var)
+        else
+            # rh is already daily; only relabel its units to "g m-2 day-1" so
+            # the UnitsChecker's raw string compare matches the model hr
+            # diagnostic (a mismatch NaN-fills the member's whole G column).
+            obs_var.attributes["units"] = "g m-2 day-1"
+        end
+        # Like ILAMB obs: sort lat ascending and shift lon to [-180, 180] so
+        # preprocess_single_obs_var aligns these with the model grid.
+        # `_preprocess_var` leaves "g m-2 day-1" and the short_name untouched.
+        obs_var = _preprocess_var(obs_var)
+        obs_var.attributes["short_name"] = alias
+        obs_var_dict[alias] = obs_var
+    end
+    return obs_var_dict
+end
+
+# Map the calibration aliases (artifact-derived short names) to the model
+# diagnostic short names used by the simulation output and the leaderboard.
+const _INVERSION_ALIAS_TO_MODEL_NAME = Dict(
+    "inv_nee" => "nee",
+    "sif_gpp" => "gpp",
+    "res_er" => "er",
+    "inv_hr" => "hr",
+)
+
+"""
+    InversionDataLoader
+
+Loads the inversion-derived carbon observations (CT2022 NEE, GOSIF GPP, residual
+ER, Hashimoto Rh from the `inversion_nee` artifact) for the leaderboard. The
+inversion analogue of `ILAMBDataLoader`: same seasonal machinery, but against the
+inversion product instead of FLUXCOM. Keyed by the *model* short names
+`nee`/`gpp`/`er`/`hr` (not the `inv_*` aliases) so they intersect with the
+simulation diagnostics.
+"""
+struct InversionDataLoader <: AbstractDataLoader
+    """Preprocessed inversion `OutputVar`s, keyed by model short name."""
+    obs_var_dict::Dict{String, Any}
+
+    """A list of available variables to load."""
+    available_vars::Set{String}
+end
+
+"""
+    InversionDataLoader()
+
+Construct a data loader for the inversion-derived carbon targets. The variables
+are already preprocessed (monthly total → daily rate, latitude sorted ascending,
+longitude shifted to [-180, 180], units set to `g m-2 day-1`) by
+`get_inversion_obs_var_dict`; here they are re-keyed and re-tagged from
+`inv_nee`/`sif_gpp`/`res_er`/`inv_hr` to `nee`/`gpp`/`er`/`hr` so they match the
+simulation diagnostics.
+"""
+function InversionDataLoader()
+    inversion_dict = get_inversion_obs_var_dict()
+    obs_var_dict = Dict{String, Any}()
+    for (alias, model_name) in _INVERSION_ALIAS_TO_MODEL_NAME
+        obs_var = inversion_dict[alias]
+        obs_var.attributes["short_name"] = model_name
+        obs_var_dict[model_name] = obs_var
+    end
+    return InversionDataLoader(obs_var_dict, Set(keys(obs_var_dict)))
+end
+
+"""
+    get(loader::InversionDataLoader, short_name::String)
+
+Get the preprocessed inversion `OutputVar` with the model short name
+`short_name` (one of `nee`, `gpp`, `er`, `hr`).
+"""
+function Base.get(loader::InversionDataLoader, short_name::String)
+    short_name in loader.available_vars ||
+        error("$short_name is not available to load")
+    return loader.obs_var_dict[short_name]
+end
+
+"""
+    get_mask_dict(data_loader::InversionDataLoader)
+
+Return a dictionary mapping model short names to a masking function that masks
+out grid points where the inversion observation is missing (NaN), mirroring the
+ILAMB carbon-variable masks (used to normalize global bias and RMSE).
+"""
+function get_mask_dict(data_loader::InversionDataLoader)
+    mask_dict = Dict{String, Any}()
+
+    make_mask_fn =
+        (sim_var, obs_var) -> begin
+            return ClimaAnalysis.make_lonlat_mask(
+                ClimaAnalysis.slice(
+                    obs_var,
+                    time = ClimaAnalysis.times(obs_var) |> first,
+                );
+                set_to_val = isnan,
+            )
+        end
+
+    for short_name in available_vars(data_loader)
+        mask_dict[short_name] = make_mask_fn
+    end
+
+    @assert keys(mask_dict) == available_vars(data_loader)
+    return mask_dict
+end
+
+"""
     get_calibration_obs_var_dict(; short_names = nothing)
 
 Return a dictionary mapping short names to `OutputVar` containing preprocessed
 observational data for calibration. This combines ERA5 energy flux variables
-(`lhf`, `shf`, `lwu`, `swu`) with ILAMB variables (`gpp`, `er`, `nee`).
+(`lhf`, `shf`, `lwu`, `swu`), ILAMB variables (`gpp`, `er`, `nee`), and the
+inversion-derived carbon targets (`inv_nee`, `sif_gpp`, `res_er`, `inv_hr`)
+from the `inversion_nee` artifact.
 
 If `short_names` is provided, only the requested variables are returned.
 """
@@ -471,6 +654,10 @@ function get_calibration_obs_var_dict(; short_names = nothing)
     for short_name in ("gpp", "er", "nee")
         obs_var_dict[short_name] = get(ilamb_data_loader, short_name)
     end
+
+    # Inversion-derived carbon targets (CT2022 NEE + GOSIF GPP + residual ER +
+    # Hashimoto Rh), keyed by inv_nee/sif_gpp/res_er/inv_hr.
+    merge!(obs_var_dict, get_inversion_obs_var_dict())
 
     if !isnothing(short_names)
         filter!(p -> p.first in short_names, obs_var_dict)

--- a/ext/land_sim_vis/leaderboard/data_sources.jl
+++ b/ext/land_sim_vis/leaderboard/data_sources.jl
@@ -78,6 +78,8 @@ _preprocess_sim_var(var, ::Val{:lwu}) = var
 _preprocess_sim_var(var, ::Val{:lhf}) = var
 _preprocess_sim_var(var, ::Val{:shf}) = var
 _preprocess_sim_var(var, ::Val{:swu}) = var
+# LAI is already dimensionless (m^2 m^-2), matching the MODIS obs; no conversion.
+_preprocess_sim_var(var, ::Val{:lai}) = var
 _preprocess_sim_var(var, name::Val) =
     error("Preprocessing var with short name ($name) is not defined")
 
@@ -505,9 +507,9 @@ function get_inversion_obs_var_dict()
     _load(varname) = begin
         obs_var = ClimaAnalysis.OutputVar(inversion_path, varname)
         ClimaAnalysis.dim_units(obs_var, "lon") == "degree" &&
-            ClimaAnalysis.set_dim_units!(obs_var, "lon", "degrees_east")
+        ClimaAnalysis.set_dim_units!(obs_var, "lon", "degrees_east")
         ClimaAnalysis.dim_units(obs_var, "lat") == "degree" &&
-            ClimaAnalysis.set_dim_units!(obs_var, "lat", "degrees_north")
+        ClimaAnalysis.set_dim_units!(obs_var, "lat", "degrees_north")
         ClimaAnalysis.transform_dates!(obs_var, Dates.firstdayofmonth)
         return ClimaAnalysis.replace(obs_var, missing => NaN)
     end
@@ -629,15 +631,72 @@ function get_mask_dict(data_loader::InversionDataLoader)
 end
 
 """
+    get_modis_lai_obs_var(; years = 2000:2020)
+
+MODIS LAI observations (Yuan et al., monthly 1°×1°, per-year files) loaded as a
+single full-timeseries `OutputVar` spanning `years`, keyed `lai`. The framework
+sets the per-sample reference date and windows by season in
+`generate_observations.jl`.
+
+Native units are `m^2 m^-2`, matching the model `lai` diagnostic, so no unit
+conversion is applied (ClimaCalibrate's `UnitsChecker` does a raw string
+compare). Latitude is sorted ascending and longitude shifted to [-180, 180] (via
+`_preprocess_var`) to align with the model grid; the short_name is kept as `lai`.
+
+The native MODIS samples are ~30.4-day spaced (calendar-unaligned, with no
+December/February sample), so they are linearly interpolated in time onto
+calendar month-starts. This is required because the calibration framework labels
+each seasonal average by the *first date* in the season
+(`ClimaAnalysis.average_season_across_time`) and matches obs to sim by exact date
+(`indexin`); the model's monthly `lai` diagnostic is month-start-dated and has
+all 12 months, so the obs must be too. Only interior month-starts are kept (the
+first/last months would require extrapolation), which is why `years` should
+bracket the calibration window by at least one month on each side.
+
+This is the calibration target for the optimal-LAI parameters
+(`ZhouOptimalLAIModel`, Zhou et al. 2025), used only when the forward model is
+run with `prognostic_lai = true`.
+"""
+function get_modis_lai_obs_var(; years = 2000:2020)
+    paths = [
+        ClimaLand.Artifacts.modis_lai_single_year_path(; year) for year in years
+    ]
+    obs_var = ClimaAnalysis.OutputVar(paths, "lai")
+    obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
+
+    # Resample onto calendar month-starts (interior only) by linear time
+    # interpolation, so seasonal averaging produces the same canonical
+    # month-start season dates as the model's monthly `lai` diagnostic.
+    start_date = Dates.DateTime(obs_var.attributes["start_date"])
+    data_dates = ClimaAnalysis.dates(obs_var)
+    month_starts = filter(
+        d -> first(data_dates) <= d <= last(data_dates),
+        Dates.firstdayofmonth(first(data_dates)):Dates.Month(1):last(
+            data_dates,
+        ),
+    )
+    target_seconds = [
+        Float64(Dates.value(Dates.Second(d - start_date))) for d in month_starts
+    ]
+    obs_var = ClimaAnalysis.resampled_as(obs_var; time = target_seconds)
+
+    obs_var = _preprocess_var(obs_var)
+    obs_var.attributes["short_name"] = "lai"
+    obs_var.attributes["units"] = "m^2 m^-2"
+    return obs_var
+end
+
+"""
     get_calibration_obs_var_dict(; short_names = nothing)
 
 Return a dictionary mapping short names to `OutputVar` containing preprocessed
 observational data for calibration. This combines ERA5 energy flux variables
-(`lhf`, `shf`, `lwu`, `swu`), ILAMB variables (`gpp`, `er`, `nee`), and the
+(`lhf`, `shf`, `lwu`, `swu`), ILAMB variables (`gpp`, `er`, `nee`), the
 inversion-derived carbon targets (`inv_nee`, `sif_gpp`, `res_er`, `inv_hr`)
-from the `inversion_nee` artifact.
+from the `inversion_nee` artifact, and the MODIS `lai` target.
 
-If `short_names` is provided, only the requested variables are returned.
+If `short_names` is provided, only the requested variables are returned (and
+the MODIS LAI file load is skipped unless `lai` is requested).
 """
 function get_calibration_obs_var_dict(; short_names = nothing)
     obs_var_dict = Dict{String, Any}()
@@ -658,6 +717,12 @@ function get_calibration_obs_var_dict(; short_names = nothing)
     # Inversion-derived carbon targets (CT2022 NEE + GOSIF GPP + residual ER +
     # Hashimoto Rh), keyed by inv_nee/sif_gpp/res_er/inv_hr.
     merge!(obs_var_dict, get_inversion_obs_var_dict())
+
+    # MODIS LAI target for optimal-LAI calibration. Loading the 21 per-year
+    # files is comparatively expensive, so only build it when requested.
+    if isnothing(short_names) || "lai" in short_names
+        obs_var_dict["lai"] = get_modis_lai_obs_var()
+    end
 
     if !isnothing(short_names)
         filter!(p -> p.first in short_names, obs_var_dict)

--- a/ext/land_sim_vis/leaderboard/data_sources.jl
+++ b/ext/land_sim_vis/leaderboard/data_sources.jl
@@ -459,6 +459,7 @@ function get_compare_vars_biases_plot_extrema(; annual = false)
         "shf" => (-50.0, 50.0) .* factor,
         "lhf" => (-40.0, 40.0) .* factor,
         "swu" => (-50.0, 50.0) .* factor,
+        "lai" => (-3.0, 3.0) .* factor,
     )
     return compare_vars_biases_plot_extrema
 end
@@ -543,22 +544,23 @@ end
 
 # Map the calibration aliases (artifact-derived short names) to the model
 # diagnostic short names used by the simulation output and the leaderboard.
-const _INVERSION_ALIAS_TO_MODEL_NAME = Dict(
-    "inv_nee" => "nee",
-    "sif_gpp" => "gpp",
-    "res_er" => "er",
-    "inv_hr" => "hr",
-)
+# `inv_hr` (Hashimoto Rh) is intentionally excluded: the leaderboard shows the
+# MODIS `lai` target in its place (see InversionDataLoader).
+const _INVERSION_ALIAS_TO_MODEL_NAME =
+    Dict("inv_nee" => "nee", "sif_gpp" => "gpp", "res_er" => "er")
 
 """
     InversionDataLoader
 
 Loads the inversion-derived carbon observations (CT2022 NEE, GOSIF GPP, residual
-ER, Hashimoto Rh from the `inversion_nee` artifact) for the leaderboard. The
-inversion analogue of `ILAMBDataLoader`: same seasonal machinery, but against the
-inversion product instead of FLUXCOM. Keyed by the *model* short names
-`nee`/`gpp`/`er`/`hr` (not the `inv_*` aliases) so they intersect with the
-simulation diagnostics.
+ER from the `inversion_nee` artifact) plus the MODIS `lai` target for the
+leaderboard. The inversion analogue of `ILAMBDataLoader`: same seasonal
+machinery, but against the inversion product instead of FLUXCOM. Keyed by the
+*model* short names `nee`/`gpp`/`er`/`lai` (not the `inv_*` aliases) so they
+intersect with the simulation diagnostics.
+
+`lai` (MODIS, Yuan et al. 2017) replaces the earlier Hashimoto `hr` panel so the
+carbon leaderboard reports the four calibrated targets NEE/GPP/ER/LAI together.
 """
 struct InversionDataLoader <: AbstractDataLoader
     """Preprocessed inversion `OutputVar`s, keyed by model short name."""
@@ -571,12 +573,12 @@ end
 """
     InversionDataLoader()
 
-Construct a data loader for the inversion-derived carbon targets. The variables
-are already preprocessed (monthly total → daily rate, latitude sorted ascending,
-longitude shifted to [-180, 180], units set to `g m-2 day-1`) by
-`get_inversion_obs_var_dict`; here they are re-keyed and re-tagged from
-`inv_nee`/`sif_gpp`/`res_er`/`inv_hr` to `nee`/`gpp`/`er`/`hr` so they match the
-simulation diagnostics.
+Construct a data loader for the inversion-derived carbon targets plus MODIS LAI.
+The carbon variables are already preprocessed (monthly total → daily rate,
+latitude sorted ascending, longitude shifted to [-180, 180], units set to
+`g m-2 day-1`) by `get_inversion_obs_var_dict`; here they are re-keyed and
+re-tagged from `inv_nee`/`sif_gpp`/`res_er` to `nee`/`gpp`/`er`. The `lai` target
+(m^2 m^-2) is loaded from `get_modis_lai_obs_var`.
 """
 function InversionDataLoader()
     inversion_dict = get_inversion_obs_var_dict()
@@ -586,14 +588,17 @@ function InversionDataLoader()
         obs_var.attributes["short_name"] = model_name
         obs_var_dict[model_name] = obs_var
     end
+    lai_obs = get_modis_lai_obs_var()
+    lai_obs.attributes["short_name"] = "lai"
+    obs_var_dict["lai"] = lai_obs
     return InversionDataLoader(obs_var_dict, Set(keys(obs_var_dict)))
 end
 
 """
     get(loader::InversionDataLoader, short_name::String)
 
-Get the preprocessed inversion `OutputVar` with the model short name
-`short_name` (one of `nee`, `gpp`, `er`, `hr`).
+Get the preprocessed `OutputVar` with the model short name `short_name` (one of
+`nee`, `gpp`, `er`, `lai`).
 """
 function Base.get(loader::InversionDataLoader, short_name::String)
     short_name in loader.available_vars ||
@@ -604,9 +609,12 @@ end
 """
     get_mask_dict(data_loader::InversionDataLoader)
 
-Return a dictionary mapping model short names to a masking function that masks
-out grid points where the inversion observation is missing (NaN), mirroring the
-ILAMB carbon-variable masks (used to normalize global bias and RMSE).
+Return a dictionary mapping model short names to a masking function used to
+normalize the global bias and RMSE. The inversion carbon variables
+(`nee`/`gpp`/`er`) are masked where the observation is missing (NaN), mirroring
+the ILAMB carbon-variable masks. `lai` uses `ClimaAnalysis.apply_oceanmask`
+instead: MODIS LAI is finite (≈0), not NaN, over ocean, so the `isnan` mask
+would mask nothing.
 """
 function get_mask_dict(data_loader::InversionDataLoader)
     mask_dict = Dict{String, Any}()
@@ -623,7 +631,9 @@ function get_mask_dict(data_loader::InversionDataLoader)
         end
 
     for short_name in available_vars(data_loader)
-        mask_dict[short_name] = make_mask_fn
+        mask_dict[short_name] =
+            short_name == "lai" ?
+            ((sim_var, obs_var) -> ClimaAnalysis.apply_oceanmask) : make_mask_fn
     end
 
     @assert keys(mask_dict) == available_vars(data_loader)

--- a/ext/land_sim_vis/leaderboard/leaderboard.jl
+++ b/ext/land_sim_vis/leaderboard/leaderboard.jl
@@ -28,40 +28,53 @@ function _percentile_contour_kwargs(
 end
 
 """
-    _monthly_climatology_global_mean(var, mask_fn = ClimaAnalysis.apply_oceanmask)
+    _monthly_climatology_global_means(sim, obs,
+                                      mask_fn = ClimaAnalysis.apply_oceanmask)
 
-Return a 12-element vector of global, lonlat-weighted monthly climatology
-means for `var`. Index `i` corresponds to month `i` (1=Jan ... 12=Dec).
-Months that have no valid samples are filled with `NaN`.
+Return a pair `(sim_monthly, obs_monthly)` of 12-element vectors of global,
+lonlat-weighted monthly climatology means. Index `i` corresponds to month `i`
+(1=Jan ... 12=Dec). Months that have no valid samples are filled with `NaN`.
 
-`mask_fn` is the same per-variable mask used by `global_bias` /  `global_rmse`
-elsewhere in this module (e.g. `apply_oceanmask` for ERA5 vars, the FLUXCOM
-NaN mask for ILAMB vars). Applying it to sim and obs identically guarantees
-that both lines are averaged over the same set of valid pixels, so the gap
-between the lines matches the global bias shown in the ANN column.
+`mask_fn` is the same per-variable mask used by `global_bias`/`global_rmse`
+elsewhere. After applying it, both sim and obs are further restricted to the
+intersection of finite cells at each time step, so the two lines are averaged
+over the same domain even where obs has data gaps that sim does not — otherwise
+the SIM/OBS gap would not match the global bias in the ANN column.
 """
-function _monthly_climatology_global_mean(
-    var,
+function _monthly_climatology_global_means(
+    sim,
+    obs,
     mask_fn = ClimaAnalysis.apply_oceanmask,
 )
-    times = ClimaAnalysis.times(var)
-    isempty(times) && return fill(NaN, 12)
-    start_date = Dates.DateTime(var.attributes["start_date"])
+    times = ClimaAnalysis.times(sim)
+    isempty(times) && return (fill(NaN, 12), fill(NaN, 12))
+    start_date = Dates.DateTime(sim.attributes["start_date"])
     months =
         [Dates.month(start_date + Dates.Second(round(Int, t))) for t in times]
-    global_means = [
-        ClimaAnalysis.weighted_average_lonlat(
-            mask_fn(ClimaAnalysis.slice(var, time = t)),
-        ).data[] for t in times
-    ]
-    out = fill(NaN, 12)
+    sim_global = Float64[]
+    obs_global = Float64[]
+    for t in times
+        sim_t = mask_fn(ClimaAnalysis.slice(sim, time = t))
+        obs_t = mask_fn(ClimaAnalysis.slice(obs, time = t))
+        # Mask both fields to the intersection of finite cells so the two
+        # weighted global means are taken over the same domain.
+        nan_either = isnan.(sim_t.data) .| isnan.(obs_t.data)
+        sim_t.data[nan_either] .= NaN
+        obs_t.data[nan_either] .= NaN
+        push!(sim_global, ClimaAnalysis.weighted_average_lonlat(sim_t).data[])
+        push!(obs_global, ClimaAnalysis.weighted_average_lonlat(obs_t).data[])
+    end
+    out_sim = fill(NaN, 12)
+    out_obs = fill(NaN, 12)
     for m in 1:12
         idxs = findall(==(m), months)
         isempty(idxs) && continue
-        vals = filter(isfinite, global_means[idxs])
-        isempty(vals) || (out[m] = sum(vals) / length(vals))
+        sim_vals = filter(isfinite, sim_global[idxs])
+        obs_vals = filter(isfinite, obs_global[idxs])
+        isempty(sim_vals) || (out_sim[m] = sum(sim_vals) / length(sim_vals))
+        isempty(obs_vals) || (out_obs[m] = sum(obs_vals) / length(obs_vals))
     end
-    return out
+    return (out_sim, out_obs)
 end
 
 """
@@ -90,6 +103,56 @@ function _nee_diverging_contour_kwargs(var, q; nlevels = 21)
 end
 
 """
+    _prepare_for_bias(base_mask, sim, obs)
+
+Return `(sim_clean, obs_clean, mask_fn)` so that `ClimaAnalysis.bias` /
+`global_bias` / `global_rmse` / `plot_bias_on_globe!` integrate over the
+intersection of finite cells, matching `_monthly_climatology_global_means`.
+
+Two problems it works around in `ClimaAnalysis.bias` when `obs` has spatial gaps
+(e.g. GOSIF-GPP/residual-ER over deserts/ice): its normalization `ones_var`
+doesn't inherit obs's NaN footprint (denominator over all land, numerator over
+land∩finite(obs) — attenuates or flips the bias), and its `resampled_as` call
+isn't NaN-aware so NaNs erode their neighbours.
+
+The fix: fill NaN with 0 in both fields (so `resampled_as` can't erode), and
+return a `mask_fn` combining `base_mask` with the union of the original sim/obs
+NaN footprints, so `ones_var` and `sim_clean − obs_clean` share one domain.
+"""
+function _prepare_for_bias(base_mask, sim, obs)
+    sim_masked = base_mask(sim)
+    obs_masked = base_mask(obs)
+    extra_nan = isnan.(sim_masked.data) .| isnan.(obs_masked.data)
+    sim_filled_data = ifelse.(isnan.(sim.data), zero(eltype(sim.data)), sim.data)
+    obs_filled_data = ifelse.(isnan.(obs.data), zero(eltype(obs.data)), obs.data)
+    sim_clean = ClimaAnalysis.OutputVar(
+        sim.attributes,
+        sim.dims,
+        sim.dim_attributes,
+        sim_filled_data,
+    )
+    obs_clean = ClimaAnalysis.OutputVar(
+        obs.attributes,
+        obs.dims,
+        obs.dim_attributes,
+        obs_filled_data,
+    )
+    mask_fn = function (var)
+        v = base_mask(var)
+        any(extra_nan) || return v
+        new_data = copy(v.data)
+        new_data[extra_nan] .= NaN
+        return ClimaAnalysis.OutputVar(
+            v.attributes,
+            v.dims,
+            v.dim_attributes,
+            new_data,
+        )
+    end
+    return sim_clean, obs_clean, mask_fn
+end
+
+"""
     compute_monthly_leaderboard(leaderboard_base_path,
                                 diagnostics_folder_path,
                                 data_source)
@@ -115,7 +178,9 @@ function compute_monthly_leaderboard(
 )
     sim_dir = ClimaAnalysis.SimDir(diagnostics_folder_path)
     data_loader =
-        uppercase(data_source) == "ERA5" ? ERA5DataLoader() : ILAMBDataLoader()
+        uppercase(data_source) == "ERA5" ? ERA5DataLoader() :
+        uppercase(data_source) == "INVERSION" ? InversionDataLoader() :
+        ILAMBDataLoader()
     mask_dict = get_mask_dict(data_loader)
 
     compare_vars_biases_plot_extrema = get_compare_vars_biases_plot_extrema()
@@ -230,12 +295,17 @@ function compute_monthly_leaderboard(
         times = reshape(times, (2, 6))
         for ((indices, t), (month, year)) in zip(pairs(times), months_and_years)
             layout = fig[Tuple(indices)...] = CairoMakie.GridLayout()
-            ClimaAnalysis.Visualize.plot_bias_on_globe!(
-                layout,
+            sim_c, obs_c, mask_c = _prepare_for_bias(
+                mask,
                 ClimaAnalysis.slice(sim_var, time = t),
                 ClimaAnalysis.slice(obs_var, time = t),
+            )
+            ClimaAnalysis.Visualize.plot_bias_on_globe!(
+                layout,
+                sim_c,
+                obs_c,
                 cmap_extrema = compare_vars_biases_plot_extrema[short_name],
-                mask = mask,
+                mask = mask_c,
             )
             CairoMakie.Label(
                 layout[0, 1],
@@ -262,25 +332,34 @@ function compute_monthly_leaderboard(
         mask = mask_dict[short_name](sim_var, obs_var)
 
         sim_vec = [
-            ClimaAnalysis.weighted_average_lonlat(
-                ClimaAnalysis.apply_oceanmask(
+            begin
+                sim_c, _, mask_c = _prepare_for_bias(
+                    mask,
                     ClimaAnalysis.slice(sim_var, time = t),
-                ),
-            ).data[] for t in times
+                    ClimaAnalysis.slice(obs_var, time = t),
+                )
+                ClimaAnalysis.weighted_average_lonlat(mask_c(sim_c)).data[]
+            end for t in times
         ]
         rmse_vec = [
-            ClimaAnalysis.global_rmse(
-                ClimaAnalysis.slice(sim_var, time = t),
-                ClimaAnalysis.slice(obs_var, time = t),
-                mask = mask,
-            ) for t in times
+            begin
+                sim_c, obs_c, mask_c = _prepare_for_bias(
+                    mask,
+                    ClimaAnalysis.slice(sim_var, time = t),
+                    ClimaAnalysis.slice(obs_var, time = t),
+                )
+                ClimaAnalysis.global_rmse(sim_c, obs_c, mask = mask_c)
+            end for t in times
         ]
         bias_vec = [
-            ClimaAnalysis.global_bias(
-                ClimaAnalysis.slice(sim_var, time = t),
-                ClimaAnalysis.slice(obs_var, time = t),
-                mask = mask,
-            ) for t in times
+            begin
+                sim_c, obs_c, mask_c = _prepare_for_bias(
+                    mask,
+                    ClimaAnalysis.slice(sim_var, time = t),
+                    ClimaAnalysis.slice(obs_var, time = t),
+                )
+                ClimaAnalysis.global_bias(sim_c, obs_c, mask = mask_c)
+            end for t in times
         ]
 
         ax_sim = CairoMakie.Axis(
@@ -396,7 +475,9 @@ function compute_seasonal_leaderboard(
     # Get everything we need from data_sources.jl
     sim_dir = ClimaAnalysis.SimDir(diagnostics_folder_path)
     data_loader =
-        uppercase(data_source) == "ERA5" ? ERA5DataLoader() : ILAMBDataLoader()
+        uppercase(data_source) == "ERA5" ? ERA5DataLoader() :
+        uppercase(data_source) == "INVERSION" ? InversionDataLoader() :
+        ILAMBDataLoader()
     short_names = intersect(
         ClimaAnalysis.available_vars(sim_dir),
         available_vars(data_loader),
@@ -526,12 +607,14 @@ function compute_seasonal_leaderboard(
             isempty(sim_var) && break
             layout = fig_bias[row_idx, col_idx] = CairoMakie.GridLayout()
             sim_var.attributes["short_name"] = "mean $(ClimaAnalysis.short_name(sim_var))"
+            sim_c, obs_c, mask_c =
+                _prepare_for_bias(mask_fn_dict[short_name], sim_var, obs_var)
             ClimaAnalysis.Visualize.plot_bias_on_globe!(
                 layout,
-                sim_var,
-                obs_var,
+                sim_c,
+                obs_c,
                 cmap_extrema = compare_vars_biases_plot_extrema[short_name],
-                mask = mask_fn_dict[short_name],
+                mask = mask_c,
             )
         end
     end
@@ -673,10 +756,12 @@ function compute_seasonal_leaderboard(
                 sim_var_full, obs_var_full = sim_obs_full_dict[short_name]
                 isempty(sim_var_full) && break
                 mask_fn = mask_fn_dict[short_name]
-                sim_monthly =
-                    _monthly_climatology_global_mean(sim_var_full, mask_fn)
-                obs_monthly =
-                    _monthly_climatology_global_mean(obs_var_full, mask_fn)
+                sim_monthly, obs_monthly =
+                    _monthly_climatology_global_means(
+                        sim_var_full,
+                        obs_var_full,
+                        mask_fn,
+                    )
                 units_str = ClimaAnalysis.units(sim_var_full)
                 ax = CairoMakie.Axis(
                     fig_sim_ann[row_idx, col_idx],
@@ -730,12 +815,17 @@ function compute_seasonal_leaderboard(
                     sim_obs_season_comparison_dict[short_name][group]
                 isempty(sim_var) && break
                 layout = fig_sim_ann[row_idx, col_idx] = CairoMakie.GridLayout()
-                ClimaAnalysis.Visualize.plot_bias_on_globe!(
-                    layout,
+                sim_c, obs_c, mask_c = _prepare_for_bias(
+                    mask_fn_dict[short_name],
                     sim_var,
                     obs_var,
+                )
+                ClimaAnalysis.Visualize.plot_bias_on_globe!(
+                    layout,
+                    sim_c,
+                    obs_c,
                     cmap_extrema = annual_compare_vars_biases_plot_extrema[short_name],
-                    mask = mask_fn_dict[short_name],
+                    mask = mask_c,
                 )
             end
         end
@@ -766,17 +856,22 @@ function compute_seasonal_leaderboard(
         # Get season and compute global bias and global rmse
         seasons = [sim_var.attributes["season"] for sim_var in sim_vars]
         sim_vec = [
-            ClimaAnalysis.weighted_average_lonlat(
-                ClimaAnalysis.apply_oceanmask(sim_var),
-            ).data[] for sim_var in sim_vars
+            begin
+                sim_c, _, mask_c = _prepare_for_bias(mask, sim_var, obs_var)
+                ClimaAnalysis.weighted_average_lonlat(mask_c(sim_c)).data[]
+            end for (sim_var, obs_var) in zip(sim_vars, obs_vars)
         ]
         rmse_vec = [
-            ClimaAnalysis.global_rmse(sim_var, obs_var, mask = mask) for
-            (sim_var, obs_var) in zip(sim_vars, obs_vars)
+            begin
+                sim_c, obs_c, mask_c = _prepare_for_bias(mask, sim_var, obs_var)
+                ClimaAnalysis.global_rmse(sim_c, obs_c, mask = mask_c)
+            end for (sim_var, obs_var) in zip(sim_vars, obs_vars)
         ]
         bias_vec = [
-            ClimaAnalysis.global_bias(sim_var, obs_var, mask = mask) for
-            (sim_var, obs_var) in zip(sim_vars, obs_vars)
+            begin
+                sim_c, obs_c, mask_c = _prepare_for_bias(mask, sim_var, obs_var)
+                ClimaAnalysis.global_bias(sim_c, obs_c, mask = mask_c)
+            end for (sim_var, obs_var) in zip(sim_vars, obs_vars)
         ]
 
         # Partition by seasons

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -256,9 +256,7 @@ The following default parameters (from the TOML file) are used:
 function PModel{FT}(
     domain,
     toml_dict::CP.ParamDict;
-    fractional_c3 = clm_photosynthesis_parameters(
-        domain.space.surface,
-    ).fractional_c3,
+    fractional_c3 = clm_photosynthesis_parameters(domain.space.surface).fractional_c3,
     binarize = false,
     cstar = toml_dict["pmodel_cstar"],
     β_c3 = toml_dict["pmodel_β_c3"],

--- a/src/standalone/Vegetation/optimal_lai.jl
+++ b/src/standalone/Vegetation/optimal_lai.jl
@@ -209,8 +209,10 @@ Provide a robust initial guess for the Lambert W0 function for use in iterative 
         return log(x) - log(max(log(x), T(1e-6)))
     elseif x < T(-0.32)
         # Near the branch point -1/e, use series expansion
-        # This handles the singular behavior at x = -1/e where W(x) = -1
-        p = sqrt(T(2) * (T(ℯ) * x + one(T)))
+        # This handles the singular behavior at x = -1/e where W(x) = -1.
+        # max(..., 0) guards the sqrt: at x ≈ -1/e the argument is ≈ 0 and can
+        # round below zero (T(ℯ) here differs from the -inv(e) used to admit x).
+        p = sqrt(max(T(2) * (T(ℯ) * x + one(T)), zero(T)))
         return -one(T) + p - p^2 / T(3) + p^3 * T(11) / T(72)
     else
         return max(x, T(-0.3))

--- a/src/standalone/Vegetation/pmodel.jl
+++ b/src/standalone/Vegetation/pmodel.jl
@@ -627,10 +627,12 @@ function update_optimal_EMA(
     Vcmax25_c3 = Vcmax_c3 / inst_temp_scaling_factor_Vcmax
     Vcmax25_c4 = Vcmax_c4 / inst_temp_scaling_factor_Vcmax
 
-    Jmax_c3 =
-        4 * ϕ0_c3 * APAR_canopy_moles / sqrt((mj_c3 / (βm * mprime_c3))^2 - 1)
-    Jmax_c4 =
-        4 * ϕ0_c4 * APAR_canopy_moles / sqrt((mj_c4 / (βm * mprime_c4))^2 - 1)
+    # guard the sqrt against a marginally-negative discriminant (rounds below
+    # zero when βm ≈ 1 and mj ≈ mprime); mirrors compute_full_pmodel_outputs.
+    arg_c3 = (mj_c3 / (βm * mprime_c3))^2 - 1
+    arg_c4 = (mj_c4 / (βm * mprime_c4))^2 - 1
+    Jmax_c3 = 4 * ϕ0_c3 * APAR_canopy_moles / (sqrt(max(arg_c3, 0)) + eps(FT))
+    Jmax_c4 = 4 * ϕ0_c4 * APAR_canopy_moles / (sqrt(max(arg_c4, 0)) + eps(FT))
     inst_temp_scaling_factor_Jmax = inst_temp_scaling(
         T_canopy,
         T_canopy,

--- a/toml/default_parameters.toml
+++ b/toml/default_parameters.toml
@@ -803,9 +803,9 @@ tag = "SlabLakeParameters"
 
 # Autotrophic respiration (JULES) parameters
 ["relative_contribution_factor"]
-value = 0.3
+value = 0.4
 type = "float"
-description = "Factor of relative contribution for growth respiration, Rgrowth (unitless). Held fixed (not calibrated)."
+description = "Factor of relative contribution for growth respiration, Rgrowth (unitless)."
 tag = "AutotrophicRespirationParameters"
 
 ["autotrophic_respiration_Q10"]
@@ -821,7 +821,7 @@ description = "Reference temperature for the Q10 maintenance-respiration factor 
 tag = "AutotrophicRespirationParameters"
 
 ["autotrophic_respiration_Rd_ref"]
-value = 7.83e-7
+value = 4.5e-7
 type = "float"
 description = "Reference leaf-level dark respiration rate (mol CO2 m-2 s-1) for the LAI-independent root and stem maintenance respiration."
 tag = "AutotrophicRespirationParameters"

--- a/toml/default_parameters.toml
+++ b/toml/default_parameters.toml
@@ -1,6 +1,6 @@
 # Moisture stress models
 [moisture_stress_c]
-value = 0.59
+value = 0.584
 type = "float"
 description = "unitless"
 tag = "SoilMoistureStress"
@@ -290,19 +290,19 @@ tag = "ConstantResetAlbedo"
 
 # P model parameters
 ["pmodel_cstar"]
-value = 0.43
+value = 0.412
 type = "float"
 description = "4 * dA/dJmax, assumed to be a constant marginal cost (Wang 2017, Stocker 2020)"
 tag = "PModelParameters"
 
 ["pmodel_β_c3"]
-value = 91.1
+value = 51.0
 type = "float"
 description = "Unit cost ratio of Vcmax to transpiration for C3 plants (Stocker 2020)"
 tag = "PModelParameters"
 
 ["pmodel_β_c4"]
-value = 5.36
+value = 12.4
 type = "float"
 description = "Unit cost ratio of Vcmax to transpiration for C4 plants"
 tag = "PModelParameters"
@@ -356,7 +356,7 @@ description = "Second order term in quadratic intrinsic quantum yield (Cai and P
 tag = "PModelParameters"
 
 ["pmodel_α"]
-value = 0.972
+value = 0.979
 type = "float"
 description = "1 - 1/T where T is the timescale of Vcmax, Jmax acclimation. Here T = 15 days. (Mengoli 2022)"
 tag = "PModelParameters"
@@ -471,7 +471,7 @@ description = "Constant factor appearing the dark respiration term for C3 plants
 tag = "PModelConstants"
 
 [canopy_K_lw]
-value = 0.919
+value = 0.867
 type = "float"
 description = "The long wave extinction coeff"
 tag = "AbstractRadiationModel"
@@ -606,25 +606,25 @@ description = "Minimum roughness"
 tag = "MoninObukhovCanopyFluxes"
 
 ["canopy_z_0m_coeff"]
-value = 0.349
+value = 0.398
 type = "float"
 description = "Scalar multipling canopy height to get z_0m"
 tag = "MoninObukhovCanopyFluxes"
 
 ["canopy_z_0b_coeff"]
-value = 0.0444
+value = 0.0478
 type = "float"
 description = "Scalar multipling canopy height to get z_0b"
 tag = "MoninObukhovCanopyFluxes"
 
 ["canopy_d_coeff"]
-value = 0.0573
+value = 0.00996
 type = "float"
 description = "Scalar multipling canopy height to get displacement height"
 tag = "MoninObukhovCanopyFluxes"
 
 ["leaf_Cd"]
-value = 0.0726
+value = 0.0576
 type = "float"
 description = ""
 tag = "MoninObukhovCanopyFluxes"
@@ -650,7 +650,7 @@ description = "Diffusivity of soil C substrate in liquid (unitless)"
 tag = "SoilCO2Parameters"
 
 ["soilCO2_reference_rate"]
-value = 3.34e-8
+value = 1.37e-8
 type = "float"
 description = "Maximum respiration rate at soilCO2_reference_temperature for DAMM model (kg C m⁻³ s⁻¹). Centered Arrhenius: Vmax = V_ref * exp(-Ea/R * (1/T - 1/T_ref))"
 tag = "SoilCO2Parameters"
@@ -662,19 +662,19 @@ description = "Reference temperature for the centered Arrhenius form of the DAMM
 tag = "SoilCO2Parameters"
 
 ["soilCO2_activation_energy"]
-value = 19800.0
+value = 23000.0
 type = "float"
 description = "Activation energy for DAMM model (J mol⁻¹)"
 tag = "SoilCO2Parameters"
 
 ["michaelis_constant"]
-value = 0.0416
+value = 0.0101
 type = "float"
 description = "Michaelis constant for substrate (kg C m⁻³)"
 tag = "SoilCO2Parameters"
 
 ["O2_michaelis_constant"]
-value = 0.00298
+value = 0.000126
 type = "float"
 description = "Michaelis constant for O₂ (m³ m⁻³)"
 tag = "SoilCO2Parameters"


### PR DESCRIPTION
closes #1743 

Next:
- add an optional kwarg to longrun (experiments/long_runs/snowy_land_pmodel.jl) so it can be run with prescribed (default) or prognostic LAI. 
- in CI, the weekly run should be both prescribed and prognostic
- have a label "run long run prognostic LAI"


others, possibly
- maybe add RAI and SAI constant to priors
- also add Eva effective SOC (k) to priors
- re-calibrate in 2 step after Kat fix to Rosetta and priors: 1. GPP + energy, 2. ER 


