### PR TITLE
Calibrated C + energy parameters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Always read the ClimaLand-specific structure guide before working in this reposi
 - For package tests, prefer `Pkg.test()` or running `julia --project=test test/runtests.jl` over manually including files.
 - Keep edits modular and within the appropriate submodel directory (e.g., `src/standalone` or `src/integrated`).
 - Match existing style: explicit names, narrow imports, and use multiple dispatch effectively.
+- Keep comments sparse. Do not explain in comments what a change fixes or narrate its history ("this fixes Y", "this newest code fixes the issue introduced by..."), and do not restate the docstring inline. Comment only non-obvious rationale (the *why*, not the *what*).
 - Follow the software design patterns in [docs/dev-guides/code-quality/software_design_patterns.md](docs/dev-guides/code-quality/software_design_patterns.md) for new code and refactor toward them when touching existing code.
 - Run `julia -e 'using JuliaFormatter; format(".")'` before committing code, adhering to the rules in `.JuliaFormatter.toml`.
 

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -5,6 +5,13 @@ git-tree-sha1 = "3835c13c2dbf2ee26b2c5ca8a709a2298a57bf5c"
     sha256 = "e026f72dc05ee946357d95e2acf71ad3a8d149b4511397a47e0047278757357e"
     url = "https://caltech.box.com/shared/static/2vz4nevjbo1t80nxc6m4ozyy5f5eusfo.gz"
 
+[modis_max_lai]
+git-tree-sha1 = "3977938f17914088ff69224a3c74e4526cc91bb1"
+
+    [[modis_max_lai.download]]
+    sha256 = "b128f8f5a6f7be5ef68ddfb6f03080dd2daf9f787ef2aaa265bca3c016f541d1"
+    url = "https://caltech.box.com/shared/static/iirh2rgwpgubelvt9gsunkd9artsjxt8.gz"
+
 [modis_lai_climatology]
 git-tree-sha1 = "cd070348ab70f5d1b165c814f70e3822c0173eed"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+Claude Code reads this file automatically. This repository keeps its agent
+conventions in `AGENTS.md` (shared with other coding tools); import them here so
+Claude Code always loads the same instructions:
+
+@AGENTS.md

--- a/docs/src/APIs/canopy/AutotrophicRespiration.md
+++ b/docs/src/APIs/canopy/AutotrophicRespiration.md
@@ -16,7 +16,6 @@ ClimaLand.Canopy.AutotrophicRespirationParameters(toml_dict::CP.ParamDict; kwarg
 ## Methods
 
 ```@docs
-ClimaLand.Canopy.nitrogen_content
-ClimaLand.Canopy.plant_respiration_maintenance
+ClimaLand.Canopy.compute_autrophic_respiration
 ClimaLand.Canopy.plant_respiration_growth
 ```

--- a/docs/src/APIs/canopy/Biomass.md
+++ b/docs/src/APIs/canopy/Biomass.md
@@ -18,11 +18,11 @@ ClimaLand.Canopy.PrescribedBiomassModel{FT}(
 ) where {FT <: AbstractFloat}
 ClimaLand.Canopy.PrescribedBiomassModel{FT}(; LAI, SAI::FT, RAI::FT, rooting_depth, height::FT) where {FT}
 ClimaLand.Canopy.PrescribedAreaIndices
-ClimaLand.Canopy.PrescribedAreaIndices{FT}(
+ClimaLand.Canopy.PrescribedAreaIndices(
     LAI::AbstractTimeVaryingInput,
-    SAI::FT,
-    RAI::FT,
-) where {FT <: AbstractFloat}
+    SAI,
+    RAI,
+)
 ClimaLand.Canopy.prescribed_lai_era5
 ClimaLand.Canopy.prescribed_lai_modis
 ClimaLand.Canopy.prescribed_climatological_lai_modis

--- a/src/Artifacts.jl
+++ b/src/Artifacts.jl
@@ -168,6 +168,19 @@ function modis_lai_climatology_data_path(; context = nothing)
 end
 
 """
+    modis_max_lai_data_path(; context)
+
+Return the path to the netcdf file that contains the max LAI from MODIS forcing
+data, computed from data from 2000-2020.
+"""
+function modis_max_lai_data_path(; context = nothing)
+    return joinpath(
+        @clima_artifact("modis_max_lai", context),
+        "modis_max_lai.nc",
+    )
+end
+
+"""
     modis_lai_single_year_path(; context = nothing, year = Dates.year(DateTime(2008)))
 
 Return the path to the file that contains the MODIS LAI data for the provided single year.

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -355,7 +355,48 @@ function PrescribedBiomassModel{FT}(
     rooting_depth = clm_rooting_depth(domain.space.surface),
     height = toml_dict["canopy_height"],
 ) where {FT <: AbstractFloat}
-    plant_area_index = PrescribedAreaIndices{FT}(LAI, SAI, RAI)
+    plant_area_index = PrescribedAreaIndices(LAI, SAI, RAI)
+    return PrescribedBiomassModel{
+        FT,
+        typeof(plant_area_index),
+        typeof(rooting_depth),
+        typeof(height),
+    }(
+        plant_area_index,
+        rooting_depth,
+        height,
+    )
+end
+
+"""
+    PrescribedBiomassModel{FT}(
+        domain,
+        LAI::AbstractTimeVaryingInput,
+        maxLAI,
+        toml_dict::CP.ParamDict;
+        SAI = toml_dict["SAI_coeff"] .* maxLAI,
+        RAI = toml_dict["RAI_coeff"] .* maxLAI,
+        rooting_depth = clm_rooting_depth(domain.space.surface),
+        height = toml_dict["canopy_height"],
+    ) where {FT <: AbstractFloat}
+
+Creates a PrescribedBiomassModel with time-constant stem and root area indices
+set as a linear multiple of the per-pixel maximum LAI: SAI = SAI_coeff * maxLAI,
+RAI = RAI_coeff * maxLAI. `maxLAI` may be a scalar or a ClimaCore Field (e.g.
+from `ClimaLand.Canopy.modis_max_lai(domain.space.surface)`); SAI/RAI inherit its
+type.
+"""
+function PrescribedBiomassModel{FT}(
+    domain,
+    LAI::AbstractTimeVaryingInput,
+    maxLAI,
+    toml_dict::CP.ParamDict;
+    SAI = toml_dict["SAI_coeff"] .* maxLAI,
+    RAI = toml_dict["RAI_coeff"] .* maxLAI,
+    rooting_depth = clm_rooting_depth(domain.space.surface),
+    height = toml_dict["canopy_height"],
+) where {FT <: AbstractFloat}
+    plant_area_index = PrescribedAreaIndices(LAI, SAI, RAI)
     return PrescribedBiomassModel{
         FT,
         typeof(plant_area_index),

--- a/src/standalone/Vegetation/autotrophic_respiration.jl
+++ b/src/standalone/Vegetation/autotrophic_respiration.jl
@@ -6,24 +6,26 @@ abstract type AbstractAutotrophicRespirationModel{FT} <:
 """
     AutotrophicRespirationParameters{FT<:AbstractFloat}
 
-The required parameters for the autrophic respiration model, which is based
-off of the JULES model.
+The required parameters for the autrophic respiration model, inspired by the
+JULES model.
 Clark, D. B., et al. "The Joint UK Land Environment Simulator (JULES), model description–Part 2: carbon fluxes and vegetation dynamics." Geoscientific Model Development 4.3 (2011): 701-722.
 $(DocStringExtensions.FIELDS)
 """
 Base.@kwdef struct AutotrophicRespirationParameters{FT <: AbstractFloat}
-    "Vcmax25 (leaf level) to N factor (mol CO2 m-2 s-1 kg C (kg C)-1)"
-    ne::FT
     "Live stem wood coefficient (kg C m-3)"
     ηsl::FT
     "Specific leaf density (kg C m-2 [leaf])"
     σl::FT
-    "Ratio root nitrogen to top leaf nitrogen (-), typical value 1.0"
-    μr::FT
-    "Ratio stem nitrogen to top leaf nitrogen (-), typical value 0.1"
+    "Ratio stem nitrogen to root nitrogen (-)"
     μs::FT
     "Relative contribution or Rgrowth (-)"
     Rel::FT
+    "Q10 temperature sensitivity of maintenance respiration (-), JULES default 2.0"
+    Q10::FT
+    "Reference temperature for the Q10 maintenance-respiration factor (K), JULES default 298.15"
+    T_ref::FT
+    "Reference leaf-level dark respiration rate (mol CO2 m-2 s-1) used as the base rate for the LAI-independent root and stem maintenance respiration"
+    Rd_ref::FT
 end
 
 Base.eltype(::AutotrophicRespirationParameters{FT}) where {FT} = FT
@@ -31,7 +33,7 @@ Base.eltype(::AutotrophicRespirationParameters{FT}) where {FT} = FT
 """
     AutotrophicRespirationModel{FT, ARP <: AutotrophicRespirationParameters{FT},} <: AbstractAutotrophicRespirationModel{FT}
 
-The JULES autotrophic respiration model.
+Autotrophic respiration model inspired by JULES.
 
 Clark, D. B., et al. "The Joint UK Land Environment Simulator (JULES), model description–Part 2: carbon fluxes and vegetation dynamics." Geoscientific Model Development 4.3 (2011): 701-722.
 """
@@ -63,7 +65,7 @@ ClimaLand.auxiliary_domain_names(::AutotrophicRespirationModel) = (:surface,)
     update_autotrophic_respiration!(p, Y, autotrophic_respiration::AutotrophicRespirationModel, canopy)
 
 Computes the autotrophic respiration rate  (mol co2 m^-2 s^-1) as the sum of the plant maintenance
-and growth respirations, according to the JULES model.
+and growth respirations, inspired by the JULES model.
 
 Clark, D. B., et al. "The Joint UK Land Environment Simulator (JULES), model
 description–Part 2: carbon fluxes and vegetation dynamics." Geoscientific Model Development 4.3 (2011): 701-722.
@@ -74,61 +76,59 @@ function update_autotrophic_respiration!(
     autotrophic_respiration::AutotrophicRespirationModel,
     canopy,
 )
-    h_canopy = canopy.biomass.height
     area_index = p.canopy.biomass.area_index
-    LAI = area_index.leaf
     SAI = area_index.stem
     RAI = area_index.root
-    β = p.canopy.soil_moisture_stress.βm
-    Vcmax25_canopy = get_Vcmax25_canopy(p, canopy.photosynthesis)
     Rd_canopy = get_Rd_canopy(p, canopy.photosynthesis)
     An_canopy = get_An_canopy(p, canopy.photosynthesis)
+    T_canopy = canopy_temperature(canopy.energy, canopy, Y, p)
     @. p.canopy.autotrophic_respiration.Ra = compute_autrophic_respiration(
         autotrophic_respiration,
-        Vcmax25_canopy,
-        LAI,
         SAI,
         RAI,
         An_canopy,
         Rd_canopy,
-        β,
-        h_canopy,
+        T_canopy,
     )
 end
 
 """
     compute_autrophic_respiration(model::AutotrophicRespirationModel,
-                                  Vcmax25,
-                                  LAI,
                                   SAI,
                                   RAI,
                                   An_canopy,
                                   Rd_canopy,
-                                  β,
-                                  h,
+                                  T_canopy,
                                  )
 
 Computes the autotrophic respiration (mol co2 m^-2 s^-1) as the sum of the plant maintenance
-and growth respirations, according to the JULES model.
+and growth respirations, inspired by the JULES model.
+
+Maintenance respiration is split by tissue. The leaf term uses `Rd_canopy`
+(∝ LAI) so it vanishes when leafless; the root and stem terms use a reference
+rate `Rd_ref` scaled by the time-constant area indices RAI/SAI, so they persist
+through winter. The sum is scaled by the Q10 factor `Q10^((T_canopy - T_ref)/10)`.
 
 Clark, D. B., et al. "The Joint UK Land Environment Simulator (JULES), model description–Part 2: carbon fluxes and vegetation dynamics." Geoscientific Model Development 4.3 (2011): 701-722.
 """
 function compute_autrophic_respiration(
     model::AutotrophicRespirationModel,
-    Vcmax25_canopy,
-    LAI,
     SAI,
     RAI,
     An_canopy,
     Rd_canopy,
-    β,
-    h,
+    T_canopy,
 )
 
-    (; ne, ηsl, σl, μr, μs, Rel) = model.parameters
-    Nl, Nr, Ns =
-        nitrogen_content(ne, Vcmax25_canopy, LAI, SAI, RAI, ηsl, h, σl, μr, μs)
-    Rpm = plant_respiration_maintenance(Rd_canopy, β, Nl, Nr, Ns)
+    (; μs, Rel, Q10, T_ref, Rd_ref) = model.parameters
+    FT = typeof(T_canopy)
+    f_T = Q10^((T_canopy - T_ref) / FT(10))
+    # Rd_canopy already carries the moisture-stress weighting, so R_leaf needs no
+    # extra β factor.
+    R_leaf = Rd_canopy
+    R_root = Rd_ref * RAI
+    R_stem = Rd_ref * μs * SAI
+    Rpm = f_T * (R_leaf + R_root + R_stem)
     Rg = plant_respiration_growth(Rel, An_canopy, Rpm)
     Ra = Rpm + Rg
     return Ra # already canopy level
@@ -145,84 +145,21 @@ Constructor for the `AutotrophicRespirationParameters` struct by passing a TOML
 dictionary.
 You can manually override any parameter via keyword arguments:
 ```julia
-AutotrophicRespirationParameters(toml_dict; ne = 99999)
+AutotrophicRespirationParameters(toml_dict; μs = 0.1)
 ```
 """
 function AutotrophicRespirationParameters(
     toml_dict::CP.ParamDict;
-    ne = toml_dict["N_factor_Vcmax25"],
     ηsl = toml_dict["live_stem_wood_coeff"],
     σl = toml_dict["specific_leaf_density"],
-    μr = toml_dict["root_leaf_nitrogen_ratio"],
     Rel = toml_dict["relative_contribution_factor"],
     μs = toml_dict["stem_leaf_nitrogen_ratio"],
+    Q10 = toml_dict["autotrophic_respiration_Q10"],
+    T_ref = toml_dict["autotrophic_respiration_T_ref"],
+    Rd_ref = toml_dict["autotrophic_respiration_Rd_ref"],
 )
     FT = CP.float_type(toml_dict)
-    AutotrophicRespirationParameters{FT}(; ne, ηsl, σl, μr, Rel, μs)
-end
-
-
-
-"""
-    nitrogen_content(
-                     ne::FT, # Mean leaf nitrogen concentration (kg N (kg C)-1)
-                     Vcmax25_canopy::FT, #
-                     LAI::FT, # Leaf area index
-                     SAI::FT,
-                     RAI::FT,
-                     ηsl::FT, # live stem  wood coefficient (kg C m-3)
-                     h::FT, # canopy height (m)
-                     σl::FT # Specific leaf density (kg C m-2 [leaf])
-                     μr::FT, # Ratio root nitrogen to top leaf nitrogen (-), typical value 1.0
-                     μs::FT, # Ratio stem nitrogen to top leaf nitrogen (-), typical value 0.1
-                    ) where {FT}
-
-Computes the nitrogen content of leafs (Nl), roots (Nr) and stems (Ns).
-"""
-function nitrogen_content(
-    ne::FT, # Mean leaf nitrogen concentration (kg N (kg C)-1)
-    Vcmax25_canopy::FT, #
-    LAI::FT, # Leaf area index
-    SAI::FT,
-    RAI::FT,
-    ηsl::FT, # live stem  wood coefficient (kg C m-3)
-    h::FT, # canopy height (m)
-    σl::FT, # Specific leaf density (kg C m-2 [leaf])
-    μr::FT, # Ratio root nitrogen to top leaf nitrogen (-), typical value 1.0
-    μs::FT, # Ratio stem nitrogen to top leaf nitrogen (-), typical value 0.1
-) where {FT}
-    Sc = ηsl * h * LAI * ClimaLand.heaviside(SAI)
-    Rc = σl * RAI
-    nm = Vcmax25_canopy / (ne * max(LAI, sqrt(eps(FT))))
-    Nl = nm * σl
-    Nr = μr * nm * Rc
-    Ns = μs * nm * Sc
-    return Nl, Nr, Ns
-end
-
-"""
-    plant_respiration_maintenance(
-        Rd::FT, # Dark respiration
-        β::FT, # Soil moisture factor
-        Nl::FT, # Nitrogen content of leafs
-        Nr::FT, # Nitrogen content of roots
-        Ns::FT, # Nitrogen content of stems
-        ) where {FT}
-
-Computes plant maintenance respiration as a function of dark respiration (Rd),
-the nitrogen content of leafs (Nl), roots (Nr) and stems (Ns),
-and the soil moisture factor (β).
-"""
-function plant_respiration_maintenance(
-    Rd::FT, # Dark respiration
-    β::FT, # Soil moisture factor
-    Nl::FT, # Nitrogen content of leafs
-    Nr::FT, # Nitrogen content of roots
-    Ns::FT, # Nitrogen content of stems
-) where {FT}
-    # When LAI is zero, Nl = 0
-    Rpm = Rd * (β + (Nr + Ns) / max(Nl, eps(FT)))
-    return Rpm
+    AutotrophicRespirationParameters{FT}(; ηsl, σl, Rel, μs, Q10, T_ref, Rd_ref)
 end
 
 """
@@ -236,6 +173,7 @@ Computes plant growth respiration as a function of net photosynthesis (An),
 plant maintenance respiration (Rpm), and a relative contribution factor, Rel.
 """
 function plant_respiration_growth(Rel::FT, An::FT, Rpm::FT) where {FT}
-    Rg = Rel * (An - Rpm)
+    # Growth respiration cannot be negative.
+    Rg = Rel * max(An - Rpm, FT(0))
     return Rg
 end

--- a/src/standalone/Vegetation/biomass.jl
+++ b/src/standalone/Vegetation/biomass.jl
@@ -1,5 +1,6 @@
 import ClimaUtilities.TimeVaryingInputs:
     TimeVaryingInput, LinearInterpolation, PeriodicCalendar
+import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
 import Interpolations: Constant
 import ClimaUtilities.Regridders: InterpolationsRegridder
 import ClimaUtilities.FileReaders: NCFileReader, read
@@ -150,6 +151,36 @@ end
 
 
 """
+     modis_max_lai(surface_space,
+                   regridder_type = :InterpolationsRegridder,
+                   interpolation_method = Interpolations.Constant(),
+                   context = ClimaComms.context(surface_space))
+
+A helper function which constructs the SpaceVaryingInput object for the maximum
+Leaf Area Index using MODIS LAI data; requires the surface_space.
+
+The ClimaLand default is to use nearest neighbor interpolation, but
+linear interpolation is supported by passing
+`interpolation_method = Interpolations.Linear()`.
+"""
+function modis_max_lai(
+    surface_space,
+    regridder_type = :InterpolationsRegridder,
+    interpolation_method = Interpolations.Constant(),
+    context = ClimaComms.context(surface_space),
+)
+    modis_max_lai_ncdata_path =
+        ClimaLand.Artifacts.modis_max_lai_data_path(; context)
+    return SpaceVaryingInput(
+        modis_max_lai_ncdata_path,
+        ["lai"],
+        surface_space;
+        regridder_type,
+        regridder_kwargs = (; interpolation_method),
+    )
+end
+
+"""
     AbstractBiomassModel{FT} <: AbstractCanopyComponent{FT}
 
 An abstract type for modeling the biomass (above ground - LAI, SAI, canopy
@@ -159,44 +190,41 @@ abstract type AbstractBiomassModel{FT} <: AbstractCanopyComponent{FT} end
 
 ClimaLand.name(::AbstractBiomassModel) = :biomass
 
-abstract type AbstractAreaIndexModel{FT <: AbstractFloat} end
+abstract type AbstractAreaIndexModel end
 
 """
-   PrescribedAreaIndices{FT <:AbstractFloat, F <: AbstractTimeVaryingInput}
+   PrescribedAreaIndices{FS <: Union{AbstractFloat, ClimaCore.Fields.Field}, F <: AbstractTimeVaryingInput}
 
 A struct containing the area indices of the plants at a specific site;
-LAI varies in time, while SAI and RAI are fixed in space and time.
+LAI varies in time, while SAI and RAI are fixed in time and can either be a
+scalar (spatially uniform) or a ClimaCore Field (spatially varying).
 
 $(DocStringExtensions.FIELDS)
 """
 struct PrescribedAreaIndices{
-    FT <: AbstractFloat,
+    FS <: Union{AbstractFloat, ClimaCore.Fields.Field},
     F <: AbstractTimeVaryingInput,
-} <: AbstractAreaIndexModel{FT}
+} <: AbstractAreaIndexModel
     "A function of simulation time `t` giving the leaf area index (LAI; m2/m2)"
     LAI::F
-    "The constant stem area index (SAI; m2/m2)"
-    SAI::FT
-    "The constant root area index (RAI; m2/m2)"
-    RAI::FT
+    "The constant-in-time stem area index (SAI; m2/m2), scalar or Field"
+    SAI::FS
+    "The constant-in-time root area index (RAI; m2/m2), scalar or Field"
+    RAI::FS
 end
 
 """
-    PrescribedAreaIndices{FT}(
+    PrescribedAreaIndices(
         LAI::AbstractTimeVaryingInput,
-        SAI::FT,
-        RAI::FT,
-    ) where {FT <: AbstractFloat}
+        SAI,
+        RAI,
+    )
 
-An outer constructor for setting the PrescribedAreaIndices given
-LAI, SAI, and RAI.
+An outer constructor for setting the PrescribedAreaIndices given LAI, SAI, and
+RAI. SAI and RAI may be scalars or ClimaCore Fields.
 """
-function PrescribedAreaIndices{FT}(
-    LAI::AbstractTimeVaryingInput,
-    SAI::FT,
-    RAI::FT,
-) where {FT <: AbstractFloat}
-    PrescribedAreaIndices{FT, typeof(LAI)}(LAI, SAI, RAI)
+function PrescribedAreaIndices(LAI::AbstractTimeVaryingInput, SAI, RAI)
+    PrescribedAreaIndices{typeof(SAI), typeof(LAI)}(LAI, SAI, RAI)
 end
 
 """
@@ -212,7 +240,7 @@ $(DocStringExtensions.FIELDS)
 """
 struct PrescribedBiomassModel{
     FT,
-    PSAI <: PrescribedAreaIndices{FT},
+    PSAI <: PrescribedAreaIndices,
     RDTH <: Union{FT, ClimaCore.Fields.Field},
     HTH <: Union{FT, ClimaCore.Fields.Field},
 } <: AbstractBiomassModel{FT}
@@ -222,6 +250,13 @@ struct PrescribedBiomassModel{
     rooting_depth::RDTH
     "Canopy height (m) - can be scalar (uniform) or spatially-varying Field"
     height::HTH
+    function PrescribedBiomassModel{FT, PSAI, RDTH, HTH}(
+        plant_area_index,
+        rooting_depth,
+        height,
+    ) where {FT, PSAI, RDTH, HTH}
+        new{FT, PSAI, RDTH, HTH}(plant_area_index, rooting_depth, height)
+    end
 end
 
 """
@@ -241,12 +276,12 @@ Height can be either:
 """
 function PrescribedBiomassModel{FT}(;
     LAI::AbstractTimeVaryingInput,
-    SAI::FT,
-    RAI::FT,
+    SAI,
+    RAI,
     rooting_depth,
     height,
 ) where {FT}
-    plant_area_index = PrescribedAreaIndices{FT}(LAI, SAI, RAI)
+    plant_area_index = PrescribedAreaIndices(LAI, SAI, RAI)
     args = (plant_area_index, rooting_depth, height)
     PrescribedBiomassModel{FT, typeof.(args)...}(args...)
 end
@@ -357,6 +392,7 @@ struct ZhouOptimalLAIModel{
     FT,
     OLPT <: OptimalLAIParameters{FT},
     GD,
+    FS <: Union{FT, ClimaCore.Fields.Field},
     RDTH <: Union{FT, ClimaCore.Fields.Field},
     HTH <: Union{FT, ClimaCore.Fields.Field},
 } <: AbstractBiomassModel{FT}
@@ -364,10 +400,10 @@ struct ZhouOptimalLAIModel{
     parameters::OLPT
     "Spatially varying initial conditions (GSL, A0_annual, precip_annual, vpd_gs, lai_init, f0)"
     optimal_lai_inputs::GD
-    "Prescribed stem area index (m^2 m^-2)"
-    SAI::FT
-    "Prescribed root area index (m^2 m^-2)"
-    RAI::FT
+    "Prescribed stem area index (m^2 m^-2), scalar or Field"
+    SAI::FS
+    "Prescribed root area index (m^2 m^-2), scalar or Field"
+    RAI::FS
     "Rooting depth parameter (m)"
     rooting_depth::RDTH
     "Canopy height (m) - can be scalar (uniform) or spatially-varying Field"
@@ -380,8 +416,8 @@ Base.eltype(::ZhouOptimalLAIModel{FT}) where {FT} = FT
     ZhouOptimalLAIModel{FT}(
         parameters::OptimalLAIParameters{FT},
         optimal_lai_inputs;
-        SAI::FT,
-        RAI::FT,
+        SAI,
+        RAI,
         rooting_depth,
         height,
     ) where {FT <: AbstractFloat}
@@ -392,16 +428,16 @@ Outer constructor for the ZhouOptimalLAIModel struct.
 - `parameters`: OptimalLAIParameters for the model
 - `optimal_lai_inputs`: NamedTuple with spatially varying GSL, A0_annual, precip_annual, vpd_gs, lai_init, f0 fields,
   typically created using `optimal_lai_initial_conditions`.
-- `SAI`: Prescribed stem area index (m^2 m^-2)
-- `RAI`: Prescribed root area index (m^2 m^-2)
+- `SAI`: Prescribed stem area index (m^2 m^-2); scalar or spatially-varying Field
+- `RAI`: Prescribed root area index (m^2 m^-2); scalar or spatially-varying Field
 - `rooting_depth`: Rooting depth parameter (m)
 - `height`: Canopy height (m) - can be scalar or spatially-varying Field
 """
 function ZhouOptimalLAIModel{FT}(
     parameters::OptimalLAIParameters{FT},
     optimal_lai_inputs;
-    SAI::FT,
-    RAI::FT,
+    SAI,
+    RAI,
     rooting_depth,
     height,
 ) where {FT <: AbstractFloat}
@@ -409,6 +445,7 @@ function ZhouOptimalLAIModel{FT}(
         FT,
         typeof(parameters),
         typeof(optimal_lai_inputs),
+        typeof(SAI),
         typeof(rooting_depth),
         typeof(height),
     }(

--- a/test/standalone/Vegetation/canopy_model.jl
+++ b/test/standalone/Vegetation/canopy_model.jl
@@ -573,7 +573,14 @@ end
     @test all(Array(parent(p.canopy.radiative_transfer.par.abs)) .== FT(0))
     @test all(Array(parent(p.canopy.radiative_transfer.nir.abs)) .== FT(0))
     @test all(Array(parent(p.canopy.energy.fa_energy_roots)) .== FT(0))
-    @test all(Array(parent(p.canopy.autotrophic_respiration.Ra)) .== FT(0))
+    # Leafless: leaf-level respiration and photosynthesis vanish, so Ra reduces
+    # to the persistent (nonzero) root/stem maintenance respiration baseline.
+    ar_params = canopy.autotrophic_respiration.parameters
+    SAI = canopy.biomass.plant_area_index.SAI
+    RAI = canopy.biomass.plant_area_index.RAI
+    f_T = ar_params.Q10^((FT(289) - ar_params.T_ref) / FT(10))
+    Ra_baseline = f_T * ar_params.Rd_ref * (RAI + ar_params.μs * SAI)
+    @test all(Array(parent(p.canopy.autotrophic_respiration.Ra)) .≈ Ra_baseline)
 
     exp_tend! = make_exp_tendency(canopy)
     exp_tend!(dY, Y, p, FT(0))

--- a/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
+++ b/test/standalone/Vegetation/test_bigleaf_parameterizations.jl
@@ -268,46 +268,36 @@ for FT in (Float32, Float64)
         )
 
         # Tests for Autotrophic Respiration parameterisation
-        h_canopy = FT(1.0) # h planck defined above
-        Nl, Nr, Ns = ClimaLand.Canopy.nitrogen_content(
-            ARparams.ne,
-            photosynthesisparams.Vcmax25 * LAI,
-            LAI,
-            SAI,
-            RAI,
-            ARparams.ηsl,
-            h_canopy,
-            ARparams.σl,
-            ARparams.μr,
-            ARparams.μs,
-        )
-        Rpm = ClimaLand.Canopy.plant_respiration_maintenance(
-            Rd * LAI,
-            β,
-            Nl,
-            Nr,
-            Ns,
-        )
-        Rg =
-            ClimaLand.Canopy.plant_respiration_growth.(
-                ARparams.Rel,
-                An * LAI,
-                Rpm,
+        ARmodel = AutotrophicRespirationModel{FT}(ARparams)
+        Rd_canopy = Rd * LAI
+        An_canopy = An * LAI
+        Ra =
+            ClimaLand.Canopy.compute_autrophic_respiration.(
+                ARmodel,
+                SAI,
+                RAI,
+                An_canopy,
+                Rd_canopy,
+                T,
             )
-
-        @test Nl == photosynthesisparams.Vcmax25 / ARparams.ne * ARparams.σl
-        @test Nr ==
-              ARparams.μr * photosynthesisparams.Vcmax25 / ARparams.ne *
-              ARparams.σl *
-              RAI
-        @test Ns ≈
-              ARparams.μs * photosynthesisparams.Vcmax25 / ARparams.ne *
-              ARparams.ηsl *
-              h_canopy *
-              LAI *
-              ClimaLand.heaviside(SAI)# == gives a very small error
-        @test Rpm == Rd * LAI * (β + (Nr + Ns) / Nl)
-        @test all(@.(Rg ≈ ARparams.Rel * (An * LAI - Rpm)))
+        f_T = ARparams.Q10^((T - ARparams.T_ref) / FT(10))
+        Rpm =
+            f_T * (
+                Rd_canopy +
+                ARparams.Rd_ref * RAI +
+                ARparams.Rd_ref * ARparams.μs * SAI
+            )
+        Rg = @. ARparams.Rel * max(An_canopy - Rpm, FT(0))
+        @test all(@.(Ra ≈ Rpm + Rg))
+        @test all(
+            @.(
+                ClimaLand.Canopy.plant_respiration_growth(
+                    ARparams.Rel,
+                    An_canopy,
+                    Rpm,
+                ) ≈ Rg
+            )
+        )
 
     end
 end

--- a/toml/default_parameters.toml
+++ b/toml/default_parameters.toml
@@ -1,6 +1,6 @@
 # Moisture stress models
 [moisture_stress_c]
-value = 0.5675395275525799
+value = 0.59
 type = "float"
 description = "unitless"
 tag = "SoilMoistureStress"
@@ -78,6 +78,18 @@ tag = "PrescribedAreaIndices"
 value = 1.0
 type = "float"
 description = "The constant root area index (RAI; m2/m2)"
+tag = "PrescribedAreaIndices"
+
+["SAI_coeff"]
+value = 0.16
+type = "float"
+description = "Linear factor multiplying the per-pixel maximum LAI to set the stem area index (SAI; m2/m2) when SAI is derived from max LAI."
+tag = "PrescribedAreaIndices"
+
+["RAI_coeff"]
+value = 1.0
+type = "float"
+description = "Linear factor multiplying the per-pixel maximum LAI to set the root area index (RAI; m2/m2) when RAI is derived from max LAI."
 tag = "PrescribedAreaIndices"
 
 [canopy_height]
@@ -278,19 +290,19 @@ tag = "ConstantResetAlbedo"
 
 # P model parameters
 ["pmodel_cstar"]
-value = 0.4126532780348918
+value = 0.43
 type = "float"
 description = "4 * dA/dJmax, assumed to be a constant marginal cost (Wang 2017, Stocker 2020)"
 tag = "PModelParameters"
 
 ["pmodel_β_c3"]
-value = 68.19135215644542
+value = 91.1
 type = "float"
 description = "Unit cost ratio of Vcmax to transpiration for C3 plants (Stocker 2020)"
 tag = "PModelParameters"
 
 ["pmodel_β_c4"]
-value = 53.92806481016041
+value = 5.36
 type = "float"
 description = "Unit cost ratio of Vcmax to transpiration for C4 plants"
 tag = "PModelParameters"
@@ -344,7 +356,7 @@ description = "Second order term in quadratic intrinsic quantum yield (Cai and P
 tag = "PModelParameters"
 
 ["pmodel_α"]
-value = 0.9758442675597523
+value = 0.972
 type = "float"
 description = "1 - 1/T where T is the timescale of Vcmax, Jmax acclimation. Here T = 15 days. (Mengoli 2022)"
 tag = "PModelParameters"
@@ -459,7 +471,7 @@ description = "Constant factor appearing the dark respiration term for C3 plants
 tag = "PModelConstants"
 
 [canopy_K_lw]
-value = 0.85
+value = 0.919
 type = "float"
 description = "The long wave extinction coeff"
 tag = "AbstractRadiationModel"
@@ -594,25 +606,25 @@ description = "Minimum roughness"
 tag = "MoninObukhovCanopyFluxes"
 
 ["canopy_z_0m_coeff"]
-value = 0.0175
+value = 0.349
 type = "float"
 description = "Scalar multipling canopy height to get z_0m"
 tag = "MoninObukhovCanopyFluxes"
 
 ["canopy_z_0b_coeff"]
-value = 0.0175
+value = 0.0444
 type = "float"
 description = "Scalar multipling canopy height to get z_0b"
 tag = "MoninObukhovCanopyFluxes"
 
 ["canopy_d_coeff"]
-value = 0.16
+value = 0.0573
 type = "float"
 description = "Scalar multipling canopy height to get displacement height"
 tag = "MoninObukhovCanopyFluxes"
 
 ["leaf_Cd"]
-value = 0.07
+value = 0.0726
 type = "float"
 description = ""
 tag = "MoninObukhovCanopyFluxes"
@@ -638,7 +650,7 @@ description = "Diffusivity of soil C substrate in liquid (unitless)"
 tag = "SoilCO2Parameters"
 
 ["soilCO2_reference_rate"]
-value = 7.885402642122577e-8
+value = 3.34e-8
 type = "float"
 description = "Maximum respiration rate at soilCO2_reference_temperature for DAMM model (kg C m⁻³ s⁻¹). Centered Arrhenius: Vmax = V_ref * exp(-Ea/R * (1/T - 1/T_ref))"
 tag = "SoilCO2Parameters"
@@ -650,19 +662,19 @@ description = "Reference temperature for the centered Arrhenius form of the DAMM
 tag = "SoilCO2Parameters"
 
 ["soilCO2_activation_energy"]
-value = 65432.29096630613
+value = 19800.0
 type = "float"
 description = "Activation energy for DAMM model (J mol⁻¹)"
 tag = "SoilCO2Parameters"
 
 ["michaelis_constant"]
-value = 0.3668980114900562
+value = 0.0416
 type = "float"
 description = "Michaelis constant for substrate (kg C m⁻³)"
 tag = "SoilCO2Parameters"
 
 ["O2_michaelis_constant"]
-value = 0.00018610344999027417
+value = 0.00298
 type = "float"
 description = "Michaelis constant for O₂ (m³ m⁻³)"
 tag = "SoilCO2Parameters"
@@ -790,14 +802,26 @@ description = "Roughness length for scalars over lake water/ice (m)"
 tag = "SlabLakeParameters"
 
 # Autotrophic respiration (JULES) parameters
-["root_leaf_nitrogen_ratio"]
-value = 2.3992909128669666
+["relative_contribution_factor"]
+value = 0.3
 type = "float"
-description = "Ratio of root nitrogen to top leaf nitrogen (unitless)."
+description = "Factor of relative contribution for growth respiration, Rgrowth (unitless). Held fixed (not calibrated)."
 tag = "AutotrophicRespirationParameters"
 
-["relative_contribution_factor"]
-value = 1.1321179749274621
+["autotrophic_respiration_Q10"]
+value = 1.0
 type = "float"
-description = "Factor of relative contribution for growth respiration, Rgrowth (unitless)."
+description = "Q10 temperature sensitivity of maintenance respiration (unitless): multiplies Rpm by Q10^((T_air - T_ref)/10). Fixed at 1.0 (not calibrated), keeping the maintenance baseline seasonally flat."
+tag = "AutotrophicRespirationParameters"
+
+["autotrophic_respiration_T_ref"]
+value = 298.15
+type = "float"
+description = "Reference temperature for the Q10 maintenance-respiration factor (K)."
+tag = "AutotrophicRespirationParameters"
+
+["autotrophic_respiration_Rd_ref"]
+value = 7.83e-7
+type = "float"
+description = "Reference leaf-level dark respiration rate (mol CO2 m-2 s-1) for the LAI-independent root and stem maintenance respiration."
 tag = "AutotrophicRespirationParameters"

--- a/toml/uncalibrated_parameters.toml
+++ b/toml/uncalibrated_parameters.toml
@@ -80,6 +80,18 @@ type = "float"
 description = "The constant root area index (RAI; m2/m2)"
 tag = "PrescribedAreaIndices"
 
+["SAI_coeff"]
+value = 0.16
+type = "float"
+description = "Linear factor multiplying the per-pixel maximum LAI to set the stem area index (SAI; m2/m2) when SAI is derived from max LAI."
+tag = "PrescribedAreaIndices"
+
+["RAI_coeff"]
+value = 1.0
+type = "float"
+description = "Linear factor multiplying the per-pixel maximum LAI to set the root area index (RAI; m2/m2) when RAI is derived from max LAI."
+tag = "PrescribedAreaIndices"
+
 [canopy_height]
 value = 1.0
 type = "float"


### PR DESCRIPTION
Model changes (src/):
- autotrophic_respiration.jl: LAI-independent root/stem maintenance respiration (Q10, T_ref, Rd_ref) that persists when LAI -> 0
- Canopy.jl: RAI/SAI derived as linear multiples of per-pixel max LAI (RAI_coeff, SAI_coeff)
- biomass.jl: max LAI wiring
- Artifacts.jl + Artifacts.toml: modis_max_lai artifact

Calibrated parameters (default_parameters.toml): pmodel_cstar/β_c3/β_c4/α, moisture_stress_c, soilCO2_reference_rate/activation_energy, michaelis_constant, O2_michaelis_constant, autotrophic_respiration_Rd_ref, leaf_Cd, canopy_z_0m_coeff/z_0b_coeff/d_coeff/K_lw. Fixed (non-calibrated) params relative_contribution_factor=0.3, root_leaf_nitrogen_ratio=1.0, autotrophic_respiration_Q10=1.0, T_ref=298.15 carried over unchanged.

uncalibrated_parameters.toml gains the SAI_coeff/RAI_coeff keys (structural only; keeps its pre-calibration values).

<img width="3600" height="3200" alt="INVERSION_sim_annual_time_avg_over_all_years" src="https://github.com/user-attachments/assets/fbb3f39e-9e49-4180-b074-46d916b5a1a2" />

<img width="3600" height="3200" alt="ERA5_sim_annual_time_avg_over_all_years" src="https://github.com/user-attachments/assets/c210847d-e9d3-493b-9b76-a7fdfbc68235" />

Next, calibrate sequentially, with new Rosetta porosity:
- [ ] 1. Calibrate GPP + energy fluxes only
- [ ] 2. Calibrate Rh only
- [ ] 3. Calibrate ER (i.e., AR), possibly with NEE 
