### PR TITLE
Add developer guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# CliMA Developer Guides — Agent Index
+
+Read this file first. It is the main index for all shared engineering guidelines. Each guide applies across the CliMA ecosystem unless stated otherwise.
+
+In consumer repos, these guides live at `docs/dev-guides/` and are supplied by a git subtree from the canonical source <https://github.com/CliMA/DeveloperGuides>. The consumer's root `AGENTS.md` references this file and the repo-specific guide. Edit shared guides in the canonical repo, not in the subtree copy.
+
+## Before you act: agent autonomy
+
+Before making changes that are externally visible or scientifically consequential (`git push`, version bumps, reproducibility-test edits, CI config changes, public API renames), check [workflow/agent_autonomy.md](workflow/agent_autonomy.md). The boundaries listed there require explicit user approval.
+
+## Architecture
+
+1. [repo_structure.md](architecture/repo_structure.md) — how to navigate any CliMA Julia package.
+2. [ecosystem_conventions.md](architecture/ecosystem_conventions.md) — module aliases, `Y`/`Yₜ`/`p` state layout, `ᶜ`/`ᶠ` notation, CI structure, reproducibility, diagnostics.
+3. [architectural_boundaries.md](architecture/architectural_boundaries.md) — layered architecture and boundary rules.
+4. [cross_repo_contracts.md](architecture/cross_repo_contracts.md) — call-site conventions for ecosystem packages.
+5. [dependency_management.md](architecture/dependency_management.md) — runtime vs dev deps, compat bounds.
+
+## Performance
+
+1. [gpu_performance.md](performance/gpu_performance.md) — GPU kernel rules, broadcast patterns, allocation avoidance.
+2. [type_stability.md](performance/type_stability.md) — Float32 compatibility, inference checks, struct field rules.
+3. [numerical_robustness.md](performance/numerical_robustness.md) — denominator regularization, clamping, NaN/Inf avoidance.
+4. [ad_compatibility.md](performance/ad_compatibility.md) — AD-safe patterns for ForwardDiff and Enzyme.
+5. [allocation_debugging.md](performance/allocation_debugging.md) — locating heap allocations with `Profile.Allocs`, JET, `@code_warntype`, flame graphs.
+
+## Code Quality
+
+1. [code_style.md](code-quality/code_style.md) — formatting, variable locality, Git workflow, feature removal, naming conventions.
+2. [documentation_policy.md](code-quality/documentation_policy.md) — docstrings, repository-level docs, minimally viable documentation.
+3. [changelogs_and_versions.md](code-quality/changelogs_and_versions.md) — `NEWS.md` format, SemVer rules, and the release/tagging flow.
+4. [variable_list.md](code-quality/variable_list.md) — standardized CliMA variable naming conventions.
+5. [software_design_patterns.md](code-quality/software_design_patterns.md) — numbered SDPs: branchless logic, functors, parameter extraction, etc.
+
+## Infrastructure
+
+1. [testing_and_validation.md](infrastructure/testing_and_validation.md) — type-stability checks, Aqua.jl, allocation regression, AD tests.
+2. [clima_comms.md](infrastructure/clima_comms.md) — device-agnostic and MPI-distributed code patterns.
+
+## Workflow
+
+1. [onboarding.md](workflow/onboarding.md) — install Julia, clone a CliMA repo, set up Revise/Infiltrator/JuliaFormatter, first PR loop.
+2. [agent_autonomy.md](workflow/agent_autonomy.md) — actions that require explicit user approval.
+3. [debugging.md](workflow/debugging.md) — interactive debugging recipes: numerical instabilities, dispatch, `Field` plotting.
+4. [review.md](workflow/review.md) — PR review instructions and checklist.
+5. [ci_triage.md](workflow/ci_triage.md) — checklist for "passes locally, fails on CI" failure modes.
+
+## Self-correction
+
+If this index is discovered to be stale or missing a guide, update it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
----
-
 # ClimaLand Agent Guide
 
 ## Ecosystem Guidelines
@@ -10,6 +8,10 @@ Please refer to the shared CliMA agent index for ecosystem-wide rules regarding 
 
 > Shared guides live at `docs/dev-guides/` and are vendored from the canonical source:
 > <https://github.com/CliMA/DeveloperGuides>. Edit shared guides there, not here.
+
+## Before You Act: Agent Autonomy
+
+Before making changes that are externally visible or scientifically consequential (`git push`, version bumps, reproducibility-test edits, CI config changes, public API renames), check [docs/dev-guides/workflow/agent_autonomy.md](docs/dev-guides/workflow/agent_autonomy.md). The boundaries listed there require explicit user approval.
 
 ## Repo-Specific Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+---
+
+# ClimaLand Agent Guide
+
+## Ecosystem Guidelines
+
+Please refer to the shared CliMA agent index for ecosystem-wide rules regarding architecture, performance, code quality, infrastructure, and workflows:
+
+- [docs/dev-guides/AGENTS.md](docs/dev-guides/AGENTS.md) — Shared CliMA agent guidelines.
+
+> Shared guides live at `docs/dev-guides/` and are vendored from the canonical source:
+> <https://github.com/CliMA/DeveloperGuides>. Edit shared guides there, not here.
+
+## Repo-Specific Guidelines
+
+Always read the ClimaLand-specific structure guide before working in this repository:
+
+- [docs/src/repo_structure.md](docs/src/repo_structure.md) — directory tree, environments, and test groups for *this* repo.
+
+## Local norms
+
+- For runtime validation of experiments, prefer `julia --project=.buildkite ...` as the `.buildkite` environment manages the necessary dependencies for simulations.
+- For package tests, prefer `Pkg.test()` or running `julia --project=test test/runtests.jl` over manually including files.
+- Keep edits modular and within the appropriate submodel directory (e.g., `src/standalone` or `src/integrated`).
+- Match existing style: explicit names, narrow imports, and use multiple dispatch effectively.
+- Follow the software design patterns in [docs/dev-guides/code-quality/software_design_patterns.md](docs/dev-guides/code-quality/software_design_patterns.md) for new code and refactor toward them when touching existing code.
+- Run `julia -e 'using JuliaFormatter; format(".")'` before committing code, adhering to the rules in `.JuliaFormatter.toml`.
+
+## Self-correction
+
+- If the code map in [docs/src/repo_structure.md](docs/src/repo_structure.md) is discovered to be stale, update it.
+- If the user gives a correction about how work should be done in this repo, add it to `Local norms` or another clearly labeled persistent section in this file or in [docs/src/repo_structure.md](docs/src/repo_structure.md) so future sessions inherit it.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Project.toml
+++ b/Project.toml
@@ -45,7 +45,7 @@ LandSimulationVisualizationExt = ["CairoMakie", "ClimaAnalysis", "GeoMakie", "Pr
 SNOTELScraperExt = ["DataFrames", "Downloads", "Statistics"]
 
 [compat]
-Adapt = "4.5.2"
+Adapt = "4.6.0"
 CairoMakie = "0.13, 0.14, 0.15"
 ClimaAnalysis = "0.5.19"
 ClimaComms = "0.6.2"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# DeveloperGuides
+
+Shared engineering standards, architectural patterns, and development guidelines for human and AI developers across the [CliMA](https://clima.caltech.edu) ecosystem.
+
+|             |                                        |
+|------------:|:---------------------------------------|
+| **License** | [![license][license-img]][license-url] |
+
+[license-img]: https://img.shields.io/github/license/CliMA/DeveloperGuides
+[license-url]: https://github.com/CliMA/DeveloperGuides/blob/main/LICENSE
+
+## Usage
+
+DeveloperGuides is included as a **Git subtree** in CliMA repositories at the standardized path `docs/dev-guides/`. The consuming repo keeps its own `AGENTS.md` at the root, which references `docs/dev-guides/AGENTS.md` (the shared guide index) plus a repo-specific guide (e.g. `docs/clima_atmos_specific.md`). See the [`AGENTS.md`](AGENTS.md) for the full guide index, and [`templates/`](templates/) for ready-to-copy starter files (root `AGENTS.md`, repo-specific guide skeleton, monthly sync workflow).
+
+```bash
+# Add the subtree to a new consumer repo
+git subtree add --prefix docs/dev-guides \
+    https://github.com/CliMA/DeveloperGuides.git main --squash
+
+# Pull the latest guides manually (most repos automate this monthly via update_dev_guides.yml)
+git subtree pull --prefix docs/dev-guides \
+    https://github.com/CliMA/DeveloperGuides.git main --squash \
+    -m "chore: sync dev guides from central repo"
+```
+
+> [!NOTE]
+> **Subtree pitfalls.**
+> 
+> - DeveloperGuides ships its own `AGENTS.md`, `LICENSE`, and `README.md` at the repo root, which conflict with the consumer's own root files during `git subtree add`. Resolve by keeping the consumer's versions: `git checkout --ours AGENTS.md LICENSE README.md && git add … && git rebase --continue`.
+> - `git subtree pull` exits with an error when there are no new commits upstream. In an automated workflow, append `|| true` so the step does not fail on months with no DeveloperGuides changes.
+
+### Contributing back
+
+Edits to shared guidelines belong here, not in the vendored copy inside a consumer repo. Open PRs against `CliMA/DeveloperGuides`; once merged, the next subtree pull propagates them to every consumer.
+
+## Directory Structure
+
+```text
+├── AGENTS.md                  # Master index for AI agents
+├── architecture/              # System design, layering, contracts
+├── performance/               # GPU, type stability, numerics, AD
+├── code-quality/              # Style, docstrings, changelogs
+├── infrastructure/            # Testing, device abstraction
+├── workflow/                  # Agent autonomy, PR review
+└── templates/                 # Starter files for consumer repos
+```
+
+## Integration with the CliMA Ecosystem
+
+DeveloperGuides is the central source of truth for engineering standards across [CliMA](https://github.com/CliMA), including:
+
+- [ClimaAtmos](https://github.com/CliMA/ClimaAtmos.jl)
+- [ClimaCore](https://github.com/CliMA/ClimaCore.jl)
+- [ClimaLand](https://github.com/CliMA/ClimaLand.jl)
+- [ClimaOcean](https://github.com/CliMA/ClimaOcean.jl)
+- [ClimaCoupler](https://github.com/CliMA/ClimaCoupler.jl)
+- [Thermodynamics](https://github.com/CliMA/Thermodynamics.jl)
+- [CloudMicrophysics](https://github.com/CliMA/CloudMicrophysics.jl)
+- [SurfaceFluxes](https://github.com/CliMA/SurfaceFluxes.jl)
+- [ClimaTimeSteppers](https://github.com/CliMA/ClimaTimeSteppers.jl)
+
+## Contributing
+
+- Each guide has a **Self-correction** section: if you discover a guide is stale or missing a pattern, update it directly.
+- New guides should be placed in the appropriate category directory and added to [`AGENTS.md`](AGENTS.md).
+- Cross-references between guides should use relative paths (e.g., `../performance/gpu_performance.md`).
+
+## Getting Help
+
+For questions or suggestions, open an issue on [GitHub](https://github.com/CliMA/DeveloperGuides/issues).

--- a/architecture/architectural_boundaries.md
+++ b/architecture/architectural_boundaries.md
@@ -1,0 +1,68 @@
+# Architectural Boundaries
+
+This guide defines the layered architecture used across CliMA model repositories and the rules that keep boundaries clean. Each repo's `*_specific.md` (linked from [AGENTS.md](../AGENTS.md)) maps these layers to its concrete directories.
+
+## 1. Layer hierarchy
+
+CliMA packages form a directed acyclic dependency graph. The canonical layering is:
+
+| Layer | Packages                                                     | Role                                                                                    |
+|:------|:-------------------------------------------------------------|:----------------------------------------------------------------------------------------|
+| L0    | [ClimaParams.jl](https://github.com/CliMA/ClimaParams.jl)    | Physical constants and calibratable parameters. No CliMA-internal dependencies.         |
+| L1    | ClimaComms.jl, ClimaCore.jl, Thermodynamics.jl               | Foundations: device abstraction + MPI, fields & discretization, thermodynamic primitives. |
+| L2    | ClimaTimeSteppers.jl, CloudMicrophysics.jl, SurfaceFluxes.jl | Higher-level libraries built on L1 — time integration and physics parameterisations.    |
+| L3    | ClimaAtmos.jl, ClimaLand.jl, ClimaOcean.jl                   | Model repos: compose L1 / L2 to integrate state variables.                              |
+| L4    | ClimaCoupler.jl                                              | Couples multiple L3 models.                                                             |
+
+**The rule**: a package at layer N may depend on packages at layers < N, but never on packages at layers ≥ N. Concretely:
+
+- Physics libraries (Thermodynamics, CloudMicrophysics, SurfaceFluxes) must not depend on ClimaCore, grid types, or any model repo.
+- Infrastructure libraries (ClimaCore, ClimaComms, ClimaTimeSteppers) must not depend on physics libraries or model repos.
+- Model repos must not depend on ClimaCoupler.
+
+Verify against actual dependencies with `Pkg.dependencies` if in doubt. A new dependency that creates an upward edge in this DAG is a design smell.
+
+### Role of each layer
+
+- **Physics libraries** (Thermodynamics.jl, CloudMicrophysics.jl, SurfaceFluxes.jl): public functions accept scalars or tuples and return scalars or `NamedTuple`s. They must not allocate `Array` or `Field` objects internally.
+- **Infrastructure libraries** (ClimaCore.jl, ClimaTimeSteppers.jl, ClimaComms.jl): own the data structures, discretization, and parallelism. They define the types that model repos compose.
+- **Parameter library** ([ClimaParams.jl](https://github.com/CliMA/ClimaParams.jl)): the central source of truth for physical constants and adjustable parameters that may be calibrated. All physics libraries read their constants from `ClimaParams`-derived parameter structs rather than hard-coding values.
+- **Model repos** (ClimaAtmos.jl, ClimaLand.jl, ClimaOcean.jl, ClimaCoupler.jl): compose physics and infrastructure. Tendency functions call into physics libraries with extracted scalar values and write results back to fields via broadcasting.
+
+When adding new code, place it in the layer that owns the relevant concern. Do not embed broadcasting, field allocation, or IO inside physics functions, and do not re-implement numerical algorithms inside model-level tendency code.
+
+## 2. Parameter container design
+
+- Containers should be focused on the specific physical or mathematical domain they serve.
+- Don't keep parameters "just in case." Fields added to a struct only to keep an old caller compiling — with no current user — accumulate as dead weight. When a refactor removes the last caller of a field, remove the field too.
+- Keep parameter containers focused on physical constants and model parameters. Configuration flags, output options, and diagnostic metadata belong in the model's infrastructure layer, not in physics parameter structs.
+
+## 3. Avoid hidden field dependencies
+
+Do not access internal or undocumented fields of a sub-package's parameter struct directly (for example, `cm2p.internal_field`). Use the documented public accessor or the primary parameter source.
+
+This makes physics refactors in sub-packages safe without cascading breakage in the model.
+
+Bad:
+
+```julia
+# Brittle: depends on the *internal* field names of a microphysics scheme
+# struct that are not part of its documented API.
+rain_terminal_velocity_coeff = cm1m_internal.rtv_coeff
+```
+
+Preferred:
+
+```julia
+# Robust: access the documented public field of the unified terminal-velocity
+# container (CloudMicrophysics.Parameters.TerminalVelocityParams).
+rain_velocity_params = tv_params.chen2022.rain
+```
+
+## 4. Module import rules
+
+See [SDP 2](../code-quality/software_design_patterns.md) for the rule on cross-submodule imports inside `src/`.
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/architecture/cross_repo_contracts.md
+++ b/architecture/cross_repo_contracts.md
@@ -1,0 +1,50 @@
+# Cross-Repo Contracts
+
+This guide documents the conventions for calling ecosystem packages from CliMA model repositories. Rules are at the call-site level; internal package APIs are not documented here.
+
+## General principle
+
+Always pass the package's *parameter container* (for example, `thermodynamics_params`, `surface_flux_params`) into physics functions rather than individual constants. This ensures consistency across model components and makes calibration transparent.
+
+## How to find the current API of a CliMA dependency
+
+You typically will not have the dependency's source checked out next to the model repo. Use this order:
+
+1. **`NEWS.md`** of the dependency, if accessible — it lists API changes per release.
+2. **The dev'd path under `~/.julia/dev/<Package>.jl`**, if the user has the package dev'd locally.
+3. **The package's `docs/src/`**, which usually documents the supported call surface.
+4. **Existing call sites in this repo** — grep for the package's module alias in `src/` to see how it is already used.
+
+Treat anything not in the package's `docs/` as internal and unstable.
+
+## Thermodynamics.jl
+
+- Pass the thermodynamics parameter container (e.g. `p.params.thermodynamics_params` in ClimaAtmos) into thermodynamic functions; do not hard-code thermodynamic constants.
+- The public API is fully functional and stateless: functions take a parameter container and the relevant scalar arguments directly.
+- Many functions are dispatched on a *formulation type* that names the independent variables. The available formulations (subtypes of `IndepVars`) are `TD.ρe()`, `TD.pe()`, `TD.ph()`, `TD.pρ()`, `TD.pθ_li()`, `TD.ρθ_li()`. For example: `TD.air_temperature(thp, TD.ph(), h, q_tot, q_liq, q_ice)`.
+- For iterative phase-equilibrium calculations inside GPU kernels, prefer variants that accept a fixed iteration count to avoid thread divergence. See [SDP 19](../code-quality/software_design_patterns.md).
+
+## CloudMicrophysics.jl
+
+- The microphysics scheme is passed as a singleton type (e.g. `Microphysics0Moment()`, `Microphysics1Moment()`, `Microphysics2Moment()`); dispatch on it eliminates dead branches at compile time.
+- The bulk-tendency wrappers (e.g. `bulk_microphysics_tendencies`) return `NamedTuple`s. Materialize them into a pre-allocated `NamedTuple`-of-`Field`s scratch slot in the cache and then issue one `@.` broadcast per target field — see the "Materialization" and "Multi-field updates" subsections in [GPU Performance Guide §3](../performance/gpu_performance.md). Process-rate primitives (e.g. `accretion`, `terminal_velocity`, `conv_q_icl_to_q_sno`) return scalars and can be broadcast directly.
+- The terminal-velocity parameters live in a unified container `CMP.TerminalVelocityParams` with fields `stokes`, `chen2022`, `blk1m`. Use these documented fields rather than poking into internal scheme-specific structs.
+
+## SurfaceFluxes.jl
+
+- Pass a `SurfaceFluxes.Parameters.SurfaceFluxesParameters` container (the concrete subtype of `AbstractSurfaceFluxesParameters`); do not hard-code flux constants.
+- Surface flux computation is expensive (root-finding on the Monin–Obukhov length); call it once per stage in the infrastructure layer, not inside tendency hot paths.
+- Public entry points include `surface_fluxes` (the bulk solver), `sensible_heat_flux`, `latent_heat_flux`, and `compute_profile_value` (for recovering profile values at a given height). Round-trip tests against these are an idiomatic way to validate flux changes — see [testing_and_validation.md §2 Round-trip tests](../infrastructure/testing_and_validation.md#2-round-trip-inverse-tests).
+
+## ClimaParams.jl
+
+Extract the specific parameter sub-struct (e.g. `thp = p.params.thermodynamics_params`) to a local variable before any `@.` broadcast — capturing the full `p.params` container can push a large struct into GPU kernel parameter memory and exceed hardware limits. See [SDP 20](../code-quality/software_design_patterns.md) for the rule, rationale, and worked example.
+
+## General cross-repo guidance
+
+- Before writing a new call site, check the target package's `NEWS.md` for recent API changes.
+- Treat every function whose name ends in `_deprecated` or that is annotated `@deprecate` as absent; use the replacement.
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/architecture/dependency_management.md
+++ b/architecture/dependency_management.md
@@ -1,0 +1,127 @@
+# Dependency Management Guide
+
+This guide covers rules for managing Julia package dependencies in CliMA repositories.
+
+## 1. Multiple `Project.toml`s in one repo
+
+CliMA repos typically have several Julia environments side-by-side, each with its own `Project.toml` (and, if instantiated, `Manifest.toml`). They serve different purposes and must be kept distinct.
+
+| Path                          | What it is                                                                                                | Activated by                                |
+|:------------------------------|:----------------------------------------------------------------------------------------------------------|:--------------------------------------------|
+| `Project.toml` (repo root)    | The package itself: runtime `[deps]`, `[compat]`, `[weakdeps]`, `[extensions]`.                           | `using Pkg; Pkg.activate(".")`              |
+| `test/Project.toml`           | Test-only dependencies (Aqua, JET, BenchmarkTools, CUDA, Documenter, etc.).                               | `Pkg.test()`                                |
+| `docs/Project.toml`           | Documentation build dependencies (Documenter, Literate, plotting).                                        | `julia --project=docs docs/make.jl`         |
+| `perf/Project.toml`           | Allocation / flame / JET scripts (BenchmarkTools, Profile tools).                                         | `julia --project=perf perf/<script>.jl`     |
+| `.buildkite/Project.toml`     | Pipeline driver environment (present in repos that run Buildkite).                                        | invoked by the pipeline runner              |
+| `<demo-dir>/Project.toml`     | Self-contained demos (e.g. `box/`, `parcel/`, `papers/` in CloudMicrophysics; `examples/` in some repos). | `julia --project=<demo-dir>`                |
+
+Rules of thumb:
+
+- **A dependency used only in tests goes in `test/Project.toml`**, never in the root `[deps]`. If it leaks into root deps, `Aqua.test_stale_deps` fails.
+- **The root `Project.toml` is the package's published contract.** Adding to its `[deps]` is a deliberate API change; it forces every downstream consumer to install that dep too.
+- **`docs/Project.toml` may `dev` the repo itself.** Documenter needs the in-tree source; do not list the package as a regular dep there.
+- **`perf/Project.toml` is local-only.** Allocation and flame scripts are run by hand or in a dedicated CI job; treat its `Manifest.toml` (if committed) as advisory, not authoritative.
+- **The runtime `[compat]` block applies only to root `[deps]`.** Test/docs/perf compats are independent and should be kept lighter so they don't fight the root bounds.
+
+When adding a new dep, ask: *who needs this at runtime when a downstream user does `using MyPackage`?* If the answer is "no one", it belongs in a non-root environment.
+
+### Test-target alternative
+
+Library repos (Thermodynamics, CloudMicrophysics, SurfaceFluxes, ClimaTimeSteppers) use a separate `test/Project.toml`. Some smaller packages use the older `[extras]` + `[targets]` pattern in the root `Project.toml` instead:
+
+```toml
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
+
+[targets]
+test = ["Test", "JuliaFormatter"]
+```
+
+Both are accepted by `Pkg.test()`; match whichever convention the repo already uses. Do not mix them.
+
+## 2. Runtime vs development dependencies
+
+**Rule**: never place development tools (for example, `JuliaFormatter.jl`, `BenchmarkTools.jl`, `Aqua.jl`, `JET.jl`) in the root `[deps]` section of `Project.toml`. Put them in `test/Project.toml` (or in the `[extras]`/`[targets]` block — see §1).
+
+**Why**: dev tools in root `[deps]` cause `Aqua.test_stale_deps` to fail (if unused by `src/`) and inflate the dependency footprint for every downstream consumer.
+
+## 3. Package extensions
+
+Julia 1.9+ supports *package extensions*: optional code paths that load only when a specific dependency is also loaded by the user. Use them to offer integrations (CUDA, plotting backends, file-format readers) without forcing every consumer to install the heavy dep. A weak dependency goes in `[weakdeps]`, paired with an `[extensions]` entry that names the trigger:
+
+```toml
+[weakdeps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+
+[extensions]
+MyPackageCUDAExt = ["CUDA"]
+
+[compat]
+CUDA = "5"
+```
+
+The extension module lives at `ext/MyPackageCUDAExt.jl` and can `using` both the parent package and the weak dep. Choose `ext/` over `src/` when the integration is optional or only meaningful with the weak dep loaded; keep small, core-path deps in `src/`. `[weakdeps]` entries still need `[compat]` entries — Aqua flags missing bounds. For the full Julia-level semantics, see the [Julia manual](https://pkgdocs.julialang.org/v1/creating-packages/#Conditional-loading-of-code-in-packages-(Extensions)).
+
+## 4. Cross-package local development
+
+When developing across multiple local packages where the local branch version is higher than the current compat allows:
+
+1. Update `Project.toml` compat to include the new version:
+
+   ```toml
+   # Before
+   CloudMicrophysics = "0.30"
+
+   # After
+   CloudMicrophysics = "0.30, 0.31"
+   ```
+
+2. Develop the local path:
+
+   ```julia
+   using Pkg
+   Pkg.develop(path="/path/to/local/CloudMicrophysics.jl")
+   ```
+
+3. Verify with `Pkg.status("CloudMicrophysics")` that the local path is active.
+
+### Nested environment conflicts
+
+In nested environments (like `test/Project.toml`), running tests from the parent directory often resolves conflicts:
+
+```bash
+julia --project=. -e 'using Pkg; Pkg.instantiate(); include("test/runtests.jl")'
+```
+
+## 5. Pruning obsolete packages
+
+When a feature is removed, check whether it was the exclusive consumer of any external package:
+
+```bash
+grep -r "PackageName" src/
+```
+
+If no remaining references exist, remove the package from both `[deps]` and `[compat]` sections of `Project.toml`. This reduces precompilation times and simplifies the dependency graph.
+
+### Verification
+
+After removing a dependency, verify the package still precompiles:
+
+```bash
+julia --project -e 'using PackageName'
+```
+
+## 6. Avoiding internal modules from dependencies
+
+Prefer standard Julia operations over internal modules from dependencies. Internal modules may be refactored or removed in future versions, without being marked as breaking changes. Quantities that are not explicitly `export`-ed or documented as part of a package's public API should be considered internals, and other packages should refrain from accessing them if possible.
+
+## 7. Writing `[compat]` bounds
+
+Keep `[compat]` entries as broad as the package's API actually supports. Overly narrow upper bounds in upstream packages are the most common source of unresolvable graphs across the CliMA ecosystem — tighten a bound only when you can name the specific incompatibility (a removed symbol, a changed signature, a regression). When working across nested environments (`docs/`, `test/`, `perf/`, `.buildkite/`) against a local checkout of the parent package, use `Pkg.develop(path="..")` so the subdirectory picks up unreleased changes.
+
+For the recovery procedure when an environment fails to resolve, see [onboarding.md §8](../workflow/onboarding.md).
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/architecture/ecosystem_conventions.md
+++ b/architecture/ecosystem_conventions.md
@@ -1,0 +1,109 @@
+# CliMA Ecosystem Conventions
+
+Conventions for reading and writing code that span every CliMA model and library repo. This guide is a *glossary first, rule book second*: things that look obvious to a long-time contributor but trip up newcomers (human and AI alike).
+
+## 1. Module aliases used across the ecosystem
+
+It is generally preferable to use public functions and data structures that are `export`-ed by a package as part of its API, either by `using` the package or by `import`-ing specific symbols from the package. Before a package's API has been finalized, though, it is often easier to use unexported quantities by aliasing the package name and accessing its internals as needed; for example, `import Thermodynamics as TD` allows any quantity from `Thermodynamics.jl` to be accessed succinctly via `TD.<name>`.
+
+When working in a CliMA model repo you will see these aliases repeatedly. If you choose to use aliases, match them in new code so call sites stay grep-able. Do **not** invent a different alias for the same package.
+
+| Alias   | Package / module                               | Where it dominates                      |
+|:--------|:-----------------------------------------------|:----------------------------------------|
+| `TD`    | `Thermodynamics`                               | every model repo                        |
+| `TDP`   | `Thermodynamics.Parameters`                    | ClimaAtmos, ClimaLand                   |
+| `SF`    | `SurfaceFluxes`                                | ClimaAtmos, ClimaCoupler                |
+| `SFP`   | `SurfaceFluxes.Parameters`                     | ClimaAtmos                              |
+| `UF`    | `SurfaceFluxes.UniversalFunctions`             | ClimaAtmos                              |
+| `CM`    | `CloudMicrophysics`                            | ClimaAtmos                              |
+| `CM0` / `CM1` / `CM2` | `CloudMicrophysics.Microphysics{0,1,2}M` | ClimaAtmos microphysics                 |
+| `CMNe`  | `CloudMicrophysics.MicrophysicsNonEq`          | ClimaAtmos non-equilibrium microphysics |
+| `BMT`   | `CloudMicrophysics.BulkMicrophysicsTendencies` | ClimaAtmos bulk microphysics wrapper    |
+| `CMP`   | `CloudMicrophysics.Parameters`                 | ClimaAtmos                              |
+| `CC`    | `ClimaCore`                                    | parameter / utility code                |
+| `CAP`   | `ClimaAtmos.Parameters`                        | ClimaAtmos internal                     |
+| `CAD`   | `ClimaAtmos.Diagnostics`                       | ClimaAtmos diagnostics                  |
+| `CP`    | `ClimaParams`                                  | any repo that reads TOML parameters     |
+| `IP`    | `Insolation.Parameters`                        | ClimaAtmos parameter wiring             |
+| `SA`    | `StaticArrays`                                 | hot-path / kernel code                  |
+| `RS`    | `RootSolvers`                                  | Thermodynamics / CloudMicrophysics      |
+| `RRTMGPI` | `ClimaAtmos.RRTMGPInterface`                 | ClimaAtmos radiation                    |
+
+In docstrings, use the same prefix you would use in code (`TD.air_temperature`, not `Thermodynamics.air_temperature`) — readers grep on the prefix.
+
+## 2. Prognostic state, tendencies, and the cache
+
+Model repos (ClimaAtmos, ClimaLand) follow a common state layout:
+
+- **`Y`** — the prognostic state vector. A `ClimaCore.Fields.FieldVector` whose top-level fields name solution regions (`Y.c` for cell-centered, `Y.f` for face-centered in ClimaAtmos; `Y.soil`, `Y.canopy` in ClimaLand). Anything timestepped lives in `Y`.
+- **`Yₜ`** — the tendency, same shape as `Y`. Tendency functions write into `Yₜ` and never allocate new fields; they read from `Y`.
+- **`p`** — the cache *bundle* passed to every right-hand-side function. In ClimaAtmos, this contains pre-allocated scratch (`p.scratch`), precomputed quantities (`p.precomputed`), atmosphere settings (`p.atmos`), and the numeric parameter struct (`p.params`, e.g. `ClimaAtmosParameters`). In ClimaLand, the cache contains scratch space and physical quantities that may be precomputed once per step or computed multiple times per step; parameters are passed in via the model, however, and not the cache.
+- **`t`** — the current simulation time (in seconds (Float64) or expressed as an `ITime`).
+
+Rules implied by this layout:
+
+1. **Never allocate `Field`s inside a tendency or cache setter.** To avoid doing so, use a scratch field from `p.scratch` (allocated during model construction in `src/cache/` for ClimaAtmos), or use lazy broadcasting. See the "Materialization" section of [GPU Performance Guide §3](../performance/gpu_performance.md).
+2. **`Yₜ` should be treated as write-only inside tendency functions.** Reading `Yₜ` back couples stages of the time integrator and can break reproducibility. The one accepted exception is *post-hoc limiters* (e.g., in ClimaLand) that clip the assembled `Yₜ` after all contributions have been written — these are a deliberate non-linear projection applied at the end of the right-hand side, not a hidden coupling between stages.
+3. **`p` must be treated as effectively immutable from the integrator's point of view.** You can write to `p.precomputed` and `p.scratch` *as part of refreshing the cache for the current stage*, but you must not mutate `p` in ways that would result in different behavior on a subsequent call with the same values of `Y` and `t`.
+
+## 3. Cell-center vs cell-face notation (`ᶜ` / `ᶠ`)
+
+ClimaCore-based repos use the Unicode prefixes `ᶜ` (cell-center, U+1D9C, typed `\^c<TAB>`) and `ᶠ` (cell-face, U+1DA0, typed `\^f<TAB>`) to mark the staggered-grid location of a field. The prefix is part of the variable name, not decoration: `ᶜρ` and `ᶠρ` are different fields living on different `ClimaCore.Spaces.AbstractSpace`s. Operators follow the same convention — the prefix on `ᶜgradᵥ`, `ᶠinterp`, etc. names the space of the *result*. Scalars and pointwise values do not carry the prefix.
+
+See [variable_list.md "Field Prefixes"](../code-quality/variable_list.md) for the full convention, and copy the prefix from an analogous existing field when introducing a new one.
+
+## 4. Parameter wiring (`ClimaParams` → physics libraries → model)
+
+Every CliMA package follows the same pattern for physical constants:
+
+```text
+TOML files in ClimaParams/src/parameters.toml
+        │
+        ▼ CP.create_toml_dict(FT)
+toml_dict :: CP.ParamDict
+        │
+        │ Constructor: ThermodynamicsParameters(toml_dict)
+        │              SurfaceFluxesParameters(toml_dict, UF.GryanikParams)
+        ▼              CMP.TerminalVelocityParams(toml_dict)
+Library-specific parameter struct (immutable, isbits-after-adapt)
+        │
+        ▼ Bundled by the model
+ClimaAtmosParameters / ClimaLandParameters / ...
+        │
+        ▼ Passed at every RHS call
+        p.params
+```
+
+Implications:
+
+- **Do not hard-code physical constants** anywhere downstream. Add them to ClimaParams (or, if scheme-specific, to the relevant library's TOML), then read them through the parameter struct.
+- **Constructors take a `CP.ParamDict`, not individual values.** When you add a new parameter, register a name-map entry in the library's parameter constructor.
+- **`FT` is fixed by `CP.float_type(toml_dict)`.** Always derive `FT` from the parameter container or the live input, not by hard-coding.
+
+## 5. CI and Buildkite
+
+Most CliMA model repos run both GitHub Actions (formatter, unit tests, docs) and Buildkite (GPU-backed integration and reproducibility runs).
+
+- **GitHub Actions** lives in `.github/workflows/`. The common workflows are `JuliaFormatter.yml` (or `julia_formatter.yml`), `UnitTests.yml`, `Documentation.yml`, and `Downstream.yml`.
+- **Buildkite** lives in `.buildkite/` with a top-level `pipeline.yml` and a runner script (e.g. `ci_driver.jl` in ClimaAtmos). Jobs are keyed by `job_id` strings that also drive output paths and reproducibility tests.
+- **Allocation benchmarks** (typically in `perf/`) are *not* run in CI. Allocation regressions must be caught at review time via the `@allocated == 0` pattern in [allocation_debugging.md §1](../performance/allocation_debugging.md).
+
+When a CI job is mentioned by name in a guide or review, it is almost always a Buildkite job name; resolve it by searching `.buildkite/pipeline.yml`.
+
+## 6. Reproducibility tests (model repos)
+
+Some model repos (notably ClimaAtmos) maintain a `reproducibility_tests/` directory that pins the simulation output of canonical jobs to within bit tolerance, keyed off `reproducibility_tests/ref_counter.jl`. A code change that flips a reproducibility test is itself a finding: report it in the PR description with the job name and the MSE diff, not as a hidden side effect.
+
+Reference counters and MSE tolerance files must not be modified without explicit user instruction — see [agent_autonomy.md](../workflow/agent_autonomy.md) for the full rule.
+
+## 7. Diagnostics
+
+`Diagnostics` is the user-facing name for any quantity written to output (NetCDF, HDF5) at a configurable cadence. Diagnostic *names* and *units* are public API.
+
+- In ClimaAtmos and ClimaLand, diagnostics are defined in `src/diagnostics/` (aliased as `CAD` for ClimaAtmos). Each diagnostic has a short name, long name, units, comments, and a compute function.
+- Renaming a diagnostic, changing its units, or removing a default diagnostic is a breaking change and requires a `NEWS.md` entry under `![][badge-💥breaking]` (see [changelogs_and_versions.md](../code-quality/changelogs_and_versions.md)).
+- Adding a *new* diagnostic does not require a breaking-change badge, but does need a `NEWS.md` entry under `![][badge-✨feature/enhancement]`.
+
+## 8. Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/architecture/repo_structure.md
+++ b/architecture/repo_structure.md
@@ -1,0 +1,46 @@
+# Navigating a CliMA repository
+
+This file describes how to orient yourself in any CliMA Julia package. For the concrete directory tree of this specific repository, see the repo-specific guide (linked from [AGENTS.md](../AGENTS.md)).
+
+## Where to start
+
+1. **`Project.toml`** — package name, version, deps, compat. Read first to confirm which package you are in and what it depends on.
+2. **`src/<PackageName>.jl`** — the package entry point. It `include`s the major subsystems; follow the includes to find the owning source area for a feature.
+3. **`README.md`** and **`docs/src/`** — the user-facing description of the package and its public API. Useful when the source layout is unfamiliar.
+4. **`NEWS.md`** — recent user-visible changes. Always check this when working with a package whose public API you are unsure about.
+5. **`test/runtests.jl`** — the test driver. The grouping it uses (often `TEST_GROUP` env var or similar) tells you which test buckets exist.
+
+## Common top-level layout
+
+Most CliMA Julia packages share these directories:
+
+- `src/` — package source code, organized by physics or runtime concept.
+- `test/` — unit and integration tests. `test/` typically mirrors `src/`.
+- `docs/` — Documenter sources (`docs/make.jl`, `docs/src/`).
+- `ext/` — Julia package extensions (loaded conditionally on dependencies).
+- `.buildkite/` — Buildkite pipeline definitions and run drivers (where used).
+- `.github/workflows/` — GitHub Actions CI.
+- `perf/` or `benchmarks/` — performance/allocation benchmarks. Often not run in CI.
+- `examples/`, `runscripts/`, `post_processing/`, `calibration/` — repo-dependent.
+
+## Conventions to expect
+
+- **Cache / precomputed quantities**: ClimaAtmos has a `src/cache/` area where per-stage scratch state update functions are defined. The convention is to allocate once at construction and never inside per-step setters.
+- **Parameter containers**: every package exposes a parameter container (often `*Parameters`) constructed from `ClimaParams.jl` TOML files.
+- **Public API**: the symbols re-exported from `src/<PackageName>.jl` are the supported surface. Internal functions and data structures may change without notice.
+- **Test-only deps**: development tooling lives in `[extras]` and is associated with specific `[targets]` like the `test` subdirectory — never in `[deps]`. See [dependency_management.md](dependency_management.md).
+
+## How to locate a feature
+
+1. Search `src/<PackageName>.jl` for the include that brings in the relevant subsystem.
+2. Within that subsystem's directory, look for a file whose name matches the physics/runtime concept (`microphysics.jl`, `radiation.jl`, etc.).
+3. Cross-reference with `test/` — the test path almost always mirrors the source path and offers a smaller, more digestible entry point.
+4. If still unsure, `git log --oneline -- <directory>` reveals recent activity and PR numbers; the PR descriptions are often the clearest design notes.
+
+## When a repo deviates from these conventions
+
+Repos like ClimaCore, Thermodynamics, and CloudMicrophysics have different source layouts than model repos. Read `src/<PackageName>.jl` and `docs/src/` first.
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/code-quality/changelogs_and_versions.md
+++ b/code-quality/changelogs_and_versions.md
@@ -1,0 +1,170 @@
+# Changelogs and Versioning
+
+This guide covers two related but separate concerns:
+
+- **The changelog (`NEWS.md`)** — a human-readable log of what changed in each release. Updated continuously, on every user-visible PR.
+- **The package version (`Project.toml`)** — a single numeric string that signals *how breaking* a change is to downstream consumers. Bumped only when a release is cut.
+
+Most PRs touch only `NEWS.md`. Only release PRs touch the version. The two come together when a release is *cut* (Part 3 below).
+
+---
+
+## Part 1 — The changelog (`NEWS.md`)
+
+### 1.1 What goes in
+
+Add an entry to `NEWS.md` when any of the following changes:
+
+- A user-visible config key or CLI flag is added, renamed, or removed.
+- A diagnostic output name or units change.
+- A public API in the package's main module is added, changed, or removed.
+- A Buildkite job name or config flag changes.
+- A new version of the package is released (the release PR itself adds the section header — see Part 3).
+
+### 1.2 What doesn't
+
+Internal refactors with zero user-visible effect do not need a `NEWS.md` entry. Performance improvements and bug fixes generally *do* deserve an entry, because users care about both.
+
+### 1.3 Layout
+
+At the top of `NEWS.md` is an always-open `main` section that accumulates unreleased entries; below it are frozen sections, one per released version, in reverse chronological order. The `main` section must always exist, even immediately after a release cut.
+
+```markdown
+main
+----
+
+- One bullet per change, plain English, past tense.
+- Include the PR number as a link: PR [#1234](https://github.com/CliMA/MyPackage.jl/pull/1234).
+
+v0.39.0
+-------
+
+- ...entries from before the last release...
+```
+
+One bullet per change. Entries under a released version are final and should not be modified after release.
+
+### 1.4 Badges
+
+Some repos (notably `ClimaAtmos`, `ClimaCore`, `ClimaTimeSteppers`) prefix entries with a badge that classifies the change. The badge definitions live at the bottom of `NEWS.md` and must not be removed.
+
+| Badge                              | When to use                                                   |
+|:-----------------------------------|:--------------------------------------------------------------|
+| `![][badge-💥breaking]`            | Breaking changes: removed functions/types, API changes        |
+| `![][badge-🔥behavioralΔ]`         | Behavioral changes: new model, different defaults             |
+| `![][badge-🤖precisionΔ]`          | Machine-precision changes: reordered arithmetic               |
+| `![][badge-🚀performance]`         | Performance improvements: fewer allocations, better inference |
+| `![][badge-✨feature/enhancement]` | New features                                                  |
+| `![][badge-🐛bugfix]`              | Bug fixes                                                     |
+
+Smaller library repos (`CloudMicrophysics`, `SurfaceFluxes`) use plain-text entries without badges. Match the convention already in the repo's `NEWS.md`.
+
+### 1.5 Example
+
+```markdown
+main
+----
+
+v0.39.0
+-------
+- ![][badge-💥breaking] Removed deprecated `old_config_key`. Use `new_config_key` instead.
+  PR [#1234](https://github.com/CliMA/MyPackage.jl/pull/1234).
+- ![][badge-✨feature/enhancement] Added `my_new_config_key` to control feature X.
+  PR [#1235](https://github.com/CliMA/MyPackage.jl/pull/1235).
+
+v0.38.4
+-------
+- ![][badge-🐛bugfix] Fixed incorrect surface flux calculation.
+  PR [#1230](https://github.com/CliMA/MyPackage.jl/pull/1230).
+```
+
+---
+
+## Part 2 — The package version (`Project.toml`)
+
+### 2.1 Where it lives
+
+The authoritative version string is the `version = "..."` line near the top of the package's root `Project.toml`. There is exactly one such string per package; it is what the Julia General registry records and what `Pkg.status` reports to downstream users. The version is *not* derived from `NEWS.md` headers or from Git tags; those are downstream of `Project.toml`.
+
+```toml
+name = "MyPackage"
+uuid = "..."
+authors = ["Climate Modeling Alliance"]
+version = "0.38.4"
+```
+
+### 2.2 Bump rules: Julia's modified SemVer
+
+CliMA packages follow [Julia's modified Semantic Versioning](https://pkgdocs.julialang.org/v1/compatibility/) — the same scheme the General registry enforces. The rules differ for pre-1.0 and post-1.0 packages.
+
+In practice, some CliMA packages deliberately diverge from strict SemVer. ClimaLand, despite being post-1.0, continues to treat the MINOR slot as the breaking slot and reserves a major bump (2.0) for a major milestone (e.g., aligned with a paper submission). Release cadence is also driven by downstream-coupling needs rather than API-stability milestones. Don't infer "no breaking changes" from the absence of a major bump — consult `NEWS.md` for the authoritative record.
+
+| Package state | Bump                          | Format              | Meaning                                                                                                              |
+|:--------------|:------------------------------|:--------------------|:---------------------------------------------------------------------------------------------------------------------|
+| **Post-1.0**  | Major (`1.x.y` → `2.0.0`)     | `MAJOR.MINOR.PATCH` | Breaking change to the public API (removed/renamed symbol, changed signature, changed default that affects results). |
+|               | Minor (`1.2.x` → `1.3.0`)     | `MAJOR.MINOR.PATCH` | Non-breaking new feature or additive API surface.                                                                    |
+|               | Patch (`1.2.0` → `1.2.1`)     | `MAJOR.MINOR.PATCH` | Bug fix or internal change with no API or behavioral effect on callers.                                              |
+| **Pre-1.0**   | "Major" (`0.14.x` → `0.15.0`) | `0.MINOR.PATCH`     | Breaking change — when `MAJOR == 0`, the `MINOR` slot is the breaking slot.                                          |
+|               | "Patch" (`0.14.5` → `0.14.6`) | `0.MINOR.PATCH`     | Anything non-breaking — both new features and bug fixes share this slot pre-1.0.                                     |
+
+Most CliMA packages are still pre-1.0, so for them a `0.X.0` bump signals a breaking change. A handful of packages use a two-component `0.X` form, in which case `X` is the breaking slot. Check the existing `version` line in the package's `Project.toml` before bumping to confirm which regime applies.
+
+### 2.3 What counts as "breaking"
+
+A change is breaking if it alters the **public surface** of the package:
+
+- Exported symbols (renames, removals, signature changes).
+- Documented function signatures and default values.
+- Documented config keys and CLI flags.
+- Diagnostic names and units.
+- Output recorded in reproducibility tests.
+
+A change is *not* breaking just because it shifts bit-level results — performance refactors, fused broadcasts, and reordered arithmetic are flagged with `🤖precisionΔ` in `NEWS.md` (see §1.4), not by bumping the breaking slot.
+
+Test for breaking-ness: *can a downstream package, pinned to the current compat, keep working without modification?* If the answer is no, bump the breaking slot.
+
+### 2.4 Merging a PR with breaking changes
+
+When merging a PR that contains breaking changes, ensure that the `NEWS.md` entry for the change is properly tagged with `![][badge-💥breaking]`. It is your responsibility to open PRs in downstream repositiories that will be affected when the breaking release is made. Ideally, the PRs in the downstream repositories should be opened before the breaking release is made. They can be tested with the new changes by `dev`ing the branch of the upstream package's repo.
+
+---
+
+## Part 3 — Cutting a release
+
+A "release" is the moment the version in `Project.toml` becomes immutable in the Julia General registry. The mechanics tie Parts 1 and 2 together.
+
+### 3.1 The release PR
+
+Cutting a release is a maintainer action and should land in **its own PR**, distinct from the changes it releases. The release PR contains exactly:
+
+1. The new version string in `Project.toml`.
+2. In `NEWS.md`: the `main` section header renamed to the new version (with `-------` underline), and a new empty `main` section opened above it.
+3. Any `[compat]` updates the release requires.
+
+That's it — no functional source changes belong in the release PR.
+
+### 3.2 Tagging mechanism
+
+CliMA packages register through the Julia General registry; GitHub tags are created automatically afterwards. The flow:
+
+1. Maintainer merges the release PR (Step 3.1).
+2. Maintainer comments `@JuliaRegistrator register` on the release commit on GitHub. This opens a PR in `JuliaRegistries/General` recording the new version.
+3. Once the registry PR auto-merges (typically within 15 minutes if compat checks pass), Julia's TagBot reacts by creating the GitHub tag `v<version>` and a GitHub Release pointing at the merge commit.
+
+The `.github/workflows/TagBot.yml` workflow that ships in every CliMA repo wires this last step — it triggers on the comment from `JuliaTagBot` and runs `JuliaRegistries/TagBot@v1`. Maintainers do not manually push tags; pushing a tag by hand bypasses the registry and breaks downstream resolvers.
+
+### 3.3 Agent autonomy
+
+Cutting a release is a maintainer action. Agents must not:
+
+- Bump `version` in `Project.toml`.
+- Rename `NEWS.md`'s `main` section to a version number.
+- Comment `@JuliaRegistrator register` or push tags.
+
+Agents *should* add `NEWS.md` entries under `main` for their own changes. See [agent_autonomy.md](../workflow/agent_autonomy.md).
+
+---
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/code-quality/code_style.md
+++ b/code-quality/code_style.md
@@ -1,0 +1,125 @@
+# Code Style Guide
+
+This guide covers formatting and naming conventions for CliMA repositories. For Git workflow and feature-removal protocol, see [onboarding.md §§5, 7](../workflow/onboarding.md).
+
+## 1. JuliaFormatter
+
+The root `.JuliaFormatter.toml` is the authoritative source of truth for code formatting. Run the formatter locally before committing:
+
+```bash
+julia -e 'using JuliaFormatter; format(".")'
+```
+
+or install JuliaFormatter as an app and use directly from the command-line:
+
+```julia-repl
+julia> import Pkg; Pkg.Apps.add("JuliaFormatter")
+```
+
+and add `~/.julia/bin/` to your PATH.
+
+Then you can run the formatter directly:
+
+```bash
+jlfmt -i .
+```
+
+### Version consistency
+
+Match the JuliaFormatter version used in CI to prevent unnecessary diff churn. Repos use the `julia-actions/julia-format` GitHub Action and pin a JuliaFormatter major version via the `version:` input:
+
+```yaml
+- uses: julia-actions/julia-format@v4
+  with:
+    version: '1'   # JuliaFormatter major version; check the repo's workflow file
+```
+
+Note: the JuliaFormatter major version is not uniform across CliMA repos — some pin `'1'`, others `'2'`, and some leave the default. Always cross-check `.github/workflows/JuliaFormatter.yml` (or `julia_formatter.yml`) in the repo you're working in before formatting. Run the formatter with `julia -e 'using JuliaFormatter; format(".")'` from the repo root.
+
+### Avoiding formatting noise
+
+Do not manually format code inconsistently with the formatter. If the formatter produces unwanted results, adjust `.JuliaFormatter.toml` rather than overriding manually.
+
+Be cautious with `git checkout -- .` to undo formatting changes — this also undoes any uncommitted functional changes. Prefer `git checkout -p` or `git add -i` for selective staging.
+
+## 2. Variable locality
+
+Constants specific to a physical algorithm should be defined as local variables inside the function, not as global module constants:
+
+```julia
+function compute_gradient(x, y)
+    # Algorithmic constant local to this function
+    ε = 1e-8
+    # ... logic ...
+end
+```
+
+This minimizes global namespace pollution and improves code clarity.
+
+## 3. File organization
+
+For large source files, use visual section headers to group related functionality:
+
+```julia
+# ============================================================================
+# Quadrature Evaluators
+# ============================================================================
+```
+
+The `test/` directory structure should mirror `src/`:
+
+- **Source**: `src/parameterized_tendencies/microphysics/tendency.jl`
+- **Test**: `test/parameterized_tendencies/microphysics/tendency.jl`
+
+## 4. Naming and syntax conventions
+
+### Capitalization
+
+- Modules, structs, and types use `TitleCase`.
+- Functions and variables use `snake_case` (lowercase, words separated by underscores).
+- Constants use `SCREAMING_SNAKE_CASE`.
+- Functions that mutate one of their arguments (conventionally the first) end in `!` — e.g. `update!`, `compute_tendency!`.
+
+### Function names
+
+- **Prefer full words over abbreviations.** `compute_strain_rate_full!` is better than `csrf!`. A few extra characters at the definition site are a vanishingly small cost compared to the cost of decoding an unfamiliar abbreviation every time a reader encounters it.
+- **Acceptable abbreviations** are universally-understood physics/math symbols (`Φ`, `ρ`, `χ`, `θ`) and well-established acronyms used widely in the relevant subfield (`EDMF`, `RRTMGP`, `SGS`, `PDF`, `LES`). When in doubt, spell it out.
+- **Lazy field prefixes (ClimaCore-based repos):** functions that return a lazy cell-center–valued field are prefixed with `ᶜ`; those that return a lazy cell-face–valued field are prefixed with `ᶠ`. Unprefixed functions are understood to be pointwise. For example, `ᶜρ` is a lazy field at cell centers; `ρ` (no prefix) is a pointwise scalar.
+
+### Type names
+
+- **Abstract types: use the bare concept name, not an `Abstract`-prefixed form.** Prefer `CloudModel`, `SpongeModel`, `JacobianAlgorithm` over `AbstractCloudModel`, `AbstractSpongeModel`, `AbstractJacobianAlgorithm`. The concept name reads more naturally in dispatch signatures (`f(x::CloudModel)`) and in documentation. Some legacy code uses `AbstractFoo`; keep it consistent within an existing module, but new hierarchies should drop the prefix.
+- **Common suffixes** signal what kind of type a struct is. Use them to make intent obvious at the call site:
+  - `…Model`: dispatch tag for a parameterization choice (e.g. `SmagorinskyLilly`, `EDMFModel`).
+  - `…Method` / `…Algorithm`: algorithmic choice (e.g. `JacobianAlgorithm`, `TracerNonnegativityMethod`).
+  - `…Parameters` or `…Params`: immutable bag of numerical parameters (e.g. `ThermodynamicsParameters`).
+  - `…Cache`: mutable workspace or precomputed state (e.g. `AtmosCache`).
+- **Avoid generic `…Type` or `…Helper` suffixes** — they don't tell the reader what kind of thing they are looking at.
+
+### Variables
+
+- Follow the conventions in the [Variable List](variable_list.md).
+- Avoid one-character names like `l` (lowercase el), `O` (uppercase oh), or `I` (uppercase eye) — they are visually ambiguous.
+- One-letter names from physics/math (`T`, `ρ`, `χ`, `Φ`) are fine when they match standard notation in the surrounding code.
+
+### Unicode
+
+- Limit use of Unicode. Avoid combining accents (dot, hat, vec) that create visually ambiguous characters.
+- Use only standard Greek letters (`α`, `β`, `Δ`, `χ`, `ρ`, …) and common math symbols (`∇`, `∂`, `∫`, `≤`).
+- Exception: the modifier-letter prefixes `ᶜ` and `ᶠ` are idiomatic in ClimaCore-based repos for lazy center/face field functions (see "Function names" above). They are visually distinct and unambiguous.
+
+### Line length
+
+The JuliaFormatter margin is the authoritative line-length limit. Most repos use `margin = 92`; check the repo's `.JuliaFormatter.toml`.
+
+### Imports
+
+Group `using`/`import` statements in the following order, separated by blank lines:
+
+1. Standard library imports.
+2. Related third-party imports.
+3. Local/application-specific imports.
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/code-quality/documentation_policy.md
+++ b/code-quality/documentation_policy.md
@@ -1,0 +1,342 @@
+# Software Documentation Policy
+
+Standards for repository-level documentation and docstrings across CliMA repositories.
+
+## 1. Goal
+
+CliMA is committed to producing high-quality, well-documented software so that knowledge is shared and not siloed. Documentation should explain the **design, purpose, and behavior** of code — not its mechanical implementation. Aim for "minimally viable documentation": enough for a technically capable reader who is not a subject-matter expert to understand and use the code.
+
+- **Do** document interfaces, expected behavior, and short examples.
+- **Do not** narrate what the code does line by line — the code itself should be self-explanatory.
+
+## 2. Repository documentation
+
+Every repository must include the following pages (typically under `docs/src/` or in `README.md`):
+
+1. **Home** — a brief description with links to important subcomponents.
+2. **Examples** — simple runnable examples covering the main uses.
+3. **API reference** — interface concepts, purpose, and function signatures.
+4. **Contribution guidelines** — how to contribute (PRs, style, CI).
+
+All repositories must also include a `LICENSE` file (Apache 2.0) and a `NOTICE` file in the repository root.
+
+### 2.1 Organizing documentation by user need
+
+The [Diátaxis](https://diataxis.fr/) framework distinguishes four documentation modes; each page should have a clear primary mode:
+
+- **Tutorials** — learning-oriented walkthroughs. State the goal up front, deliver visible results at every step, and minimize digressions. Test tutorials in CI (e.g. via Literate.jl) so they cannot silently break.
+- **How-to guides** — task-oriented directions for someone who already knows what they want. Title as verb phrases ("How to add a parameterization"), not nouns ("Parameterizations").
+- **Reference** — API docs, configuration options, data formats. Documenter's [`@autodocs`](https://documenter.juliadocs.org/stable/man/syntax/#@autodocs-block) blocks are convenient for fast-moving internal modules; prefer **manual `@docs` curation** for the public API so you control symbol ordering, separation of public from internal, and stable URL anchors.
+- **Explanation** — derivations, design rationale, trade-offs. This is the right place for mathematical formulations and theory.
+
+These modes are guides, not strict partitions: CliMA repos commonly interleave theory and worked examples (e.g. Thermodynamics.jl pairs a *Mathematical Formulation* page with a *How-To Guide*). What matters is that each page has one primary purpose and the reader can find what they need.
+
+### 2.2 Tools
+
+- [Documenter.jl](https://juliadocs.github.io/Documenter.jl/stable/) renders docstrings into documentation pages.
+- [Literate.jl](https://fredrikekre.github.io/Literate.jl/stable/) generates markdown and notebook-style examples from Julia scripts and runs them in CI.
+- Sources live in `docs/src/`; tutorials in `tutorials/` if present.
+- For local iteration, use `LiveServer.servedocs()` — see [onboarding.md §6](../workflow/onboarding.md).
+
+## 3. Docstrings
+
+Every docstring lives next to the code it describes and is the first thing a future reader (human or AI) sees. Docstrings should be useful, not decorative.
+
+This section follows [Julia's documentation conventions](https://docs.julialang.org/en/v1/manual/documentation/) and uses [Documenter.jl](https://documenter.juliadocs.org/) features for rendering.
+
+### 3.1 Calibrate depth to the function's role
+
+The more central or widely-called a function is, the more documentation it earns:
+
+| Role                                                                                                 | Minimum content                                                                                                                                                                                                            |
+|:-----------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **User-facing API** (exported, on `api.md`, constructed by users)                                    | Signature, summary, `# Arguments`, `# Returns` with units, at least one `# Examples` block, citations via `[Key](@cite)` where applicable, ``See also [`neighbour`](@ref)``.                                               |
+| **Hot-path internals** (tendency functions, cache builders, Jacobian routines, core physics helpers) | Treat as public API and add: algorithmic explanation, sign conventions, side effects spelled out (which `Y`/`Yₜ`/`p` fields are read or mutated), `See also` to major callers.                                             |
+| **Helpers with one or two call sites**                                                               | One-line summary plus a back-pointer to the caller (``Called from [`caller`](@ref)``). Skip `# Arguments` unless names/units are ambiguous.                                                                                |
+| **Trivial private helpers** (e.g. `_clamp_positive`)                                                 | Docstring optional; a short comment explaining *why* the helper exists is welcome.                                                                                                                                         |
+
+### 3.2 Anatomy of a docstring
+
+Every docstring shares the same skeleton: an indented signature, a blank line, a one-line summary in imperative mood, and optionally more detail.
+
+~~~julia
+"""
+    function_name(arg1, arg2; kwarg = default)
+
+One-line summary in imperative mood ("Compute X", "Return Y").
+
+Optional longer prose. Wrap at ~92 chars.
+"""
+function function_name(arg1, arg2; kwarg = default)
+    ...
+end
+~~~
+
+Universal rules:
+
+- **Signature line is indented 4 spaces** on the first line after `"""`. Julia's `?` and Documenter render this as the call signature; do not omit it.
+- **One-line summary** follows after a blank line, in imperative mood ("Compute…", not "Computes…").
+- **Backtick `code`** for variable names, type names, and option strings.
+- **Sentences end with periods**, including in bullet items.
+- **Be concise.** Names and formulas do the work — a docstring is not a tutorial.
+
+### 3.3 Section headings
+
+Use these headings, in this order, with a single `#`. Include only what you need.
+
+| Heading                | When to include                                                                                               |
+|:-----------------------|:--------------------------------------------------------------------------------------------------------------|
+| `# Arguments`          | Positional arguments. Skip if the signature is self-explanatory and there are ≤ 2 args.                       |
+| `# Keyword Arguments`  | Keyword arguments. Document defaults in the bullet, not just in the signature.                                |
+| `# Returns`            | When the return value is non-obvious or has structure (`NamedTuple`, multiple values, a `Field` with non-obvious units). |
+| `# Fields`             | For struct types — see §3.5.                                                                                  |
+| `# Constructor`        | When an abstract or parametric type has a meaningful outer constructor.                                       |
+| `# Examples`           | At least one short example for any user-facing function, type, or setup.                                      |
+| `# Notes`              | Caveats, performance notes.                                                                                   |
+| `# Extended help`      | Optional appendix shown only via `??function_name` — see §3.7.                                                |
+
+Use the plural form (`# Arguments`, `# Examples`) — Julia's official convention. Fix variants (`## Example`, `Arguments:`) when you encounter them.
+
+**Argument and field bullet format:**
+
+~~~text
+- `name`: One-line description. Units in square brackets at the end, e.g. [kg/m³].
+  Continuation lines indented two spaces under the bullet.
+~~~
+
+Each bullet starts with the backticked identifier. For complex options, list valid values as a nested bullet list.
+
+### 3.4 Units, math, references
+
+**Units.** Atmospheric and physics code is dimensional; units carry meaning. Use SI unless the underlying library exposes another unit (then match it and say so). Put units in square brackets at the end of the description: `[K]`, `[kg/m³]`, `[m/s²]`, `[W/m²]`, `[kg/kg]` for specific humidities. Dimensionless quantities: `[-]`. Be consistent within a docstring. Do **not** put `(...)` immediately after `[...]` — Documenter parses `[text](text)` as a markdown link and will error (see §4).
+
+**Math.** Documenter renders math with [KaTeX](https://katex.org/).
+
+- **Prefer Unicode for simple expressions** — α, β, ρ, ∂, ∇, ≤, ∈ all render inline and read more naturally than `\alpha`, `\beta`, etc., matching the variable names in the code.
+- **Use LaTeX for complex layout** — fractions, integrals with bounds, multi-line alignment.
+- **Inline:** double backticks, ``` ``α · β`` ```. **Display:** fenced ` ```math ` block.
+
+~~~markdown
+```math
+\frac{∂χ}{∂t} = -β\, ∇·(∇χ), \quad z > z_d
+```
+~~~
+
+If a docstring has many backslashes, use `raw"""..."""` so Julia does not interpret them as escapes.
+
+**Citations.** Cite via Documenter's bibliography integration. The bibliography lives at `docs/src/bibliography.bib`:
+
+~~~markdown
+Described in [Smith2020](@cite). The scheme of [Stevens2005](@cite) is extended by [Ackerman2009](@cite).
+~~~
+
+Add the BibTeX entry before citing — the docs build fails otherwise.
+
+**Cross-references.** Every function, type, or method name you mention should be linked, not just backticked. The `@ref` form costs one extra `(@ref)` and gives the reader a click-through:
+
+~~~markdown
+See also [`compute_strain_rate_face_full!`](@ref) for the face-centered version.
+~~~
+
+The target must be documented and registered on a docs page (or exported). For cross-repo references, use [DocumenterInterLinks.jl](https://juliadocs.org/DocumenterInterLinks.jl/stable/) and the `@extref` syntax:
+
+~~~markdown
+Wraps [`Thermodynamics.air_temperature`](@extref).
+~~~
+
+Without DocumenterInterLinks configured, fall back to fully qualified names in backticks so the reader at least sees the package qualifier — but prefer to set up DocumenterInterLinks.
+
+### 3.5 Structs
+
+Use a `# Fields` section to document fields:
+
+~~~julia
+"""
+    ViscousSponge{FT} <: SpongeModel
+
+Viscous sponge model; damps variables in proportion to the value of their Laplacian.
+
+# Fields
+- `zd`: Lower damping height [m].
+- `κ₂`: Damping coefficient [m²/s²].
+"""
+@kwdef struct ViscousSponge{FT} <: SpongeModel
+    zd::FT
+    κ₂::FT
+end
+~~~
+
+> **Why `# Fields` and not inline field docstrings?** Julia supports docstrings attached directly to struct fields, but Documenter does not render them in built documentation pages unless you also use `DocStringExtensions.@TYPEDFIELDS`. A `# Fields` section is a single source of truth for both REPL help and built docs.
+
+A `# Fields` section is **required** when the struct is part of the public API, has more than a few fields, or any field's meaning/units/invariants are not obvious. Optional for marker structs and tiny internal helpers.
+
+If a struct is parameterized, explain the type parameters in prose or a nested list, and include them in the signature line:
+
+~~~julia
+"""
+    SmagorinskyLilly{AXES}
+
+Smagorinsky-Lilly eddy viscosity model.
+
+`AXES` is a symbol indicating the axes the model is applied along:
+- `:UVW` — all axes,
+- `:UV`  — horizontal axes only,
+- `:W`   — vertical axis only,
+- `:UV_W` — horizontal and vertical treated separately.
+"""
+struct SmagorinskyLilly{AXES} <: EddyViscosityModel end
+~~~
+
+For **callable structs** (functors), document the type and its call method separately: the type docstring describes what it represents and its fields; the call-method docstring describes the behavior of invoking it. See [SDP 18](software_design_patterns.md) for the functor pattern itself.
+
+### 3.6 Abstract types
+
+Abstract types are the entry point for understanding a hierarchy. The docstring should:
+
+1. State the role in one sentence.
+2. Enumerate concrete subtypes with a one-line description of each.
+3. Document the outer constructor if there is one.
+4. Note any interface methods subtypes must implement.
+
+~~~julia
+"""
+    CloudModel
+
+Strategy for computing the cloud fraction.
+
+Subtypes:
+- [`GridScaleCloud`](@ref): cloud fraction based on grid-mean conditions.
+- [`QuadratureCloud`](@ref): cloud fraction from an SGS-quadrature integral.
+- [`SGSML`](@ref): ML-based diagnostic cloud fraction.
+"""
+abstract type CloudModel end
+~~~
+
+### 3.7 Mutating functions, multiple methods, structured returns
+
+A few patterns recur often enough to call out:
+
+- **In-place / cache-mutating functions** (`f!(Yₜ, Y, p, t, ...)`): state explicitly that the function mutates its first argument; state the return value (`nothing` by convention); for each model-selector argument list the concrete subtypes it dispatches on; mention which precomputed quantities it reads from the cache.
+- **Multiple methods sharing a docstring**: list each signature on its own indented line, then write one body that covers them all.
+- **Structured returns** (`NamedTuple`, composite): use a `-> ReturnType` annotation in the signature line and sketch the shape under `# Returns`.
+
+See the cheat sheet (§3.10) for the full skeleton.
+
+### 3.8 Examples and admonitions
+
+**Examples** — at least one for any user-facing API; optional for internal helpers. Use a plain fenced ` ```julia ` block; examples should be runnable in a fresh REPL after `using YourPackage` (spell out non-trivial setup). One short example is better than three sprawling ones.
+
+**Admonitions** ([Documenter syntax](https://documenter.juliadocs.org/stable/showcase/#Admonitions)) — use sparingly for genuinely important caveats. Kinds: `note`, `warning`, `tip`, `info`, `compat`, `danger`.
+
+~~~markdown
+!!! warning
+    Calling this function outside `set_precomputed_quantities!` reads stale `p.scratch`
+    values. Run after `set_implicit_precomputed_quantities_part1!`.
+~~~
+
+Keep to 1–3 sentences. If you find yourself writing more than two admonitions in one docstring, the docstring is doing too much — split it or move content into `docs/src/`.
+
+### 3.9 `# Extended help`
+
+Documenter and the Julia REPL recognize `# Extended help` as a special trailing section: `?function_name` shows everything before it; `??function_name` shows the full docstring. Use it for long boundary cases, implementation notes for maintainers, or detailed cross-cutting `See also` lists. It must appear last. Long derivations belong on a *Mathematical Formulation* page in `docs/src/`, not in extended help.
+
+### 3.10 Cheat sheet
+
+For functions:
+
+~~~julia
+"""
+    function_name(positional1, positional2; kwarg1 = default1)
+
+One-line imperative summary.
+
+Optional 1–3 paragraph elaboration. Math:
+
+```math
+y = f(x)
+```
+
+# Arguments
+- `positional1`: description [units].
+- `positional2`: description [units].
+
+# Keyword Arguments
+- `kwarg1 = default1`: description [units].
+
+# Returns
+Description of return value, with units / structure if non-obvious.
+
+# Examples
+```julia
+result = function_name(a, b; kwarg1 = c)
+```
+
+See also [`related_function`](@ref). Described in [Smith2020](@cite).
+"""
+function function_name(positional1, positional2; kwarg1 = default1)
+    ...
+end
+~~~
+
+For structs:
+
+~~~julia
+"""
+    MyStruct{T}
+
+One-line summary. Longer description, including what `T` parameterizes.
+
+# Fields
+- `field`: description [units].
+
+# Examples
+```julia
+s = MyStruct{Float64}(; field = 1.0)
+```
+"""
+@kwdef struct MyStruct{T}
+    field::T
+end
+~~~
+
+For abstract types:
+
+~~~julia
+"""
+    Foo
+
+Strategy for doing foo.
+
+Subtypes:
+- [`ConcreteFooA`](@ref): one-line description.
+- [`ConcreteFooB`](@ref): one-line description.
+"""
+abstract type Foo end
+~~~
+
+### 3.11 What we don't use, and other anti-patterns
+
+- **`DocStringExtensions`** (`$(TYPEDEF)`, `$(FIELDS)`, `$(SIGNATURES)`, …). Spell out signatures, field lists, and types by hand. Readability in source matters more than DRY.
+- **`jldoctest`** blocks. Most CliMA repos don't run doctests in CI, so jldoctests silently rot. Use plain ` ```julia ` blocks.
+- **Long mathematical derivations inline.** The docstring should give the reader enough to use the function; derivations belong on an *Explanation* page or in the source paper. Link to it.
+- **Generated docstrings via metaprogramming** (macros that splice docstrings into `@eval`'d definitions) unless unavoidable — hard to grep, hard to read, easy to break.
+- **Missing signature line** (`"""Compute X..."""` with no indented signature) — breaks REPL help and Documenter rendering.
+- **Restating the obvious** (`"""Return the input."""` for `identity`) — noise.
+- **Documenting *how* instead of *why*** — the implementation is right below; callers want what to pass in, what they get back, what assumptions apply.
+- **Out-of-date signatures.** When renaming an argument, update both the signature line and the `# Arguments` bullets. CI does not catch divergence.
+- **Inconsistent units** within one docstring — worse than no docstring.
+- **`Arguments:`, `Inputs:`, `Returns:` as plain prose lines** — these are invisible structure; Documenter renders only the `# Heading` form.
+- **Mixing imperative and third person** within one docstring — pick one.
+- **Multi-paragraph docstrings on internal helpers.** If you are writing more than ~15 lines for a helper called from one place, the prose belongs in a block comment near the call site or on a docs page.
+
+## 4. Documenter.jl pitfalls
+
+**Markdown link ambiguity.** `[kg/m^3](description)` is parsed as a markdown link and produces `:cross_references` errors if the parenthetical text is not a URL. Fix: use parentheses for units (`(kg/m^3)`), or separate brackets and parentheses with punctuation. Do not attempt to escape brackets with backslashes in Julia string literals — that causes invalid-escape-sequence errors during precompilation.
+
+**Missing docstrings.** If `makedocs` fails with "Missing docstrings", ensure every exported symbol with a docstring is included on a documentation page via `@docs` or `@autodocs`.
+
+**Undefined cross-package symbols.** Use fully qualified names (`Thermodynamics.ThermodynamicsParameters`) so Documenter's link generator can resolve them across package boundaries. For cross-repo `@ref`-style links, configure DocumenterInterLinks (§3.4).
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/code-quality/software_design_patterns.md
+++ b/code-quality/software_design_patterns.md
@@ -1,0 +1,340 @@
+# Software Design Patterns (SDPs)
+
+This file is an agent-facing checklist for writing robust, maintainable, and GPU-compatible Julia code.
+
+Unless explicitly instructed otherwise, treat all rules below as defaults.
+
+## How to use this file
+
+- Apply these patterns in new code.
+- Prefer refactoring toward these patterns when touching existing code.
+- If a rule must be broken, keep the exception narrow and document why.
+
+## 1. Use structs over strings in tendency functions
+
+Avoid string-based model dispatch in hot paths.
+
+Bad:
+
+```julia
+struct Foo{T}
+    model::T
+end
+function baz(f)
+    if f.model == "ModelA"
+        # do something ModelA-specific
+    elseif f.model == "ModelB"
+        # do something ModelB-specific
+    end
+end
+f = Foo("ModelA")
+baz(f)
+```
+
+Preferred:
+
+```julia
+struct ModelA end
+struct ModelB end
+struct Foo{T <: Union{ModelA, ModelB}}
+    model::T
+end
+function baz(f)
+    if f.model isa ModelA
+        # do something ModelA-specific
+    elseif f.model isa ModelB
+        # do something ModelB-specific
+    end
+end
+f = Foo(ModelA())
+baz(f)
+```
+
+Exception:
+
+- Strings are acceptable at initialization boundaries (for example, parsing user/config input), but convert to typed structs as early as possible.
+
+## 2. Avoid `using` / `import` between submodules of the same package
+
+Inside `src/`, do not introduce new `using` or `import` statements that pull names from a *sibling* or *parent* submodule of the same package. This rule does not restrict `using`/`import` of external packages — those are normal Julia idioms.
+
+Bad:
+
+```julia
+module Foo
+
+baz() = 1
+
+module Bar
+  using Foo: baz   # same-package cross-submodule import
+  bing() = baz()
+end
+
+end
+```
+
+Prefer explicit qualification (`Foo.baz()` at the call site) or follow whatever module-wiring convention the package already uses. The goal is to keep include/initialization order auditable and prevent accidental cycles between submodules.
+
+## 3. Do not use `Symbol`s in broadcasted expressions
+
+Avoid symbol-based broadcast patterns. Use concrete, type-stable values/structures instead.
+
+## 4. Do not use abstract types in struct fields
+
+Struct fields should be concrete/parametric for type stability and performance.
+
+## 5. Avoid broadcast from within kernels
+
+GPU compilers can fail to infer through broadcast inside kernels. Prefer explicit, inference-friendly kernel code. See [gpu_performance.md](../performance/gpu_performance.md) for the canonical definition of "kernel" and "hot path".
+
+## 6. Do not use `Function` as a struct field type
+
+Bad:
+
+```julia
+struct A
+    f::Function
+end
+```
+
+Preferred:
+
+```julia
+struct A{F <: Function}
+    f::F
+end
+```
+
+## 7. Define `isbits` structs when possible
+
+Anything passed into a GPU kernel must be `isbits` *after device adaptation*, not necessarily on the host. ClimaCore objects (e.g. `Field`, `Space`) are deliberately not `isbits` on the host and become `isbits` only after `Adapt.adapt(CUDA.KernelAdaptor(), x)` (i.e. `CUDA.cudaconvert(x)`).
+
+For a new struct that does not wrap device-resident arrays, the host-side check suffices:
+
+```julia
+isbits(A(...))
+```
+
+For a struct that *does* wrap a `Field`, `CuArray`, or similar, the meaningful check is the post-adapt one (see [gpu_performance.md §8](../performance/gpu_performance.md)):
+
+```julia
+isbits(CUDA.cudaconvert(A(...)))
+```
+
+In the wrapping case, also define `Adapt.adapt_structure` so the post-adapt object actually becomes `isbits`.
+
+## 8. Prefer immutable structs
+
+Prefer immutable structs for types that are passed into GPU kernels or broadcast expressions. `mutable struct` is acceptable for infrastructure types that are never passed into kernels — for example, grid objects (`ClimaCore.Grids`), topologies, and time-stepping integrators (`ClimaTimeSteppers.TimeStepperIntegrator`).
+
+## 9. Prefer `SVector` or `Tuple` over `Vector` / `Array`
+
+For fixed-size data, use stack-friendly/static representations.
+
+## 10. Reduce allocations
+
+- Avoid explicit allocators like `collect` and `reshape` in performance-sensitive paths.
+- Prefer allocation-light transforms (for example, `map`) instead of manual accumulate patterns that create temporary arrays.
+
+## 11. Do not use `@assert` within kernels
+
+Use `error("static message")` instead. Do not capture runtime variables in the error string within a kernel — string interpolation allocates and, on GPU, typically fails to compile because the device runtime lacks the full `print_to_string` machinery.
+
+Bad:
+
+```julia
+@assert x > 0 "x must be positive, got $x"   # @assert may be removed; interpolation allocates
+```
+
+Preferred:
+
+```julia
+x > 0 || error("x must be positive")   # static message, no interpolation
+```
+
+## 12. Do not use `@views`
+
+Follow project conventions that avoid `@views`.
+
+## 13. Do not use `Dict` in kernels
+
+`Dict` is not allowed in CPU/GPU kernels. Replace with custom structs or `NamedTuple`s.
+
+## 14. Duck-type physics functions; avoid explicit `where {FT}` on non-constructors
+
+This rule is strongest for model-side, tendency, and AD-traversed code: prefer `function f(x, y)` over `function f(x::FT, y::FT) where {FT}`. The `where {FT}` form binds every annotated argument to the *same* concrete element type, which rejects mixed-AD calls (e.g. `f(Dual(1.0), 2.0)`) and rejects `ClimaCore.Field`s whose `eltype`s differ from each other or from a `Float`. Duck typing lets each argument carry its own type and lets AD flow through naturally.
+
+Exceptions:
+
+- **Struct constructors** that statically allocate `SVector`/`SMatrix` need `::Type{FT}` to determine the element type at compile time.
+- **Library internals where homogeneous numeric types are intentional** (for example, CloudMicrophysics.jl, Thermodynamics.jl) may use `where {FT}` broadly. Defer to the package's existing style.
+
+Bad:
+
+```julia
+# Rejects f(Dual(1.0), 2.0) and any caller with mismatched eltypes
+@inline function compute(x::FT, y::FT) where {FT}
+    return x^2 + y
+end
+```
+
+Preferred:
+
+```julia
+# AD-compatible — types inferred from inputs
+@inline function compute(x, y)
+    return x^2 + y
+end
+```
+
+## 15. Infer floating-point type from values, not from `where` clauses
+
+Prefer `FT = eltype(params)`, `FT = typeof(x)`, or `FT = eltype(x)` inside function bodies. Avoid repeating `{FT}` in `where` clauses for functions that already receive typed inputs.
+
+Bad:
+
+```julia
+function f(x::AbstractArray{FT}) where {FT}
+    ε = FT(1e-10)
+    # ...
+end
+```
+
+Preferred:
+
+```julia
+function f(x)
+    FT = eltype(x)
+    ε = FT(1e-10)
+    # ...
+end
+```
+
+## 16. Use `zero(x)` / `one(x)` over `FT(0)` / `FT(1)` for accumulators
+
+Type-agnostic idioms propagate numeric type (including Dual numbers) without an explicit conversion. Use `FT(constant)` only for named constants that must be a specific type.
+
+Bad:
+
+```julia
+acc = FT(0)
+```
+
+Preferred:
+
+```julia
+acc = zero(x)
+```
+
+## 17. Replace data-dependent `if/else` with `ifelse` inside GPU kernels
+
+A data-dependent `if/else` in a GPU kernel causes warp divergence; `ifelse(cond, a, b)` computes branchlessly. Both arguments are always evaluated, so guard mathematically invalid operations (`log`, `sqrt`, division) *before* the `ifelse`, not inside a `begin...end` block inside it.
+
+For the full explanation — SIMT semantics, why `ifelse` does not skip work, and the worked `log(x)` example — see [GPU Performance Guide §1](../performance/gpu_performance.md). For choosing the right floor in the pre-guard, see [Numerical Robustness §1–2](../performance/numerical_robustness.md).
+
+## 18. Prefer functors over closures in broadcast or high-loop contexts
+
+Closures that capture multiple local variables produce heap allocations and may fail to compile on GPU (`InvalidIRError: unsupported dynamic function invocation`). Encapsulate context in a concrete callable struct (functor) instead.
+
+Bad:
+
+```julia
+f = (x) -> physics_kernel(params, state, x)
+result = integrate(f, data)
+```
+
+Preferred:
+
+```julia
+struct PhysicsEval{P, S}
+    params::P
+    state::S
+end
+(e::PhysicsEval)(x) = physics_kernel(e.params, e.state, x)
+
+result = integrate(PhysicsEval(params, state), data)
+```
+
+Validation: `@allocated integrate(PhysicsEval(params, state), data)` should be 0 after a warm-up call.
+
+## 19. Prefer fixed iteration counts in iterative solvers inside GPU kernels
+
+Convergence-based loops (`while err > tol`) cause thread divergence when different threads converge at different rates. Where the physics allows it, prefer a fixed number of iterations so all threads in a warp follow the same execution path.
+
+This is a performance guideline, not a strict rule. Use judgement: fixed iterations are appropriate when a small count (for example, 2–5 Newton steps) is known to be sufficient for the physical accuracy required.
+
+## 20. Extract parameters and non-field scalars before `@.` blocks
+
+Capturing complex parameter structs or thermodynamic parameter containers directly inside a `@.` broadcast expression forces the broadcast engine to determine their broadcast shape at runtime. Extracting them to named local variables before the broadcast (a) makes the broadcast shape unambiguous to the compiler, (b) prevents potential shape-mismatch errors in ClimaCore's field-space broadcast engine, and (c) keeps the broadcast expression readable.
+
+Bad:
+
+```julia
+@. result = my_physics(p.params.thermodynamics_params, Y.c.T, Y.c.ρ)
+```
+
+Preferred:
+
+```julia
+thp = p.params.thermodynamics_params
+@. result = my_physics(thp, Y.c.T, Y.c.ρ)
+```
+
+Note: `Ref()` is not the standard broadcast-escape pattern in this codebase. Its current use is limited to mutable scalar boxes in callbacks and non-broadcast contexts. Prefer parameter extraction.
+
+## 21. No keyword arguments inside GPU kernels
+
+Keyword arguments introduce a sorter trampoline that can prevent inlining and trigger dynamic dispatch on GPU compilers. Use positional arguments; pass parameter containers instead of individual named constants.
+
+Bad:
+
+```julia
+@inline function transform(T, θ; L_v = 2.5e6, c_p = 1004)
+    # ...
+end
+```
+
+Preferred:
+
+```julia
+@inline function transform(params, T, θ)
+    L_v = get_latent_heat(params)
+    c_p = get_cp(params)
+    # ...
+end
+```
+
+## 22. Use SafeTestsets.jl to avoid leaky unit tests
+
+Prefer `@safetestset` over `@testset` + nested `include` so variables and imports do not leak between test files. See [testing_and_validation.md](../infrastructure/testing_and_validation.md) for the pattern and per-repo conventions.
+
+## 23. Do not use list comprehensions
+
+Avoid list comprehensions like `[getproperty(dist, p) for p in params]` in hot paths or GPU code, as they explicitly allocate `Array`s on the heap.
+
+Use `map` over a `Tuple` or `SVector`, which returns a `Tuple` or `SVector` respectively without heap allocation. The rule is about the *input type*: `map` over a `Vector` / `Array` still allocates a new `Array`.
+
+```julia
+# Bad: allocates a Vector
+x = [f(p) for p in params]   # params is a Vector
+
+# Preferred: input is a Tuple → map returns a Tuple, no allocation
+x = map(f, (a, b, c))
+
+# Preferred: input is an SVector → map returns an SVector
+x = map(f, SVector(a, b, c))
+```
+
+## 24. Limit use of @generated functions
+
+Generated functions are extremely versatile and helpful for debugging, but they have significantly higher compilation latencies than non-generated functions.
+
+To minimize compilation time, only use generated functions when absolutely necessary. This includes the following situations:
+
+- Guaranteeing inlining or unrolling of code, to avoid compilation errors when the compiler fails to perform these optimizations.
+- Dynamically constructing a `String` inside a GPU kernel, which requires runtime allocations.
+- Dynamically constructing a `Symbol` inside a GPU kernel, since `Symbol`s are implemented as interned strings.
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/code-quality/variable_list.md
+++ b/code-quality/variable_list.md
@@ -1,0 +1,108 @@
+# CliMA Variable List
+
+This document unifies the naming conventions used across the CliMA codebase. It defines 'reserved' variable names in `<property>_<species>` format with the default working fluid (no-subscript) being moist air.
+
+## Type parameters
+
+The Julia code typically uses `T` as a type parameter, however this conflicts with the typical usage for temperature. Instead, good choices are:
+
+- `FT` for floating point values
+
+## Names reserved for debug variables
+
+- `dummy`
+- `scratch`
+
+## Working Fluid and Equation of State
+
+- `q_dry` = dry air mass fraction
+- `q_vap` = specific humidity, vapor
+- `q_liq` = specific humidity, liquid
+- `q_ice` = specific humidity, ice
+- `q_tot` = specific humidity, total
+
+- `ρ` = density (no subscript = moist air)
+- `R_m` = gas constant, moist
+- `R_d` = gas constant, dry
+- `R_v` = gas constant, water vapor
+- `T` = temperature, moist air
+
+## Time
+
+- `dt` = time increment
+
+## Momentum
+
+- `u` = x-velocity
+- `v` = y-velocity
+- `w` = z-velocity
+
+## Energy balance
+
+Lowercase `e_<type>` indicates a *specific* (per-unit-mass) quantity. The corresponding density-weighted volumetric forms used as prognostic variables are `ρe_<type>` (see "Prognostic variable conventions" below).
+
+- `e_kin_<spe>` = specific energy per unit mass, kinetic
+- `e_pot_<spe>` = specific energy per unit mass, potential
+- `e_int_<spe>` = specific energy per unit mass, internal
+- `e_tot_<spe>` = specific energy per unit mass, total
+
+- `cv_m`, `cv_d`, `cv_l`, `cv_v`, `cv_i` = isochoric specific heat capacities [J/(kg·K)] (moist, dry, liquid, vapor, ice)
+- `cp_m`, `cp_d`, `cp_l`, `cp_v`, `cp_i` = isobaric specific heat capacities [J/(kg·K)] (moist, dry, liquid, vapor, ice)
+
+## Microphysics
+
+Specific humidities of precipitation and cloud-condensate species:
+
+- `q_rai` = specific humidity, rain [kg/kg]
+- `q_sno` = specific humidity, snow [kg/kg]
+- `q_lcl` = specific humidity, cloud liquid [kg/kg]
+- `q_icl` = specific humidity, cloud ice [kg/kg]
+
+By convention, when all partitions of the phase of water are included, we use
+- `q_liq` = specific humidity, all liquid 
+- `q_ice` = specific humidity, all ice
+
+Terminal velocities are per-species:
+
+- `terminal_velocity_<spe>` = mass-weighted terminal fall speed of `<spe>` [m/s] — e.g. `terminal_velocity_rai`, `terminal_velocity_sno`
+
+Microphysical tendencies [kg/kg/s]. Sign convention: positive means a *source* for the species in the *to*-position of the name.
+
+- `conv_q_lcl_to_q_rai` = autoconversion: cloud liquid → rain
+- `conv_q_icl_to_q_sno` = ice autoconversion: cloud ice → snow
+- `conv_q_vap_to_q_lcl_icl` = condensation / deposition: vapor → cloud condensate (signed; negative values represent evaporation / sublimation back to vapor)
+- `evaporation_sublimation` = rain evaporation / snow sublimation; positive = vapor source
+- `accretion` = collection of cloud condensate by precipitation; positive = precipitation source
+
+## Thermodynamic state and pressure
+
+- `p` = pressure (no subscript = total pressure of moist air) [Pa]
+- `θ` = potential temperature [K]
+- `θ_liq_ice` = liquid–ice potential temperature [K]
+- `Φ` = geopotential [m²/s²]
+- `grav` = gravitational acceleration [m/s²]
+- `L_v` = latent heat of vaporization [J/kg]
+- `L_s` = latent heat of sublimation [J/kg]
+- `L_f` = latent heat of fusion [J/kg]
+
+Note: in CliMA tendency-style signatures `f!(Yₜ, Y, p, t, …)`, the local name `p` refers to the cache, not pressure.
+
+## Prognostic variable conventions
+
+CliMA models typically integrate density-weighted forms as prognostic variables and diagnose specific quantities from them inside tendencies:
+
+- `ρq_<spe>` = density × specific humidity of species `<spe>` (e.g. `ρq_tot`, `ρq_liq`, `ρq_rai`) [kg/m³]
+- `ρe_tot` = density × total specific energy [J/m³]
+
+## Field Prefixes (ClimaCore-based repos)
+
+In repos that use ClimaCore for spatial discretization, functions that *return fields* are prefixed by their staggered-grid location:
+
+- `ᶜ<name>` (typed `\^c<TAB>`) = field at cell *centers*
+- `ᶠ<name>` (typed `\^f<TAB>`) = field at cell *faces*
+
+For example, `ᶜρ(Y, p)` is a cell-center density field. The prefix lives on the *function*, not on the stored field: state-vector fields like `Y.c.ρ` are themselves cell-centered but do not carry the prefix.
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/infrastructure/clima_comms.md
+++ b/infrastructure/clima_comms.md
@@ -1,0 +1,122 @@
+# Device-Agnostic and Distributed Code (ClimaComms)
+
+This guide covers patterns for writing code that runs on CPU and GPU, and on single-process and MPI-distributed configurations. All CliMA model packages use `ClimaComms.jl` to abstract over device and parallelism.
+
+## 1. Acquiring the device and context
+
+Most patterns in this guide use a `device` and a `context` that must be in scope. They are obtained via `ClimaComms`:
+
+```julia
+import ClimaComms
+
+device  = ClimaComms.device()          # CPU or CUDA, inferred from the environment
+context = ClimaComms.context(device)   # SingletonCommsContext, or MPICommsContext if an MPI backend is loaded
+ClimaComms.init(context)               # required before any collective; no-op for singleton contexts
+```
+
+ClimaComms's MPI backend loads as a package extension triggered by `using MPI`; single-process runs do not require it. Pick up `device` and `context` once at the top of your entry point and propagate them — do not recreate them inside library functions.
+
+## 2. Device-agnostic code
+
+### Get the array type from the context, not from `Array(...)` or `CUDA.CuArray`
+
+Direct references to a concrete array type tie code to a single backend.
+
+```julia
+# ❌ Hard-codes CPU
+buffer = Array{FT}(undef, n)
+
+# ❌ Hard-codes CUDA
+using CUDA
+buffer = CUDA.CuArray{FT}(undef, n)
+
+# ✅ Device-agnostic
+ArrayType = ClimaComms.array_type(device)
+buffer = ArrayType{FT}(undef, n)
+```
+
+### Move data to host only behind a clear guard
+
+Do not silently call `Array(field)` on a GPU field to peek at values; this triggers a host transfer that is invisible to readers and breaks performance. Use it only inside diagnostics or test code where the cost is acceptable, and document why. The same applies to scalar indexing (`field[i]`), which requires `CUDA.@allowscalar` on a GPU array — wrap the call so the cost is visible.
+
+### `CUDA.allowscalar(false)` in tests
+
+GPU tests should disable scalar indexing so accidental `field[i]` accesses surface immediately rather than running 1000× slower:
+
+```julia
+import CUDA
+CUDA.allowscalar(false)
+```
+
+This is the standard pattern in `test/runtests_gpu.jl` across CliMA packages. See [testing_and_validation.md](testing_and_validation.md).
+
+## 3. MPI / distributed code
+
+In a single-process (non-MPI) context, `ClimaComms.iamroot(context)` returns `true` and the collective operations (`barrier`, `allreduce`, `bcast`) are no-ops. The patterns below are therefore safe to write unconditionally — the rank-aware guards only matter when MPI is active.
+
+### Root-only IO
+
+Files, prints, logs, and progress reporting must be guarded with a root-rank check; otherwise every rank writes the same file or line and you get garbled output, file corruption, or test flakiness.
+
+```julia
+# ❌ Every rank prints
+@info "Iteration $i complete"
+
+# ✅ Root only
+ClimaComms.iamroot(context) && @info "Iteration $i complete"
+```
+
+The same rule applies to opening output files, writing checkpoints, and updating progress bars.
+
+### Collective operations are collective
+
+Functions like `ClimaComms.barrier`, `ClimaComms.allreduce`, and `ClimaComms.bcast` must be called by **every** rank or the program deadlocks. Do not place them inside an `iamroot` branch, and do not place them inside a conditional that may be true on some ranks and false on others.
+
+```julia
+# ❌ Deadlock: only root reaches the barrier
+if ClimaComms.iamroot(context)
+    ClimaComms.barrier(context)
+end
+
+# ✅ All ranks call the barrier
+ClimaComms.barrier(context)
+```
+
+### Determinism across rank counts
+
+Tests that depend on global reductions can be sensitive to floating-point reordering across rank counts. When asserting reproducibility under MPI, prefer integer counts, exact equality on small arrays, or tolerances that exceed `eps(FT) * N` for sums of length `N`.
+
+## 4. Selecting CPU vs GPU at run time
+
+The standard pattern across CliMA test entry points:
+
+```julia
+arg = get(ARGS, 1, "")
+if arg == "Array"
+    ArrayType = Array
+elseif arg == "CuArray"
+    import CUDA
+    ArrayType = CUDA.CuArray
+    CUDA.allowscalar(false)
+else
+    try
+        import CUDA
+        ArrayType = CUDA.functional() ? CUDA.CuArray : Array
+    catch
+        ArrayType = Array
+    end
+end
+```
+
+Use this pattern when adding a new GPU test entry point so all packages stay consistent.
+
+## 5. Common pitfalls
+
+- **Implicit host transfer**: `sum(field)` on a GPU field is fine; `field[1]` is not. The first goes through a GPU reduction; the second triggers `allowscalar` and either errors (recommended) or silently transfers.
+- **Random number streams under MPI**: `rand()` is not synchronized across ranks. For an independent per-rank stream, seed an explicit RNG with a rank-dependent seed (`rng = Random.Xoshiro(base_seed + ClimaComms.mypid(context))`); for cross-rank-synchronized randomness, generate on root and broadcast (`ClimaComms.bcast`).
+- **`println` inside kernels**: not GPU-compatible and not MPI-safe. See [gpu_performance.md](../performance/gpu_performance.md) §7 for the static-error rule.
+- **Saving to a shared filesystem from every rank**: causes file lock contention. Use root-only IO or rank-suffixed filenames.
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/infrastructure/testing_and_validation.md
+++ b/infrastructure/testing_and_validation.md
@@ -1,0 +1,212 @@
+# Testing and Validation Guide
+
+This guide covers testing patterns for CliMA code: type-stability verification, allocation regression testing, and test group organization.
+
+## Type-stability checks
+
+The canonical home for type-stability tooling (`@inferred`, `JET.@report_opt`, `@code_warntype`, the Float32/Float64 test template) is [type_stability.md](../performance/type_stability.md). Use `@inferred` as a CI regression gate for any new physics function:
+
+```julia
+@test @inferred(my_physics_func(FT(1.0), FT(2.0))) isa FT
+```
+
+## Allocation regression tests
+
+After implementing or modifying hot-path code, verify zero allocations with the warm-up + `@allocated == 0` regression pattern documented in [allocation_debugging.md §1](../performance/allocation_debugging.md). Allocation benchmarks in `perf/` are not run in CI; allocation regressions must be caught at review time.
+
+## Aqua.jl quality checks
+
+All CliMA packages run `Aqua.jl` tests in CI. These checks catch common package quality issues:
+
+- `test_stale_deps`: fails if a package in `[deps]` is not used in source code. This is the most common failure — usually caused by adding a dev tool to `[deps]` instead of `[extras]` (see [Dependency Management](../architecture/dependency_management.md)).
+- `test_deps_compat`: fails if `[compat]` entries are missing for dependencies.
+- `test_undefined_exports`: fails if an exported symbol is not defined.
+- `test_unbound_args`: detects methods with unbound type parameters (can cause ambiguities).
+- `test_ambiguities`: detects method ambiguities that could cause dispatch errors.
+- `test_piracies`: detects type piracy (defining methods on types you don't own).
+
+Standard pattern across CliMA repos:
+
+```julia
+# test/aqua.jl
+using Aqua
+using MyPackage
+
+@testset "Aqua tests (performance)" begin
+    ua = Aqua.detect_unbound_args_recursively(MyPackage)
+    @test isempty(ua)
+
+    ambs = Aqua.detect_ambiguities(MyPackage; recursive = true)
+    # Filter to ambiguities involving our package only
+    pkg_match(pkgname, pkdir::Nothing) = false
+    pkg_match(pkgname, pkdir::AbstractString) = occursin(pkgname, pkdir)
+    filter!(x -> pkg_match("MyPackage", pkgdir(last(x).module)), ambs)
+    @test isempty(ambs)
+end
+
+@testset "Aqua tests (additional)" begin
+    Aqua.test_all(MyPackage; ambiguities = false, unbound_args = false)
+end
+```
+
+Note: `test_ambiguities` is separated from `test_all` because most repos filter ambiguities to their own module, excluding upstream dependency ambiguities that are not their responsibility.
+
+## AD compatibility tests
+
+Many CliMA packages include dedicated AD test files (for example, `test/ad_tests.jl` or `test/test_ad_compatibility.jl`). The standard pattern validates ForwardDiff gradients against finite differences:
+
+```julia
+using ForwardDiff
+
+function check_derivative(f, x; rtol = 5e-2, atol = 1e-8)
+    ad = ForwardDiff.derivative(f, x)
+    ε = sqrt(eps(typeof(x)))
+    fd = (f(x + ε) - f(x - ε)) / (2ε)
+    @test isapprox(ad, fd; rtol, atol)
+end
+```
+
+When adding new physics functions, add corresponding AD tests. See [AD Compatibility](../performance/ad_compatibility.md).
+
+## GPU test files
+
+Some CliMA packages maintain a separate `test/runtests_gpu.jl` entry point for GPU-specific tests (Thermodynamics.jl, SurfaceFluxes.jl); others dispatch within `runtests.jl` using `ARGS` or via Buildkite CI jobs (ClimaAtmos, ClimaCore, ClimaTimeSteppers). For the standard `ArrayType` selection pattern and `CUDA.allowscalar(false)` setup, see [clima_comms.md §4](clima_comms.md).
+
+## Test isolation: SafeTestsets
+
+Prefer `@safetestset` over `@testset` + nested `include` so variables and imports do not leak between test files:
+
+```julia
+using SafeTestsets
+
+@safetestset "Test module A" begin
+    @time include("test_module_A.jl")
+end
+@safetestset "Test module B" begin
+    @time include("test_module_B.jl")
+end
+```
+
+Model repos with many independent test files (ClimaAtmos, ClimaLand, ClimaCoupler, ClimaTimeSteppers) use `@safetestset`. ClimaCore uses a custom `UnitTest` driver (`test/tabulated_tests.jl`) that achieves the same isolation. Physics-library repos (Thermodynamics, CloudMicrophysics, SurfaceFluxes) use plain `@testset`s; if you add a new isolation-sensitive test file there, prefer `@safetestset`. (See also [SDP 22](../code-quality/software_design_patterns.md).)
+
+## Scientifically meaningful tests
+
+Beyond type-stability and allocation checks, CliMA tests should verify that code is **physically and mathematically correct**. When adding or modifying a physics function, include tests from as many of the following categories as applicable.
+
+### 1. Physical and mathematical limits (edge cases)
+
+Test behavior at extreme, degenerate, or boundary inputs. These catch numerical robustness issues that standard-range inputs miss.
+
+```julia
+# Zero input returns zero (CloudMicrophysics: terminal velocity)
+@test terminal_velocity(rain, vel_type, ρ, FT(0)) ≈ 0 atol = eps(FT)
+
+# Saturation vapor pressure vanishes as T → 0 (Thermodynamics)
+for T in (FT(1e-5), eps(FT), FT(0))
+    @test saturation_vapor_pressure(param_set, T, Liquid()) ≈ FT(0)
+end
+
+# NaN check for near-zero edge cases
+@test !isnan(terminal_velocity(snow, vel_type, FT(0.24), FT(3.0f-45)))
+
+# No snow production above freezing
+@test conv_q_icl_to_q_sno(..., T_freeze + FT(30)) == FT(0)
+
+# No snow melt below freezing
+@test snow_melt(..., T_freeze - FT(2)) ≈ FT(0)
+```
+
+### 2. Round-trip (inverse) tests
+
+When a function has a mathematical inverse, verify that composing them recovers the original input. This catches subtle sign errors, off-by-one factors, and incorrect formula transcriptions.
+
+```julia
+# Thermodynamics: internal_energy → air_temperature round-trip
+e_int = TD.internal_energy(param_set, T0, q_tot, q_liq, q_ice)
+T_rec = TD.air_temperature(param_set, TD.ρe(), e_int, q_tot, q_liq, q_ice)
+@test T_rec ≈ T0
+
+# Thermodynamics: q_vap_from_RH / relative_humidity round-trip
+q_vap = TD.q_vap_from_RH(param_set, p, T, RH, TD.Liquid())
+RH_recovered = TD.relative_humidity(param_set, T, p, q_vap)
+@test isapprox(RH_recovered, RH; rtol = FT(1e-5))
+
+# SurfaceFluxes: flux solver → profile recovery round-trip
+# Solve for fluxes at height z, then recover the profile value at z
+U_recovered = SF.compute_profile_value(output, z, SF.Momentum())
+@test isapprox(U_recovered, U_input; rtol = FT(0.02))
+```
+
+### 3. Tests against analytical results
+
+Where an analytical solution exists (even for simplified cases), test that the numerical implementation reproduces it. This is the strongest form of correctness test.
+
+```julia
+# Thermodynamics: ideal gas law (p = R_m ρ T)
+p = TD.air_pressure(param_set, T, ρ, q_tot, q_liq, q_ice)
+R_m = TD.gas_constant_air(param_set, q_tot, q_liq, q_ice)
+@test p ≈ R_m * ρ * T
+
+# Thermodynamics: Clausius-Clapeyron equation (d ln eₛ / dT = L / (Rᵥ T²))
+dlog_es_dT_fd = (log(e_sat(T + δ)) - log(e_sat(T - δ))) / (2δ)
+dlog_es_dT_cc = L / (R_v * T^2)
+@test isapprox(dlog_es_dT_fd, dlog_es_dT_cc; rtol = FT(1e-3))
+
+# ClimaTimeSteppers: forward Euler converges to exp(-t) for du/dt = -u
+@test u[1] ≈ exp(-1.0) atol = 0.001
+
+# ClimaTimeSteppers: convergence order matches tableau order
+@test convergence_order(prob, sol, LSRK54CarpenterKennedy(), dts) ≈ 4 atol = 0.1
+
+# CloudMicrophysics: accretion rate matches empirical formula (Grabowski 1996)
+@test accretion(liquid, rain, vel, ce, q_liq, q_rai, ρ) ≈
+      accretion_empir(q_rai, q_liq, q_tot) atol = 0.1 * accretion_empir(...)
+```
+
+### 4. Physical consistency tests
+
+Verify thermodynamic identities, conservation laws, and monotonicity constraints that must hold regardless of the specific input values.
+
+```julia
+# Thermodynamic identities (Thermodynamics.jl)
+@test TD.cp_m(ps, q_tot, q_liq, q_ice) -
+      TD.cv_m(ps, q_tot, q_liq, q_ice) ≈ R_m           # cp - cv = R
+@test h ≈ e_int + R_m * T                               # h = e + RT
+@test TD.latent_heat_sublim(ps, T) ≈
+      TD.latent_heat_vapor(ps, T) +
+      TD.latent_heat_fusion(ps, T)                       # Lₛ = Lᵥ + L_f
+
+# Mixture specific heats are mass-fraction weighted sums
+cp_expected = (1-q_tot)*cp_d + q_vap*cp_v + q_liq*cp_l + q_ice*cp_i
+@test TD.cp_m(param_set, q_tot, q_liq, q_ice) ≈ cp_expected
+
+# Monotonicity (CloudMicrophysics: more content → higher velocity)
+@test terminal_velocity(rain, vel, ρ, q_rai * 2) > terminal_velocity(rain, vel, ρ, q_rai)
+# λ⁻¹ increases with specific content (larger mean particle size)
+@test λ_inv_large > λ_inv_small
+
+# Sign constraints (evaporation is negative, melting is positive)
+@test evaporation_rate < 0  # subsaturated → evaporation removes mass
+@test melt_rate > 0         # T > T_freeze → melting adds liquid
+
+# Saturation partitioning: condensate is nonneg, vapor ≈ saturation
+@test q_liq ≥ 0
+@test q_ice ≥ 0
+@test isapprox(q_vap, q_vap_sat; rtol = FT(1e-6))
+
+# Derivative consistency: analytical vs. finite-difference
+Δq = FT(1e-8)
+fd_deriv = (rate(q + Δq) - rate(q - Δq)) / (2Δq)
+@test sign(analytical_deriv) == sign(fd_deriv)
+@test isapprox(analytical_deriv, fd_deriv; rtol = FT(0.2))
+```
+
+### General guidelines
+
+- **Dual-precision**: run scientific tests for both `Float32` and `Float64` to catch type-promotion bugs.
+- **Tolerances**: use `rtol` for scale-invariant comparisons and `atol` only when a value can be exactly zero. Use `eps(FT)` as a baseline for zero-comparison tolerances.
+- **Name the law**: annotate each consistency test with the physical identity it verifies (e.g., "Clausius-Clapeyron", "ideal gas law", "Lₛ = Lᵥ + L_f") so that failures map directly to physics.
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/performance/ad_compatibility.md
+++ b/performance/ad_compatibility.md
@@ -1,0 +1,76 @@
+# AD Compatibility Guide
+
+This guide covers patterns for writing Julia code that is compatible with Automatic Differentiation (AD) tools such as ForwardDiff and Enzyme. These rules apply to all tendency, physics, and parameterization functions across the CliMA ecosystem.
+
+## Core rules
+
+| Rule                                                                                    | Rationale |
+|:----------------------------------------------------------------------------------------|:----------|
+| Duck-type functions ([SDP 14](../code-quality/software_design_patterns.md))             | Dual numbers flow through without type-annotation barriers |
+| `FT = typeof(x)` or `eltype(x)` ([SDP 15](../code-quality/software_design_patterns.md)) | Lets AD supply the numeric type |
+| `zero(x)` / `one(x)` ([SDP 16](../code-quality/software_design_patterns.md))            | Type-agnostic; correctly typed for `Dual` |
+| Do not write `Dual` values into non-`Dual` buffers                                      | Invalid operation; `convert(<:AbstractFloat, dual)` throws a `MethodError` |
+
+## Before / after example
+
+```julia
+# ❌ AD-fragile — `where {FT}` forces x and y to share a type, so a mixed call
+# like compute(Dual(1.0), 2.0) will throw a MethodError
+@inline compute(x::FT, y::FT) where {FT} = y > FT(0) ? FT(1) - x^2 : FT(0)
+
+# ✅ AD-compatible — x and y can have different types, but the result always
+# matches the type of x
+@inline compute(x, y) = y > zero(y) ? one(x) - x^2 : zero(x)
+```
+
+This example can be rewritten even more efficiently using the `ifelse` function:
+
+```julia
+@inline compute(x, y) = ifelse(y > zero(y), one(x) - x^2, zero(x))
+```
+
+Using `ifelse` is not strictly necessary for ForwardDiff or Enzyme — conditional branches can be differentiated separately — but it is preferred over generic `if/else` and `?/:` constructs to avoid thread divergence on GPUs (see [SDP 17](../code-quality/software_design_patterns.md)).
+
+## When type constraints are OK
+
+Type annotations are acceptable in these specific contexts:
+
+- **Struct constructors**: `MySGS(::Type{FT}; ...)` — `FT` determines the element type of arrays (`SVector`, `SMatrix`) or parameter sets.
+- **Dispatch on non-numeric types**: `method(::GaussianSGS, ...)` — dispatching on a distribution type or model type is fine because these are not numeric values that AD would differentiate through.
+
+## AD-compatible clamping
+
+Standard `clamp(x, low, high)` is generally safe for AD. For zero-clamping the simplest idiom — used in `CloudMicrophysics.Utilities.clamp_to_nonneg` — is:
+
+```julia
+@inline clamp_to_nonneg(x) = max(zero(x), x)
+```
+
+`max` propagates the Dual partials through whichever argument wins. An equivalent branchless form is `ifelse(x < zero(x), zero(x), x)`; the `zero(x)` term ensures the negative branch carries the same type (including Dual partials) as `x`.
+
+## Testing AD compatibility
+
+```julia
+using ForwardDiff
+
+# Verify function accepts Dual numbers and returns Dual
+x_dual = ForwardDiff.Dual(1.0f0, 1.0f0)
+result = my_physics_func(x_dual, params)
+@test result isa ForwardDiff.Dual
+
+# Verify gradient computes without error
+grad = ForwardDiff.derivative(x -> my_physics_func(x, params), 1.0f0)
+@test isfinite(grad)
+```
+
+For multi-argument functions, use `ForwardDiff.gradient` or `ForwardDiff.jacobian`.
+
+## Common pitfalls
+
+1. **Type annotations on arguments**: `f(x::FT) where {FT <: AbstractFloat}` rejects `ForwardDiff.Dual` inputs, and `f(x::FT, x::FT) where {FT}` rejects inputs with mixed types. Use duck typing as much as possible, only adding type constraints when they are needed for multiple dispatch.
+2. **Constants typed from the wrong source**: Any value whose type is hardcoded like `Float64(x)`, or captured from an unrelated source like `eltype(params)`, will not pick up the `Dual` type of input arguments. Avoid manual type conversions if possible, and use `one(x)` / `zero(x)` instead of `FT(1)` / `FT(0)`.
+3. **Mutation**: In-place modification of arrays or mutable structs can break reverse-mode AD (Enzyme). Prefer returning new values from pure functions.
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/performance/allocation_debugging.md
+++ b/performance/allocation_debugging.md
@@ -1,0 +1,126 @@
+# Allocation Debugging Workflow
+
+Practical recipes for finding and fixing heap allocations in CliMA Julia code. The companion rules — what counts as a hot path and which patterns to use — live in [gpu_performance.md](gpu_performance.md). This guide is the *debug-loop* counterpart: what to do when `@allocated` is not zero.
+
+## 1. The standard regression test
+
+Every CliMA repo with a numerical hot path pins zero allocations with a unit test. The canonical pattern (warm up, then assert) appears in `Thermodynamics.test/type_stability.jl`, `ClimaTimeSteppers.test/...`, and the precomputed-quantity setters of every model repo:
+
+```julia
+# Warm up — forces compilation, fills in any first-call caches
+my_hot_function(args...)
+
+# Assert
+@test (@allocated my_hot_function(args...)) == 0
+```
+
+Two things to know:
+
+- `@allocated` returns *bytes* allocated since the last call. The first invocation is dominated by compilation and is never zero — always warm up first.
+- `@allocated` ignores *stack* allocations and small inlined boxes; it counts genuine heap allocations. So `0` from `@allocated` is a strong signal.
+
+When the test fails, the next sections tell you how to localize the cause.
+
+## 2. Localizing an allocation: `Profile.Allocs`
+
+`@allocated` tells you *that* there is an allocation but not *where*. `Profile.Allocs` (a stdlib module on currently supported Julia versions) does. The pattern used in `CloudMicrophysics.test/performance_tests.jl`:
+
+```julia
+import Profile
+
+Profile.clear()
+Profile.Allocs.@profile sample_rate = 1 my_hot_function(args...)
+results = Profile.Allocs.fetch()
+sorted = sort(results.allocs, by = x -> x.size)
+for a in sorted
+    println(a)            # type and size
+    println(a.stacktrace) # where it came from
+end
+```
+
+Tips:
+
+- `sample_rate = 1` records *every* allocation; lower rates (e.g. `0.01`) are appropriate for longer runs.
+- The largest allocation is usually the most informative — sort by `.size` and start from the bottom.
+- The stack trace points at the *allocating line*, not the *root cause*. A boxed closure variable will show as an allocation in `Core.Box` deep inside the kernel; the fix is upstream, where the closure was constructed.
+
+## 3. Localizing a *dispatch* allocation: `JET.@report_opt`
+
+A common source of allocations is a single dynamic dispatch buried in an otherwise typed function. `Profile.Allocs` will show *that* `jl_apply_generic` allocated; `JET.@report_opt` will show *which call site* the compiler failed to resolve. Used in `CloudMicrophysics.test/performance_tests.jl` (`JET.@test_opt`) and `ClimaTimeSteppers.perf/jet.jl`:
+
+```julia
+using JET
+JET.@report_opt my_hot_function(args...)
+```
+
+JET prints a list of `runtime dispatch detected` entries with the unresolved call and the failing argument type. Reading order:
+
+1. Find the deepest call that is yours (not a stdlib or third-party method).
+2. Look at the *argument types*: a `Union{...}`, `Any`, or `Function` is the giveaway. Track that argument back to where it lost type information (a struct field typed `::Function` instead of `::F`, a `Vector{Any}`, an `Union{Nothing, T}` field accessed without dispatch — see [SDP 6](../code-quality/software_design_patterns.md) and [type_stability.md §3](type_stability.md)).
+3. Fix the upstream type instability; the JET entry disappears and the allocation goes with it.
+
+Use `JET.@test_opt my_hot_function(args...)` in a `@testset` for a CI-style regression gate.
+
+## 4. Localizing an inference allocation: `@code_warntype`
+
+When the suspect is a single function and you want to see what the compiler inferred, `@code_warntype` highlights any non-concrete inferred types in red. Useful for the smallest reproducer; less useful for deep call graphs (use JET there).
+
+```julia
+@code_warntype my_hot_function(args...)
+```
+
+Read the `Body::T` line first — if `T` is `Any` or a `Union`, the return type is unstable. Then scan for red `Union{...}` annotations in the body.
+
+## 5. Benchmarking: `BenchmarkTools.@benchmark`
+
+`@allocated` is binary (zero or not zero). For *characterizing* allocations and their cost over many calls, use BenchmarkTools, as in `CloudMicrophysics.test/performance_tests.jl` and `ClimaTimeSteppers.perf/jet.jl`:
+
+```julia
+using BenchmarkTools
+trial = @benchmark $(splat(my_hot_function))($args) samples = 100 evals = 100
+# trial.memory   — total bytes allocated per call
+# trial.allocs   — number of distinct allocations per call
+# minimum(trial) — most useful time estimate (resilient to GC noise)
+```
+
+Two pitfalls:
+
+- Always interpolate (`$x`) into the macro so the benchmarked function sees the value, not a global ref.
+- `$foo($args...)` can itself allocate from splatting; prefer `$(splat(foo))($args)` or pass arguments individually.
+
+## 6. Flame graphs: `Profile` + `ProfileCanvas` / `PProf`
+
+For longer hot paths (e.g. one full RK step), a flame graph shows where time *and* allocations cluster. The pattern in `ClimaTimeSteppers.perf/flame.jl`:
+
+```julia
+using Profile, ProfileCanvas
+Profile.clear()
+@profile for _ in 1:100_000; my_step!(args...); end
+ProfileCanvas.html_file("flame.html")  # save artifact; or .view() locally
+```
+
+A model-repo equivalent (e.g. `perf/flame.jl` in ClimaAtmos) profiles a single timestep; the same idea applies to library code.
+
+## 7. Common allocation sources and their fixes
+
+| Symptom (in `Profile.Allocs` stacktrace)         | Likely cause                                          | Fix |
+|:-------------------------------------------------|:------------------------------------------------------|:----|
+| `Core.Box` deep inside a kernel                  | Captured local variable in a closure                  | Convert closure to a functor ([SDP 18](../code-quality/software_design_patterns.md)) |
+| `jl_apply_generic` with no obvious source        | Dynamic dispatch on a `Function`/`Any` field           | Parameterize the field ([SDP 6](../code-quality/software_design_patterns.md)) |
+| Allocation inside a `@.` broadcast               | Non-`isbits` argument captured in the broadcast        | Extract parameters to locals ([SDP 20](../code-quality/software_design_patterns.md)); or check `isbits(cudaconvert(...))` ([gpu_performance.md §8](gpu_performance.md)) |
+| `Array{Float64}` allocation in a Float32 path    | A `Float64` literal promoting the result                | Track down the literal ([type_stability.md §1](type_stability.md)) |
+| `Union{T, Nothing}` access in a hot path         | Optional field forces a runtime check                  | Split the method by the field's type parameter ([type_stability.md §3](type_stability.md)) |
+| Allocation inside `ifelse`                       | A `begin...end` block or non-`isbits` branch result    | Pre-compute both branches outside `ifelse` ([SDP 17](../code-quality/software_design_patterns.md)) |
+| Allocation only on GPU, not CPU                  | A kernel-incompatible operation (string interp, Dict)  | See [gpu_performance.md §7](gpu_performance.md) and [SDP 13](../code-quality/software_design_patterns.md) |
+
+## 8. When `@allocated` says zero but you still suspect a leak
+
+Three failure modes where `@allocated == 0` is misleading:
+
+1. **The allocation happens during compilation, not execution.** First-call allocations are real cost, just amortized. If startup time matters (e.g. precompile-sensitive jobs), profile with `--trace-compile=stderr`.
+2. **The allocation happens on the GPU side.** `@allocated` only measures host allocations. Use `CUDA.@time` or `CUDA.memory_status()` to see device allocations.
+3. **The allocation happens elsewhere in the call graph.** A function can be allocation-free locally while its caller (a wrapping `@.` broadcast, or a `bycolumn` iterator) allocates. Pin the test at the outermost layer that runs per timestep, not at a leaf function.
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/performance/gpu_performance.md
+++ b/performance/gpu_performance.md
@@ -1,0 +1,167 @@
+# GPU Performance Guide
+
+This guide covers patterns and pitfalls for writing high-performance, GPU-compatible Julia code in CliMA. All rules apply to any code that executes inside a `@.` broadcast kernel or a `ClimaCore` column operation.
+
+## What counts as a "kernel" or "hot path"
+
+The rules below apply whenever the surrounding code is a *kernel* or runs inside a *hot path*. Define both concretely:
+
+- **Kernel**: the right-hand side of a `@.` broadcast, the body of a `ClimaCore.lazy()` expression, the closure passed to `Operators.column_integral_*`, `Operators.column_reduce!`, or `Fields.bycolumn`, and any function transitively `@inline`d into one of the above.
+- **Hot path**: any function called once per timestep (or once per Runge–Kutta stage) for every column or every grid point. In model repos this includes tendency functions, precomputed-quantity setters, and Jacobian-update functions. In library repos (e.g. Thermodynamics.jl, CloudMicrophysics.jl), it includes any function that is designed to be called from a broadcast kernel.
+
+If a function is called in either context, treat every rule in this file and in [software_design_patterns.md](../code-quality/software_design_patterns.md) as binding.
+
+## 1. SIMT and thread divergence
+
+On GPU architectures (CUDA, ROCm), threads are grouped into warps (typically 32 threads). All threads in a warp execute the same instruction in lockstep. When a data-dependent `if/else` branch causes different threads to take different paths, the hardware must execute both branches sequentially — this is **thread divergence** and it can halve (or worse) throughput.
+
+### The remedy: `ifelse`
+
+Use `ifelse(cond, a, b)` to remove the divergent branch predicate. See [SDP 17](../code-quality/software_design_patterns.md) for the canonical pattern.
+
+**Underlying principle**: `ifelse` is an ordinary function call. Both `a` and `b` are evaluated to a value *on every thread* before the call; `ifelse` only selects which value to return. Using `ifelse` does **not** save the work of the un-taken branch — its purpose is to eliminate the warp-divergent predicate, not to skip computation. If one branch is significantly more expensive than the other, every thread still pays its cost; sometimes a divergent `if/else` is the better trade and you should measure.
+
+Three consequences follow:
+
+- **Guard mathematically invalid operations** (`log` of a non-positive, `sqrt` of a negative, division by a possibly-zero denominator) *before* the `ifelse`. See [Numerical Robustness §1–2](numerical_robustness.md) for how to choose the floor (it is not `eps(FT)` in general).
+- **No `begin...end` blocks in arguments.** Statements inside `begin...end` run unconditionally — they are not "guarded" by the condition.
+- **No recursion through `ifelse`.** Since both branches evaluate, using `ifelse` to choose between a base case and a recursive call produces unbounded recursion. Use a plain `if` for recursion.
+
+```julia
+# ❌ Bad: log(x) executes even when x ≤ 0; the begin-block runs unconditionally
+result = ifelse(x > 0,
+    begin
+        y = log(x)  # NaN when x ≤ 0
+        y + 1
+    end,
+    zero(x)
+)
+
+# ✅ Preferred: pre-compute safely, then select. The wrong log_term for x ≤ 0
+# is discarded by the ifelse, so max(x, eps) is acceptable here even though
+# it would not be a safe NaN-guard on its own (see Numerical Robustness §1).
+safe_x = max(x, eps(eltype(x)))
+log_term = log(safe_x) + one(x)
+result = ifelse(x > zero(x), log_term, zero(x))
+```
+
+## 2. Functors over closures
+
+Closures that capture local variables produce heap allocations ("boxed variables") and may trigger `InvalidIRError: unsupported dynamic function invocation` on GPU. Replace them with callable structs (functors). See [SDP 18](../code-quality/software_design_patterns.md) for the canonical pattern and the closure-vs-functor cost comparison.
+
+## 3. `lazy()` broadcast fusion
+
+`ClimaCore.lazy()` creates a lazy broadcast object that represents an operation without materializing a temporary `Field`. Multiple lazy expressions fuse into a single GPU kernel when assigned to a terminal field.
+
+### When to use `lazy()`
+
+`lazy` is exported by the [`LazyBroadcast.jl`](https://github.com/CliMA/LazyBroadcast.jl) package (`import LazyBroadcast: lazy`) and is re-exported through `ClimaCore`. Use `@. lazy(expr)` for any intermediate computed quantity that is consumed by a subsequent broadcast — it prevents heap allocation of a temporary `Field`.
+
+```julia
+# ✅ Lazy: no temporary Field allocated
+ᶜT = @. lazy(TD.air_temperature(thp, TD.ρe(), Y.c.ρe / Y.c.ρ,
+                                Y.c.ρq_tot / Y.c.ρ, Y.c.ρq_liq / Y.c.ρ,
+                                Y.c.ρq_ice / Y.c.ρ))
+result = @. lazy(physics_func(ᶜT, Y.c.ρ))
+@. output_field = result  # terminal: fuses everything into one kernel
+```
+
+### NamedTuple field-access pitfall
+
+A `lazy()` wrapper returns a `Broadcasted` object, not a real `NamedTuple`. Accessing `.field_name` on it outside a fused broadcast fails with `ERROR: type Broadcasted has no field X`.
+
+```julia
+# ❌ FAILS — lazy object is not a NamedTuple
+limited = @. lazy(limit_tendencies(A, B, C))
+@. Yₜ.c.ρq_liq += limited.Sqₗᵐ  # ERROR
+```
+
+### Materialization pattern
+
+When you need to extract multiple fields from a function's `NamedTuple` result, remove `lazy()` to materialize into a pre-allocated `Field`. **Do not** create a new temporary field inline each timestep — this allocates on every call. Instead, use a scratch field from the cache that was allocated once during model construction.
+
+```julia
+# ❌ Allocates a new Field every timestep
+limited_field = @. limit_tendencies(A, B, C)
+
+# ✅ Write into a pre-allocated cache field — zero allocations per timestep
+@. p.scratch.ᶜlimited = limit_tendencies(A, B, C)
+@. Yₜ.c.ρq_liq += p.scratch.ᶜlimited.Sqₗᵐ
+@. Yₜ.c.ρq_ice += p.scratch.ᶜlimited.Sqᵢᵐ
+```
+
+**General rule**: any `Field` that is computed inside a function called during timestepping must be pre-allocated in the cache (typically in `src/cache/`). The cache is built once during model construction. Never allocate new `Field`s inside tendency functions, callbacks, or any code that runs per-timestep.
+
+### Multi-field updates
+
+ClimaCore's broadcast machinery does not support a tuple of `Field`s on the LHS — `@. (Yₜ.c.ρq_liq, Yₜ.c.ρq_ice) += f(...)` fails in `check_broadcast_shape` / `copyto!`. Use the scratch-field pattern from the previous section: materialize the multi-field result into a pre-allocated `NamedTuple`-of-`Field`s in the cache, then issue one `@.` per target. The cost of repeating the broadcast is paid back because the RHS is just a field load, not a recomputation.
+
+## 4. `@.` broadcast rules
+
+### Dollar interpolation for non-field arguments
+
+Use `$expr` to prevent the `@.` macro from broadcasting over a subexpression. This is essential for singleton dispatch types and computed scalars.
+
+```julia
+# ✅ Singleton escaped from broadcast
+@. result = physics_func(Field_A, $(GridMeanSGS()))
+```
+
+### Do not use `Ref()` as a broadcast scalar escape
+
+`Ref()` is not the standard broadcast-escape pattern in this codebase. Its use in `src/` is limited to mutable scalar boxes in callbacks and non-broadcast contexts. Prefer parameter extraction ([SDP 20](../code-quality/software_design_patterns.md)).
+
+### Parameter extraction
+
+Extract non-`Field` arguments to local variables before the `@.` block — see [SDP 20](../code-quality/software_design_patterns.md) for the rule and rationale.
+
+## 5. Register pressure and function size
+
+Large functions (roughly > 200–300 lines) may exceed the Julia compiler's inlining budget. When this happens, broadcast kernels inside the function are not inlined, causing heap allocations for each broadcast.
+
+**Solution**: extract complex logical blocks into smaller `@inline` helper functions. Keeping the parent function small allows the compiler to stay within its heuristics threshold, ensuring all broadcasts are correctly fused.
+
+## 6. Fixed iteration solvers (advisory)
+
+Convergence-based loops (`while err > tol`) cause thread divergence when different threads converge at different rates. Where the physics allows it, prefer a fixed number of iterations. See [SDP 19](../code-quality/software_design_patterns.md).
+
+## 7. GPU-safe error handling
+
+Use `error("static message")` instead of `@assert`, and do not interpolate runtime variables into error strings inside kernels. See [SDP 11](../code-quality/software_design_patterns.md).
+
+## 8. `isbits` requirement
+
+Anything passed into a GPU kernel must be `isbits` *after device adaptation*. That is the actual contract — not that the host-side object is `isbits`. Many ClimaCore objects (notably `Field`, `Space`, and anything wrapping a `CuArray`) are deliberately not `isbits` on the host because they hold `Array`/`CuArray` payloads; they become `isbits` only after `Adapt.adapt(CUDA.KernelAdaptor(), x)` (equivalently `CUDA.cudaconvert(x)`) rewrites the array fields into device-side `CuDeviceArray`s and similar.
+
+```julia
+julia> a = fill(0.0f0, axes(Y.c));   # ClimaCore Field
+julia> isbits(a)
+false
+julia> isbits(CUDA.cudaconvert(a))
+true
+```
+
+Verify with the post-adapt check:
+
+```julia
+@assert isbits(CUDA.cudaconvert(MyStruct(...)))
+```
+
+If the post-adapt check returns `false`, check for:
+
+- `Vector` or `Array` fields that aren't backed by a `CuArray` and don't have an `Adapt.adapt_structure` method (use `SVector`/`Tuple`, or add an `Adapt` rule that rewrites the field to a device-side equivalent)
+- `String` fields
+- `Function` fields without a type parameter (use `struct A{F <: Function}; f::F; end`)
+- `mutable struct` (prefer immutable structs for data passed into kernels; `mutable struct` is acceptable for infrastructure objects like grids and integrators that are never passed into kernels)
+
+When defining a new struct that wraps device-resident arrays, add an `Adapt.adapt_structure(to, x::MyStruct) = MyStruct(adapt(to, x.field1), ...)` method so the post-adapt object becomes `isbits`.
+
+Avoid using `DataTypes` (e.g. `Float64`) or their aliases (e.g `FT`) directly in broadcast kernels. This can cause `isbits` failures on different julia versions.
+
+## 9. Allocation verification
+
+After implementing or modifying hot-path code, verify zero allocations with the warm-up + `@allocated == 0` regression-test pattern documented in [allocation_debugging.md §1](allocation_debugging.md). Allocation benchmarks in `perf/` are not run automatically in CI, so allocation regressions must be caught at review time.
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/performance/numerical_robustness.md
+++ b/performance/numerical_robustness.md
@@ -1,0 +1,90 @@
+# Numerical Robustness Guide
+
+This guide covers safe numerical idioms for avoiding NaN, Inf, and DivideError in GPU kernels and AD-compatible code.
+
+## 1. Denominator regularization
+
+Dividing by quantities that may approach zero has several reasonable handlings. The right choice depends on:
+
+- whether `x → 0` is physically valid behavior or signals a bug,
+- whether downstream code can absorb `Inf` (or a large finite number) correctly,
+- whether you want to bound the magnitude or surface the invalid state.
+
+Float division does not raise an error: `a / 0.0` returns `Inf` (or `NaN` if `a` is also zero), and IEEE arithmetic propagates that through subsequent operations. You can sometimes deliberately allow `Inf` through, but only if downstream consumers are *known* to handle it — IEEE arithmetic does not take limits (`Inf * 0 = NaN`, `Inf - Inf = NaN`), so any later multiplication by a vanishing quantity silently produces `NaN` rather than the algebraic cancellation a mathematician would expect. Cases where allowing `Inf` is fine include a downstream `ifelse` or clamp that discards the singular branch, or operations where `Inf` results in well-defined behavior.
+
+```julia
+# Sometimes fine: downstream must tolerate Inf and any NaN cascade
+ratio = a / x
+```
+
+When `a/x → ∞` is physically defined but you want a bounded result for stability or discretisation reasons, regularise with a *physically meaningful* floor `δ` (e.g. a minimum mass mixing ratio or cloud fraction):
+
+```julia
+ratio = a / max(x, δ)
+```
+
+The compact `max(x, eps(FT))` idiom is appropriate as a soft NaN-guard when `x ≥ 0` is an invariant in valid state and the guard exists only to absorb round-off:
+
+```julia
+FT = eltype(x)
+ratio = a / max(x, eps(FT))
+```
+
+Things to watch with this last pattern:
+
+- The guard treats negative `x` and small positive `x` identically (both map to `eps(FT)`). If `x ≥ 0` is genuinely invariant, this is a benign round-off correction. If `x < 0` arises from an upstream bug, the guard silently emits `≈ a · 8.4e6` for Float32 rather than surfacing the bad state.
+- `eps(FT)` is often much smaller than typical physical scales, so the guard only fires within round-off of zero. If it fires far from round-off, there is a separate bug that this guard is hiding.
+
+For signed denominators that should not be zero, `copysign(eps(FT), x)` preserves the sign of `x` while pushing the magnitude away from zero by `eps(FT)`:
+
+```julia
+safe_denom = x + copysign(eps(FT), x)
+ratio = a / safe_denom
+```
+
+Use with care: the regularised result is discontinuous at `x = 0`, jumping from `≈ -a/eps(FT)` to `≈ +a/eps(FT)` as `x` crosses zero, and the magnitude `≈ a/eps(FT)` may be much larger than any physically meaningful value. Sometimes that sign-preserving "noisy ±Inf" behavior is exactly what you want; sometimes the right behavior is to surface the zero crossing with an explicit branch.
+
+If `x ≤ 0` indicates an invalid state and you want to substitute a defined sentinel rather than a finite-but-arbitrary value, branch explicitly:
+
+```julia
+ratio = ifelse(x > δ, a / x, sentinel)
+```
+
+## 2. Safe inputs to transcendental functions
+
+`log(x)` and `sqrt(x)` are undefined for strictly negative real `x`. On CPU, Julia raises `DomainError`; inside a GPU kernel that error cannot be caught and usually crashes the launch with hard-to-interpret error messages. Model state variables that should be non-negative — mixing ratios, cloud fractions, mass densities — routinely pick up small-magnitude negative values from round-off, advection limiters, or explicit-step over-shoots. A clip guard prevents the kernel error:
+
+```julia
+# ❌ Bad: DomainError on CPU / kernel crash or silent NaN on GPU when x < 0
+result = log(x)
+result = sqrt(x)
+
+# ✅ Preferred: clamp round-off-level negatives before the call
+safe_x = max(x, zero(x))   # or max(x, δ) for a physics-chosen δ
+result = log(safe_x)
+result = sqrt(safe_x)
+```
+
+A few practical notes:
+
+- `log(0)` is `-Inf` and `sqrt(0)` is `0` — both propagate through float arithmetic without erroring or crashing a kernel. If `-Inf` is unacceptable downstream, lift the floor from `zero(x)` to a physics-chosen `δ` (see §1).
+- `NaN` inputs do not need guarding at this layer: `log(NaN) = sqrt(NaN) = NaN`, propagating silently. The bug producing the `NaN` is upstream.
+- The intent of the clip is to absorb *round-off-level* negative values. If you are routinely clipping inputs whose magnitude is far above round-off, there is an upstream bug and the clip is hiding it.
+
+When `log`/`sqrt`/division appears inside an `ifelse`, the guard goes *before* the `ifelse` because both branches are always evaluated. See [SDP 17](../code-quality/software_design_patterns.md) and [GPU Performance Guide §1](gpu_performance.md).
+
+## 3. AD-compatible clamping
+
+For zero-clamping, the canonical CliMA idiom is `max(zero(x), x)` (exported as `CloudMicrophysics.Utilities.clamp_to_nonneg`). See [ad_compatibility.md](ad_compatibility.md) for the full pattern and Dual-number rationale.
+
+## 4. Conservation invariants
+
+Mass, energy, and tracer conservation are verified at integration scale, not in unit tests. When changing a tendency, source term, or limiter, name the conservation test that should catch a bug — and if no test exists, add one or flag the gap. Consult the repo-specific guide for the location of conservation tests and CI jobs.
+
+## 5. Avoid `@assert` for runtime checks inside kernels
+
+Use `error("static message")` instead. See [SDP 11](../code-quality/software_design_patterns.md).
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/performance/type_stability.md
+++ b/performance/type_stability.md
@@ -1,0 +1,121 @@
+# Type Stability Guide
+
+This guide covers patterns for ensuring type-stable Julia code across the CliMA ecosystem, with particular emphasis on Float32 compatibility for GPU simulations.
+
+## 1. Float32 pollution checklist
+
+When targeting GPUs (which typically use `Float32`) or working within strict inference environments (such as `ClimaCore.lazy()` broadcasts), even a single `Float64` operation can cause the compiler to infer a `Union{Float32, Float64}` return type, which blocks kernel fusion and triggers `BroadcastInferenceError`.
+
+Common sources and fixes:
+
+| Source             | ❌ Bad                         | ✅ Good                                         |
+|:-------------------|:-------------------------------|:------------------------------------------------|
+| Float literal      | `x + 1.2` (`1.2` is `Float64`) | `x + FT(1.2)`                                   |
+| Infinity / NaN     | `Inf`, `NaN`                   | `FT(Inf)`, `FT(NaN)`                            |
+| Random numbers     | `rand()`                       | `rand(FT)`                                      |
+| Math constants     | `2 * π` converts to `Float64`  | `2 * FT(π)` (`x * π` is sufficient if `x::FT`)  |
+| Literal zero/one   | `0.0`, `1.0`                   | `zero(FT)`, `one(FT)`                           |
+
+## 2. Detecting type instability
+
+### `@code_warntype`
+
+Visual inspection of inferred types. Look for red `Any` or `Union` annotations in the output.
+
+```julia
+@code_warntype my_function(args...)
+```
+
+### `JET.@report_opt`
+
+Finds dynamic dispatch call sites in complex call graphs. Prefer this over `@code_warntype` for deeply nested code.
+
+```julia
+using JET
+JET.@report_opt my_tendency(Y, p, t)
+```
+
+### `@inferred`
+
+Fails at test time if the return type is not fully inferred by the compiler. Use as a CI regression gate.
+
+```julia
+@test @inferred(my_physics_func(FT(1.0), FT(2.0))) isa FT
+```
+
+## 3. Abstract types in struct fields
+
+Struct fields should be concrete or parametric for type stability and performance. See [SDP 4](../code-quality/software_design_patterns.md).
+
+### Splitting dispatch on `Union{T, Nothing}`
+
+When a struct contains an optional field typed as `Union{T, Nothing}`, accessing that field in a hot path triggers runtime type checks. Split the method based on the type parameter to compile away the branch.
+
+```julia
+struct MyParams{ICE}
+    ice::ICE  # IceParams or Nothing
+end
+
+# ❌ Runtime type check
+function compute(params::MyParams)
+    if !isnothing(params.ice)
+        # ice logic
+    end
+end
+
+# ✅ Compile-time dispatch — branch eliminated
+function compute(params::MyParams{Nothing})
+    # warm-only logic
+end
+function compute(params::MyParams{ICE}) where {ICE <: IceParams}
+    # ice logic (guaranteed present)
+end
+```
+
+## 4. Type-stability test template
+
+Gate type stability with a test that iterates over both precisions:
+
+```julia
+for FT in (Float32, Float64)
+    result = my_function(FT(1.0), FT(2.0))
+    @test result isa FT
+    @test @inferred(my_function(FT(1.0), FT(2.0))) isa FT
+end
+```
+
+For functions returning a `NamedTuple`, verify every field:
+
+```julia
+for FT in (Float32, Float64)
+    result = my_tendency(FT(1.0), FT(2.0))
+    for field in propertynames(result)
+        @test getproperty(result, field) isa FT
+    end
+end
+```
+
+## 5. Diagnosing `BroadcastInferenceError`
+
+A `BroadcastInferenceError` from `ClimaCore` usually means a function inside a `@.` or `lazy()` broadcast has a `Union` return type.
+
+### Diagnosis steps
+
+1. **Test the scalar function directly** with `@inferred` and `Float32` inputs. Do not rely only on the broadcast-level test.
+2. **Trigger all branches**: type instability often hides in conditional branches (for example, `iszero(x) ? Inf : ...`). Ensure reproduction scripts test edge cases (zeros, thresholds) that trigger every logical path.
+3. **Check `@code_warntype` output**: look for `Union{Float32, Float64}` in the return type, which indicates one branch is polluting the floating-point context.
+
+### Common "false pass" scenario
+
+A unit test may pass with standard inputs but fail in integrated simulations because:
+
+- The test inputs never trigger the code path containing the Float64 literal.
+- Edge-case inputs (zero, negative, very large) expose a hidden `Inf` or `NaN` literal.
+
+## 6. Prefer using base julia general number functions
+
+Use general number functions from Base Julia that are designed to work across numeric types, as they often have optimized methods for different types and can help maintain type stability. Examples include `iszero`, `isfinite`, `isinf`, `isone`, `isodd`, and `isnan`. These functions are more likely to return consistent types across different numeric inputs, reducing the risk of type instability in your code.
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/templates/AGENTS.md.template
+++ b/templates/AGENTS.md.template
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+<!-- Copy this file to your repo root as AGENTS.md and fill in the placeholders. -->
+
+Read these documents in the order listed when starting work on this repository.
+
+## Shared guides (via DeveloperGuides subtree)
+
+The shared engineering guidelines are vendored as a Git subtree at `docs/dev-guides/`. Julia's `Pkg` does not resolve git submodules, so subtree is the standard mechanism across the CliMA ecosystem. The full index lives at [docs/dev-guides/AGENTS.md](docs/dev-guides/AGENTS.md). Start there for:
+- Architecture, design patterns, and cross-repo contracts
+- GPU performance, type stability, and AD compatibility
+- Code style, testing, and PR review
+
+Edits to shared guidelines belong in `CliMA/DeveloperGuides`, not in the vendored copy here. A scheduled workflow (`.github/workflows/update_dev_guides.yml`) syncs the subtree monthly.
+
+## Repo-specific guide
+
+<!-- Replace the path below with your repo-specific guide location. -->
+
+- [docs/REPO_NAME_specific.md](docs/REPO_NAME_specific.md) — directory layout, key abstractions, test groups, and conventions specific to this package.

--- a/templates/repo_specific_guide.md.template
+++ b/templates/repo_specific_guide.md.template
@@ -1,0 +1,41 @@
+# REPO_NAME — Repo-Specific Guide
+
+<!-- Replace REPO_NAME throughout. This file documents things specific to this
+     package that are NOT covered by the shared DeveloperGuides. -->
+
+## Package overview
+
+<!-- One paragraph: what this package does, its role in the CliMA ecosystem. -->
+
+## Directory map
+
+<!-- Map the package's concrete directories to the architectural layers
+     defined in docs/dev-guides/architecture/architectural_boundaries.md. -->
+
+| Layer | Directory | Description |
+|:---|:---|:---|
+| Solver | `src/solver/` | ... |
+| Physics | `src/parameterized_tendencies/` | ... |
+| Cache | `src/cache/` | ... |
+| Diagnostics | `src/diagnostics/` | ... |
+
+## Key abstractions
+
+<!-- List the 3–5 most important types/modules a new contributor needs to know. -->
+
+## Test groups
+
+<!-- List the CI test groups from test/runtests.jl and what each covers. -->
+
+| Group | What it covers |
+|:---|:---|
+| `unit` | ... |
+| `gpu` | ... |
+
+## Repo-specific conventions
+
+<!-- Anything that deviates from or extends the shared guides. -->
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/templates/update_dev_guides.yml.template
+++ b/templates/update_dev_guides.yml.template
@@ -1,0 +1,57 @@
+# Drop this file into a consumer repo at `.github/workflows/update_dev_guides.yml`.
+# It pulls the latest DeveloperGuides into `docs/dev-guides/` via `git subtree`
+# on the 1st of every month and opens a PR when there are changes.
+#
+# Prerequisites:
+#   - DeveloperGuides has already been added as a subtree at `docs/dev-guides/`:
+#       git subtree add --prefix docs/dev-guides \
+#           https://github.com/CliMA/DeveloperGuides.git main --squash
+#   - The repo's GitHub Actions are allowed to open pull requests
+#     (Settings → Actions → General → "Allow GitHub Actions to create and
+#     approve pull requests").
+
+name: Update Dev Guides
+on:
+  schedule:
+    - cron: '0 0 1 * *'  # 1st of every month at 00:00 UTC
+  workflow_dispatch:
+
+jobs:
+  update-subtree:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history is required for subtree pull
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Pull latest dev guides
+        run: |
+          git checkout -b update-dev-guides
+          # Exit 0 when there is nothing new to merge (subtree pull errors in that case).
+          git subtree pull --prefix docs/dev-guides \
+              https://github.com/CliMA/DeveloperGuides.git main --squash \
+              -m "chore: sync dev guides from central repo" || true
+
+      - name: Check for updates
+        id: check
+        run: |
+          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+            echo "changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.check.outputs.changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push -f origin update-dev-guides
+          gh pr create --title "chore: sync dev guides with central repo" \
+                       --body "Automated PR to sync \`docs/dev-guides\` with the latest changes from \`CliMA/DeveloperGuides\`." \
+                       --base main --head update-dev-guides || true

--- a/workflow/agent_autonomy.md
+++ b/workflow/agent_autonomy.md
@@ -1,0 +1,66 @@
+# Agent Autonomy Boundaries
+
+This guide lists actions that an automated agent must **not** perform without an explicit, in-context instruction from the user. Local, reversible work (editing files, running tests, formatting) needs no special permission. The actions below are different: they are irreversible, externally visible, or scientifically consequential.
+
+## Always require explicit user approval
+
+### Git / GitHub
+
+- `git push` to any remote, including the agent's own branch.
+- `git push --force` (always — including on agent-owned branches).
+- `git commit --amend` on a commit that has already been pushed.
+- `git rebase` onto a different base, or any interactive rebase.
+- `git reset --hard`, `git checkout --`, `git restore .`, or `git clean -fd` when uncommitted changes exist.
+- Deleting branches (local or remote).
+- Creating, merging, or closing pull requests.
+- Adding labels, assignees, or reviewers; commenting on issues or PRs.
+- Tagging a release, or pushing tags.
+
+### Versioning and dependencies
+
+- Bumping `version` in `Project.toml`. Version bumps belong to release PRs and are owned by maintainers.
+- Editing `Manifest.toml`. Treat the manifest as derived state. Most CliMA repos do not commit it; if a repo does, do not modify it without explicit instruction.
+- Adding, removing, or relaxing `[compat]` entries in `Project.toml`.
+- Adding new entries to `[deps]` for an unrelated capability.
+- `Pkg.update()` against the project environment.
+
+### Reproducibility and reference data
+
+- Editing reference counters or reference data in any reproducibility-test directory (e.g., `reproducibility_tests/` in ClimaAtmos). These reference values gate scientific reproducibility; only update them in response to a deliberate, user-confirmed output change.
+- Editing MSE tolerance thresholds.
+- Editing recorded checksums or golden output files.
+
+### CI and infrastructure
+
+- Editing `.buildkite/pipeline.yml` job definitions or job names.
+- Editing `.github/workflows/*` or any CI configuration that affects what runs on every PR.
+- Adding or removing CI jobs.
+- Disabling tests (`@test_skip`, commenting out a `@testset`, removing a file from `runtests.jl`).
+- Skipping pre-commit or git hooks (`--no-verify`).
+
+### Public API and user-visible behavior
+
+- Renaming or removing exported symbols.
+- Renaming, removing, or changing the units of a diagnostic.
+- Changing default values of user-visible config keys.
+- Removing config keys, even if they appear unused.
+
+## Allowed without prior approval
+
+For contrast, the following are routine and do not require permission:
+
+- Reading any file in the repository.
+- Editing source under `src/`, `test/`, `docs/`, `ext/`.
+- Running `julia` to type-check, run tests, or reproduce a bug.
+- Running the formatter (`JuliaFormatter`) over changed files.
+- Creating new local commits on the current working branch.
+- Adding new tests that exercise a bug or new feature.
+- Adding `NEWS.md` entries for changes the agent has made.
+
+## When in doubt
+
+If an action could be visible to other contributors, change scientific output, or be hard to reverse, ask. The cost of a one-line confirmation is small; the cost of an unwanted force-push or a silently shifted reference value is large.
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/workflow/ci_triage.md
+++ b/workflow/ci_triage.md
@@ -1,0 +1,82 @@
+# CI Failure Triage
+
+A checklist for the most common "passes locally, fails on CI" failure modes in CliMA repos. Walk down it in order; each item is something CI exercises that a casual local run does not.
+
+## 1. Julia version mismatch
+
+Most CliMA repos test on a *matrix* of Julia versions (typically the current LTS plus one or two newer point releases) across Linux, macOS, and Windows. Check the `.github/workflows/ci.yml` of the repo you're working in to see which versions are exercised.
+
+A version-specific failure is almost always one of: a method that exists only on newer Julia versions, a precompilation cache that differs between versions, or a syntactic change accepted in one version but not another. Reproduce locally with `juliaup add <version>` and `julia +<version> --project ...`.
+
+## 2. OS mismatch (Windows in particular)
+
+Path separators (`/` vs `\`), file-mode bits, line endings (`\r\n`), and locale-dependent string sorting all bite on Windows. Use `joinpath`, `splitpath`, and `Sys.iswindows()`; never concatenate paths with `*` or string literals.
+
+`macOS-latest` runners occasionally differ from Linux in BLAS rounding at the last bit. If a tolerance test fails only on macOS by `eps(FT)`, the right fix is to loosen `atol` to `eps(FT) * N` for sums of length `N`, not to special-case the OS.
+
+## 3. Downgrade and invalidations jobs
+
+Several repos (Thermodynamics, ClimaCore, others) run two extra jobs that catch issues a plain `Pkg.test()` misses:
+
+- **Downgrade**: re-runs tests with the *lowest* compat-allowed version of every dep. Failures here mean a `[compat]` lower bound is too permissive — usually because new code used an API added in a later version. Fix by bumping the relevant lower bound.
+- **Invalidations**: compares method-table invalidations against `main`. Failures mean a change in this PR added or strengthened invalidations of upstream code, which slows TTFX for downstream users. The fix is typically to narrow a method signature or remove a type-piratical method.
+
+## 4. Downstream tests
+
+Library repos (Thermodynamics, CloudMicrophysics, SurfaceFluxes, ClimaTimeSteppers) run a `Downstream` workflow that builds *consumer* packages (ClimaAtmos, ClimaCoupler, ClimaLand) against the PR. A downstream failure means a change is API-compatible by the package's own tests but breaks a consumer that depends on a behavior the package's tests didn't pin. The fix is usually one of: (a) add a `NEWS.md` breaking-change entry and let the consumer adapt, or (b) restore the implicit behavior and add a test for it.
+
+## 5. Float32 promotion
+
+A test that uses Float64 literals (`1.2`, `Inf`, `6^x` with integer base) passes on Float64 CI runs and fails on Float32 ones with a `BroadcastInferenceError` or a `Union{Float32, Float64}`-typed result. See [type_stability.md §1](../performance/type_stability.md). The Float32 path is sometimes exercised only in a separate Buildkite job — check whether your repo's Buildkite pipeline has a `Float32` flavor before assuming GitHub Actions covers it.
+
+## 6. GPU vs CPU
+
+A test that runs on CPU in GitHub Actions may run on GPU on Buildkite. Common GPU-only failures:
+
+- Scalar indexing on a `CuArray` (`field[i]`): caught by `CUDA.allowscalar(false)` in test setup. See [clima_comms.md §1](../infrastructure/clima_comms.md).
+- `InvalidIRError: unsupported dynamic function invocation`: a closure captured a boxed variable or hit a `Function`-typed field. See [SDP 18](../code-quality/software_design_patterns.md).
+- Object not `isbits` after `cudaconvert`: a `Vector`/`String`/abstract field reached the kernel boundary. See [gpu_performance.md §8](../performance/gpu_performance.md).
+- `BroadcastInferenceError` only on GPU: a Float64 literal or an inlining-budget overflow that the CPU compiler tolerates but the GPU compiler does not.
+
+## 7. MPI rank-count sensitivity
+
+Tests that use global reductions or random number streams can pass on 1 rank and fail on 4. Two failure modes:
+
+- **Reduction ordering**: `sum` over a distributed field reorders floating-point additions per rank count. Loosen tolerances to `eps(FT) * N` for sums of length `N`, or compare in integer space when possible.
+- **Random state**: `rand()` is not synchronized across ranks. Seed explicitly per rank or generate on root and broadcast. See [clima_comms.md §2](../infrastructure/clima_comms.md).
+
+## 8. Allocation regressions
+
+Allocation tests typically use the warm-up + `@allocated == 0` pattern (see [allocation_debugging.md](../performance/allocation_debugging.md)). If they pass locally but fail on CI:
+
+- The CI runner is colder; check that the test calls the function once before the assertion.
+- A new precompilation entry in your branch may have shifted what the first call allocates — the warm-up captures it, but a sibling test running just before may not have. Add an explicit warm-up inside the test, not at module top level.
+
+## 9. Documentation build failures
+
+The `Documentation` workflow runs `docs/make.jl`. Two recurring failures:
+
+- **Missing docstrings**: an exported symbol with no docstring (or with one not referenced from a docs page) triggers `Documenter`'s "missing docstring" error. Add an `@docs` block or use `@autodocs` over the module.
+- **Cross-reference errors**: `[text](text)` in a docstring is parsed as a link. Use parentheses for units (`(kg/m^3)`), not brackets. See [documentation_policy.md](../code-quality/documentation_policy.md).
+
+## 10. Formatter
+
+A formatter failure is almost never about your changes — your local JuliaFormatter major version differs from CI's. See [code_style.md §1](../code-quality/code_style.md) for the version-matching procedure.
+
+## 11. Aqua
+
+`test_stale_deps` failing usually means a dev tool slipped into root `[deps]`; move it to `test/Project.toml`. `test_piracies` means you defined a method on a type you do not own; either move the method to the package that owns the type or wrap the type in your own struct. See [testing_and_validation.md](../infrastructure/testing_and_validation.md).
+
+## 12. Buildkite shared-depot corruption
+
+Buildkite jobs on shared CliMA clusters use a per-pipeline Julia [depot](https://pkgdocs.julialang.org/dev/depots/#Shared-depots-for-distributed-computing) to amortize precompilation across runs. The depot occasionally becomes corrupted — usually after a Julia version bump or an interrupted precompile — and the symptom is a failure in the *initialization* step, not in your code. Telltale messages:
+
+- `Warning: The call to compilecache failed to create a usable precompiled cache file`
+- `ERROR: LoadError: Failed to precompile <package>`
+- `ERROR: \`Pkg=...\` depends on \`OtherPkg=...\`, but no such entry exists in the manifest`
+
+(Exact wording varies by Julia version; the consistent signal is a precompile/manifest failure during pipeline initialization, not in the test step itself.) When you see these on a fresh PR with no manifest changes, the depot is the suspect. Clearing it is a one-line maintainer action; the next pipeline run rebuilds the cache. The procedure is documented in the [CliMA slurm-buildkite wiki](https://github.com/CliMA/slurm-buildkite/wiki/Clearing-Shared-Depots).
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/workflow/debugging.md
+++ b/workflow/debugging.md
@@ -1,0 +1,105 @@
+# Interactive Debugging Recipes
+
+Practical recipes for chasing wrong values, NaNs, and dispatch surprises in CliMA Julia code. For *allocation* debugging see [allocation_debugging.md](../performance/allocation_debugging.md); for type-inference issues see [type_stability.md](../performance/type_stability.md). This guide covers everything else.
+
+## 1. Numerical instability: NaNs, blowups, and "it crashed at step 437"
+
+A simulation that starts cleanly and crashes a few hundred steps in is usually a numerical-stability issue, not a logic bug. The standard workflow:
+
+1. **Find the failing step.** Run the simulation once with the failing config and note the step number where the NaN or domain error appears.
+2. **Reproduce up to just before the crash.** Start an interactive simulation and advance it one step at a time until one step before the failure. CliMA model repos drive [`ClimaTimeSteppers`](https://github.com/CliMA/ClimaTimeSteppers.jl), so the call is `CTS.step!(integrator)` (with `import ClimaTimeSteppers as CTS`).
+3. **Inspect the state.** Look at `Y`, `Yₜ`, and `p.precomputed` fields for: NaNs, negative values where positivity is required (e.g. specific humidity, density, water content), zeros where a quantity must be nonzero, and extreme magnitudes that suggest a runaway feedback.
+
+```julia
+import ClimaCore as CC
+# Quick check across a field
+extrema(parent(Y.c.ρ))             # finite range?
+any(isnan, parent(Y.c.ρ))          # any NaN?
+```
+
+For atmosphere-specific stability heuristics (CFL, hyperviscosity, sponge layers), see the [ClimaAtmos stability wiki](https://github.com/CliMA/ClimaAtmos.jl/wiki/Stability-of-simulations).
+
+4. **Enable `DebugOnly.call_post_op_callback`** if the source of the instability isn't obvious. When enabled, this callback runs after every `ClimaCore` operation, allowing you to determine the exact operation that produces the first NaN. The callback is expensive, so only enable it for debugging. For setup, see the [ClimaCore debugging guide](https://clima.github.io/ClimaCore.jl/dev/debugging/#DebugOnly.call_post_op_callback).
+
+## 2. Inspecting state with `@show`, `@info`, and `Infiltrator`
+
+In order of intrusiveness:
+
+```julia
+@show x                  # one-line printout: "x = 3.14"
+@info "before update" x y # structured log line, easier to grep
+```
+
+`@show` and `@info` are fine for narrowing down where a value goes wrong. When you want to *stop* and explore the surrounding scope, use [Infiltrator.jl](https://github.com/JuliaDebug/Infiltrator.jl):
+
+```julia
+using Infiltrator
+function suspicious_fn(a, b)
+    c = a + b
+    Main.@infiltrate     # REPL opens here with a, b, c visible
+    return c / a
+end
+```
+
+At the `infil>` prompt you can read locals, call functions, and continue with `@continue`. Infiltrator must live in your base environment (`~/.julia/config/startup.jl` is the usual place) so Julia finds it regardless of the active project.
+
+For step-through execution, [Debugger.jl](https://github.com/JuliaDebug/Debugger.jl)'s `@enter f(args...)` works for small functions but is slow on the interpreter; Infiltrator is faster for most CliMA hot-path debugging.
+
+## 3. "Why is *that* method being called?" — dispatch debugging
+
+Subtle bugs often come from a function being called with a slightly wrong argument type, dispatching to a more generic method that returns the wrong thing. Three quick introspection moves:
+
+```julia
+@which my_func(arg1, arg2)         # the exact method that will run
+
+methods(my_func)                   # every method of my_func
+
+import InteractiveUtils
+InteractiveUtils.methodswith(typeof(arg1), my_func)  # all methods of my_func taking arg1's type
+```
+
+If `@which` points at a more abstract method than you expected, the argument's static type is the culprit — track back to where it lost its concrete type. For type-instability tooling (`@code_warntype`, `JET.@report_opt`) see [allocation_debugging.md §§3–4](../performance/allocation_debugging.md).
+
+## 4. Plotting `ClimaCore.Field`s
+
+When numerical inspection isn't enough, a heatmap usually reveals the structure (a single column? a hemisphere? the poles?) of a bug. `ClimaCoreMakie` plots `Field`s directly:
+
+```julia
+using ClimaCoreMakie, CairoMakie, Makie
+
+field = ...                                  # a 2D Field
+fig = Figure()
+ax = Axis(fig[1, 1], title = "T_sfc $(extrema(parent(field)))")
+hm = fieldheatmap!(ax, field)
+Colorbar(fig[:, end+1], hm)
+Makie.save("T_sfc.png", fig)
+```
+
+For a 3D `Field`, extract a level first:
+
+```julia
+import ClimaCore as CC
+field_sfc = CC.Fields.level(field_3d, 1)     # bottom level
+fieldheatmap!(ax, field_sfc)
+```
+
+For Oceananigans state inspection, the [ClimaCoupler debugging guide](https://clima.github.io/ClimaCoupler.jl/dev/debugging/) has a "Plotting Oceananigans fields" section that covers 2D fields (`OC.interior()`), 3D fields (surface-level indexing), and `AbstractOperation` fields.
+
+## 5. Common patterns that produce silently-wrong values
+
+| Symptom                                          | Likely cause                                                         |
+|:-------------------------------------------------|:---------------------------------------------------------------------|
+| A field is zero where it should be updated      | The writer was never wired into the integrator (the tendency function exists but no caller assigns into `Yₜ.<field>`) |
+| A field carries stale values across stages       | A tendency function reads from `Yₜ` instead of writing to it — `Yₜ` must be write-only per [ecosystem_conventions.md §2](../architecture/ecosystem_conventions.md) |
+| Result differs by `~eps` from a reference        | Reordered floating-point arithmetic from a refactor — usually harmless, but flag with `🤖precisionΔ` ([changelogs_and_versions.md §1.4](../code-quality/changelogs_and_versions.md)) |
+| Float32 simulation diverges where Float64 is fine | A `1.0`/`Inf`/`6^x` literal promoted to Float64 — see [type_stability.md §1](../performance/type_stability.md) |
+| NaN appears only on GPU                          | A scalar-indexing fallback that returns garbage, or a non-`isbits` arg in a kernel — see [gpu_performance.md §§7–8](../performance/gpu_performance.md) |
+| Result depends on MPI rank count                 | A non-associative reduction or per-rank random state — see [clima_comms.md §2](../infrastructure/clima_comms.md) |
+
+## 6. Other common pitfalls
+
+- If an operation on ClimaCore `Field`s shows unexpected values in the REPL, check whether the `Field` has a mask. Masked values can appear as NaN or garbage when printed, even though the non-masked data is correct.
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/workflow/onboarding.md
+++ b/workflow/onboarding.md
@@ -1,0 +1,149 @@
+# Onboarding to a CliMA Repository
+
+A short walk from a fresh machine to a productive REPL session inside any CliMA Julia package. This guide is intentionally generic — repo-specific quirks live in the package's own `*_specific.md` guide.
+
+## 1. Install the core tools
+
+1. **Julia.** Install via [`juliaup`](https://julialang.org/downloads/). `juliaup add release` installs the current stable channel; CliMA repos test on the current LTS and one or two newer point releases — check `.github/workflows/ci.yml` of the repo you're working in for the exact matrix.
+2. **Git** and a GitHub account with an SSH key — see GitHub's [SSH setup guide](https://docs.github.com/en/authentication/connecting-to-github-with-ssh).
+3. *(Optional but recommended)* a Julia-aware editor: VS Code with the Julia extension, Helix, or Emacs/Vim with `julia-mode`/`julia-vim`.
+
+## 2. Clone and instantiate
+
+```bash
+git clone git@github.com:CliMA/<repo-name>.jl.git
+cd <repo-name>.jl
+julia --project
+```
+
+Inside the REPL:
+
+```julia
+using Pkg
+Pkg.instantiate()    # download every dep at the manifest-pinned version
+Pkg.status()         # sanity-check the resolved versions
+import <RepoName>    # confirm the package loads
+```
+
+If `Pkg.instantiate()` fails, see §8 below for the standard recovery sequence.
+
+## 3. Keep a long-running REPL — and avoid restarting it
+
+Julia's first-call latency comes from compilation. Restarting the REPL throws that work away. The two pieces of standard tooling that let you iterate without restarting:
+
+- **[Revise.jl](https://github.com/timholy/Revise.jl)** — watches package source files and patches updated method definitions into the running session.
+- **[Infiltrator.jl](https://github.com/JuliaDebug/Infiltrator.jl)** — drops you into an interactive REPL at a `@infiltrate` breakpoint without instrumenting the function, so it does not invalidate compiled code.
+
+Install both into your *base* (`v1.x`) environment so every REPL gets them automatically:
+
+```julia
+julia -e 'using Pkg; Pkg.add(["Revise", "Infiltrator"])'
+```
+
+Then add a startup file at `~/.julia/config/startup.jl`:
+
+```julia
+using Revise
+using Infiltrator
+```
+
+Now your normal loop is: start the REPL once, `using <RepoName>`, edit code, re-run — no restart needed.
+
+## 4. Formatting
+
+CliMA repos use [JuliaFormatter](https://github.com/domluna/JuliaFormatter.jl), invoked from the repo root:
+
+```julia
+using JuliaFormatter
+format(".")
+```
+
+CI pins a specific JuliaFormatter major version that varies between repos — see [code_style.md §1](../code-quality/code_style.md) for the version-matching procedure and the recommended pre-commit hook.
+
+## 5. Git workflow
+
+Prefer **rebasing** over merging to keep history linear:
+
+```bash
+git fetch origin main
+git rebase origin/main
+```
+
+When starting a new task, base your branch on the latest remote `main`:
+
+```bash
+git stash
+git checkout main
+git pull origin main
+git checkout -b <initials>/<short-description>   # e.g. ts/fix-precip-bug
+git stash pop
+```
+
+Each commit should be a logical unit of work and keep the model compilable.
+
+## 6. The first PR loop
+
+A typical first PR follows this rhythm:
+
+1. Branch: `git checkout -b <initials>/<short-description>` (e.g. `ts/fix-precip-bug`).
+2. Make changes; iterate in the REPL with Revise.
+3. Run the package's tests: `Pkg.test()` (prefer this over manually `include`ing `test/runtests.jl` — `Pkg.test` activates the test environment with the test-only deps).
+4. Format: `using JuliaFormatter; format(".")`.
+5. Add a `NEWS.md` entry if the change is user-visible — see [changelogs_and_versions.md](../code-quality/changelogs_and_versions.md).
+6. Commit, push, and open the PR. The repo-specific guide names the canonical CI driver and the test groups that should be green before review.
+
+For PR-review conventions, see [review.md](review.md). For what AI agents may and may not do without explicit approval, see [agent_autonomy.md](agent_autonomy.md).
+
+## 7. Removing a feature
+
+When a feature is deprecated or removed, follow the full cleanup protocol:
+
+1. **Source removal**: delete implementation code, structs, and methods.
+2. **Configuration purge**: remove options from config files and parsers; ensure that choosing a removed option triggers a clear `error` listing valid alternatives.
+3. **Test cleanup**: delete targeted tests; update integration tests to use supported alternatives. Mirror changes between `src/` and `test/`.
+4. **Dependency slimming**: if a package was used only by the removed feature, drop it from both `[deps]` and `[compat]` ([dependency_management.md §5](../architecture/dependency_management.md)).
+5. **Documentation update**: update docstrings and docs pages to reflect the removal.
+6. **`NEWS.md` entry**: under `![][badge-💥breaking]` if it was a public surface ([changelogs_and_versions.md](../code-quality/changelogs_and_versions.md)).
+
+## 8. Resolving a stuck environment
+
+`Pkg` occasionally fails to find a satisfiable version set — typically after a `[compat]` change. The cheapest-to-most-expensive recovery sequence:
+
+```julia
+import Pkg
+Pkg.instantiate()   # 1. make the manifest match Project.toml
+Pkg.resolve()       # 2. re-run the resolver against current compat bounds
+Pkg.update()        # 3. move every direct dep to its newest compat-allowed version
+```
+
+If those do not converge, one package is usually pinned at a version that no longer fits. Remove and re-add it so the resolver picks a fresh version:
+
+```julia
+Pkg.rm("OffendingPackage")
+Pkg.add("OffendingPackage")
+```
+
+Two mutually-constraining packages should be removed and re-added together. `Pkg.status()` shows current pins; `Pkg.resolve()` prints the resolver's diagnostic — read that before guessing.
+
+## 9. Useful Julia tooling beyond the basics
+
+These all live in your *base* environment, not the project's:
+
+- **[TestEnv.jl](https://github.com/JuliaTesting/TestEnv.jl)** — `using TestEnv; TestEnv.activate()` makes the test-only deps available in an interactive REPL, so you can debug a failing test without `Pkg.test`'s startup cost.
+- **[BenchmarkTools.jl](https://github.com/JuliaCI/BenchmarkTools.jl)** — `@benchmark` for measuring time and allocations of hot-path code. See [allocation_debugging.md §5](../performance/allocation_debugging.md).
+- **[LiveServer.jl](https://github.com/JuliaDocs/LiveServer.jl)** — `servedocs()` builds the docs site locally and auto-reloads on file changes.
+- **[About.jl](https://github.com/tecosaur/About.jl)** — `about(x)` summarizes any value's type, memory layout, and methods.
+- **[OhMyREPL.jl](https://github.com/KristofferC/OhMyREPL.jl)** - provides syntax highlighting within the REPL
+  - Add `using OhMyREPL` to `~/.julia/config/startup.jl` to ensure it loads with every REPL session.
+- **[Kaimon.jl](https://github.com/kahliburke/Kaimon.jl)** - provides AI agents with direct access to the Julia REPL, with your standard tools like `Revise` and `Infiltrator` for quick iteration and debugging
+
+## 10. Knowing where to look
+
+- The Julia manual: [docs.julialang.org](https://docs.julialang.org/en/v1/manual/getting-started/). The [Variables](https://docs.julialang.org/en/v1/manual/variables/) through [Documentation](https://docs.julialang.org/en/v1/manual/documentation/) sections cover what you need for day-to-day work.
+- [Modern Julia Workflows](https://modernjuliaworkflows.org/writing/) — a current, opinionated guide to REPL-driven Julia development.
+- The [Julia performance tips](https://docs.julialang.org/en/v1/manual/performance-tips/) — read once when you start writing hot-path code; [type_stability.md](../performance/type_stability.md) and [gpu_performance.md](../performance/gpu_performance.md) are the CliMA-specific extension.
+- For ecosystem-wide conventions (`Y`/`Yₜ`/`p` state, `ᶜ`/`ᶠ` notation, module aliases), see [ecosystem_conventions.md](../architecture/ecosystem_conventions.md).
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.

--- a/workflow/review.md
+++ b/workflow/review.md
@@ -1,0 +1,96 @@
+# PR Review Instructions
+
+You are reviewing PRs for a CliMA package.
+
+Keep the review concise, evidence-based, and findings-first. Optimize for concrete bugs, regressions, and missing validation. Do not write broad architecture summaries.
+
+## Review workflow
+
+Work in this order:
+
+1. Review changed files first.
+2. Step to the nearest controlling compute paths only when needed to confirm behavior or risk.
+3. Use local evidence: changed code, nearby tests, call sites, docs, and config usage.
+4. Check [software_design_patterns.md](../code-quality/software_design_patterns.md) for changed code and any adjacent code whose behavior is directly affected.
+5. Report only evidence-backed findings or clearly labeled risks/open questions.
+
+## Review checklist
+
+### Correctness and science risk (in order)
+
+- [ ] Check behavior, numerics, stability, conservation, restart reproducibility, diagnostics, and config semantics.
+- [ ] Prioritize high-risk areas: implicit solver, Jacobian, prognostic equations, parameterized tendencies, restart logic, and output/reproducibility paths.
+- [ ] Label concerns as one of: definite bug, likely regression, or plausible risk.
+- [ ] Flag any user-visible config key, diagnostic name, default, release-facing behavior, or CLI flag change that is missing a `NEWS.md` entry. See [changelogs_and_versions.md](../code-quality/changelogs_and_versions.md).
+
+### Validation
+
+- [ ] Map validation to the test groups defined in the repo's `test/runtests.jl`. The repo-specific guide (linked from [AGENTS.md](../AGENTS.md)) lists the groups and example jobs.
+- [ ] For config or runtime workflow changes, name the affected CI driver and Buildkite/GitHub Actions jobs explicitly.
+- [ ] If validation is missing, name the exact missing test group, nearby test file, or CI job.
+
+### Compatibility, performance, and style
+
+- [ ] Check API and config compatibility: keys, defaults, diagnostics/output names, initialization, restart/reproducibility behavior, and downstream public APIs.
+- [ ] Check concrete performance risks in hot paths (see [gpu_performance.md](../performance/gpu_performance.md) for the definition of hot path): allocations, type instability, repeated work, and scaling regressions.
+- [ ] Flag data-dependent `if/else` inside GPU kernels as `high` (thread divergence).
+- [ ] Flag closures passed to any `integrate`, `quadrature`, or `bycolumn` call as `high` (functor required).
+- [ ] Flag Float32 literals (`1.0`, `Inf`, integer-base exponentiation like `6^x`) in functions touched by Float32 simulations as `medium`.
+- [ ] Flag new `where {FT}` annotations on non-constructor physics functions as `low` (AD compatibility).
+- [ ] Check consistency with the repo's contributor guide and `.JuliaFormatter.toml`.
+- [ ] Avoid low-signal style commentary unless it hides or causes a real issue.
+
+## Severity rules
+
+Use exactly these labels: `high`, `medium`, `low`. Choose the severity based on user-visible and scientific impact, not on how easy the fix is.
+
+| Label    | When to use                                                                                                      | Examples                                                                                                                                                                                                                     |
+|:---------|:-----------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `high`   | Correctness or science regressions, hot-path performance breakage, compatibility breaks with clear impact.       | Wrong numerics; broken conservation; restart non-bit-reproducibility; silently changed defaults; public API broken without deprecation; GPU runs broken; new allocation or type instability in a tendency/Jacobian hot path. |
+| `medium` | Likely regressions, plausible science risk without definitive proof, missing safeguards around changed behavior. | Plausible numerical drift; missing test coverage for changed behavior; undocumented config or diagnostic change; formatting/style violation that hides a real issue.                                                         |
+| `low`    | Issues with no expected behavior impact.                                                                         | Style, naming, or documentation nits; refactor suggestions with no behavior impact. May be batched into one bullet.                                                                                                          |
+
+## Output schema (must follow)
+
+### Review summary
+
+Start with a brief scope statement that includes:
+
+- Files changed.
+- Tests run.
+- Any specific areas of focus.
+- Any known review limitations.
+
+Then list findings in descending severity.
+
+For each finding, include all of the following:
+
+- Severity label: `high`, `medium`, or `low`.
+- Category.
+- Short title.
+- Affected files or functions.
+- Specific bug or risk.
+- Two to five sentences of reasoning grounded in local evidence.
+- Missing validation, if applicable.
+
+Then include:
+
+- Open questions/assumptions.
+- Residual testing gaps.
+
+If no findings are found, write exactly:
+
+`No concrete bugs found.`
+
+Then list residual risks briefly.
+
+## Repo facts to enforce
+
+- Some simulation validation is Buildkite-driven; the repo-specific guide names the canonical CI driver.
+- Restart/reproducibility, conservation, diagnostics, and implicit solver changes are especially sensitive.
+- Allocation benchmarks (typically under `perf/`) are not run in CI; allocation regressions must be caught in review using the `@allocated` pattern.
+- If evidence is insufficient, report a risk or open question; do not invent failures.
+
+## Self-correction
+
+If this guide is discovered to be stale or missing a pattern, update it.


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

Adds DeveloperGuides as a subtree, plus a local AGENTS.md file with land-specific info. The subtree updates automatically monthly. 

Only one file here needs review: the local AGENTS.md in the repo root. The rest is copied from the DeveloperGuides repo and needs to be changed there. 


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
