### PR TITLE
Use CTS cache_imp! and simplify implicit cache update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ ClimaLand.jl Release Notes
 ========================
 main
 ----
+- Reduce unnecessary computation for sublimation, shortwave radiation, and implicit cache; removal of make_imp_tendency and make_update_jacobian functions PR[#1757](https://github.com/CliMA/ClimaLand.jl/pull/1757)
 - Add `inversion_nee` artifact (inversion-derived NEE/GPP/ER/Rh, monthly 1°×1°, 2002–2020) and `inversion_nee_dataset_path` accessor PR[#1760](https://github.com/CliMA/ClimaLand.jl/pull/1760)
 - Make SoilCO2 and O2 implicitly stepped PR[#1752](https://github.com/CliMA/ClimaLand.jl/pull/1752)
 - Change timestep to 900s from 450s in calibration, longruns and benchmarks; reduce the number of short/default diagnostics PR[#1756](https://github.com/CliMA/ClimaLand.jl/pull/1756)

--- a/docs/src/APIs/SolverFunctions.md
+++ b/docs/src/APIs/SolverFunctions.md
@@ -35,10 +35,8 @@ ClimaLand.boundary_var_types
 ## Implicit Tendencies
 
 ```@docs
-ClimaLand.make_imp_tendency
 ClimaLand.make_compute_imp_tendency
 ClimaLand.make_compute_jacobian
-ClimaLand.make_jacobian
 ClimaLand.initialize_jacobian
 ```
 

--- a/experiments/benchmarks/richards.jl
+++ b/experiments/benchmarks/richards.jl
@@ -45,9 +45,9 @@ const FT = Float64;
 
 ######################################################################
 ## This result is from a benchmark run on an A100 on the clima cluster
-const PREVIOUS_GPU_TIME_S = 0.38
+const PREVIOUS_GPU_TIME_S = 0.37
 ## This result is from a benchmark run with a single process on the clima cluster
-const PREVIOUS_CPU_TIME_S = 1.23
+const PREVIOUS_CPU_TIME_S = 1.03
 ######################################################################
 
 include("benchmark_utils.jl")

--- a/experiments/benchmarks/snowy_land.jl
+++ b/experiments/benchmarks/snowy_land.jl
@@ -38,7 +38,7 @@ const FT = Float64
 ## This result is from a benchmark run on an A100 on the clima cluster
 const PREVIOUS_GPU_TIME_S = 0.315
 ## This result is from a benchmark run with a single process on the clima cluster
-const PREVIOUS_CPU_TIME_S = 20.7
+const PREVIOUS_CPU_TIME_S = 16.5
 ######################################################################
 
 include("benchmark_utils.jl")

--- a/experiments/integrated/performance/conservation/ozark_conservation.jl
+++ b/experiments/integrated/performance/conservation/ozark_conservation.jl
@@ -235,12 +235,13 @@ for float_type in (Float32, Float64)
     # Integrated plant hydraulics and soil model
     land = SoilCanopyModel{FT}(soilco2, soil, canopy)
     exp_tendency! = make_exp_tendency(land)
-    imp_tendency! = make_imp_tendency(land)
-    jacobian! = make_jacobian(land)
+    imp_tendency! = make_compute_imp_tendency(land)
+    jacobian! = make_compute_jacobian(land)
     set_initial_cache! = make_set_initial_cache(land)
     Y, p, cds = initialize(land)
     jac_kwargs =
         (; jac_prototype = ClimaLand.initialize_jacobian(Y), Wfact = jacobian!)
+    CL_cache_imp! = ClimaLand.make_update_implicit_cache(land)
 
     set_ic! = FluxnetSimulations.make_set_fluxnet_initial_conditions(
         site_ID,
@@ -280,6 +281,7 @@ for float_type in (Float32, Float64)
                 jac_kwargs...,
             ),
             dss! = ClimaLand.dss!,
+            cache_imp! = (Y, p, t) -> CL_cache_imp!(p, Y, t),
         ),
         Y,
         (t0, tf),

--- a/src/ClimaLand.jl
+++ b/src/ClimaLand.jl
@@ -42,7 +42,7 @@ this interface and it should not be used for that purpose.
 Many methods taking an argument of type `AbstractLandModel` are
 extensions of functions defined for `AbstractModel`s.
 There are default methods that apply for all `AbstractLandModel`s,
-including `make_update_aux`, `make_exp_tendency`, `make_imp_tendency`,
+including `make_update_aux`, `make_exp_tendency`,
 `make_compute_exp_tendency`, `make_compute_imp_tendency`,
 `initialize_prognostic`, `initialize_auxiliary`, `initialize`,
 and `coordinates`.
@@ -151,18 +151,16 @@ function initialize_lsm_aux(land::AbstractLandModel, land_coords)
 end
 
 
-function make_imp_tendency(land::AbstractLandModel)
+function make_compute_imp_tendency(land::AbstractLandModel)
     components = land_components(land)
     compute_imp_tendency_list =
         map(x -> make_compute_imp_tendency(getproperty(land, x)), components)
-    update_imp_c! = make_update_implicit_cache(land)
-    NVTX.@annotate function imp_tendency!(dY, Y, p, t)
-        update_imp_c!(p, Y, t)
+    NVTX.@annotate function compute_imp_tendency!(dY, Y, p, t)
         for f! in compute_imp_tendency_list
             f!(dY, Y, p, t)
         end
     end
-    return imp_tendency!
+    return compute_imp_tendency!
 end
 
 function make_exp_tendency(land::AbstractLandModel)

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -623,8 +623,8 @@ function make_update_implicit_cache(
         update_imp_aux_soil!(p, Y, t)
         update_imp_aux_soilco2!(p, Y, t)
         update_imp_aux_canopy!(p, Y, t)
-        # Radiation - updates Rn for soil, snow, lake also
-        lsm_radiant_energy_fluxes!(
+        # Implicit Radiation terms
+        implicit_radiant_energy_fluxes!(
             p,
             land,
             land.canopy.radiative_transfer,
@@ -642,7 +642,6 @@ function make_update_implicit_cache(
     end
     return update_implicit_cache!
 end
-
 
 """
     lsm_radiant_energy_fluxes!(p,land::LandModel{FT},
@@ -756,6 +755,69 @@ NVTX.@annotate function lsm_radiant_energy_fluxes!(
     @. LW_u = (1 - ϵ_canopy) * LW_u_ground + ϵ_canopy * _σ * T_canopy^4
 end
 
+"""
+    implicit_radiant_energy_fluxes!(p,land::LandModel{FT},
+                                    canopy_radiation::Canopy.AbstractRadiationModel{FT},
+                                    Y,
+                                    t,
+                                    ) where {FT}
+
+
+A function which updates terms which depend on canopy temperature
+and are implicit.
+"""
+NVTX.@annotate function implicit_radiant_energy_fluxes!(
+    p,
+    land::LandModel{FT},
+    canopy_radiation::Canopy.AbstractRadiationModel{FT},
+    Y,
+    t,
+) where {FT}
+    canopy = land.canopy
+    canopy_bc = canopy.boundary_conditions
+    snow = land.snow
+    radiation = canopy_bc.radiation
+    earth_param_set = canopy.earth_param_set
+    _σ = LP.Stefan(earth_param_set)
+    LW_d = p.drivers.LW_d
+
+    ϵ_canopy = p.canopy.radiative_transfer.ϵ # this takes into account LAI/SAI
+    T_canopy = ClimaLand.Canopy.canopy_temperature(canopy.energy, canopy, Y, p)
+
+    ϵ_soil = ClimaLand.surface_emissivity(land.soil, Y, p)
+    T_soil = ClimaLand.component_temperature(land.soil, Y, p)
+
+    ϵ_snow = land.snow.parameters.ϵ_snow
+    T_snow = p.snow.T_sfc
+
+    # in W/m^2
+    LW_d_canopy = p.scratch1
+    LW_u_soil = p.scratch2
+    LW_u_snow = p.scratch3
+    LW_net_canopy = p.canopy.radiative_transfer.LW_n
+    LW_u = p.LW_u
+
+    # Working through the math, this satisfies: LW_d - LW_u = LW_c + LW_soil + LW_snow
+    @. LW_d_canopy = ((1 - ϵ_canopy) * LW_d + ϵ_canopy * _σ * T_canopy^4) # double checked
+
+    @. LW_u_soil = ϵ_soil * _σ * T_soil^4 + (1 - ϵ_soil) * LW_d_canopy # double checked
+    @. LW_u_snow = ϵ_snow * _σ * T_snow^4 + (1 - ϵ_snow) * LW_d_canopy # identical to soil, checked
+    LW_u_lake = p.sfc_scratch
+    # updates lake p.lake.R_n and LW_u_lake
+    if land.lake isa Nothing
+        LW_u_lake .= 0
+    else
+        ϵ_lake = land.lake.parameters.emissivity
+        T_lake = p.lake.T
+        @. LW_u_lake = ϵ_lake * _σ * T_lake^4 + (1 - ϵ_lake) * LW_d_canopy
+    end
+    LW_u_ground =
+        ground_lw_upwelling(land.lake, p, LW_u_soil, LW_u_snow, LW_u_lake)
+    @. LW_net_canopy =
+        ϵ_canopy * LW_d - 2 * ϵ_canopy * _σ * T_canopy^4 +
+        ϵ_canopy * LW_u_ground
+    @. LW_u = (1 - ϵ_canopy) * LW_u_ground + ϵ_canopy * _σ * T_canopy^4
+end
 
 ### Extensions of existing functions to account for prognostic soil/canopy
 """
@@ -950,15 +1012,18 @@ NVTX.@annotate function snow_boundary_fluxes!(
         model.parameters.earth_param_set,
     )
 
+    residual_surface_flux =
+        Snow.get_residual_surface_flux(model.parameters.surf_temp, Y, p)
     # positive fluxes are TOWARDS atmos, but R_n positive if snow absorbs energy
-    p.snow.total_energy_flux .=
-        e_flux_falling_snow .* (1 .- p.lake_fraction) .+
+    @. p.snow.total_energy_flux =
+        e_flux_falling_snow * (1 - p.lake_fraction) +
         (
-            Snow.get_residual_surface_flux(model.parameters.surf_temp, Y, p) .+
-            p.snow.turbulent_fluxes.lhf .+ p.snow.turbulent_fluxes.shf .+
-            p.snow.R_n .- p.snow.energy_runoff .- p.ground_heat_flux .+
+            residual_surface_flux +
+            p.snow.turbulent_fluxes.lhf +
+            p.snow.turbulent_fluxes.shf +
+            p.snow.R_n - p.snow.energy_runoff - p.ground_heat_flux +
             e_flux_falling_rain
-        ) .* p.snow.snow_cover_fraction
+        ) * p.snow.snow_cover_fraction
     return nothing
 end
 

--- a/src/integrated/soil_canopy_model.jl
+++ b/src/integrated/soil_canopy_model.jl
@@ -301,7 +301,7 @@ function make_update_implicit_cache(
         update_imp_aux_soilco2!(p, Y, t)
         update_imp_aux_canopy!(p, Y, t)
         # Radiation - updates Rn for soil and snow also
-        lsm_radiant_energy_fluxes!(
+        implicit_radiant_energy_fluxes!(
             p,
             land,
             land.canopy.radiative_transfer,
@@ -391,6 +391,48 @@ function lsm_radiant_energy_fluxes!(
     @. LW_u_soil = ϵ_soil * _σ * T_soil^4 + (1 - ϵ_soil) * LW_d_canopy # double checked
     # This is a sign inconsistency. Here Rn is positive if towards soil. X_X
     @. R_net_soil += ϵ_soil * LW_d_canopy - ϵ_soil * _σ * T_soil^4 # double checked
+    @. LW_net_canopy =
+        ϵ_canopy * LW_d - 2 * ϵ_canopy * _σ * T_canopy^4 + ϵ_canopy * LW_u_soil
+
+    @. LW_u = (1 - ϵ_canopy) * LW_u_soil + ϵ_canopy * _σ * T_canopy^4 # double checked
+end
+
+"""
+    implicit_radiant_energy_fluxes!(p, land::SoilCanopyModel{FT},
+                                    canopy_radiation::Canopy.AbstractRadiationModel{FT},
+                                    Y,
+                                    t,
+                                    ) where {FT}
+
+
+A function which updates terms which depend on canopy temperature
+and are implicit.
+"""
+function implicit_radiant_energy_fluxes!(
+    p,
+    land::SoilCanopyModel{FT},
+    canopy_radiation::Canopy.AbstractRadiationModel{FT},
+    Y,
+    t,
+) where {FT}
+    canopy = land.canopy
+    earth_param_set = canopy.earth_param_set
+    _σ = LP.Stefan(earth_param_set)
+    LW_d = p.drivers.LW_d
+
+    ϵ_canopy = p.canopy.radiative_transfer.ϵ # this takes into account LAI/SAI
+    T_canopy = ClimaLand.Canopy.canopy_temperature(canopy.energy, canopy, Y, p)
+    ϵ_soil = land.soil.parameters.emissivity
+    T_soil = ClimaLand.Domains.top_center_to_surface(p.soil.T)
+
+    # in W/m^2
+    LW_d_canopy = p.scratch1
+    LW_u_soil = p.scratch2
+    LW_net_canopy = p.canopy.radiative_transfer.LW_n
+    LW_u = p.LW_u
+    # Working through the math, this satisfies: LW_d - LW_u = LW_c + LW_soil
+    @. LW_d_canopy = ((1 - ϵ_canopy) * LW_d + ϵ_canopy * _σ * T_canopy^4) # double checked
+    @. LW_u_soil = ϵ_soil * _σ * T_soil^4 + (1 - ϵ_soil) * LW_d_canopy # double checked
     @. LW_net_canopy =
         ϵ_canopy * LW_d - 2 * ϵ_canopy * _σ * T_canopy^4 + ϵ_canopy * LW_u_soil
 

--- a/src/integrated/soil_snow_model.jl
+++ b/src/integrated/soil_snow_model.jl
@@ -486,7 +486,7 @@ of `ClimaLand.source!` for soil sublimation with snow or lakes present.
 """
 @kwdef struct PartialAreaSoilSublimation{FT} <:
               ClimaLand.Soil.AbstractSoilSource{FT}
-    explicit::Bool = false
+    explicit::Bool = true
 end
 
 """

--- a/src/shared_utilities/implicit_timestepping.jl
+++ b/src/shared_utilities/implicit_timestepping.jl
@@ -5,30 +5,7 @@ import LinearAlgebra
 import LinearAlgebra: I
 using NVTX
 
-export make_jacobian, make_compute_jacobian, set_dfluxBCdY!, initialize_jacobian
-
-"""
-    make_jacobian(model::AbstractModel)
-
-Creates and returns a function which updates the auxiliary
-variables `p` in place and then updates the entries of the
-Jacobian matrix `W` for the `model` in place.
-
-The default is that no updates are required, no implicit tendency is
-present, and hence the timestepping is entirely explicit.
-
-Note that the returned function `jacobian!` should be
-used as `Wfact!` in `ClimaTimeSteppers.jl`.
-"""
-function make_jacobian(model::AbstractModel)
-    update_implicit_cache! = make_update_implicit_cache(model)
-    compute_jacobian! = make_compute_jacobian(model)
-    NVTX.@annotate function jacobian!(W, Y, p, dtγ, t)
-        update_implicit_cache!(p, Y, t)
-        compute_jacobian!(W, Y, p, dtγ, t)
-    end
-    return jacobian!
-end
+export make_compute_jacobian, set_dfluxBCdY!, initialize_jacobian
 
 """
     make_compute_jacobian(model::AbstractModel)

--- a/src/shared_utilities/models.jl
+++ b/src/shared_utilities/models.jl
@@ -1,7 +1,6 @@
 export AbstractModel,
     AbstractImExModel,
     AbstractExpModel,
-    make_imp_tendency,
     make_exp_tendency,
     make_compute_imp_tendency,
     make_compute_exp_tendency,
@@ -44,7 +43,7 @@ abstract type AbstractModel{FT <: AbstractFloat} end
 
 An abstract type for models which have both implicit and explicitly stepped variables
 This inherits all the default function definitions from AbstractModel, as well
-as `make_imp_tendency` and `make_compute_imp_tendency` defaults.
+as `make_compute_imp_tendency` defaults.
 """
 abstract type AbstractImExModel{FT} <: AbstractModel{FT} end
 
@@ -53,7 +52,7 @@ abstract type AbstractImExModel{FT} <: AbstractModel{FT} end
 
 An abstract type for models with only explicitly stepped variables.
 This inherits all the default function definitions from AbstractModel, as well
-as a `make_imp_tendency` default.
+as a `make_compute_imp_tendency` default.
 """
 abstract type AbstractExpModel{FT} <: AbstractModel{FT} end
 
@@ -268,37 +267,6 @@ add anything, consistent with the default of no additional
 driver variables in the cache.
 """
 add_drivers_to_cache(p, model::AbstractModel) = p
-
-"""
-    make_imp_tendency(model::AbstractImExModel)
-
-Returns an `imp_tendency` that updates auxiliary variables and
-updates the prognostic state of variables that are stepped implicitly.
-
-`compute_imp_tendency!` should be compatible with ClimaTimeSteppers.jl solvers.
-"""
-function make_imp_tendency(model::AbstractImExModel)
-    compute_imp_tendency! = make_compute_imp_tendency(model)
-    update_implicit_cache! = make_update_implicit_cache(model)
-    function imp_tendency!(dY, Y, p, t)
-        update_implicit_cache!(p, Y, t)
-        compute_imp_tendency!(dY, Y, p, t)
-    end
-    return imp_tendency!
-end
-
-"""
-    make_imp_tendency(model::AbstractModel)
-
-Returns an `imp_tendency` that does nothing. This model type is not
-stepped implicitly.
-"""
-function make_imp_tendency(model::AbstractModel)
-    compute_imp_tendency! = make_compute_imp_tendency(model)
-    function imp_tendency!(dY, Y, p, t)
-        compute_imp_tendency!(dY, Y, p, t)
-    end
-end
 
 """
     make_exp_tendency(model::AbstractModel)

--- a/src/simulations/Simulations.jl
+++ b/src/simulations/Simulations.jl
@@ -172,14 +172,17 @@ function LandSimulation(
     exp_tendency! = make_exp_tendency(model)
     if model isa ClimaLand.AbstractExpModel
         T_imp! = nothing
+        cache_imp! = Returns(nothing)
     else
-        imp_tendency! = ClimaLand.make_imp_tendency(model)
-        jacobian! = ClimaLand.make_jacobian(model)
+        imp_tendency! = ClimaLand.make_compute_imp_tendency(model)
+        jacobian! = ClimaLand.make_compute_jacobian(model)
         jac_kwargs = (;
             jac_prototype = ClimaLand.initialize_jacobian(Y),
             Wfact = jacobian!,
         )
         T_imp! = ClimaTimeSteppers.ODEFunction(imp_tendency!; jac_kwargs...)
+        CL_cache_imp! = ClimaLand.make_update_implicit_cache(model)
+        cache_imp! = (Y, p, t) -> CL_cache_imp!(p, Y, t)
     end
 
     # Create SciML ODE Problem
@@ -188,6 +191,7 @@ function LandSimulation(
             T_exp! = exp_tendency!,
             T_imp! = T_imp!,
             dss! = ClimaLand.dss!,
+            cache_imp! = cache_imp!,
         ),
         Y,
         (t0, tf),

--- a/src/standalone/Soil/energy_hydrology.jl
+++ b/src/standalone/Soil/energy_hydrology.jl
@@ -909,12 +909,11 @@ end
 """
     SoilSublimation{FT} <: AbstractSoilSource{FT}
 
-Soil Sublimation source type. Used to defined a method
-of `ClimaLand.source!` for soil sublimation; treated implicitly
-in ϑ_l, ρe_int but explicitly in θ_i.
+Soil Sublimation source type. Treated explicitly since the turbulent
+fluxes for SHF and LHF are also treated explicitly.
 """
 @kwdef struct SoilSublimation{FT} <: AbstractSoilSource{FT}
-    explicit::Bool = false
+    explicit::Bool = true
 end
 """
     source!(dY::ClimaCore.Fields.FieldVector,

--- a/test/diagnostics/diagnostics_tests.jl
+++ b/test/diagnostics/diagnostics_tests.jl
@@ -308,7 +308,8 @@ end
         return
     end
 
-    ClimaLand.make_imp_tendency(::ClimaLand.LandModel) = Returns(nothing)
+    ClimaLand.make_compute_imp_tendency(::ClimaLand.LandModel) =
+        Returns(nothing)
     ClimaLand.make_exp_tendency(::ClimaLand.LandModel) = Returns(nothing)
     ClimaLand.make_update_aux(::ClimaLand.LandModel) = Returns(nothing)
     ClimaLand.make_update_boundary_fluxes(::ClimaLand.LandModel) =

--- a/test/integrated/full_land.jl
+++ b/test/integrated/full_land.jl
@@ -506,8 +506,8 @@ end
     dY = similar(Y)
     # Implicit tendency
     @. dY = 0
-    imp_tendency! = make_imp_tendency(land)
-    imp_tendency!(dY, Y, p, t0)
+    compute_imp_tendency! = make_compute_imp_tendency(land)
+    compute_imp_tendency!(dY, Y, p, t0)
     @info("testing implicit tendency")
     check_ocean_values_Y(dY, binary_mask)
 
@@ -522,10 +522,11 @@ end
     # Jacobian checks
     @info("testing Jacobian updates")
 
-    jacobian! = ClimaLand.make_jacobian(land)
+    jacobian! = ClimaLand.make_compute_jacobian(land)
     jac_prototype = ClimaLand.initialize_jacobian(Y)
-
+    update_implicit_cache! = ClimaLand.make_update_implicit_cache(land)
     # Check that the jacobian update respects the mask
+    update_implicit_cache!(p, Y, t0)
     jacobian!(jac_prototype, Y, p, Δt, t0)
     (; matrix) = jac_prototype
     ∂ϑres∂ϑ = matrix[@name(soil.ϑ_l), @name(soil.ϑ_l)]
@@ -591,10 +592,11 @@ end
         CTS.ClimaODEFunction(
             T_exp! = exp_tendency!,
             T_imp! = ClimaTimeSteppers.ODEFunction(
-                imp_tendency!;
+                compute_imp_tendency!;
                 jac_kwargs...,
             ),
             dss! = ClimaLand.dss!,
+            cache_imp! = (Y, p, t) -> update_implicit_cache!(p, Y, t),
         ),
         Y,
         (t0, t0 + Δt),

--- a/test/shared_utilities/implicit_timestepping/energy_hydrology_model.jl
+++ b/test/shared_utilities/implicit_timestepping/energy_hydrology_model.jl
@@ -79,7 +79,7 @@ for FT in (Float32, Float64)
         )
         # We do not set the initial aux state here because we want to test that it is updated correctly in the jacobian correctly.
         jacobian = ClimaLand.initialize_jacobian(Y)
-        jac_tendency! = make_jacobian(soil)
+        jac_tendency! = make_compute_jacobian(soil)
         update_cache! = make_update_cache(soil)
         dtγ = FT(1.0)
         update_cache!(p, Y, FT(0))

--- a/test/shared_utilities/implicit_timestepping/richards_model.jl
+++ b/test/shared_utilities/implicit_timestepping/richards_model.jl
@@ -53,8 +53,10 @@ for FT in (Float32, Float64)
             # we want to test that it is updated correctly in
             # the jacobian correctly.
             jacobian = ClimaLand.initialize_jacobian(Y)
-            jac_tendency! = make_jacobian(soil)
+            uic! = ClimaLand.make_update_implicit_cache(soil)
+            jac_tendency! = make_compute_jacobian(soil)
             dtγ = FT(1.0)
+            uic!(p, Y, FT(0.0))
             jac_tendency!(jacobian, Y, p, dtγ, FT(0.0))
 
             K_ic = hydraulic_conductivity(
@@ -186,8 +188,10 @@ for FT in (Float32, Float64)
             # we want to test that it is updated correctly in
             # the jacobian correctly.
             jacobian = ClimaLand.initialize_jacobian(Y)
-            jacobian_tendency! = make_jacobian(soil)
+            uic! = ClimaLand.make_update_implicit_cache(soil)
+            jacobian_tendency! = make_compute_jacobian(soil)
             dtγ = FT(1.0)
+            uic!(p, Y, FT(0.0))
             jacobian_tendency!(jacobian, Y, p, dtγ, FT(0.0))
 
             K_ic = hydraulic_conductivity(

--- a/test/shared_utilities/variable_types.jl
+++ b/test/shared_utilities/variable_types.jl
@@ -42,11 +42,6 @@ FT = Float32
     @test tendency_args == ((default = [0],), 2, 3, 4)
 
     tendency_args = ((default = [1],), 2, 3, 4)
-    dm_imp_tendency! = make_imp_tendency(dm)
-    @test dm_imp_tendency!(tendency_args...) == [0]
-    @test tendency_args == ((default = [0],), 2, 3, 4)
-
-    tendency_args = ((default = [1],), 2, 3, 4)
     dm_compute_imp_tendency! = make_compute_imp_tendency(dm)
     @test dm_compute_imp_tendency!(tendency_args...) == [0]
     @test tendency_args == ((default = [0],), 2, 3, 4)
@@ -64,11 +59,6 @@ end
     struct DefaultImExModel{FT} <: AbstractImExModel{FT} end
     dm_imex = DefaultImExModel{FT}()
     ClimaLand.name(::DefaultImExModel) = :default_imex
-
-    tendency_args = ((default_imex = [1],), 2, 3, 4)
-    dm_imp_tendency! = make_imp_tendency(dm_imex)
-    @test dm_imp_tendency!(tendency_args...) == [0]
-    @test tendency_args == ((default_imex = [0],), 2, 3, 4)
 
     tendency_args = ((default_imex = [1],), 2, 3, 4)
     dm_compute_imp_tendency! = make_compute_imp_tendency(dm_imex)

--- a/test/standalone/Soil/conservation.jl
+++ b/test/standalone/Soil/conservation.jl
@@ -144,8 +144,8 @@ for FT in (Float32, Float64)
                     ),
                 ),
             ) < sqrt(eps(FT))
-            imp_tendency! = make_imp_tendency(soil)
-            imp_tendency!(dY, Y, p, t0)
+            compute_imp_tendency! = make_compute_imp_tendency(soil)
+            compute_imp_tendency!(dY, Y, p, t0)
             @test dY.soil.∫F_vol_liq_water_dt ==
                   ClimaCore.Fields.zeros(domain.space.surface) .- FT(2.0)
         end
@@ -239,8 +239,8 @@ for FT in (Float32, Float64)
                     ),
                 ),
             ) < sqrt(eps(FT)) * abs(FT(((cmax - cmin) * -1e-5)))
-            imp_tendency! = make_imp_tendency(soil)
-            imp_tendency!(dY, Y, p, t0)
+            compute_imp_tendency! = make_compute_imp_tendency(soil)
+            compute_imp_tendency!(dY, Y, p, t0)
             # test that ∫ dY = -[F_sfc - F_bot] + ∫Sdz
             cache .*= 0
             ClimaCore.Operators.column_integral_definite!(

--- a/test/standalone/Soil/mask_test.jl
+++ b/test/standalone/Soil/mask_test.jl
@@ -53,8 +53,8 @@ using Test
     dY = similar(Y)
     @. dY = 2.0
 
-    imp_tendency! = make_imp_tendency(soil)
-    imp_tendency!(dY, Y, p, t0)
+    compute_imp_tendency! = make_compute_imp_tendency(soil)
+    compute_imp_tendency!(dY, Y, p, t0)
 
     binary_mask = .~parent(domain.space.surface.grid.mask.is_active)[:]
     # Test that the masked parts of dY did not update and are still equal to 2.0

--- a/test/standalone/Soil/soil_test_3d.jl
+++ b/test/standalone/Soil/soil_test_3d.jl
@@ -407,10 +407,10 @@ for FT in (Float32, Float64)
         t0 = FT(0)
         set_initial_cache! = make_set_initial_cache(soil)
         set_initial_cache!(p, Y, t0)
-        imp_tendency! = make_imp_tendency(soil)
+        compute_imp_tendency! = make_compute_imp_tendency(soil)
         exp_tendency! = make_exp_tendency(soil)
         dY = similar(Y)
-        imp_tendency!(dY, Y, p, t0)
+        compute_imp_tendency!(dY, Y, p, t0)
 
         ## vertical change should be zero except at the boundary, where it should be ±30.
         @test (

--- a/test/standalone/Soil/soiltest.jl
+++ b/test/standalone/Soil/soiltest.jl
@@ -74,9 +74,9 @@ for FT in (Float32, Float64)
         dY = similar(Y)
 
         exp_tendency! = make_exp_tendency(soil)
-        imp_tendency! = make_imp_tendency(soil)
+        compute_imp_tendency! = make_compute_imp_tendency(soil)
         exp_tendency!(dY, Y, p, t0)
-        imp_tendency!(dY, Y, p, t0)
+        compute_imp_tendency!(dY, Y, p, t0)
         ClimaLand.dss!(dY, p, t0)
 
         @test mean(Array(parent(dY.soil.ϑ_l))) < eps(FT)
@@ -180,9 +180,9 @@ for FT in (Float32, Float64)
         set_initial_cache!(p, Y, t0)
 
         # Test implicit tendency - should update internal energy only (Ksat = 0 for hydrology)
-        imp_tendency! = make_imp_tendency(soil_heat_on)
+        compute_imp_tendency! = make_compute_imp_tendency(soil_heat_on)
         dY = similar(Y)
-        imp_tendency!(dY, Y, p, t0)
+        compute_imp_tendency!(dY, Y, p, t0)
         ClimaLand.dss!(dY, p, t0)
 
         F_face = FT(0)
@@ -277,7 +277,7 @@ for FT in (Float32, Float64)
         set_initial_cache! = make_set_initial_cache(soil_water_on)
         set_initial_cache!(p, Y, t0)
         exp_tendency! = make_exp_tendency(soil_water_on)
-        imp_tendency! = make_imp_tendency(soil_water_on)
+        compute_imp_tendency! = make_compute_imp_tendency(soil_water_on)
         dY = similar(Y)
 
         # Test explicit tendency - all should be zero, since water is treated implicitly
@@ -288,7 +288,7 @@ for FT in (Float32, Float64)
         @test maximum(abs.(Array(parent(dY.soil.ϑ_l)))) == FT(0)
 
         # Test implicit tendency - should update liquid water content and energy, no phase change so ice has zero change
-        imp_tendency!(dY, Y, p, t0)
+        compute_imp_tendency!(dY, Y, p, t0)
         @test maximum(abs.(Array(parent(dY.soil.θ_i)))) == FT(0)
 
         function dKdθ(θ::FT)::FT where {FT}
@@ -488,8 +488,8 @@ for FT in (Float32, Float64)
         @test maximum(abs.(Array(parent(dY.soil.ϑ_l)))) == FT(0)
         @test maximum(abs.(Array(parent(dY.soil.θ_i)))) == FT(0)
 
-        imp_tendency! = make_imp_tendency(soil_both_off)
-        imp_tendency!(dY, Y, p, t0)
+        compute_imp_tendency! = make_compute_imp_tendency(soil_both_off)
+        compute_imp_tendency!(dY, Y, p, t0)
 
         # Test implicit tendency - expect all variables to be 0
         @test maximum(abs.(Array(parent(dY.soil.ρe_int)))) == FT(0)
@@ -556,8 +556,8 @@ for FT in (Float32, Float64)
         @test maximum(abs.(Array(parent(dY.soil.ϑ_l)))) == FT(0)
 
         # Test implicit tendency - expect liquid water content and energy to be updated, set ice change to zero
-        imp_tendency! = make_imp_tendency(soil_both_on)
-        imp_tendency!(dY, Y, p, t0)
+        compute_imp_tendency! = make_compute_imp_tendency(soil_both_on)
+        compute_imp_tendency!(dY, Y, p, t0)
         ρe_int_l = Array(
             parent(
                 Soil.volumetric_internal_energy_liq.(

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -176,8 +176,8 @@ import ClimaParams
 
         set_initial_cache! = make_set_initial_cache(canopy)
         exp_tendency! = make_exp_tendency(canopy)
-        imp_tendency! = ClimaLand.make_imp_tendency(canopy)
-        jacobian! = ClimaLand.make_jacobian(canopy)
+        compute_imp_tendency! = ClimaLand.make_compute_imp_tendency(canopy)
+        jacobian! = ClimaLand.make_compute_jacobian(canopy)
         # set up jacobian info
         jac_kwargs = (;
             jac_prototype = ClimaLand.initialize_jacobian(Y),
@@ -434,13 +434,13 @@ end
 
         set_initial_cache! = make_set_initial_cache(canopy)
         t0 = FT(0.0)
-        imp_tendency! = ClimaLand.make_imp_tendency(canopy)
-        jacobian! = ClimaLand.make_jacobian(canopy)
+        compute_imp_tendency! = ClimaLand.make_compute_imp_tendency(canopy)
+        jacobian! = ClimaLand.make_compute_jacobian(canopy)
 
         set_initial_cache!(p, Y, t0)
         T_sfc = Y.canopy.energy.T
         dY = similar(Y)
-        imp_tendency!(dY, Y, p, t0)
+        compute_imp_tendency!(dY, Y, p, t0)
         jac = ClimaLand.initialize_jacobian(Y)
         jacobian!(jac, Y, p, FT(1), t0)
         jac_value = jac.matrix[@name(canopy.energy.T), @name(canopy.energy.T)]
@@ -452,7 +452,7 @@ end
         set_initial_cache!(p_2, Y_2, t0)
         T_sfc2 = Y_2.canopy.energy.T
         dY_2 = similar(Y_2)
-        imp_tendency!(dY_2, Y_2, p_2, t0)
+        compute_imp_tendency!(dY_2, Y_2, p_2, t0)
 
         finitediff_LW =
             (


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
- Updates the implicit cache once per iteration (instead of in the implicit tendency and the Jacobian) (3 fewer calls to update implicit cache relative to main). 
- Correctly classifies soil sublimation tendency as explicit (3 fewer calls relative to main)
- creates a function which only updates the implicit part of lsm_radiant_energy_fluxes.


SYPD on the snow land 2 year run goes from ~160 (https://buildkite.com/clima/climaland-long-runs/builds/4832) to 180.

Note that the plotting in the long run for snowy land has been fixed in main and will pass once I rebase (after making any review comment fixes).

## To-do

## Content
We now use cache_imp! from ClimaTimesteppers to update the implicit cache once per iteration. Previously, our Jacobian update was:
"update jacobian"
-update implicit cache
-compute Jacobian (uses updated cache values)
And our "update implicit tendency" was:
-update implicit cache
-compute implicit tendency (uses updated cache values)

This then led to the implicit cache being updated 2x per iteration. I removed the functions "update implicit tendency" and "update Jacobian" and now we just have the "compute jacobian" and "compute implicit tendency" functions. Since we update the implicit cache via ClimaTimesteppers, we do not need to do so on the CliMA Land side anymore. For example, an equivalent solution might have been to keep the implicit cache update in the update implicit tendency function (but remove it from the update Jacobian function), but we don't need to recreate this functionality in CL.

The other changes should be pretty straightforward to review...

only canopy LW fluxes depend on canopy temperature and need to get updated each iteration, and all radiative fluxes for soil, snow, lake are explicit, so that is why I was able to split the lsm_radiation function as I did.

A future PR can look at using the CTS cache! functionality and change our explicit tendency similarly, but TBD on that.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
