### PR TITLE
Add inversion_nee artifact (NEE/GPP/ER/Rh, 2002-2020)

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -253,3 +253,10 @@ git-tree-sha1 = "1e10a01d843f8e2a12ae7691a997c2c5c9a8c72d"
     [[ilamb_respiration_nee.download]]
     sha256 = "a7ff814d3b89fa80826670185079960b5cd3d5bf634d4d9cb502a3741d2ed437"
     url = "https://caltech.box.com/shared/static/mb69shq9y8wnhi7hx23cf70v1b1cf1ln.gz"
+
+[inversion_nee]
+git-tree-sha1 = "d400472ea191639cb1dafac41b09ce36383aee54"
+
+    [[inversion_nee.download]]
+    sha256 = "84ccc2b60b276575342886535d78faa83f64dd83e327f65b31a10da8f9da721c"
+    url = "https://caltech.box.com/shared/static/13xeg76obc5cc73h2sqzhogx0hr97poz.gz"

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ ClimaLand.jl Release Notes
 ========================
 main
 ----
+- Add `inversion_nee` artifact (inversion-derived NEE/GPP/ER/Rh, monthly 1°×1°, 2002–2020) and `inversion_nee_dataset_path` accessor PR[#1760](https://github.com/CliMA/ClimaLand.jl/pull/1760)
 - Make SoilCO2 and O2 implicitly stepped PR[#1752](https://github.com/CliMA/ClimaLand.jl/pull/1752)
 - Change timestep to 900s from 450s in calibration, longruns and benchmarks; reduce the number of short/default diagnostics PR[#1756](https://github.com/CliMA/ClimaLand.jl/pull/1756)
 

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -555,6 +555,34 @@ function ilamb_respiration_nee_dataset_path(filename; context = nothing)
 end
 
 """
+    inversion_nee_dataset_path(; context = nothing)
+
+Triggers the download of the inversion-derived NEE, GPP, ER, and Rh dataset
+(monthly, 1°×1°, 2002–2020), and returns the path to the NetCDF file.
+
+The file `derived_nee_gpp_er_rh_2002_2020.nc` contains:
+  - `nee` — NEE from CarbonTracker CT2022 `bio_flux_opt`, g C m⁻² month⁻¹
+    (positive = source, fire separated, includes residual LUC and lateral
+    fluxes)
+  - `gpp` — GOSIF-GPP v2, regridded to 1°, g C m⁻² month⁻¹
+    (positive = uptake)
+  - `er`  — Ecosystem respiration, residual ER = NEE + GPP, g C m⁻² month⁻¹
+    (positive = source)
+  - `rh`  — Heterotrophic respiration derived from Hashimoto 2015 monthly
+    Rs × annual Rh/Rs ratio, **g C m⁻² day⁻¹** (Hashimoto native units;
+    different from nee/gpp/er, see artifact README). Positive = source.
+    Hashimoto coverage 1965–2012; 2013–2020 are filled with the 2002–2012
+    monthly climatology.
+  - `fire_ct`, `fire_gfed5` — diagnostic fire fluxes (GFED4.1s and GFED5.1)
+
+See the artifact README for sign conventions, biases, and citations.
+"""
+function inversion_nee_dataset_path(; context = nothing)
+    dir = @clima_artifact("inversion_nee", context)
+    return joinpath(dir, "derived_nee_gpp_er_rh_2002_2020.nc")
+end
+
+"""
     imerg_landsea_mask_path(; context = nothing)
 
 Return the path to the IMERG land-sea mask NetCDF file.


### PR DESCRIPTION
Adds the `inversion_nee` artifact, an isolated piece split out from the NEE calibration work on `ar/calibrate_inversion_nee` so it can be reviewed and merged independently.

## Changes
- **`Artifacts.toml`**: new `[inversion_nee]` artifact entry (git-tree-sha1 + Caltech Box download).
- **`src/Artifacts.jl`**: new `inversion_nee_dataset_path(; context = nothing)` accessor returning the path to `derived_nee_gpp_er_rh_2002_2020.nc`.

## Dataset
Monthly, 1°×1°, 2002–2020:
- `nee` — CarbonTracker CT2022 `bio_flux_opt`, g C m⁻² month⁻¹ (positive = source)
- `gpp` — GOSIF-GPP v2, regridded to 1°, g C m⁻² month⁻¹ (positive = uptake)
- `er` — residual ER = NEE + GPP, g C m⁻² month⁻¹ (positive = source)
- `rh` — Hashimoto 2015 Rs × annual Rh/Rs ratio, **g C m⁻² day⁻¹** (native Hashimoto units; differs from nee/gpp/er); 2013–2020 filled with 2002–2012 monthly climatology
- `fire_ct`, `fire_gfed5` — diagnostic fire fluxes (GFED4.1s, GFED5.1)

Sign conventions, biases, and citations are documented in the accessor docstring and the artifact README.