### PR TITLE
remove SAI from energy tendency, LW_u, turbulent fluxes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ ClimaLand.jl Release Notes
 ========================
 main
 ----
+- ![][badge-🔥behavioralΔ] Remove SAI from energy fluxes, tendency PR [#1782](https://github.com/CliMA/ClimaLand.jl/pull/1782)
 - ![][badge-🔥behavioralΔ] Set the `optimal_lai_z`/`optimal_lai_sigma`/`optimal_lai_alpha`
   defaults to values calibrated against MODIS LAI (Yuan et al. 2017): 21.4 / 0.939 / 0.0701.
   Only affects runs using prognostic LAI (`ZhouOptimalLAIModel`); the prescribed-LAI default

--- a/docs/src/standalone/pages/vegetation/canopy_energy/canopy_energy.md
+++ b/docs/src/standalone/pages/vegetation/canopy_energy/canopy_energy.md
@@ -10,12 +10,7 @@ The ClimaLand code can be found [here](https://github.com/CliMA/ClimaLand.jl/blo
 The canopy temperature is modeled prognostically. Its time tendency is given by
 
 ```math
-\frac{dT_c}{dt} =
-\frac{
-    LW_n + SW_n - (\mathrm{SHF} + \mathrm{LHF}) + F_\mathrm{roots}
-}{
-    a_c \cdot \max(A_\mathrm{leaf} + A_\mathrm{stem}, \epsilon)
-},
+a_c A_\mathrm{leaf} \frac{dT_c}{dt} = LW_n + SW_n - (\mathrm{SHF} + \mathrm{LHF}) + F_\mathrm{roots},
 ```
 
 where
@@ -34,9 +29,7 @@ where
 
  $a_{c}$ is the canopy heat capacity per unit area (J m$^{-2}$ K$^{-1}$),
 
- $A_{\mathrm{leaf}}$ and $A_{\mathrm{stem}}$ are the leaf and stem area indices (–),
-
- and $\epsilon$ is the machine epsilon for numerical stability.
+ $A_{\mathrm{leaf}}$ is the leaf area index (–).
 
 ---
 

--- a/src/standalone/Vegetation/canopy_boundary_fluxes.jl
+++ b/src/standalone/Vegetation/canopy_boundary_fluxes.jl
@@ -163,11 +163,11 @@ NVTX.@annotate function canopy_boundary_fluxes!(
     zero_on_lai(X::FT, lai::FT) where {FT} = lai < FT(0.05) ? FT(0) : X
     @. p.canopy.turbulent_fluxes.shf = zero_on_lai(
         p.canopy.turbulent_fluxes.shf,
-        p.canopy.biomass.area_index.leaf + p.canopy.biomass.area_index.stem,
+        p.canopy.biomass.area_index.leaf,
     )
     @. p.canopy.turbulent_fluxes.∂shf∂T = zero_on_lai(
         p.canopy.turbulent_fluxes.∂shf∂T,
-        p.canopy.biomass.area_index.leaf + p.canopy.biomass.area_index.stem,
+        p.canopy.biomass.area_index.leaf,
     )
     # Update the root flux of water per unit ground area in place
     root_water_flux_per_ground_area!(
@@ -338,9 +338,7 @@ function ClimaLand.get_update_surface_temperature_function(
 )
     sfp = model.boundary_conditions.turbulent_flux_parameterization
     Cd = sfp.Cd
-    AI = @. lazy(
-        p.canopy.biomass.area_index.leaf + p.canopy.biomass.area_index.stem,
-    )
+    AI = p.canopy.biomass.area_index.leaf
     function update_T_sfc_at_a_point(
         ζ,
         param_set,
@@ -435,9 +433,7 @@ the canopy temperature.
 function ClimaLand.get_∂T_sfc∂T_function(model::CanopyModel, Y, p)
     sfp = model.boundary_conditions.turbulent_flux_parameterization
     Cd = sfp.Cd
-    AI = @. lazy(
-        p.canopy.biomass.area_index.leaf + p.canopy.biomass.area_index.stem,
-    )
+    AI = p.canopy.biomass.area_index.leaf
     function update_∂T_sfc∂T_at_a_point(
         u_star,
         g_h,

--- a/src/standalone/Vegetation/canopy_energy.jl
+++ b/src/standalone/Vegetation/canopy_energy.jl
@@ -131,11 +131,11 @@ function make_update_implicit_boundary_fluxes(
         zero_on_lai(X::FT, lai::FT) where {FT} = lai < FT(0.05) ? FT(0) : X
         @. p.canopy.turbulent_fluxes.shf = zero_on_lai(
             p.canopy.turbulent_fluxes.shf,
-            p.canopy.biomass.area_index.leaf + p.canopy.biomass.area_index.stem,
+            p.canopy.biomass.area_index.leaf,
         )
         @. p.canopy.turbulent_fluxes.∂shf∂T = zero_on_lai(
             p.canopy.turbulent_fluxes.∂shf∂T,
-            p.canopy.biomass.area_index.leaf + p.canopy.biomass.area_index.stem,
+            p.canopy.biomass.area_index.leaf,
         )
         # Update the canopy radiation
         canopy_radiant_energy_fluxes!(
@@ -177,7 +177,7 @@ function make_compute_imp_tendency(
                 p.canopy.radiative_transfer.SW_n +
                 p.canopy.turbulent_fluxes.shf +
                 p.canopy.turbulent_fluxes.lhf - p.canopy.energy.fa_energy_roots
-            ) / (ac_canopy * max(area_index.leaf + area_index.stem, eps(FT)))
+            ) / (ac_canopy * max(area_index.leaf, eps(FT)))
     end
     return compute_imp_tendency!
 end
@@ -246,7 +246,7 @@ function ClimaLand.make_compute_jacobian(
         @. ∂Tres∂T =
             float(dtγ) * MatrixFields.DiagonalMatrixRow(
                 (∂LW_n∂T - ∂shf∂T - ∂lhf∂T) /
-                (ac_canopy * max(area_index.leaf + area_index.stem, eps(FT))),
+                (ac_canopy * max(area_index.leaf, eps(FT))),
             ) - (I,)
     end
     return compute_jacobian!
@@ -279,9 +279,7 @@ function ClimaLand.total_energy_per_area!(
 )
     area_index = p.canopy.biomass.area_index
     @. surface_field .=
-        model.parameters.ac_canopy *
-        (area_index.stem + area_index.leaf) *
-        Y.canopy.energy.T
+        model.parameters.ac_canopy * area_index.leaf * Y.canopy.energy.T
     return nothing
 end
 

--- a/src/standalone/Vegetation/radiation.jl
+++ b/src/standalone/Vegetation/radiation.jl
@@ -814,13 +814,12 @@ function update_radiative_transfer!(
     nir_d = p.canopy.radiative_transfer.nir_d
     area_index = p.canopy.biomass.area_index
     LAI = area_index.leaf
-    SAI = area_index.stem
     bc = canopy.boundary_conditions
 
     # update radiative transfer
     (; G_Function, Ω, λ_γ_PAR, K_lw) = radiative_transfer.parameters
     @. p.canopy.radiative_transfer.ϵ =
-        radiative_transfer.parameters.ϵ_canopy * (1 - exp(-K_lw * (LAI + SAI))) #from CLM 5.0, Tech note 4.20
+        radiative_transfer.parameters.ϵ_canopy * (1 - exp(-K_lw * LAI)) #from CLM 5.0, Tech note 4.20
     compute_PAR!(par_d, radiative_transfer, bc.radiation, p, t)
     compute_NIR!(nir_d, radiative_transfer, bc.radiation, p, t)
 

--- a/test/standalone/Vegetation/conservation.jl
+++ b/test/standalone/Vegetation/conservation.jl
@@ -119,7 +119,7 @@ for FT in (Float32, Float64)
             ClimaLand.total_energy_per_area!(total_energy, canopy, Y, p, t0)
             @test all(
                 parent(total_energy) .≈
-                (LAI_value + SAI) * canopy.energy.parameters.ac_canopy * Temp0,
+                LAI_value * canopy.energy.parameters.ac_canopy * Temp0,
             )
 
             total_water = ClimaCore.Fields.zeros(domain.space.surface)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Background 
Accounting for stems/roots is important for modelling autotrophic respiration during the winter. We had also included SAI in the thermal mass of the canopy (appearing in the tendency for canopy energy), in the long wave emission, and in the sensible heat flux. The thermal mass contribution should be negligible. The latter too may matter at some level. However, on main, we had always run with SAI = 0, so we did not check the effects of this. PR #1707  tried running with nonzero SAI, but found it worsened energy fluxes. More recently, changes to improve autotrophic respiration led to nonzero SAI, but this also has a negative impact on energy fluxes, in particular, SHF.

Additionally, it may be incorrect to model the effect of trunks on SHF, LW_net, but not SW_net, which we had not been doing. 

See the discussion here: https://github.com/CliMA/ClimaLand.jl/pull/1707

## Purpose 
This PR removes SAI from any energy flux computations and from the tendency for temperature.