### PR TITLE
Modify broadcast to work with ClimaCore bug

### DIFF
--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -535,9 +535,9 @@ function ClimaLand.make_compute_jacobian(model::EnergyHydrology{FT}) where {FT}
                 MatrixFields.LowerDiagonalMatrixRow(p.soil.topBC_scratch)
         end
         # dtγ can be an ITime or a float
+        negative_dtγ = FT(-float(dtγ))
         @. ∂ϑres∂ϑ =
-            FT(-1) *
-            float(dtγ) *
+            negative_dtγ *
             (divf2c_matrix() ⋅ p.soil.full_bidiag_matrix_scratch) - (I,)
 
         # Now create the flux term for ∂ρe∂ϑ using bidiag_matrix_scratch
@@ -552,8 +552,7 @@ function ClimaLand.make_compute_jacobian(model::EnergyHydrology{FT}) where {FT}
                 ),
             ) ⋅ p.soil.bidiag_matrix_scratch
         @. ∂ρeres∂ϑ =
-            FT(-1) *
-            float(dtγ) *
+            negative_dtγ *
             (divf2c_matrix() ⋅ p.soil.full_bidiag_matrix_scratch) - (I,)
 
         # Now overwrite bidiag_matrix_scratch and full_bidiag scratch for the ρe ρe bidiagonal
@@ -570,8 +569,7 @@ function ClimaLand.make_compute_jacobian(model::EnergyHydrology{FT}) where {FT}
             MatrixFields.DiagonalMatrixRow(interpc2f_op(-p.soil.κ)) ⋅
             p.soil.bidiag_matrix_scratch
         @. ∂ρeres∂ρe =
-            FT(-1) *
-            float(dtγ) *
+            negative_dtγ *
             (divf2c_matrix() ⋅ p.soil.full_bidiag_matrix_scratch) - (I,)
     end
     return compute_jacobian!

--- a/src/standalone/Soil/rre.jl
+++ b/src/standalone/Soil/rre.jl
@@ -448,11 +448,10 @@ function ClimaLand.make_compute_jacobian(model::RichardsModel{FT}) where {FT}
                 MatrixFields.LowerDiagonalMatrixRow(p.soil.topBC_scratch)
         end
         # Compute divergence matrix
+        negative_dtγ = FT(-float(dtγ))
         @. ∂ϑres∂ϑ =
-            FT(-1) *
-            float(dtγ) *
+            negative_dtγ *
             (divf2c_matrix() ⋅ p.soil.full_bidiag_matrix_scratch) - (I,)
-
 
     end
     return compute_jacobian!

--- a/test/integrated/full_land.jl
+++ b/test/integrated/full_land.jl
@@ -210,14 +210,17 @@ snow, soil, soilco2).
 Useful for checking if land model functions are updating the
 values over the ocean.
 """
-function check_ocean_values_Y(Y, binary_mask; val = 0.0)
+function check_ocean_values_Y(Y, binary_mask; val = 0.0, broken = false)
+    # broken kwarg is used because ClimaCore 0.14.52 changed the tridiagnal solver to
+    # be not mask aware, which causes some of these to break. Once we update ClimaCore,
+    # we can remove the broken kwargs and the conditionals below.
     @test extrema(Array(parent(Y.soil.ϑ_l))[:, 1, 1, 1, Array(binary_mask)]) ==
-          (val, val)
+          (val, val) broken = broken
     @test extrema(Array(parent(Y.soil.θ_i))[:, 1, 1, 1, Array(binary_mask)]) ==
           (val, val)
     @test extrema(
         Array(parent(Y.soil.ρe_int))[:, 1, 1, 1, Array(binary_mask)],
-    ) == (val, val)
+    ) == (val, val) broken = broken
     @test extrema(Array(parent(Y.snow.U))[1, 1, 1, Array(binary_mask)]) ==
           (val, val)
     @test extrema(Array(parent(Y.snow.S))[1, 1, 1, Array(binary_mask)]) ==
@@ -584,7 +587,17 @@ end
         jac_prototype.matrix,
         b,
     )
-    check_ocean_values_Y(x, binary_mask; val = 1.0)
+    # ClimaCore 0.14.52 changed the tridiagnal solver to
+    # be not mask aware
+    tridiagonal_solve_not_mask_aware =
+        pkgversion(ClimaCore) == v"0.14.52" &&
+        ClimaComms.device() isa ClimaComms.CUDADevice
+    check_ocean_values_Y(
+        x,
+        binary_mask;
+        val = 1.0,
+        broken = tridiagonal_solve_not_mask_aware,
+    )
 
     # Take a step
     jac_kwargs = (; jac_prototype = jac_prototype, Wfact = jacobian!)
@@ -619,7 +632,11 @@ end
         saveat = [t0, t0 + Δt],
     )
     u = sol.u[end]
-    check_ocean_values_Y(u, binary_mask)
+    check_ocean_values_Y(
+        u,
+        binary_mask;
+        broken = tridiagonal_solve_not_mask_aware,
+    )
 end
 
 @testset "Default LandModel with inland waters" begin

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -211,11 +211,14 @@ import ClimaParams
         LW_d = FT.(longwave_radiation(t0))
         LW_d_canopy = @. (1 - ϵ_canopy) * LW_d + ϵ_canopy * _σ * T_canopy^4
         LW_u_soil = @. ϵ_soil * _σ * T_soil^4 + (1 - ϵ_soil) * LW_d_canopy
-        @test p.canopy.radiative_transfer.LW_n == @. (
-            ϵ_canopy * LW_d - 2 * ϵ_canopy * _σ * T_canopy^4 +
-            ϵ_canopy * LW_u_soil
+        @test all(
+            Array(parent(p.canopy.radiative_transfer.LW_n)) .≈ Array(
+                parent(
+                    @. ϵ_canopy * LW_d - 2 * ϵ_canopy * _σ * T_canopy^4 +
+                       ϵ_canopy * LW_u_soil
+                ),
+            ),
         )
-
         @test all(Array(parent(p.canopy.energy.fa_energy_roots)) .== FT(0))
         @test all(
             Array(


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This is a temporary work-around for the regression caused by the new ClimaCore release.
## To-do
- alternatively, we can cap the ClimaCore version used in the tests. This should not impact the coupler, because I believe the issue is only with the Richards model


- [x] I have read and checked the items on the review checklist.
