### PR TITLE
Fix prognostic-LAI canopy height NaN and missing component constructors

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -248,10 +248,10 @@ git-tree-sha1 = "c35ba0e899040cb8153226ab751f69100f475d39"
     url = "https://caltech.box.com/shared/static/tn1bnqjmegyetw5kzd2ixq5pbnb05s3u.gz"
 
 [optimal_lai_inputs]
-git-tree-sha1 = "cba8e02b52d8ebbde04a3fbb3269d775a6a08cc3"
+git-tree-sha1 = "2ce5e5e05e4f17c86b07eadff1f9dd551e779524"
 
     [[optimal_lai_inputs.download]]
-    sha256 = "d23d59d049eaa49a53d6e4b53c310caa9409783d471de83c0ee97375c00228d4"
+    sha256 = "dfaa2e9c649e609f274a5db15a4504067df5c6cfea00d6676d468177d2432654"
     url = "https://caltech.box.com/shared/static/y8igrojuyvbww0gn5zi8und9wgsqhtv5.gz"
 
 [neural_snow]

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -303,7 +303,6 @@ end
                 forcing.atmos,
             ),
             toml_dict,
-            Δt,
         ) : nothing,
         canopy = Canopy.CanopyModel{FT}(
             Domains.obtain_surface_domain(domain),
@@ -368,7 +367,6 @@ function LandModel{FT}(
             forcing.atmos,
         ),
         toml_dict,
-        Δt,
     ) : nothing,
     canopy = Canopy.CanopyModel{FT}(
         Domains.obtain_surface_domain(domain),

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -436,7 +436,7 @@ energy and water constraints. LAI is stored in `p.canopy.biomass.area_index.leaf
 - `SAI`: Stem area index (m2/m2), default from toml_dict
 - `RAI`: Root area index (m2/m2), default from toml_dict
 - `rooting_depth`: Rooting depth (m), default from CLM data
-- `height`: Canopy height (m), default spatially varying from CLM data
+- `height`: Canopy height (m), default the constant `canopy_height` from `toml_dict`
 
 # Example
 ```julia
@@ -455,7 +455,12 @@ function ZhouOptimalLAIModel{FT}(
     SAI::FT = toml_dict["SAI"],
     RAI::FT = toml_dict["RAI"],
     rooting_depth = clm_rooting_depth(domain.space.surface),
-    height = clm_canopy_height(domain.space.surface),
+    # Use the constant `canopy_height` (as the prescribed-biomass models do)
+    # rather than the CLM canopy-height field: the latter is ~0 at barren/alpine
+    # cells, which makes the leaf-water storage `LAI * height` in the ϑ_l tendency
+    # vanish, so once the prognostic LAI greens up the transpiration/root fluxes
+    # drive ϑ_l (and the coupled canopy/soil state) to NaN.
+    height = toml_dict["canopy_height"],
 ) where {FT <: AbstractFloat}
     parameters = OptimalLAIParameters{FT}(toml_dict)
     return ZhouOptimalLAIModel{FT}(
@@ -608,6 +613,15 @@ function PModelConductance{FT}(
     cond_params = PModelConductanceParameters(Drel = Drel)
     return PModelConductance{FT}(cond_params)
 end
+
+# PModelConductance has no spatially-varying parameters, so the domain is
+# ignored; this method exists only to match the uniform (domain, toml_dict)
+# component signature used by the CanopyModel constructor.
+PModelConductance{FT}(
+    domain,
+    toml_dict::CP.ParamDict;
+    Drel = toml_dict["relative_diffusivity_of_water_vapor"],
+) where {FT <: AbstractFloat} = PModelConductance{FT}(toml_dict; Drel)
 
 
 ########################################################


### PR DESCRIPTION
Extracts three self-contained fixes from `ar/calibrate_inversion_nee` onto a clean branch off `main`.

## Changes

- **`src/standalone/Vegetation/Canopy.jl`**
  - `ZhouOptimalLAIModel`: default `height` to the constant `canopy_height` from the TOML dict instead of the spatially-varying CLM canopy-height field. The CLM field is ~0 at barren/alpine cells, which makes the leaf-water storage `LAI * height` vanish in the `ϑ_l` tendency, so the transpiration/root fluxes drive `ϑ_l` (and the coupled canopy/soil state) to NaN once prognostic LAI greens up.
  - Add a `PModelConductance{FT}(domain, toml_dict; Drel)` method delegating to the existing `(toml_dict; Drel)` constructor, matching the uniform `(domain, toml_dict)` component signature that the `CanopyModel` constructor already invokes (currently a latent `MethodError`).

- **`src/integrated/land.jl`**
  - Drop the erroneous 4th positional `Δt` argument passed to `SoilCO2Model{FT}` in both `LandModel` constructors. `SoilCO2Model` has no method taking `Δt`, and the other call sites (`soil_canopy_model.jl`, `soil_energy_hydrology_biogeochemistry.jl`) already omit it.

- **`Artifacts.toml`**
  - Bump the `optimal_lai_inputs` artifact (new tree hash / sha256 / url).

🤖 Generated with [Claude Code](https://claude.com/claude-code)