### PR TITLE
add Rosetta parameters as an option

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,3 +1,10 @@
+[soil_params_rosetta]
+git-tree-sha1 = "3835c13c2dbf2ee26b2c5ca8a709a2298a57bf5c"
+
+    [[soil_params_rosetta.download]]
+    sha256 = "e026f72dc05ee946357d95e2acf71ad3a8d149b4511397a47e0047278757357e"
+    url = "https://caltech.box.com/shared/static/2vz4nevjbo1t80nxc6m4ozyy5f5eusfo.gz"
+
 [modis_lai_climatology]
 git-tree-sha1 = "cd070348ab70f5d1b165c814f70e3822c0173eed"
 

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -266,6 +266,20 @@ function soil_params_artifact_folder_path(; context = nothing, lowres = false)
 end
 
 """
+    rosetta_soil_params_artifact_path(; context)
+
+Return the path to the folder that contains the soil hydraulic parameters 
+from Montzka, C et al. (2017): A global data set of soil hydraulic 
+properties and sub-grid variability of soil water retention and 
+hydraulic conductivity curves. Earth System Science Data, 9(2), 
+529-543, https://doi.org/10.5194/essd-9-529-2017..
+"""
+function rosetta_soil_params_artifact_path(; context = nothing)
+    dir = @clima_artifact("soil_params_rosetta", context)
+    return joinpath(dir, "soil_params_rosetta.nc")
+end
+
+"""
     soil_grids_params_artifact_path(; lowres = true, context)
 
 Return the path to the file that contains the soil texture parameters

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -177,7 +177,7 @@ end
             LAI,
             toml_dict;
             prognostic_land_components,
-            soil_moisture_stress = Canopy.PiecewiseMoistureStressModel{FT}(domain, toml_dict),
+            soil_moisture_stress = Canopy.PiecewiseMoistureStressModel{FT}(domain, toml_dict; soil_params = (;ν = soil.parameters.ν, θ_r = soil.parameters.θ_r)),
         ),
         snow = Snow.SnowModel(
             FT,
@@ -252,7 +252,8 @@ function LandModel{FT}(
         prognostic_land_components,
         soil_moisture_stress = Canopy.PiecewiseMoistureStressModel{FT}(
             domain,
-            toml_dict,
+            toml_dict;
+            soil_params = (; ν = soil.parameters.ν, θ_r = soil.parameters.θ_r),
         ),
     ),
     snow = Snow.SnowModel(
@@ -314,7 +315,7 @@ end
             LAI,
             toml_dict;
             prognostic_land_components,
-            soil_moisture_stress = Canopy.PiecewiseMoistureStressModel{FT}(domain, toml_dict),
+            soil_moisture_stress = Canopy.PiecewiseMoistureStressModel{FT}(domain, toml_dict; soil_params = (;ν = soil.parameters.ν, θ_r = soil.parameters.θ_r)),
         ),
         snow = Snow.SnowModel(
             FT,
@@ -380,7 +381,8 @@ function LandModel{FT}(
         prognostic_land_components,
         soil_moisture_stress = Canopy.PiecewiseMoistureStressModel{FT}(
             domain,
-            toml_dict,
+            toml_dict;
+            soil_params = (; ν = soil.parameters.ν, θ_r = soil.parameters.θ_r),
         ),
     ),
     snow = Snow.SnowModel(

--- a/src/standalone/Soil/spatially_varying_parameters.jl
+++ b/src/standalone/Soil/spatially_varying_parameters.jl
@@ -233,6 +233,113 @@ function soil_vangenuchten_parameters(
 end
 
 """
+    rosetta_soil_vangenuchten_parameters(
+        surface_space,
+        subsurface_space,
+        regridder_type = :InterpolationsRegridder,
+        extrapolation_bc = (
+            Interpolations.Periodic(),
+            Interpolations.Flat(),
+            Interpolations.Flat(),
+        ),
+       interpolation_method = Interpolations.Constant(),
+    )
+
+Reads spatially varying van Genuchten parameters for the soil model, from NetCDF files
+based the van Genuchten data product from Montzka, C et al. (2017)
+ and regrids them to the grid defined by the
+`subsurface_space` and `surface_space` of the Clima simulation, as appropriate.
+Returns a NamedTuple of ClimaCore Fields.
+
+In particular, this file returns a field for
+- (α, n, m) (van Genuchten parameters)
+- Ksat
+- porosity
+- residual water content
+
+Please see the docstring for `soil_vangenuchten_parameters` for more
+details.
+
+Note that saved initial conditions are parameter dependent.
+"""
+function rosetta_soil_vangenuchten_parameters(
+    subsurface_space,
+    FT;
+    regridder_type = :InterpolationsRegridder,
+    extrapolation_bc = (
+        Interpolations.Periodic(),
+        Interpolations.Flat(),
+        Interpolations.Flat(),
+    ),
+    interpolation_method = Interpolations.Constant(),
+)
+    context = ClimaComms.context(subsurface_space)
+    soil_params_artifact_path =
+        Artifacts.rosetta_soil_params_artifact_path(; context)
+    vg_α = SpaceVaryingInput(
+        soil_params_artifact_path,
+        "vg_α",
+        subsurface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc, interpolation_method),
+    )
+    vg_n = SpaceVaryingInput(
+        soil_params_artifact_path,
+        "vg_n",
+        subsurface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc, interpolation_method),
+    )
+    masked_to_value(field, value) = field == 0.0 ? eltype(field)(value) : field
+
+    μ = FT(0.14)
+    vg_α .= masked_to_value.(vg_α, 10.0^μ)
+    μ = FT(1.52)
+    vg_n .= masked_to_value.(vg_n, μ)
+
+    vg_fields_to_hcm_field(α::FT, n::FT) where {FT} =
+        ClimaLand.Soil.vanGenuchten{FT}(; @NamedTuple{α::FT, n::FT}((α, n))...)
+    hydrology_cm = vg_fields_to_hcm_field.(vg_α, vg_n)
+
+    θ_r = SpaceVaryingInput(
+        soil_params_artifact_path,
+        "θ_r",
+        subsurface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc, interpolation_method),
+    )
+
+    ν = SpaceVaryingInput(
+        soil_params_artifact_path,
+        "ν",
+        subsurface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc, interpolation_method),
+    )
+    K_sat = SpaceVaryingInput(
+        soil_params_artifact_path,
+        "Ksat",
+        subsurface_space;
+        regridder_type,
+        regridder_kwargs = (; extrapolation_bc, interpolation_method),
+    )
+
+    # Set missing values to the mean. For Ksat, we use the mean in log space.
+    μ = FT(-5.4)
+    K_sat .= masked_to_value.(K_sat, 10.0^μ)
+    K_sat .= max.(K_sat, sqrt(eps(FT)))
+    K_sat .= min.(K_sat, FT(5e-5))
+
+    ν .= masked_to_value.(ν, 0.44)
+
+    θ_r .= masked_to_value.(θ_r, 0.07)
+
+    return (; ν = ν, hydrology_cm = hydrology_cm, K_sat = K_sat, θ_r = θ_r)
+end
+
+
+
+"""
     soil_composition_parameters(
         surface_space,
         subsurface_space,


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR adds a new artifact to ClimaLand which contains the soil van genuchten parameters derived using ROSETTA. 

Note that to make some pixels in the Sahara stable under evaporation using these parameters, I had to change a parameter value, but that is not done in this PR. It can be done if we change to using the ROSETTA by default..


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
