### PR TITLE
Make ClimaLand compatible with upcoming ClimaTimestepper release

### DIFF
--- a/src/simulations/Simulations.jl
+++ b/src/simulations/Simulations.jl
@@ -17,7 +17,7 @@ import ..Diagnostics: close_output_writers
 """
     LandSimulation{
         M <: ClimaLand.AbstractModel,
-        T <: ClimaTimeSteppers.DistributedODEAlgorithm,
+        T <: ClimaTimeSteppers.TimeSteppingAlgorithm,
         UC,
         DI,
         RC,
@@ -45,7 +45,7 @@ forcing and update the LAI using prescribed data.
 """
 struct LandSimulation{
     M <: ClimaLand.AbstractModel,
-    T <: ClimaTimeSteppers.DistributedODEAlgorithm,
+    T <: ClimaTimeSteppers.TimeSteppingAlgorithm,
     UC,
     DI,
     RC,


### PR DESCRIPTION
* `DistributedODEAlgorithm` is a backward-compat alias in CTS. This PR replaces its use with the canonical `TimeSteppingAlgorithm` so CTS can drop the alias.

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
