### PR TITLE
CLM parameters not defined everywhere on land

### DIFF
--- a/src/standalone/Vegetation/spatially_varying_parameters.jl
+++ b/src/standalone/Vegetation/spatially_varying_parameters.jl
@@ -6,6 +6,8 @@ import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
 import ClimaUtilities.ClimaArtifacts: @clima_artifact
 import ClimaLand: Artifacts
 
+zeros_to_val(x; v) = x == 0 ? eltype(x)(v) : x
+
 """
     clm_canopy_radiation_parameters(
         surface_space;
@@ -61,6 +63,7 @@ function clm_canopy_radiation_parameters(
     modis_ci_artifact_path = Artifacts.modis_ci_data_folder_path(; context)
 
     # TwoStreamModel parameters
+    # Clumping index missing value is NaN - set to 1
     nans_to_one(x) = isnan(x) ? eltype(x)(1) : x
     Ω = SpaceVaryingInput(
         joinpath(modis_ci_artifact_path, "He_et_al_2012_1x1.nc"),
@@ -70,6 +73,12 @@ function clm_canopy_radiation_parameters(
         regridder_kwargs = (; extrapolation_bc, interpolation_method),
         file_reader_kwargs = (; preprocess_func = nans_to_one,),
     )
+
+    # We run into a small issue where LAI may be nonzero where these plant properties from CLM
+    # are not defined (set to zero)
+    # Here we set them equal to temperature broadleaf deciduous BDT values from CLM5
+    # Values over the ocean will still be zero
+
     χl = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "xl",
@@ -77,6 +86,7 @@ function clm_canopy_radiation_parameters(
         regridder_type,
         regridder_kwargs = (; extrapolation_bc, interpolation_method),
     )
+    χl .= zeros_to_val.(χl; v = 0.25)
     G_Function = ClimaLand.Canopy.CLMGFunction.(χl)
     α_PAR_leaf = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
@@ -85,6 +95,8 @@ function clm_canopy_radiation_parameters(
         regridder_type,
         regridder_kwargs = (; extrapolation_bc, interpolation_method),
     )
+    α_PAR_leaf .= zeros_to_val.(α_PAR_leaf; v = 0.1)
+
     τ_PAR_leaf = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "taulvis",
@@ -92,6 +104,7 @@ function clm_canopy_radiation_parameters(
         regridder_type,
         regridder_kwargs = (; extrapolation_bc, interpolation_method),
     )
+    τ_PAR_leaf .= zeros_to_val.(τ_PAR_leaf; v = 0.05)
     α_NIR_leaf = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "rholnir",
@@ -99,6 +112,7 @@ function clm_canopy_radiation_parameters(
         regridder_type,
         regridder_kwargs = (; extrapolation_bc, interpolation_method),
     )
+    α_NIR_leaf .= zeros_to_val.(α_NIR_leaf; v = 0.45)
     τ_NIR_leaf = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "taulnir",
@@ -106,6 +120,7 @@ function clm_canopy_radiation_parameters(
         regridder_type,
         regridder_kwargs = (; extrapolation_bc, interpolation_method),
     )
+    τ_NIR_leaf .= zeros_to_val.(τ_NIR_leaf; v = 0.25)
     return (;
         Ω = Ω,
         G_Function = G_Function,
@@ -166,6 +181,11 @@ function clm_photosynthesis_parameters(
 )
     context = ClimaComms.context(surface_space)
     clm_artifact_path = Artifacts.clm_data_folder_path(; context, lowres)
+    # We run into a small issue where LAI may be nonzero where these plant properties from CLM
+    # are not defined (set to zero)
+    # Here we set Vcmax25 equal to the median value over land.
+    # The missing value for fractional c3 is already 1 
+
     # vcmax is read in units of umol CO2/m^2/s and then converted to mol CO2/m^2/s
     Vcmax25 = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
@@ -175,6 +195,7 @@ function clm_photosynthesis_parameters(
         regridder_kwargs = (; extrapolation_bc, interpolation_method),
         file_reader_kwargs = (; preprocess_func = (data) -> data / 1_000_000,),
     )
+    Vcmax25 .= zeros_to_val.(Vcmax25; v = 43 / 1_000_000) # 43 is the median in the nonzero values
     # photosynthesis mechanism is read as a proportion of c3 plants (0 to 1)
     # 1.0 indicates all c3 and 0.0 indicates all c4
     fractional_c3 = SpaceVaryingInput(
@@ -234,6 +255,7 @@ function clm_rooting_depth(
 )
     context = ClimaComms.context(surface_space)
     clm_artifact_path = Artifacts.clm_data_folder_path(; context, lowres)
+    # The missing value for fractional c3 is already something sensible
     rooting_depth = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
         "rooting_depth",
@@ -291,7 +313,9 @@ function clm_medlyn_g1(
 )
     context = ClimaComms.context(surface_space)
     clm_artifact_path = Artifacts.clm_data_folder_path(; context, lowres)
-
+    # We run into a small issue where LAI may be nonzero where these plant properties from CLM
+    # are not defined (set to zero)
+    # Here we set g1 equal to the value for BDT: 4.45 sqrt(kPa)
     # g1 is read in units of sqrt(kPa) and then converted to sqrt(Pa)
     g1 = SpaceVaryingInput(
         joinpath(clm_artifact_path, "vegetation_properties_map.nc"),
@@ -301,6 +325,8 @@ function clm_medlyn_g1(
         regridder_kwargs = (; extrapolation_bc, interpolation_method),
         file_reader_kwargs = (; preprocess_func = (data) -> data * 10^(3 / 2),),
     )
+    g1 .= zeros_to_val.(g1; v = 4.45 * 10^(3 / 2)) # 4.45 is BDT g1
+
     return g1
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The CLM parameters are not defined where their model has determined that there is no vegetation. However, MODIS LAI may be inconsistent with this. Because of this, we define these missing but over land parameters to be
- equal to the PFT parameters of broadleaf deciduous temperature if available
- equal to the median value of land values if PFT value unavailable
- C3 fraction = 1
- Omega = 1
- rooting depth was already nonzero everywhere and I believe was set to a mean over land.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
