### PR TITLE
Distinguish between manual and scheduled ILAMB runs

### DIFF
--- a/experiments/ilamb/ilamb_setup.jl
+++ b/experiments/ilamb/ilamb_setup.jl
@@ -1,6 +1,10 @@
 import Dates
 
-const NUM_MODELS_TO_KEEP = 3
+# Total number of manual model runs to keep
+const NUM_MANUAL_MODEL_RUNS = 1
+
+# Total number of scheduled model runs to keep
+const NUM_SCHEDULED_MODEL_RUNS = 1
 
 """
     setup_run_for_ilamb(
@@ -9,7 +13,8 @@ const NUM_MODELS_TO_KEEP = 3
         ilamb_build_dir::String,
         buildkite_id::String,
         commit_id::String,
-        num_models_to_keep::Integer,
+        num_manual_model_run_to_keep::Integer,
+        num_scheduled_model_run_to_keep::Integer,
     )
 
 Set up the ILAMB diagnostics produced from the run for ILAMB.
@@ -19,8 +24,9 @@ does not exist, creating a model directory in the `MODELS` directory for this
 run, and creating symbolic links in the model directory pointing to NetCDF files
 in `ilamb_diagnostics_dir`.
 
-If there are more models present than `num_models_to_keep`, models are
-automatically removed starting with the oldest model.
+At most `num_manual_model_run_to_keep` model runs from non-scheduled builds are
+kept and at most `num_scheduled_model_run_to_keep` model runs from scheduled
+builds are kept.
 """
 function setup_run_for_ilamb(
     ilamb_diagnostics_dir::String,
@@ -28,7 +34,8 @@ function setup_run_for_ilamb(
     ilamb_build_dir::String,
     buildkite_id::String,
     commit_id::String,
-    num_models_to_keep::Integer,
+    num_manual_model_run_to_keep::Integer,
+    num_scheduled_model_run_to_keep::Integer,
 )
     ilamb_diagnostics_dir = abspath(ilamb_diagnostics_dir)
     ilamb_models_parent_dir = abspath(ilamb_models_parent_dir)
@@ -52,8 +59,10 @@ function setup_run_for_ilamb(
     create_symlinks(ilamb_diagnostics_dir, model_dir)
     validate_symlinks(MODELS_dir)
 
-    delete_old_runs(MODELS_dir, num_models_to_keep)
+    delete_old_model_runs(MODELS_dir, num_manual_model_run_to_keep)
+    delete_old_scheduled_model_runs(MODELS_dir, num_scheduled_model_run_to_keep)
     clean_build_dir(MODELS_dir, ilamb_build_dir)
+    return nothing
 end
 
 """
@@ -143,23 +152,74 @@ function validate_symlinks(MODELS_dir::String)
 end
 
 """
-    delete_old_runs(MODELS_dir::String, N::Integer)
+    delete_old_model_runs(MODELS_dir::String, N::Integer)
 
-Delete model directories in `MODELS_dir` until there are only `N` model
-directories remaining.
+Delete model directories produced from manual model runs in `MODELS_dir` until
+there are at most `N` model directories remaining.
 
 Only directories corresponding to ClimaLand simulation outputs (matching the
 pattern created by `create_model_name`) can be deleted. Directories are sorted
 by Buildkite ID, with lower IDs considered older and deleted first.
 """
-function delete_old_runs(MODELS_dir::String, N::Integer)
+function delete_old_model_runs(MODELS_dir::String, N::Integer)
+    _delete_model_runs(
+        MODELS_dir,
+        N,
+        is_model_from_simulation,
+        "manual model runs",
+    )
+    return nothing
+end
+
+"""
+    delete_old_scheduled_model_runs(MODELS_dir::String, N::Integer)
+
+Delete model directories produced from scheduled model runs in `MODELS_dir`
+until there are at most `N` model directories remaining.
+
+Only directories corresponding to ClimaLand simulation outputs (matching the
+pattern created by `create_model_name`) can be deleted. Directories are sorted
+by Buildkite ID, with lower IDs considered older and deleted first.
+"""
+function delete_old_scheduled_model_runs(MODELS_dir::String, N::Integer)
+    _delete_model_runs(
+        MODELS_dir,
+        N,
+        is_model_from_scheduled_simulation,
+        "scheduled model runs",
+    )
+    return nothing
+end
+
+"""
+    _delete_model_runs(
+        MODELS_dir::String,
+        N::Integer,
+        predicate,
+        dir_description,
+    )
+
+Helper function to delete directories in `MODELS_dir`, so there are at most `N`
+directories satisfying the `predicate`.
+
+The argument `dir_description` is used in the log record to indicates what kind
+of directories are being deleted.
+"""
+function _delete_model_runs(
+    MODELS_dir::String,
+    N::Integer,
+    predicate,
+    dir_description,
+)
+    # Only interested in directories identified by `predicate` that can be
+    # deleted
     dirs = filter(isdir, readdir(MODELS_dir, join = true))
+    filter!(dir -> basename(dir) |> predicate, dirs)
     length(dirs) <= N && return nothing
     num_to_delete = length(dirs) - N
-    filter!(dir -> basename(dir) |> is_model_from_simulation, dirs)
     sort!(dirs, by = dir -> extract_buildkite_id(basename(dir)))
     dirs_to_remove = first(dirs, num_to_delete)
-    @info "Removing directories: $dirs_to_remove"
+    @info "Removing directories produced from $dir_description: $dirs_to_remove"
     rm.(dirs_to_remove, recursive = true)
     return nothing
 end
@@ -204,13 +264,32 @@ end
 """
     is_model_from_simulation(model_name::String)
 
-Return true if `model_name` matches the pattern produced by `create_model_name`.
+Return `true` if `model_name` matches the pattern produced by
+`create_model_name` with the commit ID matching the regex `[0-9a-f]{7}`.
+
+Any non-scheduled builds should produce a model name such that
+`is_model_from_simulation` return `true`.
 """
 function is_model_from_simulation(model_name::String)
     # \d* - Match any number of digits (corresponds to buildkite ID)
     # \d{4}-\d{2}-\d{2} - Match the date format
     # [0-9a-f]{7} - Match the commit ID that is shortened to 7 characters
     return occursin(r"\d+_\d{4}-\d{2}-\d{2}_[0-9a-f]{7}", model_name)
+end
+
+"""
+    is_model_from_scheduled_simulation(model_name::String)
+
+Return `true` if `model_name` matches the pattern produced by
+`create_model_name`, but the commit ID is replaced by the word "latest".
+
+Any scheduled builds should produce a model name with "latest" for the last
+part of the name.
+"""
+function is_model_from_scheduled_simulation(model_name::String)
+    # \d* - Match any number of digits (corresponds to buildkite ID)
+    # \d{4}-\d{2}-\d{2} - Match the date format
+    return occursin(r"\d+_\d{4}-\d{2}-\d{2}_latest", model_name)
 end
 
 """
@@ -235,13 +314,18 @@ if abspath(PROGRAM_FILE) == @__FILE__
     ilamb_build_dir = joinpath(ilamb_models_parent_dir, "_build")
     # This can also be any unique identifier
     buildkite_id = ARGS[3]
-    commit_id = ARGS[4]
+    # BUILDKITE_SOURCE can be "webhook", "api", "ui", "trigger_job", "schedule"
+    is_scheduled_run = get(ENV, "BUILDKITE_SOURCE", "") == "schedule"
+    # If the BUILDKITE_SOURCE is not "schedule", then we assume that it is a
+    # run that is created manually
+    commit_id = is_scheduled_run ? "latest" : ARGS[4]
     setup_run_for_ilamb(
         ilamb_diagnostics_dir,
         ilamb_models_parent_dir,
         ilamb_build_dir,
         buildkite_id,
         commit_id,
-        NUM_MODELS_TO_KEEP,
+        NUM_MANUAL_MODEL_RUNS,
+        NUM_SCHEDULED_MODEL_RUNS,
     )
 end

--- a/experiments/ilamb/tests/test_ilamb_setup.jl
+++ b/experiments/ilamb/tests/test_ilamb_setup.jl
@@ -53,14 +53,16 @@ end
         buildkite_id = "1"
 
         ilamb_build_dir = joinpath(ilamb_root_dir, "_build")
-        num_models_to_keep = 2
+        num_manual_models_to_keep = 2
+        num_scheduled_models_to_keep = 1
         setup_run_for_ilamb(
             ilamb_diag_dir,
             ilamb_root_dir,
             ilamb_build_dir,
             buildkite_id,
             commit_id,
-            num_models_to_keep,
+            num_manual_models_to_keep,
+            num_scheduled_models_to_keep,
         )
 
         # Test existence of directories and symlinks
@@ -101,7 +103,8 @@ end
             ilamb_build_dir,
             buildkite_id,
             commit_id,
-            num_models_to_keep,
+            num_manual_models_to_keep,
+            num_scheduled_models_to_keep,
         )
 
         model_name2 = "$(buildkite_id)_$(Dates.Date(Dates.now()))_$commit_id"
@@ -146,7 +149,8 @@ end
             ilamb_build_dir,
             buildkite_id,
             commit_id,
-            num_models_to_keep,
+            num_manual_models_to_keep,
+            num_scheduled_models_to_keep,
         )
 
         model_name3 = "$(buildkite_id)_$(Dates.Date(Dates.now()))_$commit_id"
@@ -166,6 +170,59 @@ end
         @test isfile(joinpath(ilamb_build_dir, "benchmark_$model_name2.nc"))
         @test isfile(joinpath(ilamb_build_dir, "benchmark_$model_name3.nc"))
         @test isfile(joinpath(ilamb_build_dir, "benchmark_$model_name3.png"))
+
+        # Make another ILAMB diagnostics (simulating another run) but with
+        # latest for the commit ID
+        ilamb_diag_dir4, evspsbl_filepath4, gpp_filepath4 =
+            make_dummy_ilamb_diagnostics("ilamb_diagnostics3")
+        commit_id = "latest"
+        buildkite_id = "4"
+        setup_run_for_ilamb(
+            ilamb_diag_dir4,
+            ilamb_root_dir,
+            ilamb_build_dir,
+            buildkite_id,
+            commit_id,
+            num_manual_models_to_keep,
+            num_scheduled_models_to_keep,
+        )
+
+        model_name4 = "$(buildkite_id)_$(Dates.Date(Dates.now()))_$commit_id"
+        model_dir4 = joinpath(MODELS_dir, model_name4)
+        populate_build_dir(ilamb_build_dir, model_dir4)
+
+        # No directories should be deleted since the number of scheduled model
+        # runs to keep is 1
+        @test isdir(model_dir2)
+        @test isdir(model_dir3)
+        @test isdir(model_dir4)
+
+        # Make another ILAMB diagnostics (simulating another run) with latest
+        # for the commit ID
+        ilamb_diag_dir5, evspsbl_filepath5, gpp_filepath5 =
+            make_dummy_ilamb_diagnostics("ilamb_diagnostics4")
+        commit_id = "latest"
+        buildkite_id = "5"
+        setup_run_for_ilamb(
+            ilamb_diag_dir5,
+            ilamb_root_dir,
+            ilamb_build_dir,
+            buildkite_id,
+            commit_id,
+            num_manual_models_to_keep,
+            num_scheduled_models_to_keep,
+        )
+
+        model_name5 = "$(buildkite_id)_$(Dates.Date(Dates.now()))_$commit_id"
+        model_dir5 = joinpath(MODELS_dir, model_name5)
+        populate_build_dir(ilamb_build_dir, model_dir5)
+
+        # Directory produced from last simulated ILAMB run should be deleted
+        # since the number of scheduled model runs to keep is 1
+        @test isdir(model_dir2)
+        @test isdir(model_dir3)
+        @test !isdir(model_dir4)
+        @test isdir(model_dir5)
     end
 end
 
@@ -182,53 +239,61 @@ end
     @test !is_model_from_simulation(model_name5)
 end
 
-@testset "Delete old runs" begin
-    N = 5
-    for num_directories in [10, 5, 3]
+@testset "Delete old model runs" begin
+    delete_model_dirs_fns =
+        [delete_old_model_runs, delete_old_scheduled_model_runs]
+    commit_ids = ["1234567", "latest"]
+
+    for (delete_model_dirs_fn, commit_id) in
+        zip(delete_model_dirs_fns, commit_ids)
+
+        N = 5
+        for num_directories in [10, 5, 3]
+            temp_dir = mktempdir(cleanup = false)
+            @info "Deleting old runs with $num_directories directories" temp_dir
+            MODELS_dir = joinpath(temp_dir, "MODELS")
+            mkdir(MODELS_dir)
+
+            for i in 1:num_directories
+                model_name = "$(i)_2010-01-01_$commit_id"
+                mkdir(joinpath(MODELS_dir, model_name))
+            end
+
+            delete_model_dirs_fn(MODELS_dir, N)
+
+            available_dirs = readdir(MODELS_dir, join = true)
+            remaining_directories = min(num_directories, N)
+            @test length(available_dirs) == remaining_directories
+            @test Set(basename.(available_dirs)) == Set([
+                "$(i)_2010-01-01_$commit_id" for
+                i in last(1:num_directories, remaining_directories)
+            ])
+        end
+
+        # If there are extra directories
         temp_dir = mktempdir(cleanup = false)
-        @info "Deleting old runs with $num_directories directories" temp_dir
+        @info "Deleting old runs from 4 model directories and 2 directories that should not be removed" temp_dir
         MODELS_dir = joinpath(temp_dir, "MODELS")
         mkdir(MODELS_dir)
 
-        for i in 1:num_directories
-            # Needed for the modified time to not be exactly the same
-            model_name = "$(i)_2010-01-01_1234567"
+        for i in 1:8
+            model_name = "$(i)_2010-01-01_$commit_id"
             mkdir(joinpath(MODELS_dir, model_name))
         end
 
-        delete_old_runs(MODELS_dir, N)
+        mkdir(joinpath(MODELS_dir, "Hello"))
+        mkdir(joinpath(MODELS_dir, "World"))
+
+        delete_model_dirs_fn(MODELS_dir, N)
 
         available_dirs = readdir(MODELS_dir, join = true)
-        remaining_directories = min(num_directories, N)
-        @test length(available_dirs) == remaining_directories
-        @test Set(basename.(available_dirs)) == Set([
-            "$(i)_2010-01-01_1234567" for
-            i in last(1:num_directories, remaining_directories)
-        ])
+        @test length(available_dirs) == 7
+        @test Set(basename.(available_dirs)) == union(
+            Set(["$(i)_2010-01-01_$commit_id" for i in 4:8]),
+            Set(["Hello", "World"]),
+        )
+
     end
-
-    # If there are extra directories
-    temp_dir = mktempdir(cleanup = false)
-    @info "Deleting old runs from 4 model directories and 2 directories that should not be removed" temp_dir
-    MODELS_dir = joinpath(temp_dir, "MODELS")
-    mkdir(MODELS_dir)
-
-    for i in 1:4
-        model_name = "$(i)_2010-01-01_1234567"
-        mkdir(joinpath(MODELS_dir, model_name))
-    end
-
-    mkdir(joinpath(MODELS_dir, "Hello"))
-    mkdir(joinpath(MODELS_dir, "World"))
-
-    delete_old_runs(MODELS_dir, N)
-
-    available_dirs = readdir(MODELS_dir, join = true)
-    @test length(available_dirs) == 5
-    @test Set(basename.(available_dirs)) == union(
-        Set(["$(i)_2010-01-01_1234567" for i in 2:4]),
-        Set(["Hello", "World"]),
-    )
 end
 
 @testset "Clean build directory" begin


### PR DESCRIPTION
For the ILAMB leaderboard, the scheduled ILAMB runs did not update the latest ILAMB run. The current latest ILAMB run is `4598_2026-03-05_latest` and the other ILAMB run is `4864_2026-06-16_58913e6`. This PR makes it so any scheduled ILAMB run will update the latest ILAMB run.

To do this, this PR introduces the constants `NUM_MANUAL_MODEL_RUNS ` and `NUM_SCHEDULED_MODEL_RUNS` which keep track of how many directories to retain when deleting old directories. Both constants are set to 1, so the scheduled run will override the last scheduled run. In addition, any new manual run will override the old manual run.