### PR TITLE
Snow parameterizations helping permafrost

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,17 @@ ClimaLand.jl Release Notes
 ========================
 main
 ----
+- ![][badge-✨feature] Add selectable snow thermal conductivity parameterizations
+  (`JordanSnowConductivityModel`, default, after Jordan 1991; and
+  `SturmSnowConductivityModel`, after Sturm et al. 1997) and a piecewise-linear
+  snow-bottom-temperature parameterization (`snow_T_bottom`) used to compute the
+  snow-soil ground heat flux. Adds the `snowtb`, `snowtsfc`, `snowtbot`, `snowk`, and
+  `ghf` diagnostics. PR [#1766](https://github.com/CliMA/ClimaLand.jl/pull/1766)
+- ![][badge-💥breaking] The `SnowParameters` field `κ_ice` is replaced by `κ_snow`, an
+  `AbstractSnowConductivityModel` (default `JordanSnowConductivityModel`). PR [#1766](https://github.com/CliMA/ClimaLand.jl/pull/1766)
+- ![][badge-🔥behavioralΔ] The snow-soil ground heat flux is now driven by the
+  temperature at the bottom of the snowpack rather than the bulk snow temperature,
+  changing the snow/soil energy exchange. PR [#1766](https://github.com/CliMA/ClimaLand.jl/pull/1766)
 
 v1.9.0
 -----

--- a/docs/src/APIs/ClimaLand.md
+++ b/docs/src/APIs/ClimaLand.md
@@ -64,6 +64,12 @@ ClimaLand.RunoffBC
 ClimaLand.RootExtraction
 ```
 
+## SoilSnowModel
+
+```@docs
+ClimaLand.snow_T_bottom
+```
+
 ## LandSoilBiogeochemistry
 
 ```@docs

--- a/docs/src/APIs/Snow.md
+++ b/docs/src/APIs/Snow.md
@@ -56,6 +56,8 @@ ClimaLand.Snow.AtmosDrivenSnowBC
 
 ```@docs
 ClimaLand.Snow.WuWuSnowCoverFractionModel
+ClimaLand.Snow.JordanSnowConductivityModel
+ClimaLand.Snow.SturmSnowConductivityModel
 ClimaLand.Snow.ZenithAngleAlbedoModel
 ClimaLand.Snow.ConstantAlbedoModel
 ```

--- a/experiments/benchmarks/snowy_land.jl
+++ b/experiments/benchmarks/snowy_land.jl
@@ -36,7 +36,7 @@ const FT = Float64
 
 ######################################################################
 ## This result is from a benchmark run on an A100 on the clima cluster
-const PREVIOUS_GPU_TIME_S = 0.315
+const PREVIOUS_GPU_TIME_S = 0.269
 ## This result is from a benchmark run with a single process on the clima cluster
 const PREVIOUS_CPU_TIME_S = 16.5
 ######################################################################

--- a/experiments/standalone/Snow/snowmip_simulation.jl
+++ b/experiments/standalone/Snow/snowmip_simulation.jl
@@ -86,6 +86,7 @@ model = ClimaLand.Snow.SnowModel(
     density,
     α_snow,
     surf_temp,
+    κ_snow = Snow.SturmSnowConductivityModel(toml_dict),
 )
 
 Y, p, coords = ClimaLand.initialize(model)

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -623,7 +623,9 @@ function get_possible_diagnostics(model::LandModel)
         "nee",
         "cveg",
         "tr",
-        "snow_tbot",
+        "snowtbot",
+        "snowk",
+        "ghf",
     ]
 
     return unique!(append!(component_diagnostics, additional_diagnostics))

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -470,6 +470,7 @@ function get_possible_diagnostics(model::EnergyHydrology)
         "infil",
         "iwc",
         "precip",
+        "tair",
         "sdr",
     ]
 
@@ -538,7 +539,7 @@ function get_possible_diagnostics(model::CanopyModel)
     return diagnostics
 end
 function get_possible_diagnostics(model::SnowModel)
-    return ["swe", "snd", "snowc"]
+    return ["swe", "snd", "snowc", "snowtsfc", "snowtb"]
 end
 function get_possible_diagnostics(model::BucketModel)
     return [
@@ -613,8 +614,17 @@ function get_possible_diagnostics(model::LandModel)
         model.canopy.boundary_conditions.radiation,
     )
 
-    additional_diagnostics =
-        ["swa", "swu", "lwu", "tair", "precip", "nee", "cveg"]
+    additional_diagnostics = [
+        "swa",
+        "swu",
+        "lwu",
+        "tair",
+        "precip",
+        "nee",
+        "cveg",
+        "tr",
+        "snow_tbot",
+    ]
 
     return unique!(append!(component_diagnostics, additional_diagnostics))
 end
@@ -631,7 +641,7 @@ function get_short_diagnostics(model::SoilCO2Model)
     return ["sco2", "hr", "so2"]
 end
 function get_short_diagnostics(model::CanopyModel)
-    diagnostics = ["gpp", "lai", "trans", "er"]
+    diagnostics = ["gpp", "lai", "trans", "er", "lwp"]
     add_diagnostics!(diagnostics, model, model.biomass)
     return diagnostics
 end
@@ -673,6 +683,7 @@ function get_short_diagnostics(model::LandModel)
         "iwc",
         "nee",
         "ra",
+        "tr",
     ]
 
     # Add conditional diagnostics based on soil runoff type, since this

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -1131,20 +1131,20 @@ function define_diagnostics!(land_model, possible_diags)
         short_name = "snowtb",
         long_name = "Snow bulk temperature",
         standard_name = "snow_bulk_temp",
-        units = "",
-        comments = "The snow bulk temperature",
+        units = "K",
+        comments = "The bulk (layer-averaged) temperature of the snowpack",
         compute! = (out, Y, p, t) ->
             compute_snow_bulk_temp!(out, Y, p, t, land_model),
     )
 
     conditional_add_diagnostic_variable!(
         possible_diags;
-        short_name = "snowκ",
+        short_name = "snowk",
         long_name = "Snow thermal conductivity",
-        standard_name = "snow_κ",
-        units = "",
-        comments = "The snow thermal K",
-        compute! = (out, Y, p, t) -> compute_snow_κ!(out, Y, p, t, land_model),
+        standard_name = "snow_thermal_conductivity",
+        units = "W m^-1 K^-1",
+        comments = "The thermal conductivity of the snowpack",
+        compute! = (out, Y, p, t) -> compute_snow_k!(out, Y, p, t, land_model),
     )
     # Snow sfc temperature
     conditional_add_diagnostic_variable!(
@@ -1152,7 +1152,7 @@ function define_diagnostics!(land_model, possible_diags)
         short_name = "snowtsfc",
         long_name = "Snow sfc temperature",
         standard_name = "snow_sfc_temp",
-        units = "",
+        units = "K",
         comments = "The snow surface temperature",
         compute! = (out, Y, p, t) ->
             compute_snow_sfc_temp!(out, Y, p, t, land_model),
@@ -1163,8 +1163,8 @@ function define_diagnostics!(land_model, possible_diags)
         short_name = "snowtbot",
         long_name = "Snow bot temperature",
         standard_name = "snow_bot_temp",
-        units = "",
-        comments = "The snow bottom temperature",
+        units = "K",
+        comments = "The temperature at the bottom of the snowpack",
         compute! = (out, Y, p, t) ->
             compute_snow_bot_temp!(out, Y, p, t, land_model),
     )
@@ -1172,9 +1172,10 @@ function define_diagnostics!(land_model, possible_diags)
     conditional_add_diagnostic_variable!(
         possible_diags;
         short_name = "ghf",
-        long_name = "Snow soil heat flux",
-        standard_name = "ghf",
-        units = "",
+        long_name = "Ground heat flux",
+        standard_name = "ground_heat_flux",
+        units = "W m^-2",
+        comments = "The conductive heat flux between the snow and the soil; positive values transfer energy from the soil up into the snowpack",
         compute! = (out, Y, p, t) -> compute_ghf!(out, Y, p, t, land_model),
     )
 

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -1144,7 +1144,7 @@ function define_diagnostics!(land_model, possible_diags)
         standard_name = "snow_thermal_conductivity",
         units = "W m^-1 K^-1",
         comments = "The thermal conductivity of the snowpack",
-        compute! = (out, Y, p, t) -> compute_snow_k!(out, Y, p, t, land_model),
+        compute! = (out, Y, p, t) -> compute_snowk!(out, Y, p, t, land_model),
     )
     # Snow sfc temperature
     conditional_add_diagnostic_variable!(

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -1125,6 +1125,59 @@ function define_diagnostics!(land_model, possible_diags)
             compute_snow_cover_fraction!(out, Y, p, t, land_model),
     )
 
+    # Snow bulk temperature
+    conditional_add_diagnostic_variable!(
+        possible_diags;
+        short_name = "snowtb",
+        long_name = "Snow bulk temperature",
+        standard_name = "snow_bulk_temp",
+        units = "",
+        comments = "The snow bulk temperature",
+        compute! = (out, Y, p, t) ->
+            compute_snow_bulk_temp!(out, Y, p, t, land_model),
+    )
+
+    conditional_add_diagnostic_variable!(
+        possible_diags;
+        short_name = "snowκ",
+        long_name = "Snow thermal conductivity",
+        standard_name = "snow_κ",
+        units = "",
+        comments = "The snow thermal K",
+        compute! = (out, Y, p, t) -> compute_snow_κ!(out, Y, p, t, land_model),
+    )
+    # Snow sfc temperature
+    conditional_add_diagnostic_variable!(
+        possible_diags;
+        short_name = "snowtsfc",
+        long_name = "Snow sfc temperature",
+        standard_name = "snow_sfc_temp",
+        units = "",
+        comments = "The snow surface temperature",
+        compute! = (out, Y, p, t) ->
+            compute_snow_sfc_temp!(out, Y, p, t, land_model),
+    )
+
+    conditional_add_diagnostic_variable!(
+        possible_diags;
+        short_name = "snowtbot",
+        long_name = "Snow bot temperature",
+        standard_name = "snow_bot_temp",
+        units = "",
+        comments = "The snow bottom temperature",
+        compute! = (out, Y, p, t) ->
+            compute_snow_bot_temp!(out, Y, p, t, land_model),
+    )
+
+    conditional_add_diagnostic_variable!(
+        possible_diags;
+        short_name = "ghf",
+        long_name = "Snow soil heat flux",
+        standard_name = "ghf",
+        units = "",
+        compute! = (out, Y, p, t) -> compute_ghf!(out, Y, p, t, land_model),
+    )
+
     ### Slab Lake ###
     # Lake internal energy (prognostic)
     conditional_add_diagnostic_variable!(

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -1106,7 +1106,7 @@ end
 @diagnostic_compute "snow_cover_fraction" LandModel p.snow.snow_cover_fraction
 @diagnostic_compute "snow_sfc_temp" LandModel p.snow.T_sfc
 @diagnostic_compute "snow_bot_temp" LandModel p.snow_T_bot
-@diagnostic_compute "snow_k" LandModel p.snow.κ
+@diagnostic_compute "snowk" LandModel p.snow.κ
 @diagnostic_compute "snow_bulk_temp" LandModel p.snow.T
 @diagnostic_compute "evapotranspiration" EnergyHydrology p.soil.turbulent_fluxes.vapor_flux_liq
 

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -1106,7 +1106,7 @@ end
 @diagnostic_compute "snow_cover_fraction" LandModel p.snow.snow_cover_fraction
 @diagnostic_compute "snow_sfc_temp" LandModel p.snow.T_sfc
 @diagnostic_compute "snow_bot_temp" LandModel p.snow_T_bot
-@diagnostic_compute "snow_κ" LandModel p.snow.κ
+@diagnostic_compute "snow_k" LandModel p.snow.κ
 @diagnostic_compute "snow_bulk_temp" LandModel p.snow.T
 @diagnostic_compute "evapotranspiration" EnergyHydrology p.soil.turbulent_fluxes.vapor_flux_liq
 

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -70,6 +70,8 @@ get_z_coordinates(m::Union{SoilCanopyModel, LandModel, SoilSnowModel}) =
     m.soil.domain.fields.z
 get_z_coordinates(m::Union{SoilCO2Model, EnergyHydrology}) = m.domain.fields.z
 
+@diagnostic_compute "ghf" LandModel p.ground_heat_flux
+
 ### Conservation ##
 @diagnostic_compute "water_volume_per_area" EnergyHydrology p.soil.total_water
 @diagnostic_compute "energy_per_area" EnergyHydrology p.soil.total_energy
@@ -414,7 +416,12 @@ end
     CanopyModel,
 } p.drivers.SW_d
 @diagnostic_compute "snowfall" Union{SoilCanopyModel, LandModel, CanopyModel} p.drivers.P_snow
-@diagnostic_compute "tair" Union{SoilCanopyModel, LandModel, CanopyModel} p.drivers.T
+@diagnostic_compute "tair" Union{
+    EnergyHydrology,
+    SoilCanopyModel,
+    LandModel,
+    CanopyModel,
+} p.drivers.T
 @diagnostic_compute "specific_humidity" Union{
     SoilCanopyModel,
     LandModel,
@@ -1097,6 +1104,10 @@ end
 @diagnostic_compute "snow_water_equivalent" LandModel Y.snow.S
 @diagnostic_compute "snow_depth" LandModel p.snow.z_snow
 @diagnostic_compute "snow_cover_fraction" LandModel p.snow.snow_cover_fraction
+@diagnostic_compute "snow_sfc_temp" LandModel p.snow.T_sfc
+@diagnostic_compute "snow_bot_temp" LandModel p.snow_T_bot
+@diagnostic_compute "snow_κ" LandModel p.snow.κ
+@diagnostic_compute "snow_bulk_temp" LandModel p.snow.T
 @diagnostic_compute "evapotranspiration" EnergyHydrology p.soil.turbulent_fluxes.vapor_flux_liq
 
 

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -426,6 +426,7 @@ The names of the additional auxiliary variables that are
 included in the land model.
 """
 lsm_aux_vars(m::LandModel) = (
+    :snow_T_bot,
     :root_extraction,
     :root_energy_extraction,
     :LW_u,
@@ -472,6 +473,7 @@ lsm_aux_types(m::LandModel{FT}) where {FT} = (
     FT,
     FT,
     FT,
+    FT,
     NamedTuple{(:PAR, :NIR), Tuple{FT, FT}},
     FT,
     FT,
@@ -484,6 +486,7 @@ The domain names of the additional auxiliary variables that are
 included in the land model.
 """
 lsm_aux_domain_names(m::LandModel) = (
+    :surface,
     :subsurface,
     :subsurface,
     :surface,

--- a/src/integrated/soil_snow_model.jl
+++ b/src/integrated/soil_snow_model.jl
@@ -121,6 +121,7 @@ lsm_aux_vars(m::SoilSnowModel) = (
     :excess_water_flux,
     :excess_heat_flux,
     :ground_heat_flux,
+    :snow_T_bot,
     :effective_soil_sfc_T,
     :sfc_scratch,
     :subsfc_scratch,
@@ -134,7 +135,7 @@ The types of the additional auxiliary variables that are
 included in the integrated Soil-Snow model.
 """
 lsm_aux_types(m::SoilSnowModel{FT}) where {FT} =
-    (FT, FT, FT, FT, FT, FT, FT, FT)
+    (FT, FT, FT, FT, FT, FT, FT, FT, FT)
 
 """
     lsm_aux_domain_names(m::SoilSnowModel)
@@ -143,6 +144,7 @@ The domain names of the additional auxiliary variables that are
 included in the integrated Soil-Snow model.
 """
 lsm_aux_domain_names(m::SoilSnowModel) = (
+    :surface,
     :surface,
     :surface,
     :surface,
@@ -213,19 +215,10 @@ end
 
 Computes and updates `p.ground_heat_flux` with the ground heat flux. We approximate this
 as
-    F_g =  - κ_eff (T_snow - T_soil)/Δz_eff,
+    F_g =  F_g =  - g_eff (T_snow_bottom - T_soil_sfc)
 
 where:
-    κ_eff = κ_soil * κ_snow / (κ_snow * Δz_soil / 2 + κ_soil * Δz_snow / 2)* (Δz_soil + Δz_snow)/2
-    Δz_eff =( Δz_soil + Δz_snow)/2
-
-This is what JULES does to compute the diffusive heat flux between snow and soil, for example,
-see equation 24 and 25, with k=N, of Best et al, Geosci. Model Dev., 4, 677–699, 2011
-
-However, this is for a multi-layer snow model, with
-T_snow and Δz_snow related to the bottom layer.
-We only have a single layer snow model, and using Δz_snow = height of snow leads to a very small flux when the snow is deep.
-Due to this, we cap Δz_snow at 10 cm.
+    g_eff = κ_soil * κ_snow / (κ_snow * Δz_soil / 2 + κ_soil * Δz_snow / 2).
 """
 NVTX.@annotate function update_soil_snow_ground_heat_flux!(
     p,
@@ -244,14 +237,76 @@ NVTX.@annotate function update_soil_snow_ground_heat_flux!(
     Δz_soil = soil_domain.fields.Δz_top
 
     # Temperatures
-    T_snow = p.snow.T
+    T̄ = p.snow.T
+    T_sfc = p.snow.T_sfc
     T_soil = ClimaLand.Domains.top_center_to_surface(p.soil.T)
-
+    @. p.snow_T_bot = snow_T_bottom(
+        κ_snow,
+        κ_soil * κ_snow / (κ_snow * Δz_soil / 2 + κ_soil * Δz_snow / 2), # g_eff
+        T_soil,
+        T̄,
+        T_sfc,
+        max(p.snow.z_snow, eps(FT)),
+        p.snow.ρ_snow,
+        snow_params.earth_param_set,
+    )
     # compute the flux
+    # g_eff = κ_soil * κ_snow / (κ_snow * Δz_soil / 2 + κ_soil * Δz_snow / 2)
     @. p.ground_heat_flux =
         -κ_soil * κ_snow / (κ_snow * Δz_soil / 2 + κ_soil * Δz_snow / 2) *
-        (T_snow - T_soil)
+        (p.snow_T_bot - T_soil)
     return nothing
+end
+
+"""
+    snow_T_bottom(
+        κ::FT,
+        g_eff::FT,
+        T_soil::FT,
+        T̄::FT,
+        T_sfc::FT,
+        z::FT,
+        ρ::FT,
+        earth_param_set,
+    ) where {FT}
+
+A parameterization for the temperature at the bottom of the snowpack, assuming a piecewise
+linear profile for temperature within the snowpack:
+T(x) = T_bot + (T(d)-T_bot)/(z-d)*x if 0 <= x <= z-d
+T(x) = T(d) + (T_sfc - T(d))/(d)*(x - (z-d)) if z-d <= x <= z
+
+with the following constraints:
+(1) ∑F(T_sfc) = -κ(T_sfc - T(d))/d OR T_sfc = T̄ # surface energy balance or assume surface temp equals the bulk
+(2) T̄ = 1/2[(T_sfc + T(d))*(d/z) + (T(d) + T_bot)*(z-d)/z] # Average of the profile is equal to the bulk temperature
+(3) -κ/(z-d)(T(d) - T_bot) = -g_eff (T_bot - T_soil) # bottom energy balance
+
+Then solve for T_bot to get the below formula.
+
+Note that if d << z, we obtain a T_bot which satisfies
+-κ/(z/2)(T̄ -T_bot) = -g_eff(T_bot -T_soil)
+which is reasonable.
+
+If d -> z, we get
+T_bot = 2T̄ - T_sfc; T̄ = 1/2(T(d) + T_sfc), so that
+T(d) = T_bot, which is also reasonable.
+"""
+function snow_T_bottom(
+    κ::FT,
+    g_eff::FT,
+    T_soil::FT,
+    T̄::FT,
+    T_sfc::FT,
+    z::FT,
+    ρ::FT,
+    earth_param_set,
+) where {FT}
+    d = Snow.surface_temp_scaling_length(κ, ρ, z, earth_param_set)
+    _T_freeze = LP.T_freeze(earth_param_set)
+    return min(
+        (2 * T̄ - d / z * T_sfc + g_eff * (z - d) / κ * T_soil) /
+        (g_eff / κ * (z - d) + 1 + (z - d) / z),
+        _T_freeze,
+    )
 end
 
 

--- a/src/integrated/soil_snow_model.jl
+++ b/src/integrated/soil_snow_model.jl
@@ -224,10 +224,10 @@ Here `T_snow_bottom` is the temperature at the base of the snowpack
  and `T_soil_sfc` is the temperature of the top soil layer. The flux
 is positive when energy flows from the soil up into the snowpack.
 
-There is a free parameter here, the ``width" of the layer of snow at the
-bottom of the snowpack, `Δz_snow`. We treat this layer as 10cm thick, except
-for when the snowpack is less than this thickness in height, in which case we use the thickness
-the snowpack directly.
+For simplicit, we assume that the thickness of the bottom layer of the
+snowpack is the same as the thickness of the soil top layer.
+When the snowpack is less than this 
+thickness in height, we use the thickness the snowpack directly.
 """
 NVTX.@annotate function update_soil_snow_ground_heat_flux!(
     p,
@@ -237,21 +237,17 @@ NVTX.@annotate function update_soil_snow_ground_heat_flux!(
     soil_domain,
     FT,
 )
-    # Thermal conductivities of soil and snow
     κ_snow = p.snow.κ
     κ_soil = ClimaLand.Domains.top_center_to_surface(p.soil.κ)
-
-    # Depths
-    Δz_snow = @. lazy(min(p.snow.z_snow, FT(0.1)))
     Δz_soil = soil_domain.fields.Δz_top
-
-    # Temperatures
+    Δz_snow = Δz_soil
     T̄ = p.snow.T
     T_sfc = p.snow.T_sfc
     T_soil = ClimaLand.Domains.top_center_to_surface(p.soil.T)
     @. p.snow_T_bot = snow_T_bottom(
         κ_snow,
-        κ_soil * κ_snow / (κ_snow * Δz_soil / 2 + κ_soil * Δz_snow / 2), # g_eff
+        κ_soil * κ_snow /
+        (κ_snow * Δz_soil / 2 + κ_soil * min(p.snow.z_snow, Δz_snow) / 2), # g_eff
         T_soil,
         T̄,
         T_sfc,
@@ -262,7 +258,8 @@ NVTX.@annotate function update_soil_snow_ground_heat_flux!(
     # compute the flux
     # g_eff = κ_soil * κ_snow / (κ_snow * Δz_soil / 2 + κ_soil * Δz_snow / 2)
     @. p.ground_heat_flux =
-        -κ_soil * κ_snow / (κ_snow * Δz_soil / 2 + κ_soil * Δz_snow / 2) *
+        -κ_soil * κ_snow /
+        (κ_snow * Δz_soil / 2 + κ_soil * min(p.snow.z_snow, Δz_snow) / 2) *
         (p.snow_T_bot - T_soil)
     return nothing
 end

--- a/src/integrated/soil_snow_model.jl
+++ b/src/integrated/soil_snow_model.jl
@@ -215,10 +215,19 @@ end
 
 Computes and updates `p.ground_heat_flux` with the ground heat flux. We approximate this
 as
-    F_g =  F_g =  - g_eff (T_snow_bottom - T_soil_sfc)
+    F_g = - g_eff (T_snow_bottom - T_soil_sfc)
 
 where:
     g_eff = κ_soil * κ_snow / (κ_snow * Δz_soil / 2 + κ_soil * Δz_snow / 2).
+
+Here `T_snow_bottom` is the temperature at the base of the snowpack 
+ and `T_soil_sfc` is the temperature of the top soil layer. The flux
+is positive when energy flows from the soil up into the snowpack.
+
+There is a free parameter here, the ``width" of the layer of snow at the
+bottom of the snowpack, `Δz_snow`. We treat this layer as 10cm thick, except
+for when the snowpack is less than this thickness in height, in which case we use the thickness
+the snowpack directly.
 """
 NVTX.@annotate function update_soil_snow_ground_heat_flux!(
     p,
@@ -270,25 +279,40 @@ end
         earth_param_set,
     ) where {FT}
 
-A parameterization for the temperature at the bottom of the snowpack, assuming a piecewise
-linear profile for temperature within the snowpack:
-T(x) = T_bot + (T(d)-T_bot)/(z-d)*x if 0 <= x <= z-d
-T(x) = T(d) + (T_sfc - T(d))/(d)*(x - (z-d)) if z-d <= x <= z
+A parameterization for the temperature at the bottom of the snowpack.
 
-with the following constraints:
-(1) ∑F(T_sfc) = -κ(T_sfc - T(d))/d OR T_sfc = T̄ # surface energy balance or assume surface temp equals the bulk
-(2) T̄ = 1/2[(T_sfc + T(d))*(d/z) + (T(d) + T_bot)*(z-d)/z] # Average of the profile is equal to the bulk temperature
-(3) -κ/(z-d)(T(d) - T_bot) = -g_eff (T_bot - T_soil) # bottom energy balance
+The arguments are the snow thermal conductivity `κ`, the effective snow-soil
+conductance `g_eff`, the top soil temperature `T_soil`, the bulk snow temperature `T̄`,
+the snow surface temperature `T_sfc`, the snow depth `z`, the snow density `ρ`, and the
+`earth_param_set`. The skin-layer depth `d = surface_temp_scaling_length(κ, ρ, z, …)` is
+the same length scale used to diagnose the surface temperature (if that parameterization
+is chosen).
 
-Then solve for T_bot to get the below formula.
+We assume a piecewise-linear temperature profile within the snowpack, with `x` measured
+upward from the base (`x = 0` at the bottom, `x = z` at the surface):
 
-Note that if d << z, we obtain a T_bot which satisfies
--κ/(z/2)(T̄ -T_bot) = -g_eff(T_bot -T_soil)
-which is reasonable.
+```
+T(x) = T_bot + (T(d) - T_bot) / (z - d) * x           for 0   <= x <= z-d
+T(x) = T(d)  + (T_sfc - T(d)) / d * (x - (z - d))      for z-d <= x <= z
+```
 
-If d -> z, we get
-T_bot = 2T̄ - T_sfc; T̄ = 1/2(T(d) + T_sfc), so that
-T(d) = T_bot, which is also reasonable.
+subject to the following constraints:
+
+```
+(1) ∑F(T_sfc) = -κ (T_sfc - T(d)) / d   OR   T_sfc = T̄    # surface energy balance, or T_sfc set to the bulk temp
+(2) T̄ = 1/2 [ (T_sfc + T(d)) (d/z) + (T(d) + T_bot) (z-d)/z ]   # profile average equals the bulk temperature
+(3) -κ/(z-d) (T(d) - T_bot) = -g_eff (T_bot - T_soil)          # flux continuity at the snow-soil interface
+```
+
+Constraint (1) determines `T_sfc` (an input here); solving (2) and (3) for `T_bot` gives
+the formula below. The result is capped at the freezing temperature.
+
+Limiting behavior:
+- if `d << z` (deep snow), `T_bot` satisfies `-κ/(z/2) (T̄ - T_bot) = -g_eff (T_bot - T_soil)`;
+- if `d -> z` (shallow snow), `T_bot = 2 T̄ - T_sfc`, and since `T̄ = 1/2 (T(d) + T_sfc)`
+  this gives `T(d) = T_bot`.
+
+Both limits are physically reasonable.
 """
 function snow_T_bottom(
     κ::FT,

--- a/src/standalone/Snow/Snow.jl
+++ b/src/standalone/Snow/Snow.jl
@@ -467,7 +467,6 @@ function SnowParameters(
     surf_temp::STM = BulkSurfaceTemperatureModel{CP.float_type(toml_dict)}(),
     z_0m = toml_dict["snow_momentum_roughness_length"],
     z_0b = toml_dict["snow_scalar_roughness_length"],
-    κ_ice = toml_dict["thermal_conductivity_of_water_ice"],
     ϵ_snow = toml_dict["snow_emissivity"],
     θ_r = toml_dict["holding_capacity_of_water_in_snow"],
     Ksat = toml_dict["wet_snow_hydraulic_conductivity"],

--- a/src/standalone/Snow/Snow.jl
+++ b/src/standalone/Snow/Snow.jl
@@ -45,6 +45,8 @@ export SnowParameters,
     ConstantAlbedoModel,
     ZenithAngleAlbedoModel,
     WuWuSnowCoverFractionModel,
+    SturmSnowConductivityModel,
+    JordanSnowConductivityModel,
     maximum_snow_cover_fraction!
 
 """
@@ -299,6 +301,75 @@ function EquilibriumGradientTemperatureModel{FT}(;
 end
 
 """
+    AbstractSnowConductivityModel{FT}
+
+Defines the model type for snow thermal conductivity parameterization
+for use within an `AbstractSnowModel` type.
+
+These parameterizations are stored in parameters.κ_snow, and
+are used to update the value of p.snow.κ_snow.
+"""
+abstract type AbstractSnowConductivityModel{FT <: AbstractFloat} end
+Base.broadcastable(ps::AbstractSnowConductivityModel) = tuple(ps)
+
+"""
+    JordanSnowConductivityModel{FT} <: AbstractSnowConductivityModel{FT}
+
+A parameterization for the snow thermal conductivity based on Jordan, Rachel E.
+ "A one-dimensional temperature model for a snow cover: Technical
+documentation for SNTHERM. 89." (1991).
+"""
+struct JordanSnowConductivityModel{FT} <: AbstractSnowConductivityModel{FT}
+    κ_ice::FT
+    linear_coeff::FT
+    quadratic_coeff::FT
+end
+
+function JordanSnowConductivityModel(toml_dict)
+    κ_ice = toml_dict["thermal_conductivity_of_water_ice"]
+    l_coeff = toml_dict["jordan_linear_snow_thermal_conductivity"]
+    q_coeff = toml_dict["jordan_quadratic_snow_thermal_conductivity"]
+    return JordanSnowConductivityModel(κ_ice, l_coeff, q_coeff)
+end
+
+"""
+    SturmSnowConductivityModel{FT} <: AbstractSnowConductivityModel{FT}
+
+A parameterization for the snow thermal conductivity based on Sturm, M.,
+Holmgren, J., König, M.,  and Morris, K.: The thermal conductivity of
+seasonal snow, J. Glaciol., 43, 26–41,
+https://doi.org/10.3189/S0022143000002781, 1997.
+"""
+struct SturmSnowConductivityModel{FT} <: AbstractSnowConductivityModel{FT}
+    threshold::FT
+    max::FT
+    m1::FT
+    b1::FT
+    m2::FT
+    b2::FT
+    q2::FT
+end
+
+function SturmSnowConductivityModel(toml_dict)
+    threshold = toml_dict["sturm_threshold_snow_thermal_conductivity"]
+    m1 = toml_dict["sturm_m1_snow_thermal_conductivity"]
+    m2 = toml_dict["sturm_m2_snow_thermal_conductivity"]
+    b1 = toml_dict["sturm_b1_snow_thermal_conductivity"]
+    b2 = toml_dict["sturm_b2_snow_thermal_conductivity"]
+    q2 = toml_dict["sturm_q2_snow_thermal_conductivity"]
+    max_density = toml_dict["sturm_maxrho_snow_thermal_conductivity"]
+    return SturmSnowConductivityModel(
+        threshold,
+        max_density,
+        m1,
+        b1,
+        m2,
+        b2,
+        q2,
+    )
+end
+
+"""
     SnowParameters{FT <: AbstractFloat, PSE}
 
 A struct for storing parameters of the `SnowModel`.
@@ -314,6 +385,7 @@ $(DocStringExtensions.FIELDS)
 """
 Base.@kwdef struct SnowParameters{
     FT <: AbstractFloat,
+    KM <: AbstractSnowConductivityModel,
     DM <: AbstractDensityModel,
     AM <: AbstractAlbedoModel,
     SCFM <: AbstractSnowCoverFractionModel,
@@ -334,8 +406,8 @@ Base.@kwdef struct SnowParameters{
     θ_r::FT
     "Hydraulic conductivity of wet snow (m/s)"
     Ksat::FT
-    "Thermal conductivity of ice (W/m/K)"
-    κ_ice::FT
+    "Thermal conductivity of snow"
+    κ_snow::KM
     "Timestep of the model (s)"
     Δt::FT
     "Parameter to prevent dividing by zero when computing snow temperature (m)"
@@ -361,15 +433,15 @@ end
             toml_dict,
             CP.float_type(toml_dict)(1.0),
         ),
+        κ_snow::KM = JordanSnowConductivityModel(toml_dict),
         surf_temp::STM = BulkSurfaceTemperatureModel{CP.float_type(toml_dict)}(),
         z_0m = toml_dict["snow_momentum_roughness_length"],
         z_0b = toml_dict["snow_scalar_roughness_length"],
-        κ_ice = toml_dict["thermal_conductivity_of_water_ice"],
         ϵ_snow = toml_dict["snow_emissivity"],
         θ_r = toml_dict["holding_capacity_of_water_in_snow"],
         Ksat = toml_dict["wet_snow_hydraulic_conductivity"],
         ΔS = toml_dict["delta_S"],
-    ) where {DM, AM, SCFM}
+    ) where {KM, DM, AM, SCFM}
 
 TOML dictionary constructor for the `SnowParameters`` struct.
 ```julia
@@ -391,6 +463,7 @@ function SnowParameters(
         toml_dict,
         CP.float_type(toml_dict)(1.0),
     ),
+    κ_snow::KM = JordanSnowConductivityModel(toml_dict),
     surf_temp::STM = BulkSurfaceTemperatureModel{CP.float_type(toml_dict)}(),
     z_0m = toml_dict["snow_momentum_roughness_length"],
     z_0b = toml_dict["snow_scalar_roughness_length"],
@@ -399,19 +472,19 @@ function SnowParameters(
     θ_r = toml_dict["holding_capacity_of_water_in_snow"],
     Ksat = toml_dict["wet_snow_hydraulic_conductivity"],
     ΔS = toml_dict["delta_S"],
-) where {DM, AM, SCFM, STM}
+) where {DM, KM, AM, SCFM, STM}
     Δt = float(Δt)
     FT = CP.float_type(toml_dict)
     earth_param_set = LP.LandParameters(toml_dict)
-    return SnowParameters{FT, DM, AM, SCFM, STM, typeof(earth_param_set)}(;
+    return SnowParameters{FT, KM, DM, AM, SCFM, STM, typeof(earth_param_set)}(;
         Δt,
         earth_param_set,
         z_0m,
         z_0b,
-        κ_ice,
         ϵ_snow,
         θ_r,
         Ksat,
+        κ_snow,
         ΔS,
         density,
         α_snow,
@@ -429,20 +502,21 @@ function SnowParameters{FT}(
     ϵ_snow,
     θ_r,
     Ksat,
-    κ_ice,
+    κ_snow::KM,
     ΔS = FT(0.1),
     scf::SCFM,
     surf_temp::STM = BulkSurfaceTemperatureModel{FT}(),
     earth_param_set::PSE,
 ) where {
     FT <: AbstractFloat,
+    KM <: AbstractSnowConductivityModel,
     DM <: AbstractDensityModel,
     AM <: AbstractAlbedoModel,
     SCFM <: AbstractSnowCoverFractionModel,
     STM <: AbstractSnowSurfaceTemperatureModel,
     PSE,
 }
-    return SnowParameters{FT, DM, AM, SCFM, PSE}(
+    return SnowParameters{FT, KM, DM, AM, SCFM, PSE}(
         density,
         z_0m,
         z_0b,
@@ -450,7 +524,7 @@ function SnowParameters{FT}(
         ϵ_snow,
         θ_r,
         Ksat,
-        κ_ice,
+        κ_snow,
         float(Δt),
         ΔS,
         scf,
@@ -483,7 +557,7 @@ end
 
 """
     SnowModel(;
-        parameters::SnowParameters{FT, DM, PSE},
+        parameters::SnowParameters{FT},
         domain::ClimaLand.Domains.AbstractDomain,
         boundary_conditions::BC
     ) where {FT, DM, PSE, BC}
@@ -491,10 +565,10 @@ end
 Construct a `SnowModel` with `parameters`, `domain`, and `boundary_conditions`.
 """
 function SnowModel(;
-    parameters::SnowParameters{FT, DM, PSE},
+    parameters::SnowParameters{FT},
     domain::ClimaLand.Domains.AbstractDomain,
     boundary_conditions::BC,
-) where {FT, DM, PSE, BC}
+) where {FT, BC}
     args = (parameters, boundary_conditions, domain)
     SnowModel{FT, typeof.(args)...}(args...)
 end
@@ -511,6 +585,7 @@ end
         z_0b = toml_dict["snow_scalar_roughness_length"],
         ϵ_snow = toml_dict["snow_emissivity"],
         α_snow = ConstantAlbedoModel(toml_dict["snow_albedo"]),
+        κ_snow = JordanSnowConductivityModel(toml_dict),
         density = MinimumDensityModel(toml_dict["snow_density"]),
         scf = WuWuSnowCoverFractionModel(toml_dict, sum(ClimaLand.Domains.average_horizontal_resolution_degrees(domain)) / 2),
         surf_temp = BulkSurfaceTemperatureModel{FT}(),
@@ -539,6 +614,7 @@ function SnowModel(
     ϵ_snow = toml_dict["snow_emissivity"],
     α_snow = ZenithAngleAlbedoModel(toml_dict),
     density = MinimumDensityModel(toml_dict["snow_density"]),
+    κ_snow = JordanSnowConductivityModel(toml_dict),
     scf = WuWuSnowCoverFractionModel(
         toml_dict,
         sum(ClimaLand.Domains.average_horizontal_resolution_degrees(domain)) /
@@ -561,6 +637,7 @@ function SnowModel(
         z_0b,
         θ_r,
         Ksat,
+        κ_snow,
         ΔS,
     )
     boundary_conditions = AtmosDrivenSnowBC(
@@ -810,8 +887,8 @@ function ClimaLand.make_update_aux(model::SnowModel{FT}) where {FT}
         ) # This could depend on ρ_snow
 
         @. p.snow.κ = snow_thermal_conductivity(
+            parameters.κ_snow,
             p.snow.ρ_snow,
-            parameters.κ_ice,
             parameters.earth_param_set,
         )
 

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -239,8 +239,8 @@ end
 
 """
     snow_thermal_conductivity(
+        scheme::JordanSnowConductivityModel,
         ρ_snow::FT,
-        κ_ice::FT,
         earth_param_set,
     ) where {FT}
 
@@ -256,15 +256,48 @@ and the second by x², with ρ\\_ice in kg/m³.
 When ρ\\_snow = ρ\\_ice, we recover κ\\_snow = κ\\_ice.
 """
 function snow_thermal_conductivity(
+    scheme::JordanSnowConductivityModel,
     ρ_snow::FT,
-    κ_ice::FT,
     earth_param_set,
 ) where {FT}
-    _κ_air = FT(LP.K_therm(earth_param_set))
-    _ρ_ice = FT(LP.ρ_cloud_ice(earth_param_set))
+    κ_ice = scheme.κ_ice
+    _κ_air = LP.K_therm(earth_param_set)
+    _ρ_ice = LP.ρ_cloud_ice(earth_param_set)
     return _κ_air +
-           (FT(0.07) * (ρ_snow / _ρ_ice) + FT(0.93) * (ρ_snow / _ρ_ice)^2) *
-           (κ_ice - _κ_air)
+           (
+        scheme.linear_coeff * (ρ_snow / _ρ_ice) +
+        scheme.quadratic_coeff * (ρ_snow / _ρ_ice)^2
+    ) * (κ_ice - _κ_air)
+end
+
+"""
+    snow_thermal_conductivity(
+        scheme::SturmSnowConductivityModel,
+        ρ_snow::FT,
+        earth_param_set,
+    ) where {FT}
+
+Computes the thermal conductivity, given the density
+of the snow, according to Sturm, M., Holmgren, J., König, M., 
+and Morris, K.: The thermal conductivity of seasonal snow, J. Glaciol., 43, 26–41,
+https://doi.org/10.3189/S0022143000002781, 1997.
+
+We have adjusted the original equation to make the coefficients
+non-dimensional by multiplying and dividing by ρ\\_ice as appropriate.
+"""
+function snow_thermal_conductivity(
+    scheme::SturmSnowConductivityModel,
+    ρ_snow::FT,
+    earth_param_set,
+) where {FT}
+    _ρ_ice = LP.ρ_cloud_ice(earth_param_set)
+
+    x = min(ρ_snow / _ρ_ice, scheme.max / _ρ_ice)
+    if x < scheme.threshold
+        return scheme.b1 + scheme.m1 * x
+    else
+        return scheme.b2 + scheme.m2 * x + scheme.q2 * x^2
+    end
 end
 
 """

--- a/test/diagnostics/diagnostics_tests.jl
+++ b/test/diagnostics/diagnostics_tests.jl
@@ -362,6 +362,22 @@ end
             simulation.diagnostics[1].output_writer.dict["sco2_1000s_inst"].vals[1],
         ) .== FT(0.000412),
     )
+
+    snow_diag_vars = ["snowtbot", "ghf", "snowk", "snowtsfc", "snowtb"]
+    possible = ClimaLand.Diagnostics.get_possible_diagnostics(model)
+    for v in snow_diag_vars
+        @test v in possible
+    end
+    snow_diags = ClimaLand.Diagnostics.default_diagnostics(
+        model,
+        start_date;
+        output_writer = ClimaDiagnostics.Writers.DictWriter(),
+        output_vars = snow_diag_vars,
+        reduction_period,
+        reduction_type,
+        dt,
+    )
+    @test length(snow_diags) == length(snow_diag_vars)
 end
 
 @testset "CanopyModel invalid windspeed diagnostic (coupled)" begin

--- a/test/integrated/soil_snow.jl
+++ b/test/integrated/soil_snow.jl
@@ -33,6 +33,7 @@ for lsm_aux_var in (
     :excess_water_flux,
     :excess_heat_flux,
     :ground_heat_flux,
+    :snow_T_bot,
     :effective_soil_sfc_T,
     :sfc_scratch,
     :subsfc_scratch,

--- a/test/integrated/soil_snow.jl
+++ b/test/integrated/soil_snow.jl
@@ -148,3 +148,75 @@ ClimaLand.Snow.snow_boundary_fluxes!(
     parent(p_snow_alone.snow.total_energy_flux .- p.snow.total_energy_flux) .≈
     parent(p.snow.snow_cover_fraction .* p.ground_heat_flux),
 )
+
+@testset "snow_T_bottom analytic limits and cap" begin
+    κ = FT(0.3)
+    ρ = FT(300)
+    g_eff = FT(1.2)
+    T_soil = FT(272.0)
+    Tbar = FT(263.0)
+    T_sfc = FT(255.0)
+    _T_freeze = FT(LP.T_freeze(earth_param_set))
+
+    # Reproduces the documented closed-form solution
+    z = FT(1.5)
+    d = ClimaLand.Snow.surface_temp_scaling_length(κ, ρ, z, earth_param_set)
+    expected = min(
+        (2 * Tbar - d / z * T_sfc + g_eff * (z - d) / κ * T_soil) /
+        (g_eff / κ * (z - d) + 1 + (z - d) / z),
+        _T_freeze,
+    )
+    @test ClimaLand.snow_T_bottom(
+        κ,
+        g_eff,
+        T_soil,
+        Tbar,
+        T_sfc,
+        z,
+        ρ,
+        earth_param_set,
+    ) == expected
+
+    # Deep snow (d << z): T_bot -> (2 T̄ + g_eff z/κ T_soil) / (g_eff z/κ + 2)
+    z_deep = FT(100.0)
+    T_bot_deep = ClimaLand.snow_T_bottom(
+        κ,
+        g_eff,
+        T_soil,
+        Tbar,
+        T_sfc,
+        z_deep,
+        ρ,
+        earth_param_set,
+    )
+    deep_limit =
+        (2 * Tbar + g_eff * z_deep / κ * T_soil) / (g_eff * z_deep / κ + 2)
+    @test T_bot_deep ≈ deep_limit rtol = FT(1e-2)
+
+    # Shallow snow (d -> z): T_bot -> 2 T̄ - T_sfc
+    z_thin = FT(1e-4)
+    T_bot_thin = ClimaLand.snow_T_bottom(
+        κ,
+        g_eff,
+        T_soil,
+        Tbar,
+        T_sfc,
+        z_thin,
+        ρ,
+        earth_param_set,
+    )
+    @test T_bot_thin ≈ 2 * Tbar - T_sfc rtol = FT(1e-2)
+
+    # Warm soil drives T_bot above freezing -> capped at T_freeze
+    T_bot_cap = ClimaLand.snow_T_bottom(
+        κ,
+        g_eff,
+        FT(290.0),
+        FT(272.0),
+        FT(271.0),
+        z,
+        ρ,
+        earth_param_set,
+    )
+    @test T_bot_cap == _T_freeze
+end

--- a/test/standalone/Snow/parameterizations.jl
+++ b/test/standalone/Snow/parameterizations.jl
@@ -100,8 +100,8 @@ for FT in (Float32, Float64)
         @test typeof(parameters.Ksat) == FT
         @test parameters.θ_r == θ_r
         @test typeof(parameters.θ_r) == FT
-        @test parameters.κ_ice == κ_ice
-        @test typeof(parameters.κ_ice) == FT
+        @test parameters.κ_snow.κ_ice == κ_ice
+        @test typeof(parameters.κ_snow) == Snow.JordanSnowConductivityModel{FT}
 
         roughness_model = SurfaceFluxes.ConstantRoughnessParams{FT}(z_0m, z_0b)
 
@@ -109,7 +109,7 @@ for FT in (Float32, Float64)
         @test specific_heat_capacity(FT(1.0), param_set) == _cp_l
         @test specific_heat_capacity(FT(0.0), param_set) == _cp_i
         ρ_snow = ρ_min
-        @test snow_thermal_conductivity(ρ_snow, parameters.κ_ice, param_set) ==
+        @test snow_thermal_conductivity(parameters.κ_snow, ρ_snow, param_set) ==
               κ_air +
               (FT(0.07) * (ρ_snow / _ρ_i) + FT(0.93) * (ρ_snow / _ρ_i)^2) *
               (κ_ice - κ_air)

--- a/test/standalone/Snow/parameterizations.jl
+++ b/test/standalone/Snow/parameterizations.jl
@@ -113,6 +113,21 @@ for FT in (Float32, Float64)
               κ_air +
               (FT(0.07) * (ρ_snow / _ρ_i) + FT(0.93) * (ρ_snow / _ρ_i)^2) *
               (κ_ice - κ_air)
+
+        # Sturm et al. (1997) snow thermal conductivity
+        sturm = Snow.SturmSnowConductivityModel(toml_dict)
+        @test typeof(sturm) == Snow.SturmSnowConductivityModel{FT}
+        # densities below the threshold, above the threshold, and above the
+        # maximum density (where the non-dimensional density is capped)
+        for ρ_test in FT.([100, 350, 800])
+            x = min(ρ_test / _ρ_i, sturm.max / _ρ_i)
+            expected =
+                x < sturm.threshold ? sturm.b1 + sturm.m1 * x :
+                sturm.b2 + sturm.m2 * x + sturm.q2 * x^2
+            @test snow_thermal_conductivity(sturm, ρ_test, param_set) ==
+                  expected
+        end
+
         @test all(
             maximum_liquid_mass_fraction.(ρ_min, T, θ_r, Ref(param_set)) .-
             [FT(0), θ_r * _ρ_l / ρ_snow, θ_r * _ρ_l / ρ_snow] .== 0,

--- a/toml/default_parameters.toml
+++ b/toml/default_parameters.toml
@@ -169,6 +169,61 @@ value = 0.1
 type = "float"
 description = "Parameter to prevent dividing by zero when computing snow temperature (m)"
 
+# Snow thermal conductivity parameters
+["jordan_linear_snow_thermal_conductivity"]
+value = 0.07
+type = "float"
+description = "Parameter fit to data by Jordan (1991); not meant to be re-calibrated; unitless"
+tag = "JordanSnowConductivityModel"
+
+["jordan_quadratic_snow_thermal_conductivity"]
+value = 0.93
+type = "float"
+description = "Parameter fit to data by Jordan (1991); not meant to be re-calibrated; unitless"
+tag = "JordanSnowConductivityModel"
+
+["sturm_threshold_snow_thermal_conductivity"]
+value = 0.17
+type = "float"
+description = "Parameter fit to data by Sturm et al (1997); not meant to be re-calibrated; unitless"
+tag = "SturmSnowConductivityModel"
+
+["sturm_m1_snow_thermal_conductivity"]
+value = 0.20
+type = "float"
+description = "Parameter fit to data by Sturm et al (1997); not meant to be re-calibrated (W m⁻¹ K⁻¹)"
+tag = "SturmSnowConductivityModel"
+
+["sturm_m2_snow_thermal_conductivity"]
+value = -0.93
+type = "float"
+description = "Parameter fit to data by Sturm et al (1997); not meant to be re-calibrated (W m⁻¹ K⁻¹)"
+tag = "SturmSnowConductivityModel"
+
+["sturm_b1_snow_thermal_conductivity"]
+value = 0.023
+type = "float"
+description = "Parameter fit to data by Sturm et al (1997); not meant to be re-calibrated (W m⁻¹ K⁻¹)"
+tag = "SturmSnowConductivityModel"
+
+["sturm_b2_snow_thermal_conductivity"]
+value = 0.138
+type = "float"
+description = "Parameter fit to data by Sturm et al (1997); not meant to be re-calibrated (W m⁻¹ K⁻¹)"
+tag = "SturmSnowConductivityModel"
+
+["sturm_q2_snow_thermal_conductivity"]
+value = 2.72
+type = "float"
+description = "Parameter fit to data by Sturm et al (1997); not meant to be re-calibrated (W m⁻¹ K⁻¹)"
+tag = "SturmSnowConductivityModel"
+
+["sturm_maxrho_snow_thermal_conductivity"]
+value = 600
+type = "float"
+description = "Parameter fit to data by Sturm et al (1997); not meant to be re-calibrated (kg/m^3)"
+tag = "SturmSnowConductivityModel"
+
 # WuWuSnowCoverFractionModel parameters
 
 ["gamma"]


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Adds a simple parameterization for the bottom temperature of the snow (not optional), modularizes the thermal conductivity model of the snow, and adds a second parameterization option for this (Sturm).

This typically makes the bottom temperature warmer than the bulk temperature, which improves snow insulation over the soil, and has a big effect on permafrost locations. The Sturm conductivity model is also lower than the Jordan parameterization in general, and this helps with permafrost.

## To-do


## Impact
Main:
<img width="1000" height="1200" alt="image" src="https://github.com/user-attachments/assets/d25ea395-6e41-4696-a266-c9e2c7314bd9" />

Bottom alone:
<img width="1000" height="1200" alt="image" src="https://github.com/user-attachments/assets/cdba08fa-4587-402d-ab6a-77fed9b9d9cf" />

Sturm + Tbottom:
<img width="1000" height="1200" alt="image" src="https://github.com/user-attachments/assets/600cc374-e5d4-4a8f-a5aa-993398393881" />

## Content
Adds bottom snow temp as a cache variable to integrated models with soil and snow, and computes it during the ground heat flux computation

Adds another parameterization for thermal conductivity


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
