### PR TITLE
Review fixes: snow conductivity/bottom-temp diagnostics, docs, and tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,17 @@ ClimaLand.jl Release Notes
 ========================
 main
 ----
+- ![][badge-✨feature] Add selectable snow thermal conductivity parameterizations
+  (`JordanSnowConductivityModel`, default, after Jordan 1991; and
+  `SturmSnowConductivityModel`, after Sturm et al. 1997) and a piecewise-linear
+  snow-bottom-temperature parameterization (`snow_T_bottom`) used to compute the
+  snow-soil ground heat flux. Adds the `snowtb`, `snowtsfc`, `snowtbot`, `snowk`, and
+  `ghf` diagnostics. PR [#1766](https://github.com/CliMA/ClimaLand.jl/pull/1766)
+- ![][badge-💥breaking] The `SnowParameters` field `κ_ice` is replaced by `κ_snow`, an
+  `AbstractSnowConductivityModel` (default `JordanSnowConductivityModel`). PR [#1766](https://github.com/CliMA/ClimaLand.jl/pull/1766)
+- ![][badge-🔥behavioralΔ] The snow-soil ground heat flux is now driven by the
+  temperature at the bottom of the snowpack rather than the bulk snow temperature,
+  changing the snow/soil energy exchange. PR [#1766](https://github.com/CliMA/ClimaLand.jl/pull/1766)
 
 v1.9.0
 -----

--- a/docs/src/APIs/ClimaLand.md
+++ b/docs/src/APIs/ClimaLand.md
@@ -64,6 +64,12 @@ ClimaLand.RunoffBC
 ClimaLand.RootExtraction
 ```
 
+## SoilSnowModel
+
+```@docs
+ClimaLand.snow_T_bottom
+```
+
 ## LandSoilBiogeochemistry
 
 ```@docs

--- a/src/diagnostics/default_diagnostics.jl
+++ b/src/diagnostics/default_diagnostics.jl
@@ -623,7 +623,9 @@ function get_possible_diagnostics(model::LandModel)
         "nee",
         "cveg",
         "tr",
-        "snow_tbot",
+        "snowtbot",
+        "snowk",
+        "ghf",
     ]
 
     return unique!(append!(component_diagnostics, additional_diagnostics))

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -1131,20 +1131,20 @@ function define_diagnostics!(land_model, possible_diags)
         short_name = "snowtb",
         long_name = "Snow bulk temperature",
         standard_name = "snow_bulk_temp",
-        units = "",
-        comments = "The snow bulk temperature",
+        units = "K",
+        comments = "The bulk (layer-averaged) temperature of the snowpack",
         compute! = (out, Y, p, t) ->
             compute_snow_bulk_temp!(out, Y, p, t, land_model),
     )
 
     conditional_add_diagnostic_variable!(
         possible_diags;
-        short_name = "snowκ",
+        short_name = "snowk",
         long_name = "Snow thermal conductivity",
-        standard_name = "snow_κ",
-        units = "",
-        comments = "The snow thermal K",
-        compute! = (out, Y, p, t) -> compute_snow_κ!(out, Y, p, t, land_model),
+        standard_name = "snow_thermal_conductivity",
+        units = "W m^-1 K^-1",
+        comments = "The thermal conductivity of the snowpack",
+        compute! = (out, Y, p, t) -> compute_snow_k!(out, Y, p, t, land_model),
     )
     # Snow sfc temperature
     conditional_add_diagnostic_variable!(
@@ -1152,7 +1152,7 @@ function define_diagnostics!(land_model, possible_diags)
         short_name = "snowtsfc",
         long_name = "Snow sfc temperature",
         standard_name = "snow_sfc_temp",
-        units = "",
+        units = "K",
         comments = "The snow surface temperature",
         compute! = (out, Y, p, t) ->
             compute_snow_sfc_temp!(out, Y, p, t, land_model),
@@ -1163,8 +1163,8 @@ function define_diagnostics!(land_model, possible_diags)
         short_name = "snowtbot",
         long_name = "Snow bot temperature",
         standard_name = "snow_bot_temp",
-        units = "",
-        comments = "The snow bottom temperature",
+        units = "K",
+        comments = "The temperature at the bottom of the snowpack",
         compute! = (out, Y, p, t) ->
             compute_snow_bot_temp!(out, Y, p, t, land_model),
     )
@@ -1172,9 +1172,10 @@ function define_diagnostics!(land_model, possible_diags)
     conditional_add_diagnostic_variable!(
         possible_diags;
         short_name = "ghf",
-        long_name = "Snow soil heat flux",
-        standard_name = "ghf",
-        units = "",
+        long_name = "Ground heat flux",
+        standard_name = "ground_heat_flux",
+        units = "W m^-2",
+        comments = "The conductive heat flux between the snow and the soil; positive values transfer energy from the soil up into the snowpack",
         compute! = (out, Y, p, t) -> compute_ghf!(out, Y, p, t, land_model),
     )
 

--- a/src/diagnostics/land_compute_methods.jl
+++ b/src/diagnostics/land_compute_methods.jl
@@ -1106,7 +1106,7 @@ end
 @diagnostic_compute "snow_cover_fraction" LandModel p.snow.snow_cover_fraction
 @diagnostic_compute "snow_sfc_temp" LandModel p.snow.T_sfc
 @diagnostic_compute "snow_bot_temp" LandModel p.snow_T_bot
-@diagnostic_compute "snow_κ" LandModel p.snow.κ
+@diagnostic_compute "snow_k" LandModel p.snow.κ
 @diagnostic_compute "snow_bulk_temp" LandModel p.snow.T
 @diagnostic_compute "evapotranspiration" EnergyHydrology p.soil.turbulent_fluxes.vapor_flux_liq
 

--- a/src/integrated/soil_snow_model.jl
+++ b/src/integrated/soil_snow_model.jl
@@ -215,10 +215,19 @@ end
 
 Computes and updates `p.ground_heat_flux` with the ground heat flux. We approximate this
 as
-    F_g =  F_g =  - g_eff (T_snow_bottom - T_soil_sfc)
+    F_g = - g_eff (T_snow_bottom - T_soil_sfc)
 
 where:
     g_eff = κ_soil * κ_snow / (κ_snow * Δz_soil / 2 + κ_soil * Δz_snow / 2).
+
+Here `T_snow_bottom` is the temperature at the base of the snowpack 
+ and `T_soil_sfc` is the temperature of the top soil layer. The flux
+is positive when energy flows from the soil up into the snowpack.
+
+There is a free parameter here, the ``width" of the layer of snow at the
+bottom of the snowpack, `Δz_snow`. We treat this layer as 10cm thick, except
+for when the snowpack is less than this thickness in height, in which case we use the thickness
+the snowpack directly.
 """
 NVTX.@annotate function update_soil_snow_ground_heat_flux!(
     p,
@@ -270,25 +279,40 @@ end
         earth_param_set,
     ) where {FT}
 
-A parameterization for the temperature at the bottom of the snowpack, assuming a piecewise
-linear profile for temperature within the snowpack:
-T(x) = T_bot + (T(d)-T_bot)/(z-d)*x if 0 <= x <= z-d
-T(x) = T(d) + (T_sfc - T(d))/(d)*(x - (z-d)) if z-d <= x <= z
+A parameterization for the temperature at the bottom of the snowpack.
 
-with the following constraints:
-(1) ∑F(T_sfc) = -κ(T_sfc - T(d))/d OR T_sfc = T̄ # surface energy balance or assume surface temp equals the bulk
-(2) T̄ = 1/2[(T_sfc + T(d))*(d/z) + (T(d) + T_bot)*(z-d)/z] # Average of the profile is equal to the bulk temperature
-(3) -κ/(z-d)(T(d) - T_bot) = -g_eff (T_bot - T_soil) # bottom energy balance
+The arguments are the snow thermal conductivity `κ`, the effective snow-soil
+conductance `g_eff`, the top soil temperature `T_soil`, the bulk snow temperature `T̄`,
+the snow surface temperature `T_sfc`, the snow depth `z`, the snow density `ρ`, and the
+`earth_param_set`. The skin-layer depth `d = surface_temp_scaling_length(κ, ρ, z, …)` is
+the same length scale used to diagnose the surface temperature (if that parameterization
+is chosen).
 
-Then solve for T_bot to get the below formula.
+We assume a piecewise-linear temperature profile within the snowpack, with `x` measured
+upward from the base (`x = 0` at the bottom, `x = z` at the surface):
 
-Note that if d << z, we obtain a T_bot which satisfies
--κ/(z/2)(T̄ -T_bot) = -g_eff(T_bot -T_soil)
-which is reasonable.
+```
+T(x) = T_bot + (T(d) - T_bot) / (z - d) * x           for 0   <= x <= z-d
+T(x) = T(d)  + (T_sfc - T(d)) / d * (x - (z - d))      for z-d <= x <= z
+```
 
-If d -> z, we get
-T_bot = 2T̄ - T_sfc; T̄ = 1/2(T(d) + T_sfc), so that
-T(d) = T_bot, which is also reasonable.
+subject to the following constraints:
+
+```
+(1) ∑F(T_sfc) = -κ (T_sfc - T(d)) / d   OR   T_sfc = T̄    # surface energy balance, or T_sfc set to the bulk temp
+(2) T̄ = 1/2 [ (T_sfc + T(d)) (d/z) + (T(d) + T_bot) (z-d)/z ]   # profile average equals the bulk temperature
+(3) -κ/(z-d) (T(d) - T_bot) = -g_eff (T_bot - T_soil)          # flux continuity at the snow-soil interface
+```
+
+Constraint (1) determines `T_sfc` (an input here); solving (2) and (3) for `T_bot` gives
+the formula below. The result is capped at the freezing temperature.
+
+Limiting behavior:
+- if `d << z` (deep snow), `T_bot` satisfies `-κ/(z/2) (T̄ - T_bot) = -g_eff (T_bot - T_soil)`;
+- if `d -> z` (shallow snow), `T_bot = 2 T̄ - T_sfc`, and since `T̄ = 1/2 (T(d) + T_sfc)`
+  this gives `T(d) = T_bot`.
+
+Both limits are physically reasonable.
 """
 function snow_T_bottom(
     κ::FT,

--- a/src/standalone/Snow/Snow.jl
+++ b/src/standalone/Snow/Snow.jl
@@ -467,7 +467,6 @@ function SnowParameters(
     surf_temp::STM = BulkSurfaceTemperatureModel{CP.float_type(toml_dict)}(),
     z_0m = toml_dict["snow_momentum_roughness_length"],
     z_0b = toml_dict["snow_scalar_roughness_length"],
-    κ_ice = toml_dict["thermal_conductivity_of_water_ice"],
     ϵ_snow = toml_dict["snow_emissivity"],
     θ_r = toml_dict["holding_capacity_of_water_in_snow"],
     Ksat = toml_dict["wet_snow_hydraulic_conductivity"],

--- a/test/diagnostics/diagnostics_tests.jl
+++ b/test/diagnostics/diagnostics_tests.jl
@@ -362,6 +362,22 @@ end
             simulation.diagnostics[1].output_writer.dict["sco2_1000s_inst"].vals[1],
         ) .== FT(0.000412),
     )
+
+    snow_diag_vars = ["snowtbot", "ghf", "snowk", "snowtsfc", "snowtb"]
+    possible = ClimaLand.Diagnostics.get_possible_diagnostics(model)
+    for v in snow_diag_vars
+        @test v in possible
+    end
+    snow_diags = ClimaLand.Diagnostics.default_diagnostics(
+        model,
+        start_date;
+        output_writer = ClimaDiagnostics.Writers.DictWriter(),
+        output_vars = snow_diag_vars,
+        reduction_period,
+        reduction_type,
+        dt,
+    )
+    @test length(snow_diags) == length(snow_diag_vars)
 end
 
 @testset "CanopyModel invalid windspeed diagnostic (coupled)" begin

--- a/test/integrated/soil_snow.jl
+++ b/test/integrated/soil_snow.jl
@@ -148,3 +148,75 @@ ClimaLand.Snow.snow_boundary_fluxes!(
     parent(p_snow_alone.snow.total_energy_flux .- p.snow.total_energy_flux) .≈
     parent(p.snow.snow_cover_fraction .* p.ground_heat_flux),
 )
+
+@testset "snow_T_bottom analytic limits and cap" begin
+    κ = FT(0.3)
+    ρ = FT(300)
+    g_eff = FT(1.2)
+    T_soil = FT(272.0)
+    Tbar = FT(263.0)
+    T_sfc = FT(255.0)
+    _T_freeze = FT(LP.T_freeze(earth_param_set))
+
+    # Reproduces the documented closed-form solution
+    z = FT(1.5)
+    d = ClimaLand.Snow.surface_temp_scaling_length(κ, ρ, z, earth_param_set)
+    expected = min(
+        (2 * Tbar - d / z * T_sfc + g_eff * (z - d) / κ * T_soil) /
+        (g_eff / κ * (z - d) + 1 + (z - d) / z),
+        _T_freeze,
+    )
+    @test ClimaLand.snow_T_bottom(
+        κ,
+        g_eff,
+        T_soil,
+        Tbar,
+        T_sfc,
+        z,
+        ρ,
+        earth_param_set,
+    ) == expected
+
+    # Deep snow (d << z): T_bot -> (2 T̄ + g_eff z/κ T_soil) / (g_eff z/κ + 2)
+    z_deep = FT(100.0)
+    T_bot_deep = ClimaLand.snow_T_bottom(
+        κ,
+        g_eff,
+        T_soil,
+        Tbar,
+        T_sfc,
+        z_deep,
+        ρ,
+        earth_param_set,
+    )
+    deep_limit =
+        (2 * Tbar + g_eff * z_deep / κ * T_soil) / (g_eff * z_deep / κ + 2)
+    @test T_bot_deep ≈ deep_limit rtol = FT(1e-2)
+
+    # Shallow snow (d -> z): T_bot -> 2 T̄ - T_sfc
+    z_thin = FT(1e-4)
+    T_bot_thin = ClimaLand.snow_T_bottom(
+        κ,
+        g_eff,
+        T_soil,
+        Tbar,
+        T_sfc,
+        z_thin,
+        ρ,
+        earth_param_set,
+    )
+    @test T_bot_thin ≈ 2 * Tbar - T_sfc rtol = FT(1e-2)
+
+    # Warm soil drives T_bot above freezing -> capped at T_freeze
+    T_bot_cap = ClimaLand.snow_T_bottom(
+        κ,
+        g_eff,
+        FT(290.0),
+        FT(272.0),
+        FT(271.0),
+        z,
+        ρ,
+        earth_param_set,
+    )
+    @test T_bot_cap == _T_freeze
+end

--- a/test/standalone/Snow/parameterizations.jl
+++ b/test/standalone/Snow/parameterizations.jl
@@ -113,6 +113,21 @@ for FT in (Float32, Float64)
               κ_air +
               (FT(0.07) * (ρ_snow / _ρ_i) + FT(0.93) * (ρ_snow / _ρ_i)^2) *
               (κ_ice - κ_air)
+
+        # Sturm et al. (1997) snow thermal conductivity
+        sturm = Snow.SturmSnowConductivityModel(toml_dict)
+        @test typeof(sturm) == Snow.SturmSnowConductivityModel{FT}
+        # densities below the threshold, above the threshold, and above the
+        # maximum density (where the non-dimensional density is capped)
+        for ρ_test in FT.([100, 350, 800])
+            x = min(ρ_test / _ρ_i, sturm.max / _ρ_i)
+            expected =
+                x < sturm.threshold ? sturm.b1 + sturm.m1 * x :
+                sturm.b2 + sturm.m2 * x + sturm.q2 * x^2
+            @test snow_thermal_conductivity(sturm, ρ_test, param_set) ==
+                  expected
+        end
+
         @test all(
             maximum_liquid_mass_fraction.(ρ_min, T, θ_r, Ref(param_set)) .-
             [FT(0), θ_r * _ρ_l / ρ_snow, θ_r * _ρ_l / ρ_snow] .== 0,


### PR DESCRIPTION

- Fix a diagnostic name mismatch: the LandModel possible‑diagnostics list named `"snow_tbot"`
  while the diagnostic is registered as `"snowtbot"`. As written the snow‑bottom‑temperature
  diagnostic was unreachable and `default_diagnostics(land_model; output_vars = :long)` would
  error with `"diagnostic snow_tbot does not exist"`. Renamed to `"snowtbot"`.

- Make the `ghf` and snow‑conductivity diagnostics reachable (they were registered but never
  added to any possible‑diagnostics list). Renamed the non‑ASCII short name `snowκ` → `snowk`
  (it was the only non‑ASCII diagnostic name and would become a non‑ASCII NetCDF variable),
  keeping the compute method consistent.
- Add `units` to the new diagnostics (`K` for the snow temperatures, `W m^-1 K^-1` for `snowk`,
  `W m^-2` for `ghf`) and a `comments` field to `ghf`.

- Fix a duplicated `F_g =  F_g =` in the `update_soil_snow_ground_heat_flux!` docstring and
  restore the explanation of why `Δz_snow` is capped at 10 cm.
- Remove the vestigial, unused `κ_ice` keyword from the `SnowParameters(toml_dict, Δt; …)`
  constructor (it was silently ignored after the `κ_ice → κ_snow` refactor).
- Expand and reflow the `snow_T_bottom` docstring (math in code fences so it renders) and add it
  to the API docs (`docs/src/APIs/ClimaLand.md`).

**Tests**
- `SturmSnowConductivityModel` conductivity test across the low/high/capped density branches.
- `snow_T_bottom` unit tests covering the closed form, both analytic limits, and the
  freezing‑point cap.
- A diagnostics regression test asserting the snow diagnostics (`snowtbot`, `ghf`, `snowk`,
  `snowtsfc`, `snowtb`) are reachable for a `LandModel`.

**NEWS.md** — added entries for the feature, the breaking `κ_ice → κ_snow` change, and the
ground‑heat‑flux behavioral change.

### Open question for the author

The Sturm low‑density slope `m1 = 0.20` looks slightly inconsistent with the non‑dimensionalization
used for the other coefficients: the threshold (`0.17`), `m2` (`−0.93 ≈ −1.01·ρ_ice`) and `q2`
(`2.72 ≈ 3.233·ρ_ice²`) all correspond to `ρ_ice ≈ 0.917 g/cm³`, which would give
`m1 = 0.234·ρ_ice ≈ 0.215` (and slightly better continuity at the threshold). Worth double‑checking
against the source. It only affects fresh, low‑density snow, so I did not change the parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
