### PR TITLE
Refactor data sources for leaderboard

### DIFF
--- a/.buildkite/Project.toml
+++ b/.buildkite/Project.toml
@@ -44,7 +44,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
-ClimaAnalysis = "0.5.19"
+ClimaAnalysis = "0.5.22"
 ClimaCalibrate = "0.3"
 ClimaDiagnostics = "0.3.4"
 ClimaTimeSteppers = "0.8.11, 0.9"

--- a/Project.toml
+++ b/Project.toml
@@ -47,7 +47,7 @@ SNOTELScraperExt = ["DataFrames", "Downloads", "Statistics"]
 [compat]
 Adapt = "4.6.0"
 CairoMakie = "0.13, 0.14, 0.15"
-ClimaAnalysis = "0.5.19"
+ClimaAnalysis = "0.5.22"
 ClimaComms = "0.6.2"
 ClimaCore = "0.14.50"
 ClimaDiagnostics = "0.3.4"

--- a/docs/src/calibration.md
+++ b/docs/src/calibration.md
@@ -392,11 +392,14 @@ for a list of different covariance matrices that can be used.
 To add additional variables or change how a variable is preprocessed, you must
 add the variable to the data sources and specify how the variable should be
 preprocessed. The name of the variable should match the name in the diagnostics.
-As of now, each variable from the ERA5 data is loaded by the function
-`get_era5_obs_var_dict` in `ext/land_sim_vis/leaderboard/data_sources.jl`. See
-the documentation of `get_obs_var_dict` for how to add a new variable. In
-addition, you should also add the same variable to `get_sim_var_dict` in the
-same file as before.
+Observational data is loaded via the `ERA5DataLoader` and `ILAMBDataLoader`
+structs defined in `ext/land_sim_vis/leaderboard/data_sources.jl`. The function
+`get_calibration_obs_var_dict` combines both loaders into a single dictionary of
+preprocessed `OutputVar`s. To add a new variable, register it with the
+appropriate loader (see the leaderboard documentation for details) and add a
+`preprocess` method for the new short name. The simulation-side preprocessing is
+handled by `preprocess_sim_var` (and the corresponding `_preprocess_sim_var`
+function) in the same file.
 
 Further preprocessing is done in the function `preprocess_single_era5_var` in
 `generate_observations.jl`. After adding the variable, you should specify any

--- a/docs/src/leaderboard/leaderboard.md
+++ b/docs/src/leaderboard/leaderboard.md
@@ -3,94 +3,98 @@
 ## Long run
 
 ### Add a new variable to compare against observations
-The infrastructure to compute errors against observations is in the `leaderboard` folder.
-This folder contains two files: `data_sources.jl`, responsible for loading and preprocessing
-variables of interest, and `leaderboard.jl`, which computes error and draw plots. To add a
-new variable to the comparison, you modify the `data_sources.jl`.
+
+The infrastructure to compute errors against observations is in the
+`leaderboard` folder. This folder contains two files: `data_sources.jl`,
+responsible for loading and preprocessing variables of interest, and
+`leaderboard.jl`, which computes error and draws plots. To add a new variable to
+the comparison, you modify `data_sources.jl`.
+
+The file `data_sources.jl` is organized around two data loader structs,
+`ILAMBDataLoader` and `ERA5DataLoader`, both subtypes of `AbstractDataLoader`.
+Each loader exposes a `Base.get` method that returns a preprocessed
+[`OutputVar`](https://clima.github.io/ClimaAnalysis.jl/stable/var/) and a
+`preprocess` method that dispatches on the variable short name via
+`Val{:shortname}`.
 
 ### Computation
-As of now, the leaderboard produces bias plots with the global bias and global root mean
-squared error (RMSE). These quantities are computed for each month with the first year of
-the simulation not considered as that is the spinup time. The start date of the simulation
-is 2008 which means that only the year 2009 is used to compare against observational data.
+
+As of now, the leaderboard produces bias plots with the global bias and global
+root mean squared error (RMSE). These quantities are computed for each month
+with the first year of the simulation not considered as that is the spinup time.
+The start date of the simulation is 2008 which means that only the year 2009 is
+used to compare against observational data.
 
 ### Add a new variable to the bias plots
-There are four functions that you need to modify to add a new variable which are
-`get_sim_var_dict`, `get_obs_var_dict`, `get_mask_dict`, and
-`get_compare_vars_biases_plot_extrema`. Each function returns a dictionary that must be
-modified to add a new variable to the leaderboard. The dictionaries are `sim_var_dict`,
-`obs_var_dict`, `mask_dict`, and `compare_vars_biases_plot_extrema`.
 
-To add a variable for the leaderboard, add a key-value pair to the dictionary `sim_var_dict`
-whose key is the short name of the variable and the value is a function that returns a
-[`OutputVar`](https://clima.github.io/ClimaAnalysis.jl/stable/var/). Any preprocessing is done
-in the function which includes unit conversion and shifting the dates.
+To add a new variable you need to touch four places in `data_sources.jl`:
+`_preprocess_sim_var`, the appropriate data loader constructor and `preprocess`
+method, `get_mask_dict`, and `get_compare_vars_biases_plot_extrema`.
 
-```julia
-sim_var_dict["et"] =
-        () -> begin
-            # Load in variable
-            sim_var = get(
-                ClimaAnalysis.SimDir(diagnostics_folder_path),
-                short_name = "et",
-            )
-            return sim_var
-        end
-```
+**1. Preprocess the simulation variable**
 
-Then, add a key-value pair to the dictionary `obs_var_dict` whose key is the same short name
-as before and the value is a function that takes in a start date and returns a `OutputVar`.
-Any preprocessing is done in the function.
+Add a `_preprocess_sim_var` method dispatching on `Val{:shortname}` to convert
+units or perform any other preprocessing on the simulation output.
 
 ```julia
-obs_var_dict["et"] =
-    (start_date) -> begin
-    # We use ClimaArtifacts to use a dataset from ILAMB
-        obs_var = ClimaAnalysis.OutputVar(
-            ClimaLand.Artifacts.ilamb_dataset_path(;
-                context = "evspsbl_MODIS_et_0.5x0.5.nc",
-            ),
-            "et",
-            # start_date is used to align the dates in the observational data
-            # with the simulation data
-            new_start_date = start_date,
-            # Shift dates to the first day of the month before aligning the dates
-            shift_by = Dates.firstdayofmonth,
+function _preprocess_sim_var(var, ::Val{:et})
+    (ClimaAnalysis.units(var) == "kg m^-2 s^-1") && (
+        var = ClimaAnalysis.convert_units(
+            var,
+            "mm / day",
+            conversion_function = units -> units * 86400.0,
         )
-        # More preprocessing to match the units with the simulation data
-        ClimaAnalysis.units(obs_var) == "kg/m2/s" &&
-            (obs_var = ClimaAnalysis.set_units(obs_var, "kg m^-2 s^-1"))
-        # ClimaAnalysis cannot handle `missing` values, but does support handling NaNs
-        obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
-        return obs_var
-    end
+    )
+    return var
+end
 ```
+
+`preprocess_sim_var` is called automatically by `leaderboard.jl` on the
+`OutputVar` loaded from the simulation diagnostics.
+
+**2. Add the observational variable to a data loader**
+
+Observational data is provided by `ILAMBDataLoader` (ILAMB datasets) or
+`ERA5DataLoader` (ERA5 monthly averages). To add a new variable to
+`ILAMBDataLoader`, register the NetCDF file in the constructor and add a
+`preprocess` method for the new short name.
+
+In the `ILAMBDataLoader()` constructor:
+
+```julia
+new_var_filepath = ClimaLand.Artifacts.ilamb_dataset_path("new_var_dataset.nc")
+ClimaAnalysis.add_file!(catalog, new_var_filepath, "nc_varname" => "new_var")
+```
+
+Then add a preprocessing method:
+
+```julia
+function preprocess(::ILAMBDataLoader, var, ::Val{:new_var})
+    replace!(var, missing => NaN)
+    return _preprocess_var(var)
+end
+```
+
+`Base.get(loader, short_name)` will call `ClimaAnalysis.transform_dates!`
+which shifts the times to the first day of the month before dispatching to
+`preprocess`, so date alignment is handled automatically.
 
 !!! tip "Preprocessing"
-    Observational and simulational data should be preprocessed for dates and units. When
-    using ClimaDiagnostics to report monthly averages from a simulation, monthly averages
-    are output on the first day following the month when the average was computed. For
-    instance, the monthly average corresponding to January 2010 is on the date 1 Feb 2010.
-    Preprocessing is done to shift this date to 1 Jan 2010. When preprocessing data, we
-    follow the convention that the first day corresponds to the monthly average for that
-    month. For observational data, you should check the convention being followed and
-    preprocess the dates if necessary.
+    Observational and simulation data should use the same units and time
+    conventions. We follow the convention that a monthly average is associated
+    with the first day of that month. The function `transform_dates!` is applied
+    automatically in `Base.get` for both loaders, so you only need to handle
+    unit conversion and `missing`/NaN cleanup in `preprocess`.
 
-    For `obs_var_dict`, the anonymous function must take in a start date. The start date is
-    used in `leaderboard.jl` to adjust the seconds in the `OutputVar` to match between start
-    date in the simulation data.
+**3. Add a mask**
 
-    Units should be the same between the simulation and observational data.
-
-Next, add a key-value pair to the dictionary `mask_dict` whose key is the same short name
-as before and the value is a function that takes in a `OutputVar` representing simulation
-data and a `OutputVar` representing observational data and returns a masking function or
-`nothing` if no masking function is needed. The masking function is used to correctly
-normalize the global bias and global RMSE. See the example below where a mask is made using
-the observational data.
+Add an entry to `get_mask_dict` for the loader that provides the new variable.
+The value is a function that takes `sim_var` and `obs_var` and returns a masking
+function. The masking function is used to correctly normalize the global bias
+and global RMSE.
 
 ```julia
-mask_dict["et"] =
+mask_dict["new_var"] =
     (sim_var, obs_var) -> begin
         return ClimaAnalysis.make_lonlat_mask(
             # We do this to get a `OutputVar` with only two dimensions:
@@ -106,14 +110,16 @@ mask_dict["et"] =
     end
 ```
 
-Finally, add a key-value pair to the dictionary `compare_vars_biases_plot_extrema` whose
-key is the same short name as before and the value is a tuple of floats which determine
-the range of the bias plots.
+**4. Set bias plot limits**
+
+Add a key-value pair to `get_compare_vars_biases_plot_extrema` whose value is a
+tuple `(lower, upper)` setting the color scale range for the bias plots.
 
 ```julia
 compare_vars_biases_plot_extrema = Dict(
-    "et" => (-0.00001, 0.00001),
-    "gpp" => (-8.0, 8.0),
-    "lwu" => (-40.0, 40.0),
+    "et" => (-2.0, 2.0) .* factor,
+    "gpp" => (-6.0, 6.0) .* factor,
+    "new_var" => (-10.0, 10.0) .* factor,
+    ...
 )
 ```

--- a/experiments/calibration/generate_observations.jl
+++ b/experiments/calibration/generate_observations.jl
@@ -115,7 +115,8 @@ function preprocess_obs_vars(short_names, start_date, nelements)
         )
     end
     vars = map(short_names) do short_name
-        var = obs_var_dict[short_name](start_date)
+        var = obs_var_dict[short_name]
+        ClimaAnalysis.set_reference_date!(var, start_date)
         preprocess_single_obs_var(var, short_name, nelements)
     end
     return vars

--- a/experiments/calibration/observation_map.jl
+++ b/experiments/calibration/observation_map.jl
@@ -4,6 +4,18 @@ import ClimaCalibrate
 import ClimaCalibrate.EnsembleBuilder
 import ClimaCalibrate.Checker
 
+# For now, we will reuse `data_sources.jl` that is used for making the
+# leaderboard, since it is the easiest option.
+include(
+    joinpath(
+        pkgdir(ClimaLand),
+        "ext",
+        "land_sim_vis",
+        "leaderboard",
+        "data_sources.jl",
+    ),
+)
+
 include(
     joinpath(
         pkgdir(ClimaLand),
@@ -89,9 +101,10 @@ function process_member_data!(
         )
     end
 
-    sim_var_dict = ext.get_sim_var_dict(diagnostics_folder_path)
+    simdir = ClimaAnalysis.SimDir(diagnostics_folder_path)
     vars = map(short_names) do short_name
-        var = sim_var_dict[short_name]()
+        var = get(simdir, short_name)
+        var = preprocess_sim_var(var)
         var = ClimaAnalysis.average_season_across_time(var, ignore_nan = false)
 
         # To prevent double counting along the longitudes since -180 and 180

--- a/ext/land_sim_vis/leaderboard/data_sources.jl
+++ b/ext/land_sim_vis/leaderboard/data_sources.jl
@@ -1,325 +1,396 @@
+import Dates
+
+import ClimaLand
+import ClimaAnalysis
+import ClimaAnalysis: OutputVar, NCCatalog
+import ClimaUtilities.ClimaArtifacts: @clima_artifact
+
 """
-    get_sim_var_dict(diagnostics_folder_path)
+    preprocess_sim_var(var::OutputVar)
 
-Return a dictionary mapping short names to `OutputVar` containing preprocessed
-simulation data. This is used by the function `compute_leaderboard`.
+Preprocess the simulation variable `var` based on its short name.
 
-To add a variable for the leaderboard, add a key-value pair to the dictionary
-`sim_var_dict` whose key is the short name of the variable and the value is an
-anonymous function that returns a `OutputVar`. For each variable, any
-preprocessing should be done in the corresponding anonymous function which
-includes unit conversion.
-
-The variable should have only three dimensions: time, longitude, and latitude.
+Return the preprocessed `OutputVar`.
 """
-function get_sim_var_dict(diagnostics_folder_path)
-    # Dict for loading in simulation data
-    sim_var_dict = Dict{String, Any}()
+function preprocess_sim_var(var::OutputVar)
+    return _preprocess_sim_var(var, Val(Symbol(ClimaAnalysis.short_name(var))))
+end
 
-    sim_var_dict["lwu"] =
-        () -> begin
-            sim_var = get(
-                ClimaAnalysis.SimDir(diagnostics_folder_path),
-                short_name = "lwu",
-            )
-            return sim_var
-        end
+function _preprocess_sim_var(var, ::Val{:et})
+    (ClimaAnalysis.units(var) == "kg m^-2 s^-1") && (
+        var = ClimaAnalysis.convert_units(
+            var,
+            "mm / day",
+            conversion_function = units -> units * 86400.0,
+        )
+    )
+    return var
+end
 
-    sim_var_dict["et"] =
-        () -> begin
-            sim_var = get(
-                ClimaAnalysis.SimDir(diagnostics_folder_path),
-                short_name = "et",
-            )
-            (ClimaAnalysis.units(sim_var) == "kg m^-2 s^-1") && (
-                sim_var = ClimaAnalysis.convert_units(
-                    sim_var,
-                    "mm / day",
-                    conversion_function = units -> units * 86400.0,
-                )
-            )
-            return sim_var
-        end
+function _preprocess_sim_var(var, ::Val{:gpp})
+    # converting from `mol CO2 m^-2 s^-1` in sim to `g C m-2 day-1` in obs
+    (ClimaAnalysis.units(var) == "mol CO2 m^-2 s^-1") && (
+        var = ClimaAnalysis.convert_units(
+            var,
+            "g m-2 day-1",
+            conversion_function = units -> units * 86400.0 * 12.011,
+        )
+    )
+    return var
+end
 
+function _preprocess_sim_var(var, ::Val{:er})
+    (ClimaAnalysis.units(var) == "mol CO2 m^-2 s^-1") && (
+        var = ClimaAnalysis.convert_units(
+            var,
+            "g m-2 day-1",
+            conversion_function = units -> units * 86400.0 * 12.011,
+        )
+    )
+    return var
+end
 
-    sim_var_dict["gpp"] =
-        () -> begin
-            sim_var = get(
-                ClimaAnalysis.SimDir(diagnostics_folder_path),
-                short_name = "gpp",
-            )
-            # converting from to `mol CO2 m^-2 s^-1` in sim to `g C m-2 day-1` in obs
-            (ClimaAnalysis.units(sim_var) == "mol CO2 m^-2 s^-1") && (
-                sim_var = ClimaAnalysis.convert_units(
-                    sim_var,
-                    "g m-2 day-1",
-                    conversion_function = units -> units * 86400.0 * 12.011,
-                )
-            )
-            return sim_var
-        end
+function _preprocess_sim_var(var, ::Val{:nee})
+    (ClimaAnalysis.units(var) == "mol CO2 m^-2 s^-1") && (
+        var = ClimaAnalysis.convert_units(
+            var,
+            "g m-2 day-1",
+            conversion_function = units -> units * 86400.0 * 12.011,
+        )
+    )
+    return var
+end
 
-    sim_var_dict["er"] =
-        () -> begin
-            sim_var = get(
-                ClimaAnalysis.SimDir(diagnostics_folder_path),
-                short_name = "er",
-            )
-            (ClimaAnalysis.units(sim_var) == "mol CO2 m^-2 s^-1") && (
-                sim_var = ClimaAnalysis.convert_units(
-                    sim_var,
-                    "g m-2 day-1",
-                    conversion_function = units -> units * 86400.0 * 12.011,
-                )
-            )
-            return sim_var
-        end
+_preprocess_sim_var(var, ::Val{:lwu}) = var
+_preprocess_sim_var(var, ::Val{:lhf}) = var
+_preprocess_sim_var(var, ::Val{:shf}) = var
+_preprocess_sim_var(var, ::Val{:swu}) = var
+_preprocess_sim_var(var, name::Val) =
+    error("Preprocessing var with short name ($name) is not defined")
 
-    sim_var_dict["nee"] =
-        () -> begin
-            sim_var = get(
-                ClimaAnalysis.SimDir(diagnostics_folder_path),
-                short_name = "nee",
-            )
-            (ClimaAnalysis.units(sim_var) == "mol CO2 m^-2 s^-1") && (
-                sim_var = ClimaAnalysis.convert_units(
-                    sim_var,
-                    "g m-2 day-1",
-                    conversion_function = units -> units * 86400.0 * 12.011,
-                )
-            )
-            return sim_var
-        end
+"""
+    AbstractDataLoader
 
-    sim_var_dict["lhf"] =
-        () -> begin
-            sim_var = get(
-                ClimaAnalysis.SimDir(diagnostics_folder_path),
-                short_name = "lhf",
-            )
-            return sim_var
-        end
+Supertype for all data loaders.
 
-    sim_var_dict["shf"] =
-        () -> begin
-            sim_var = get(
-                ClimaAnalysis.SimDir(diagnostics_folder_path),
-                short_name = "shf",
-            )
-            return sim_var
-        end
+`AbstractDataLoader`s have to provide two methods: `available_vars` and
+`Base.get`.
 
-    sim_var_dict["swu"] =
-        () -> begin
-            sim_var = get(
-                ClimaAnalysis.SimDir(diagnostics_folder_path),
-                short_name = "swu",
-            )
-            return sim_var
-        end
-    return sim_var_dict
+`AbstractDataLoader`s load preprocessed data as `OutputVar`s that can be broadly
+used for any kind of calibration and making leaderboard plots.
+"""
+abstract type AbstractDataLoader end
+
+"""
+    available_vars(data_loader::AbstractDataLoader)
+
+Return the available preprocessed variables in `data_loader`.
+"""
+available_vars(data_loader::AbstractDataLoader) = data_loader.available_vars
+
+function Base.show(io::IO, data_loader::AbstractDataLoader)
+    vars = sort(collect(data_loader.available_vars))
+    printstyled(io, nameof(typeof(data_loader)), bold = true, color = :green)
+    print(io, ": ")
+    print(io, join(vars, ", "))
 end
 
 """
-    get_obs_var_dict(data_source)
+    preprocess(data_loader::AbstractDataLoader, var, ::Val{varname}) where {varname}
 
-Return a dictionary mapping short names to `OutputVar` containing preprocessed
-observational data. This is used by the function `compute_leaderboard`.The
-argument `data_source` can either be "ERA5" or "ILAMB".
+Preprocess `var` with short name `varname` using `data_loader`.
 
-To add a variable for the leaderboard, add a key-value pair to the dictionary
-`obs_var_dict` whose key is the short name of the variable and the value is an
-anonymous function that returns a `OutputVar`. The function must take in a
-start date which is used to align the times in the observational data to match
-the simulation data. The short name must be the same as in `sim_var_dict` in the
-function `sim_var_dict`. For each variable, any preprocessing is done in the
-corresponding anonymous function which includes unit conversion and shifting the
-dates.
-
-The variable should have only three dimensions: latitude, longitude, and time.
+Subtypes of `AbstractDataLoader` must implement this method for each variable
+they support. Throws an error if no preprocessing method is defined for
+`varname`.
 """
-function get_obs_var_dict(data_source)
-    if uppercase(data_source) == "ILAMB"
-        return get_ilamb_obs_var_dict()
-    elseif uppercase(data_source) == "ERA5"
-        return get_era5_obs_var_dict()
-    else
-        error("Did not expect $data_source for the data source")
-    end
+function preprocess(
+    data_loader::AbstractDataLoader,
+    _,
+    ::Val{varname},
+) where {varname}
+    error(
+        "No preprocessing function is found for $varname. Add a method for preprocess(::$(typeof(data_loader)), ::Val{:$varname}) that preprocess this variable as a OutputVar",
+    )
 end
 
 """
-    get_ilamb_obs_var_dict()
+    ERA5DataLoader
 
-Get ILAMB observational data. See `get_obs_var_dict` for more information for
-how to add new variables.
+A struct for loading preprocessed ERA5 data as `OutputVar`s.
 """
-function get_ilamb_obs_var_dict()
-    # Dict for loading in observational data
-    obs_var_dict = Dict{String, Any}()
+struct ERA5DataLoader <: AbstractDataLoader
+    """A catalog built from NetCDF files, designed to initialize `OutputVar`s.
+    See ClimaAnalysis documentation for more information about NCCatalog."""
+    catalog::NCCatalog
 
-    obs_var_dict["gpp"] =
-        (start_date) -> begin
-            obs_var = ClimaAnalysis.OutputVar(
-                ClimaLand.Artifacts.ilamb_dataset_path("gpp_FLUXCOM_gpp.nc"),
-                "gpp",
-                new_start_date = start_date,
-                shift_by = Dates.firstdayofmonth,
-            )
-            ClimaAnalysis.dim_units(obs_var, "lon") == "degree" &&
-                (obs_var.dim_attributes["lon"]["units"] = "degrees_east")
-            ClimaAnalysis.dim_units(obs_var, "lat") == "degree" &&
-                (obs_var.dim_attributes["lat"]["units"] = "degrees_north")
-            obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
-            return obs_var
-        end
-
-    obs_var_dict["er"] =
-        (start_date) -> begin
-            obs_var = ClimaAnalysis.OutputVar(
-                ClimaLand.Artifacts.ilamb_respiration_nee_dataset_path(
-                    "reco_FLUXCOM_reco.nc",
-                ),
-                "reco",
-                new_start_date = start_date,
-                shift_by = Dates.firstdayofmonth,
-            )
-            ClimaAnalysis.dim_units(obs_var, "lon") == "degree" &&
-                (obs_var.dim_attributes["lon"]["units"] = "degrees_east")
-            ClimaAnalysis.dim_units(obs_var, "lat") == "degree" &&
-                (obs_var.dim_attributes["lat"]["units"] = "degrees_north")
-            obs_var.attributes["short_name"] = "er"
-            obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
-            return obs_var
-        end
-
-    obs_var_dict["nee"] =
-        (start_date) -> begin
-            obs_var = ClimaAnalysis.OutputVar(
-                ClimaLand.Artifacts.ilamb_respiration_nee_dataset_path(
-                    "nee_FLUXCOM_nee.nc",
-                ),
-                "nee",
-                new_start_date = start_date,
-                shift_by = Dates.firstdayofmonth,
-            )
-            ClimaAnalysis.dim_units(obs_var, "lon") == "degree" &&
-                (obs_var.dim_attributes["lon"]["units"] = "degrees_east")
-            ClimaAnalysis.dim_units(obs_var, "lat") == "degree" &&
-                (obs_var.dim_attributes["lat"]["units"] = "degrees_north")
-            obs_var.attributes["short_name"] = "nee"
-            obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
-            # nee_FLUXCOM_nee.nc has no _FillValue attribute, so the netCDF
-            # default fill (~9.97e36) leaks through as real data — set it to NaN.
-            obs_var = ClimaAnalysis.replace(
-                x -> (!ismissing(x) && abs(x) > 1e20) ? NaN : x,
-                obs_var,
-            )
-            return obs_var
-        end
-
-    return obs_var_dict
+    """A list of available variables to load."""
+    available_vars::Set{String}
 end
 
-"""
-    get_era5_obs_var_dict()
+const ERA5_TO_CLIMA_NAMES = [
+    "mslhf" => "lhf",
+    "msshf" => "shf",
+    "msuwlwrf" => "lwu",
+    "msuwswrf" => "swu",
+]
+const STANDARD_UNITS = Dict("W m**-2" => "W m^-2", "W m-2" => "W m^-2")
 
-Get ERA5 observational data. See `get_obs_var_dict` for more information for
-how to add new variables.
 """
-function get_era5_obs_var_dict()
-    obs_var_dict = Dict{String, Any}()
-    era5_data_path = joinpath(
-        ClimaLand.Artifacts.era5_monthly_averages_single_level_path(),
+    ERA5DataLoader(; era5_to_clima_names = ERA5_TO_CLIMA_NAMES)
+
+Construct a data loader that can be used to load preprocessed ERA5 monthly
+time-averaged data in `OutputVar`, where
+- the short name, sign of the data, and units match CliMA conventions
+- the latitudes are shifted to be -180 to 180 degrees,
+- the times are at the start of the time period (e.g. the time average of
+  January is on the first of January instead of January 15th),
+- units match the variables in the output of the CliMA diagnostics.
+
+The ERA5 data comes from the
+`era5_monthly_averages_surface_single_level_1979_2024` artifact. See
+[ClimaArtifacts](https://github.com/CliMA/ClimaArtifacts/tree/main/era5_monthly_averages_single_level_1979_2024)
+for more information about this artifact.
+
+The keyword argument `era5_to_clima_names` is a vector of pairs mapping
+ERA5 name to CliMA name.
+"""
+function ERA5DataLoader(; era5_to_clima_names = ERA5_TO_CLIMA_NAMES)
+    artifact_dir =
+        @clima_artifact"era5_monthly_averages_surface_single_level_1979_2024"
+    flux_file = joinpath(
+        artifact_dir,
         "era5_monthly_averages_surface_single_level_197901-202410.nc",
     )
 
-    obs_var_dict["lhf"] =
-        (start_date) -> begin
-            obs_var = ClimaAnalysis.OutputVar(
-                era5_data_path,
-                "mslhf",
-                new_start_date = start_date,
-                shift_by = Dates.firstdayofmonth,
-            )
-            (ClimaAnalysis.units(obs_var) == "W m**-2") && (
-                obs_var = ClimaAnalysis.convert_units(
-                    obs_var,
-                    "W m^-2",
-                    conversion_function = units -> units * -1.0,
-                )
-            )
-            obs_var.attributes["short_name"] = "lhf"
-            return obs_var
-        end
-
-    obs_var_dict["shf"] =
-        (start_date) -> begin
-            obs_var = ClimaAnalysis.OutputVar(
-                era5_data_path,
-                "msshf",
-                new_start_date = start_date,
-                shift_by = Dates.firstdayofmonth,
-            )
-
-            (ClimaAnalysis.units(obs_var) == "W m**-2") && (
-                obs_var = ClimaAnalysis.convert_units(
-                    obs_var,
-                    "W m^-2",
-                    conversion_function = units -> units * -1.0,
-                )
-            )
-            obs_var.attributes["short_name"] = "shf"
-            return obs_var
-        end
-
-    obs_var_dict["lwu"] =
-        (start_date) -> begin
-            obs_var = ClimaAnalysis.OutputVar(
-                era5_data_path,
-                "msuwlwrf",
-                new_start_date = start_date,
-                shift_by = Dates.firstdayofmonth,
-            )
-            (ClimaAnalysis.units(obs_var) == "W m**-2") &&
-                (obs_var = ClimaAnalysis.set_units(obs_var, "W m^-2"))
-            obs_var.attributes["short_name"] = "lwu"
-            return obs_var
-        end
-
-    obs_var_dict["swu"] =
-        (start_date) -> begin
-            obs_var = ClimaAnalysis.OutputVar(
-                era5_data_path,
-                "msuwswrf",
-                new_start_date = start_date,
-                shift_by = Dates.firstdayofmonth,
-            )
-
-            (ClimaAnalysis.units(obs_var) == "W m**-2") &&
-                (obs_var = ClimaAnalysis.set_units(obs_var, "W m^-2"))
-            obs_var.attributes["short_name"] = "swu"
-            return obs_var
-        end
-    return obs_var_dict
+    catalog = NCCatalog()
+    ClimaAnalysis.add_file!(catalog, flux_file, era5_to_clima_names...)
+    return ERA5DataLoader(catalog, Set(last.(era5_to_clima_names)))
 end
 
 """
-    get_mask_dict()
+    get(loader::ERA5DataLoader, short_name::String)
+
+Get the preprocessed `OutputVar` with the name `short_name` from the ERA5
+dataset.
+"""
+function Base.get(loader::ERA5DataLoader, short_name::String)
+    (; catalog, available_vars) = loader
+    short_name in available_vars || error(
+        "$short_name is not available to load. To add this variable, add it to ERA5_TO_CLIMA_NAMES as a pair mapping ERA5 name to CliMA name and create a new ERA5DataLoader",
+    )
+    var = get(catalog, short_name;)
+    ClimaAnalysis.transform_dates!(var, Dates.firstdayofmonth)
+    return preprocess(loader, var, Val(Symbol(short_name)))
+end
+
+"""
+    preprocess(::ERA5DataLoader, var, ::Val{varname}) where {varname}
+
+Preprocess `var` with short name `varname`.
+"""
+preprocess(::ERA5DataLoader, var, ::Val{:shf}) =
+    _preprocess_var(var; flip_sign = true)
+preprocess(::ERA5DataLoader, var, ::Val{:lhf}) =
+    _preprocess_var(var; flip_sign = true)
+preprocess(::ERA5DataLoader, var, ::Val{:lwu}) = _preprocess_var(var)
+preprocess(::ERA5DataLoader, var, ::Val{:swu}) = _preprocess_var(var)
+
+function _preprocess_var(var; flip_sign = false)
+    short_name = ClimaAnalysis.short_name(var)
+
+    flip_sign && replace!(val -> -val, var)
+    issorted(ClimaAnalysis.latitudes(var)) ||
+        ClimaAnalysis.reverse_dim!(var, ClimaAnalysis.latitude_name(var))
+
+    # Longitudes in other datasets is 0 to 360 degrees, but longitudes in CliMA
+    # diagnostics range from -180 to 180 degrees
+    if ClimaAnalysis.has_longitude(var)
+        var = ClimaAnalysis.shift_longitude(var, -180.0, 180.0)
+    end
+
+    var_units = ClimaAnalysis.units(var)
+    var_units in keys(STANDARD_UNITS) &&
+        (var = ClimaAnalysis.set_units(var, STANDARD_UNITS[var_units]))
+
+    # Functions in ClimaAnalysis can mutate the short name. Calibration uses
+    # short names to check the observational and simulation data, so we keep the
+    # same short name as before.
+    ClimaAnalysis.set_short_name!(var, short_name)
+    return var
+end
+
+"""
+    ILAMBDataLoader
+
+A struct for loading preprocessed ILAMB data as `OutputVar`s.
+"""
+struct ILAMBDataLoader <: AbstractDataLoader
+    """A catalog built from NetCDF files, designed to initialize `OutputVar`s.
+    See ClimaAnalysis documentation for more information about NCCatalog."""
+    catalog::NCCatalog
+
+    """A list of available variables to load."""
+    available_vars::Set{String}
+end
+
+"""
+    ILAMBDataLoader()
+
+Construct a data loader which you can use to load preprocessed ILAMB monthly
+time-averaged data as `OutputVar`s, where
+- the short name and units match CliMA conventions,
+- the times are at the start of the time period (e.g. the time average of
+  January is on the first of January instead of January 15th),
+- units match the variables in the output of the CliMA diagnostics.
+
+The supported variables are `et` (MODIS evapotranspiration), `gpp` (FLUXCOM
+gross primary production), `lwu` (CERESed4.2 upwelling longwave radiation), `er`
+(FLUXCOM ecosystem respiration), and `nee` (FLUXCOM net ecosystem exchange).
+"""
+function ILAMBDataLoader()
+    et_filepath =
+        ClimaLand.Artifacts.ilamb_dataset_path("evspsbl_MODIS_et_0.5x0.5.nc")
+    gpp_filepath = ClimaLand.Artifacts.ilamb_dataset_path("gpp_FLUXCOM_gpp.nc")
+    lwu_filepath =
+        ClimaLand.Artifacts.ilamb_dataset_path("rlus_CERESed4.2_rlus.nc")
+    er_filepath = ClimaLand.Artifacts.ilamb_respiration_nee_dataset_path(
+        "reco_FLUXCOM_reco.nc",
+    )
+    nee_filepath = ClimaLand.Artifacts.ilamb_respiration_nee_dataset_path(
+        "nee_FLUXCOM_nee.nc",
+    )
+
+    catalog = NCCatalog()
+    ClimaAnalysis.add_file!(catalog, et_filepath, "et" => "et")
+    ClimaAnalysis.add_file!(catalog, gpp_filepath, "gpp" => "gpp")
+    ClimaAnalysis.add_file!(catalog, lwu_filepath, "rlus" => "lwu")
+    ClimaAnalysis.add_file!(catalog, er_filepath, "reco" => "er")
+    ClimaAnalysis.add_file!(catalog, nee_filepath, "nee" => "nee")
+
+    return ILAMBDataLoader(catalog, Set(["et", "gpp", "lwu", "er", "nee"]))
+end
+
+"""
+    get(loader::ILAMBDataLoader, short_name::String)
+
+Get the preprocessed `OutputVar` with the name `short_name` from the ILAMB
+dataset.
+"""
+function Base.get(loader::ILAMBDataLoader, short_name::String)
+    (; catalog, available_vars) = loader
+    short_name in available_vars ||
+        error("$short_name is not available to load")
+    var = get(catalog, short_name;)
+    ClimaAnalysis.transform_dates!(var, Dates.firstdayofmonth)
+    return preprocess(loader, var, Val(Symbol(short_name)))
+end
+
+"""
+    preprocess(::ILAMBDataLoader, var, ::Val{:et})
+
+Preprocess `var` for evapotranspiration from ILAMB MODIS data.
+"""
+function preprocess(::ILAMBDataLoader, var, ::Val{:et})
+    if ClimaAnalysis.units(var) == "kg/m2/s"
+        var = ClimaAnalysis.convert_units(
+            var,
+            "mm / day",
+            conversion_function = units -> units * 86400.0,
+        )
+    end
+    replace!(var, missing => NaN)
+    return _preprocess_var(var)
+end
+
+"""
+    preprocess(::ILAMBDataLoader, var, ::Val{:gpp})
+
+Preprocess `var` for gross primary production from ILAMB FLUXCOM data.
+"""
+function preprocess(::ILAMBDataLoader, var, ::Val{:gpp})
+    ClimaAnalysis.dim_units(var, "lon") == "degree" &&
+        ClimaAnalysis.set_dim_units!(var, "lon", "degrees_east")
+    ClimaAnalysis.dim_units(var, "lat") == "degree" &&
+        ClimaAnalysis.set_dim_units!(var, "lat", "degrees_north")
+    replace!(var, missing => NaN)
+    return _preprocess_var(var)
+end
+
+"""
+    preprocess(::ILAMBDataLoader, var, ::Val{:lwu})
+
+Preprocess `var` for upwelling longwave radiation from ILAMB CERESed4.2 data.
+"""
+preprocess(::ILAMBDataLoader, var, ::Val{:lwu}) = _preprocess_var(var)
+
+"""
+    preprocess(::ILAMBDataLoader, var, ::Val{:er})
+
+Preprocess `var` for ecosystem respiration from ILAMB FLUXCOM data.
+"""
+function preprocess(::ILAMBDataLoader, var, ::Val{:er})
+    ClimaAnalysis.dim_units(var, "lon") == "degree" &&
+        ClimaAnalysis.set_dim_units!(var, "lon", "degrees_east")
+    ClimaAnalysis.dim_units(var, "lat") == "degree" &&
+        ClimaAnalysis.set_dim_units!(var, "lat", "degrees_north")
+    replace!(var, missing => NaN)
+    return _preprocess_var(var)
+end
+
+"""
+    preprocess(::ILAMBDataLoader, var, ::Val{:nee})
+
+Preprocess `var` for net ecosystem exchange from the NOAA CarbonTracker CT2022
+product.
+"""
+function preprocess(::ILAMBDataLoader, var, ::Val{:nee})
+    ClimaAnalysis.dim_units(var, "lon") == "degree" &&
+        set_dim_units!(var, "lon", "degrees_east")
+    ClimaAnalysis.dim_units(var, "lat") == "degree" &&
+        set_dim_units!(var, "lat", "degrees_north")
+    replace!(var, missing => NaN)
+    # nee_FLUXCOM_nee.nc has no _FillValue attribute, so the netCDF
+    # default fill (~9.97e36) leaks through as real data — set it to NaN.
+    replace!(x -> (!ismissing(x) && abs(x) > 1e20) ? NaN : x, var)
+    return _preprocess_var(var)
+end
+
+"""
+    get_mask_dict(data_loader::ERA5DataLoader)
+
+Return a dictionary mapping short names to a function which takes in `sim_var`,
+an `OutputVar` containing simulation data, and `obs_var`, an `OutputVar`
+containing observational data, and returns a masking function. The masking
+function is used to correctly normalize the global bias and global RMSE.
+"""
+function get_mask_dict(data_loader::ERA5DataLoader)
+    # Dict for loading in masks
+    mask_dict = Dict{String, Any}()
+
+    make_mask_fn =
+        (sim_var, obs_var) -> begin
+            return ClimaAnalysis.apply_oceanmask
+        end
+
+    mask_dict["shf"] = make_mask_fn
+    mask_dict["lhf"] = make_mask_fn
+    mask_dict["swu"] = make_mask_fn
+    mask_dict["lwu"] = make_mask_fn
+
+    @assert keys(mask_dict) == available_vars(data_loader)
+    return mask_dict
+end
+
+"""
+    get_mask_dict(data_loader::ILAMBDataLoader)
 
 Return a dictionary mapping short names to a function which takes in `sim_var`,
 a `OutputVar` containing simulation data, and `obs_var`, a `OutputVar`
-containing observational data, and return a masking function. The argument
-`data_source` is either `ILAMB` or `ERA5`.
-
-To add a variable to the leaderboard, add a key-value pair to the dictionary
-`mask_dict` whose key is the same short name in `sim_var_dict` and the value is
-a function that takes in a `OutputVar` representing simulation data and a
-`OutputVar` representing observational data and returns a masking function or
-`nothing` if a masking function is not needed. The masking function is used to
-correctly normalize the global bias and global RMSE.
+containing observational data, and returns a masking function. The masking
+function is used to correctly normalize the global bias and global RMSE.
 """
-function get_mask_dict(data_source)
+function get_mask_dict(data_loader::ILAMBDataLoader)
     # Dict for loading in masks
     mask_dict = Dict{String, Any}()
 
@@ -328,70 +399,24 @@ function get_mask_dict(data_source)
             return ClimaAnalysis.apply_oceanmask
         end
 
-    if uppercase(data_source) == "ILAMB"
-        ilamb_nan_mask =
-            (sim_var, obs_var) -> begin
-                return ClimaAnalysis.make_lonlat_mask(
-                    ClimaAnalysis.slice(
-                        obs_var,
-                        time = ClimaAnalysis.times(obs_var) |> first,
-                    );
-                    set_to_val = isnan,
-                )
-            end
-        mask_dict["gpp"] = ilamb_nan_mask
-        mask_dict["er"] = ilamb_nan_mask
-        mask_dict["nee"] = ilamb_nan_mask
-    elseif uppercase(data_source) == "ERA5"
-        mask_dict["shf"] =
-            (sim_var, obs_var) -> begin
-                return ClimaAnalysis.apply_oceanmask
-            end
+    make_mask_fn =
+        (sim_var, obs_var) -> begin
+            return ClimaAnalysis.make_lonlat_mask(
+                ClimaAnalysis.slice(
+                    obs_var,
+                    time = ClimaAnalysis.times(obs_var) |> first,
+                );
+                set_to_val = isnan,
+            )
+        end
 
-        mask_dict["lhf"] =
-            (sim_var, obs_var) -> begin
-                return ClimaAnalysis.apply_oceanmask
-            end
+    mask_dict["et"] = make_mask_fn
+    mask_dict["gpp"] = make_mask_fn
+    mask_dict["er"] = make_mask_fn
+    mask_dict["nee"] = make_mask_fn
 
-        mask_dict["swu"] =
-            (sim_var, obs_var) -> begin
-                return ClimaAnalysis.apply_oceanmask
-            end
-    else
-        error("Did not expect $data_source for the data source")
-    end
+    @assert keys(mask_dict) == available_vars(data_loader)
     return mask_dict
-end
-
-"""
-    get_calibration_obs_var_dict(; short_names = nothing)
-
-Return a dictionary mapping short names to `OutputVar` containing preprocessed
-observational data for calibration. This combines ERA5 energy flux variables
-(lhf, shf, lwu, swu) with ILAMB GPP (FLUXCOM) data.
-
-If `short_names` is provided, only the requested variables are returned.
-"""
-function get_calibration_obs_var_dict(; short_names = nothing)
-    obs_var_dict = Dict{String, Any}()
-    # ERA5 energy fluxes
-    era5_dict = get_era5_obs_var_dict()
-    merge!(obs_var_dict, era5_dict)
-    # ILAMB GPP, ecosystem respiration (FLUXCOM reco), and NEE
-    ilamb_dict = get_ilamb_obs_var_dict()
-    if haskey(ilamb_dict, "gpp")
-        obs_var_dict["gpp"] = ilamb_dict["gpp"]
-    end
-    if haskey(ilamb_dict, "er")
-        obs_var_dict["er"] = ilamb_dict["er"]
-    end
-    if haskey(ilamb_dict, "nee")
-        obs_var_dict["nee"] = ilamb_dict["nee"]
-    end
-    if !isnothing(short_names)
-        filter!(p -> p.first in short_names, obs_var_dict)
-    end
-    return obs_var_dict
 end
 
 """
@@ -399,14 +424,13 @@ end
 
 Return a dictionary mapping short names to ranges for the bias plots.
 
-If annual = true, the limits are tightened since the errors in annual means
+If `annual = true`, the limits are tightened since the errors in annual means
 are smaller.
 
 To add a variable to the leaderboard, add a key-value pair to the dictionary
-`compare_vars_biases_plot_extrema` whose key is a short name key is the same
-short name in `sim_var_pfull_dict` in the function `get_sim_var_pfull_dict` and
-the value is a tuple, where the first element is the lower bound and the last
-element is the upper bound for the bias plots.
+`compare_vars_biases_plot_extrema` whose key is the short name of the variable
+and whose value is a tuple `(lower, upper)` setting the color scale bounds for
+the bias plots.
 """
 function get_compare_vars_biases_plot_extrema(; annual = false)
     factor = annual ? 1 / sqrt(2) : 1.0 # treats each season as ~ independent
@@ -421,4 +445,36 @@ function get_compare_vars_biases_plot_extrema(; annual = false)
         "swu" => (-50.0, 50.0) .* factor,
     )
     return compare_vars_biases_plot_extrema
+end
+
+"""
+    get_calibration_obs_var_dict(; short_names = nothing)
+
+Return a dictionary mapping short names to `OutputVar` containing preprocessed
+observational data for calibration. This combines ERA5 energy flux variables
+(`lhf`, `shf`, `lwu`, `swu`) with ILAMB variables (`gpp`, `er`, `nee`).
+
+If `short_names` is provided, only the requested variables are returned.
+"""
+function get_calibration_obs_var_dict(; short_names = nothing)
+    obs_var_dict = Dict{String, Any}()
+    # ERA5 energy fluxes
+    era5_data_loader = ERA5DataLoader()
+    # ILAMB GPP, ecosystem respiration (FLUXCOM reco), and NEE
+    ilamb_data_loader = ILAMBDataLoader()
+
+    for short_name in available_vars(era5_data_loader)
+        obs_var_dict[short_name] = get(era5_data_loader, short_name)
+    end
+
+    # Add more variables to obs_var_dict
+    for short_name in ("gpp", "er", "nee")
+        obs_var_dict[short_name] = get(ilamb_data_loader, short_name)
+    end
+
+    if !isnothing(short_names)
+        filter!(p -> p.first in short_names, obs_var_dict)
+    end
+
+    return obs_var_dict
 end

--- a/ext/land_sim_vis/leaderboard/leaderboard.jl
+++ b/ext/land_sim_vis/leaderboard/leaderboard.jl
@@ -101,27 +101,28 @@ latitude, and time. The observational data is determined by `data_source` and ca
 The parameter `leaderboard_base_path` is the path to save the leaderboards and bias plots,
 and `diagnostics_folder_path` is the path to the simulation data.
 
-Loading and preprocessing simulation data is done by `get_sim_var_dict`. Loading and
-preprocessing observational data is done by `get_obs_var_dict`. The masks are normalizing
-the global RMSE and bias are determined by `get_mask_dict`. The ranges of the bias plots are
-determined by `get_compare_vars_biases_plot_extrema`. See the functions defined in
-data_sources.jl.
+Loading and preprocessing simulation data is done by loading `OutputVar`s from a
+`SimDir` and passing them through `preprocess_sim_var`. Loading and preprocessing
+observational data is done by `ERA5DataLoader` or `ILAMBDataLoader`. The masks for
+normalizing the global RMSE and bias are determined by `get_mask_dict`. The ranges
+of the bias plots are determined by `get_compare_vars_biases_plot_extrema`. See
+the functions defined in data_sources.jl.
 """
 function compute_monthly_leaderboard(
     leaderboard_base_path,
     diagnostics_folder_path,
     data_source,
 )
-    sim_var_dict = get_sim_var_dict(diagnostics_folder_path)
-    obs_var_dict = get_obs_var_dict(data_source)
-    mask_dict = get_mask_dict(data_source)
+    sim_dir = ClimaAnalysis.SimDir(diagnostics_folder_path)
+    data_loader =
+        uppercase(data_source) == "ERA5" ? ERA5DataLoader() : ILAMBDataLoader()
+    mask_dict = get_mask_dict(data_loader)
 
     compare_vars_biases_plot_extrema = get_compare_vars_biases_plot_extrema()
-    available_sim_vars = ClimaAnalysis.available_vars(
-        ClimaAnalysis.SimDir(diagnostics_folder_path),
+    short_names = intersect(
+        ClimaAnalysis.available_vars(sim_dir),
+        available_vars(data_loader),
     )
-    short_names =
-        intersect(keys(sim_var_dict), keys(obs_var_dict), available_sim_vars)
     issubset(short_names, keys(mask_dict)) ||
         error("Not all variables ($short_names) have a mask $(keys(mask_dict))")
 
@@ -129,11 +130,10 @@ function compute_monthly_leaderboard(
 
     # Set up dict for storing simulation and observational data after processing
     # and for storing the month we are interested in
-    sim_obs_comparsion_dict = Dict()
+    sim_obs_comparison_dict = Dict()
 
     # Print dates for debugging
-    _, var_func = first(sim_var_dict)
-    var = var_func()
+    var = preprocess_sim_var(get(sim_dir, first(short_names)))
     output_dates =
         Dates.DateTime(var.attributes["start_date"]) .+
         Dates.Second.(ClimaAnalysis.times(var))
@@ -143,10 +143,10 @@ function compute_monthly_leaderboard(
     for short_name in short_names
         @info short_name
         # Simulation data
-        sim_var = sim_var_dict[short_name]()
+        sim_var = get(sim_dir, short_name)
 
         # Observational data
-        obs_var = obs_var_dict[short_name](sim_var.attributes["start_date"])
+        obs_var = get(data_loader, short_name)
 
         # Remove first spin_up_months months from simulation
         spin_up_months = 12
@@ -154,6 +154,15 @@ function compute_monthly_leaderboard(
         ClimaAnalysis.times(sim_var)[end] >= spinup_cutoff && (
             sim_var =
                 ClimaAnalysis.window(sim_var, "time", left = spinup_cutoff)
+        )
+
+        # Preprocess sim var to match conventions of data loaders
+        sim_var = preprocess_sim_var(sim_var)
+
+        # Make the relative time the same between observational and simulation data
+        ClimaAnalysis.set_reference_date!(
+            obs_var,
+            sim_var.attributes["start_date"],
         )
 
         # Get the first valid time and last valid time
@@ -180,12 +189,12 @@ function compute_monthly_leaderboard(
         obs_var = ClimaAnalysis.shift_longitude(obs_var, -180.0, 180.0)
         obs_var = ClimaAnalysis.resampled_as(obs_var, sim_var)
 
-        sim_obs_comparsion_dict[short_name] = (sim_var, obs_var)
+        sim_obs_comparison_dict[short_name] = (sim_var, obs_var)
     end
 
-    # Plot monthly comparsions
+    # Plot monthly comparisons
     for short_name in short_names
-        sim_var, obs_var = sim_obs_comparsion_dict[short_name]
+        sim_var, obs_var = sim_obs_comparison_dict[short_name]
 
         # Grab the last 12 months if possible for plotting
         times = ClimaAnalysis.times(sim_var)
@@ -248,7 +257,7 @@ function compute_monthly_leaderboard(
     fig = CairoMakie.Figure(size = (250 + 450 * length(short_names), 900))
     fig_rmse_bias = fig[1, 1] = CairoMakie.GridLayout()
     for (col, short_name) in enumerate(short_names)
-        sim_var, obs_var = sim_obs_comparsion_dict[short_name]
+        sim_var, obs_var = sim_obs_comparison_dict[short_name]
         times = ClimaAnalysis.times(sim_var)
         mask = mask_dict[short_name](sim_var, obs_var)
 
@@ -372,11 +381,12 @@ latitude, and time. The observational data is determined by `data_source` and ca
 The parameter `leaderboard_base_path` is the path to save the leaderboards and bias plots,
 and `diagnostics_folder_path` is the path to the simulation data.
 
-Loading and preprocessing simulation data is done by `get_sim_var_dict`. Loading and
-preprocessing observational data is done by `get_obs_var_dict`. The masks are normalizing
-the global RMSE and bias are determined by `get_mask_dict`. The ranges of the bias plots are
-determined by `get_compare_vars_biases_plot_extrema`. See the functions defined in
-data_sources.jl.
+Loading and preprocessing simulation data is done by loading `OutputVar`s from a
+`SimDir` and passing them through `preprocess_sim_var`. Loading and preprocessing
+observational data is done by `ERA5DataLoader` or `ILAMBDataLoader`. The masks for
+normalizing the global RMSE and bias are determined by `get_mask_dict`. The ranges
+of the bias plots are determined by `get_compare_vars_biases_plot_extrema`. See
+the functions defined in data_sources.jl.
 """
 function compute_seasonal_leaderboard(
     leaderboard_base_path,
@@ -384,18 +394,16 @@ function compute_seasonal_leaderboard(
     data_source,
 )
     # Get everything we need from data_sources.jl
-    sim_var_dict = get_sim_var_dict(diagnostics_folder_path)
-    obs_var_dict = get_obs_var_dict(data_source)
-    available_sim_vars = ClimaAnalysis.available_vars(
-        ClimaAnalysis.SimDir(diagnostics_folder_path),
+    sim_dir = ClimaAnalysis.SimDir(diagnostics_folder_path)
+    data_loader =
+        uppercase(data_source) == "ERA5" ? ERA5DataLoader() : ILAMBDataLoader()
+    short_names = intersect(
+        ClimaAnalysis.available_vars(sim_dir),
+        available_vars(data_loader),
     )
-    short_names =
-        intersect(keys(sim_var_dict), keys(obs_var_dict), available_sim_vars)
 
-    # Need to intialize mask function
-    mask_dict = get_mask_dict(data_source)
-    issubset(short_names, keys(mask_dict)) ||
-        error("Not all variables ($short_names) have a mask $(keys(mask_dict))")
+    # Need to initialize mask function
+    mask_dict = get_mask_dict(data_loader)
     # Store the mask functions after initialization
     mask_fn_dict = Dict()
 
@@ -403,9 +411,9 @@ function compute_seasonal_leaderboard(
 
     # Set up dict for storing simulation and observational data after processing
     # Map short name to Dict which maps season to tuple of OutputVars
-    sim_obs_season_comparsion_dict = Dict()
+    sim_obs_season_comparison_dict = Dict()
     # Map short name to time series of time averages for each season
-    sim_obs_time_avg_over_seasons_comparsion_dict = Dict()
+    sim_obs_time_avg_over_seasons_comparison_dict = Dict()
     # Map short name to (sim_var, obs_var) full windowed time series, used by
     # the MON column to compute a monthly climatology.
     sim_obs_full_dict = Dict()
@@ -415,10 +423,10 @@ function compute_seasonal_leaderboard(
     for short_name in short_names
         @info short_name
         # Simulation data
-        sim_var = sim_var_dict[short_name]()
+        sim_var = get(sim_dir, short_name)
 
         # Observational data
-        obs_var = obs_var_dict[short_name](sim_var.attributes["start_date"])
+        obs_var = get(data_loader, short_name)
 
         # Make masking function
         mask_fn_dict[short_name] = mask_dict[short_name](sim_var, obs_var)
@@ -428,6 +436,15 @@ function compute_seasonal_leaderboard(
         ClimaAnalysis.times(sim_var)[end] >= spinup_cutoff && (
             sim_var =
                 ClimaAnalysis.window(sim_var, "time", left = spinup_cutoff)
+        )
+
+        # Preprocess sim var to match conventions of data loaders
+        sim_var = preprocess_sim_var(sim_var)
+
+        # Make the relative time the same between observational and simulation data
+        ClimaAnalysis.set_reference_date!(
+            obs_var,
+            sim_var.attributes["start_date"],
         )
 
         # Determine which times can be used
@@ -451,7 +468,6 @@ function compute_seasonal_leaderboard(
         )
 
         # Resample
-        obs_var = ClimaAnalysis.shift_longitude(obs_var, -180.0, 180.0)
         obs_var = ClimaAnalysis.resampled_as(obs_var, sim_var)
         # Stash the full windowed time series so the MON column can compute a
         # monthly climatology before we collapse along time below.
@@ -468,7 +484,7 @@ function compute_seasonal_leaderboard(
         )
 
         # Save observation and simulation data
-        sim_obs_season_comparsion_dict[short_name] = Dict(
+        sim_obs_season_comparison_dict[short_name] = Dict(
             season => (sim_var_s, obs_var_s) for
             (season, sim_var_s, obs_var_s) in
             zip(seasons, sim_var_seasons, obs_var_seasons)
@@ -487,7 +503,7 @@ function compute_seasonal_leaderboard(
         time_averages_obs_var =
             ClimaAnalysis.average_time.(obs_var_seasons_over_time)
 
-        sim_obs_time_avg_over_seasons_comparsion_dict[short_name] =
+        sim_obs_time_avg_over_seasons_comparison_dict[short_name] =
             (time_averages_sim_var, time_averages_obs_var)
     end
 
@@ -506,7 +522,7 @@ function compute_seasonal_leaderboard(
             fontsize = 30,
         )
         for (col_idx, group) in enumerate(groups)
-            sim_var, obs_var = sim_obs_season_comparsion_dict[short_name][group]
+            sim_var, obs_var = sim_obs_season_comparison_dict[short_name][group]
             isempty(sim_var) && break
             layout = fig_bias[row_idx, col_idx] = CairoMakie.GridLayout()
             sim_var.attributes["short_name"] = "mean $(ClimaAnalysis.short_name(sim_var))"
@@ -595,7 +611,7 @@ function compute_seasonal_leaderboard(
         )
         for (col_idx, group) in enumerate(groups)
             if group == "SIM"
-                sim_var, _ = sim_obs_season_comparsion_dict[short_name]["ANN"]
+                sim_var, _ = sim_obs_season_comparison_dict[short_name]["ANN"]
                 isempty(sim_var) && break
                 layout = fig_sim_ann[row_idx, col_idx] = CairoMakie.GridLayout()
                 # Clip the colorbar to the 5th-95th percentile of the
@@ -711,7 +727,7 @@ function compute_seasonal_leaderboard(
                 )
             else
                 sim_var, obs_var =
-                    sim_obs_season_comparsion_dict[short_name][group]
+                    sim_obs_season_comparison_dict[short_name][group]
                 isempty(sim_var) && break
                 layout = fig_sim_ann[row_idx, col_idx] = CairoMakie.GridLayout()
                 ClimaAnalysis.Visualize.plot_bias_on_globe!(
@@ -741,10 +757,10 @@ function compute_seasonal_leaderboard(
     fig_rmse_bias = fig[1, 1] = CairoMakie.GridLayout()
 
 
-    # Loop over sim_obs_season_over_time_comparsion_dict
+    # Loop over sim_obs_season_over_time_comparison_dict
     for (col, short_name) in enumerate(short_names)
         sim_vars, obs_vars =
-            sim_obs_time_avg_over_seasons_comparsion_dict[short_name]
+            sim_obs_time_avg_over_seasons_comparison_dict[short_name]
         mask = mask_fn_dict[short_name]
 
         # Get season and compute global bias and global rmse


### PR DESCRIPTION
This PR refactors the data sources for the leaderboard to use the struct `DataLoader`s. This replaces the dictionary that map names to functions which then takes a start date to materialize the `OutputVar`. This is currently being used for the coupler calibration (see https://github.com/CliMA/ClimaCoupler.jl/blob/main/src/CalibrationTools.jl).

This PR is one step towards attempting to keep the interface for the coupler and land calibration pipelines roughly the same.

The PR reverts the downgrade test to use v1 instead of v2 since it is simpler to understand and debug. There were also problems with the Project.toml.

- Downloads is a standard library, so the version should be 1 instead of 1.6.
- Flux 0.15 and 0.16 is not compatible with Julia 1.12. See https://github.com/FluxML/Flux.jl/issues/2583.
- Dataframes needed to be updated due to ClimaTimeSteppers and Dataframes depending on PrettyTables.

TODO
- [x] Update documentation