### PR TITLE
Calibrated optimal-LAI defaults + prognostic-LAI long run option

### DIFF
--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -39,8 +39,12 @@ steps:
 
   - wait
 
+  # The standard (prescribed-LAI) long runs. Run on the weekly scheduled build,
+  # on manual builds, and when the "Run long runs" label is present — but skip
+  # when a PR is labeled ONLY "long run opt lai" (that label runs just the
+  # prognostic-LAI group below), so each label triggers exactly one mode.
   - group: "Global Land Models"
-    if: build.env("LONGER_RUN") == null && build.env("PERTURBED_RUN") == null
+    if: build.env("LONGER_RUN") == null && build.env("PERTURBED_RUN") == null && (build.source == "schedule" || !(build.pull_request.labels includes "long run opt lai") || build.pull_request.labels includes "Run long runs")
     steps:
 
       - label: ":snow_capped_mountain: Snowy Land + P Model"
@@ -81,6 +85,28 @@ steps:
           slurm_time: 00:30:00
         env:
           CLIMACOMMS_DEVICE: "CUDA"
+
+  # Prognostic (modeled) LAI run of snowy_land_pmodel (ZhouOptimalLAIModel),
+  # selected via the `PROGNOSTIC_LAI` env var. Runs on the weekly scheduled
+  # build so the standard weekly long runs cover BOTH prescribed and prognostic
+  # LAI, and on demand when a PR carries the "long run opt lai" label.
+  - group: "Optimal LAI Global Land Model"
+    if: build.env("LONGER_RUN") == null && build.env("PERTURBED_RUN") == null && (build.source == "schedule" || build.pull_request.labels includes "long run opt lai")
+    steps:
+
+      - label: ":seedling: Snowy Land + P Model (Optimal LAI)"
+        key: "snowy_land_pmodel_opt_lai_run"
+        command:
+          - julia --color=yes --project=.buildkite experiments/long_runs/snowy_land_pmodel.jl
+        artifact_paths:
+          - "snowy_land_pmodel_opt_lai_longrun_gpu/*png"
+          - "snowy_land_pmodel_opt_lai_longrun_gpu/*pdf"
+        agents:
+          slurm_gpus: 1
+          slurm_time: 3:00:00
+        env:
+          CLIMACOMMS_DEVICE: "CUDA"
+          PROGNOSTIC_LAI: ""
 
   - group: "Perturbed Low-res Global Land Models"
     if: build.env("PERTURBED_RUN") != null

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Always read the ClimaLand-specific structure guide before working in this reposi
 - For package tests, prefer `Pkg.test()` or running `julia --project=test test/runtests.jl` over manually including files.
 - Keep edits modular and within the appropriate submodel directory (e.g., `src/standalone` or `src/integrated`).
 - Match existing style: explicit names, narrow imports, and use multiple dispatch effectively.
-- Keep comments sparse. Do not explain in comments what a change fixes or narrate its history ("this fixes Y", "this newest code fixes the issue introduced by..."), and do not restate the docstring inline. Comment only non-obvious rationale (the *why*, not the *what*).
+- Keep comments sparse and succinct. Write every comment for a first-time reader of the *final* code, not as a diff narration: do not explain what a change fixes or its history ("this fixes Y", "this newest code fixes the issue introduced by..."), and do not restate the docstring inline. Prefer one short line over a multi-line block; comment only non-obvious rationale (the *why*, not the *what*).
 - Follow the software design patterns in [docs/dev-guides/code-quality/software_design_patterns.md](docs/dev-guides/code-quality/software_design_patterns.md) for new code and refactor toward them when touching existing code.
 - Run `julia -e 'using JuliaFormatter; format(".")'` before committing code, adhering to the rules in `.JuliaFormatter.toml`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,16 @@ ClimaLand.jl Release Notes
 ========================
 main
 ----
+- ![][badge-🔥behavioralΔ] Set the `optimal_lai_z`/`optimal_lai_sigma`/`optimal_lai_alpha`
+  defaults to values calibrated against MODIS LAI (Yuan et al. 2017): 21.4 / 0.939 / 0.0701.
+  Only affects runs using prognostic LAI (`ZhouOptimalLAIModel`); the prescribed-LAI default
+  is unchanged. PR [#1794](https://github.com/CliMA/ClimaLand.jl/pull/1794)
+- ![][badge-✨feature] Add a `PROGNOSTIC_LAI` switch to `experiments/long_runs/snowy_land_pmodel.jl`
+  to run with prognostic optimal LAI instead of prescribed MODIS LAI, and run it weekly on CI
+  (plus on demand via the `long run opt lai` label). PR [#1794](https://github.com/CliMA/ClimaLand.jl/pull/1794)
+- ![][badge-✨feature] Add an `INVERSION` leaderboard (model vs inversion-derived NEE/GPP/ER,
+  plus MODIS LAI on prognostic-LAI runs only) to the snowy-land long run. PR [#1794](https://github.com/CliMA/ClimaLand.jl/pull/1794)
+
 v1.10.1
 -----
 - Fix GPU crash in CLM canopy radiation parameter regridding

--- a/experiments/long_runs/snowy_land_pmodel.jl
+++ b/experiments/long_runs/snowy_land_pmodel.jl
@@ -53,11 +53,18 @@ const LONGER_RUN = haskey(ENV, "LONGER_RUN") ? true : false
 # `export UNCALIBRATED=""` in the terminal and run this script, or
 # pass `UNCALIBRATED=""` as an environment variable on buildkite.
 const UNCALIBRATED = haskey(ENV, "UNCALIBRATED") ? true : false
+# If you want to run with prognostic (modeled) LAI from the optimal-LAI model
+# (Zhou et al. 2025, `ZhouOptimalLAIModel`) instead of prescribed MODIS LAI,
+# type `export PROGNOSTIC_LAI=""` in the terminal and run this script, or pass
+# `PROGNOSTIC_LAI=""` as an environment variable on Buildkite. The default
+# (unset) prescribes MODIS LAI.
+const PROGNOSTIC_LAI = haskey(ENV, "PROGNOSTIC_LAI") ? true : false
 context = ClimaComms.context()
 ClimaComms.init(context)
 device = ClimaComms.device()
 device_suffix = device isa ClimaComms.CPUSingleThreaded ? "cpu" : "gpu"
-root_path = "snowy_land_pmodel_longrun_$(device_suffix)"
+lai_suffix = PROGNOSTIC_LAI ? "_opt_lai" : ""
+root_path = "snowy_land_pmodel$(lai_suffix)_longrun_$(device_suffix)"
 diagnostics_outdir = joinpath(root_path, "global_diagnostics")
 outdir =
     ClimaUtilities.OutputPathGenerator.generate_output_path(diagnostics_outdir)
@@ -68,9 +75,9 @@ function setup_model(
     stop_date,
     Δt,
     domain,
-    toml_dict,
+    toml_dict;
+    prognostic_lai = false,
 ) where {FT}
-    surface_domain = ClimaLand.Domains.obtain_surface_domain(domain)
     surface_space = domain.space.surface
     # Forcing data - high resolution
     atmos, radiation = ClimaLand.prescribed_forcing_era5(
@@ -84,23 +91,33 @@ function setup_model(
     )
     forcing = (; atmos, radiation)
 
-    # Read in LAI from MODIS data
-    LAI = ClimaLand.Canopy.prescribed_lai_modis(
-        surface_space,
-        start_date,
-        stop_date,
-    )
-
-    # Construct the land model with all default components
     prognostic_land_components = (:canopy, :lake, :snow, :soil, :soilco2)
-    land = LandModel{FT}(
-        forcing,
-        LAI,
-        toml_dict,
-        domain,
-        Δt;
-        prognostic_land_components,
-    )
+    if prognostic_lai
+        # The LandModel constructor uses the prognostic LAI model if no
+        # prescribed LAI is passed.
+        land = LandModel{FT}(
+            forcing,
+            toml_dict,
+            domain,
+            Δt;
+            prognostic_land_components,
+        )
+    else
+        # Prescribed LAI (default): read LAI from MODIS data.
+        LAI = ClimaLand.Canopy.prescribed_lai_modis(
+            surface_space,
+            start_date,
+            stop_date,
+        )
+        land = LandModel{FT}(
+            forcing,
+            LAI,
+            toml_dict,
+            domain,
+            Δt;
+            prognostic_land_components,
+        )
+    end
     return land
 end
 
@@ -122,9 +139,18 @@ else
     toml_dict = LP.create_toml_dict(FT)
 end
 
-model = setup_model(FT, start_date, stop_date, Δt, domain, toml_dict)
+model = setup_model(
+    FT,
+    start_date,
+    stop_date,
+    Δt,
+    domain,
+    toml_dict;
+    prognostic_lai = PROGNOSTIC_LAI,
+)
 simulation = LandSimulation(start_date, stop_date, Δt, model; outdir)
 @info "Run: Global Soil-Canopy-Snow Model"
+@info "LAI: $(PROGNOSTIC_LAI ? "prognostic (ZhouOptimalLAIModel)" : "prescribed (MODIS)")"
 @info "Resolution: $(domain.nelements)"
 @info "Timestep: $Δt s"
 @info "Start Date: $start_date"
@@ -134,7 +160,11 @@ ClimaLand.Simulations.solve!(simulation)
 
 LandSimVis.make_annual_timeseries(simulation; savedir = root_path)
 LandSimVis.make_heatmaps(simulation; savedir = root_path, date = stop_date)
-LandSimVis.make_leaderboard_plots(simulation; savedir = root_path)
+LandSimVis.make_leaderboard_plots(
+    simulation;
+    savedir = root_path,
+    leaderboard_data_sources = ["ERA5", "ILAMB", "FlagshipCarbonMetrics"],
+)
 
 if LONGER_RUN
     include("../ilamb/ilamb_conversion.jl")

--- a/ext/land_sim_vis/leaderboard/data_sources.jl
+++ b/ext/land_sim_vis/leaderboard/data_sources.jl
@@ -61,10 +61,25 @@ function _preprocess_sim_var(var, ::Val{:nee})
     return var
 end
 
+function _preprocess_sim_var(var, ::Val{:hr})
+    # heterotrophic respiration: convert `mol CO2 m^-2 s^-1` in sim to
+    # `g C m-2 day-1` in obs (used for the inv_hr inversion target).
+    (ClimaAnalysis.units(var) == "mol CO2 m^-2 s^-1") && (
+        var = ClimaAnalysis.convert_units(
+            var,
+            "g m-2 day-1",
+            conversion_function = units -> units * 86400.0 * 12.011,
+        )
+    )
+    return var
+end
+
 _preprocess_sim_var(var, ::Val{:lwu}) = var
 _preprocess_sim_var(var, ::Val{:lhf}) = var
 _preprocess_sim_var(var, ::Val{:shf}) = var
 _preprocess_sim_var(var, ::Val{:swu}) = var
+# LAI is already dimensionless (m^2 m^-2), matching the MODIS obs; no conversion.
+_preprocess_sim_var(var, ::Val{:lai}) = var
 _preprocess_sim_var(var, name::Val) =
     error("Preprocessing var with short name ($name) is not defined")
 
@@ -439,12 +454,243 @@ function get_compare_vars_biases_plot_extrema(; annual = false)
         "gpp" => (-6.0, 6.0) .* factor,
         "er" => (-6.0, 6.0) .* factor,
         "nee" => (-4.0, 4.0) .* factor,
+        "hr" => (-4.0, 4.0) .* factor,
         "lwu" => (-40.0, 40.0) .* factor,
         "shf" => (-50.0, 50.0) .* factor,
         "lhf" => (-40.0, 40.0) .* factor,
         "swu" => (-50.0, 50.0) .* factor,
+        "lai" => (-3.0, 3.0) .* factor,
     )
     return compare_vars_biases_plot_extrema
+end
+
+"""
+    _monthly_total_to_daily_rate!(obs_var)
+
+In-place: convert `obs_var.data` from `g C m⁻² month⁻¹` to a daily rate by
+dividing each time slice by its real days-in-month (28–31), rather than the
+constant 365.25/12 ≈ 30.4375. Avoids the ~5% source of error the constant
+days-per-month assumption introduces. Sets the units string to `"g m-2 day-1"`.
+"""
+function _monthly_total_to_daily_rate!(obs_var)
+    native = ClimaAnalysis.units(obs_var)
+    native == "g C m-2 month-1" || error(
+        "expected a monthly total in \"g C m-2 month-1\", got \"$native\"",
+    )
+    for (i, date) in enumerate(ClimaAnalysis.dates(obs_var))
+        slice = ClimaAnalysis.view_select(
+            obs_var;
+            by = ClimaAnalysis.Index(),
+            time = i,
+        )
+        slice.data ./= Dates.daysinmonth(date)
+    end
+    ClimaAnalysis.set_units!(obs_var, "g m-2 day-1")
+    return obs_var
+end
+
+"""
+    get_inversion_obs_var_dict()
+
+Inversion-derived NEE/GPP/ER/Rh observations from the `inversion_nee` artifact
+(`derived_nee_gpp_er_rh_2002_2020.nc`, monthly 1°×1°, 2002–2020), returned as
+full-timeseries `OutputVar`s (the framework sets the per-sample reference date
+and windows by season in `generate_observations.jl`).
+
+Variables (all positive = source except gpp = uptake):
+  - `nee` from CarbonTracker CT2022, g C m⁻² month⁻¹
+  - `gpp` from GOSIF-GPP v2,        g C m⁻² month⁻¹
+  - `er`  residual = nee + gpp,     g C m⁻² month⁻¹
+  - `rh`  from Hashimoto 2015,      **g C m⁻² day⁻¹** (native units)
+
+All four are returned in g C m⁻² day⁻¹ (nee/gpp/er divided by actual
+days-in-month; rh already daily), with the units *string* set to `"g m-2 day-1"`
+to match the model diagnostics — ClimaCalibrate's `UnitsChecker` does a raw
+string compare. Short_names are retagged to `inv_nee`/`sif_gpp`/`res_er`/`inv_hr`
+so they don't collide with the FLUXCOM `gpp`/`er`/`nee` keys.
+"""
+function get_inversion_obs_var_dict()
+    inversion_path = ClimaLand.Artifacts.inversion_nee_dataset_path()
+
+    _load(varname) = begin
+        obs_var = ClimaAnalysis.OutputVar(inversion_path, varname)
+        ClimaAnalysis.dim_units(obs_var, "lon") == "degree" &&
+        ClimaAnalysis.set_dim_units!(obs_var, "lon", "degrees_east")
+        ClimaAnalysis.dim_units(obs_var, "lat") == "degree" &&
+        ClimaAnalysis.set_dim_units!(obs_var, "lat", "degrees_north")
+        ClimaAnalysis.transform_dates!(obs_var, Dates.firstdayofmonth)
+        return ClimaAnalysis.replace(obs_var, missing => NaN)
+    end
+
+    obs_var_dict = Dict{String, Any}()
+    for (alias, varname, monthly) in (
+        ("inv_nee", "nee", true),
+        ("sif_gpp", "gpp", true),
+        ("res_er", "er", true),
+        ("inv_hr", "rh", false), # rh already a daily rate; relabeled below
+    )
+        obs_var = _load(varname)
+        if monthly
+            # Convert to a daily rate and set units to "g m-2 day-1".
+            _monthly_total_to_daily_rate!(obs_var)
+        else
+            # rh is already a daily rate; relabel "g C m-2 day-1" → "g m-2 day-1"
+            # so the UnitsChecker's raw string compare matches the model hr
+            # diagnostic (a mismatch NaN-fills the member's whole G column).
+            native = ClimaAnalysis.units(obs_var)
+            native == "g C m-2 day-1" || error(
+                "inversion `$varname` expected units \"g C m-2 day-1\", got \"$native\"",
+            )
+            ClimaAnalysis.set_units!(obs_var, "g m-2 day-1")
+        end
+        # Like ILAMB obs: sort lat ascending and shift lon to [-180, 180] so
+        # preprocess_single_obs_var aligns these with the model grid.
+        # `_preprocess_var` leaves "g m-2 day-1" and the short_name untouched.
+        obs_var = _preprocess_var(obs_var)
+        obs_var.attributes["short_name"] = alias
+        obs_var_dict[alias] = obs_var
+    end
+    return obs_var_dict
+end
+
+# Map the calibration aliases (artifact-derived short names) to the model
+# diagnostic short names used by the simulation output and the leaderboard.
+# `inv_hr` (Hashimoto Rh) is intentionally excluded: the leaderboard shows the
+# MODIS `lai` target in its place (see FlagshipCarbonMetricsDataLoader).
+const _INVERSION_ALIAS_TO_MODEL_NAME =
+    Dict("inv_nee" => "nee", "sif_gpp" => "gpp", "res_er" => "er")
+
+"""
+    FlagshipCarbonMetricsDataLoader
+
+Loads our flagship carbon-cycle observations for the leaderboard: CT2022 NEE,
+GOSIF GPP, and residual ER from the `inversion_nee` artifact, plus the MODIS
+`lai` target. Like `ILAMBDataLoader`, it serves monthly obs keyed by the model
+short names `nee`/`gpp`/`er`/`lai`, but sourced from these products instead of
+FLUXCOM.
+"""
+struct FlagshipCarbonMetricsDataLoader <: AbstractDataLoader
+    """Preprocessed inversion `OutputVar`s, keyed by model short name."""
+    obs_var_dict::Dict{String, Any}
+
+    """A list of available variables to load."""
+    available_vars::Set{String}
+end
+
+"""
+    FlagshipCarbonMetricsDataLoader()
+
+Construct a data loader for the inversion-derived carbon targets and MODIS LAI.
+The carbon variables are already preprocessed (monthly total → daily rate,
+latitude sorted ascending, longitude shifted to [-180, 180], units set to
+`g m-2 day-1`) by `get_inversion_obs_var_dict`; here they are re-keyed and
+re-tagged from `inv_nee`/`sif_gpp`/`res_er` to `nee`/`gpp`/`er`. The `lai` target
+(m^2 m^-2) is loaded from `get_modis_lai_obs_var`.
+"""
+function FlagshipCarbonMetricsDataLoader()
+    inversion_dict = get_inversion_obs_var_dict()
+    obs_var_dict = Dict{String, Any}()
+    for (alias, model_name) in _INVERSION_ALIAS_TO_MODEL_NAME
+        obs_var = inversion_dict[alias]
+        obs_var.attributes["short_name"] = model_name
+        obs_var_dict[model_name] = obs_var
+    end
+    lai_obs = get_modis_lai_obs_var()
+    lai_obs.attributes["short_name"] = "lai"
+    obs_var_dict["lai"] = lai_obs
+    return FlagshipCarbonMetricsDataLoader(
+        obs_var_dict,
+        Set(keys(obs_var_dict)),
+    )
+end
+
+"""
+    get(loader::FlagshipCarbonMetricsDataLoader, short_name::String)
+
+Get the preprocessed `OutputVar` with the model short name `short_name` (one of
+`nee`, `gpp`, `er`, `lai`).
+"""
+function Base.get(loader::FlagshipCarbonMetricsDataLoader, short_name::String)
+    short_name in loader.available_vars ||
+        error("$short_name is not available to load")
+    return loader.obs_var_dict[short_name]
+end
+
+"""
+    get_mask_dict(data_loader::FlagshipCarbonMetricsDataLoader)
+
+Return a dictionary mapping model short names to a masking function used to
+normalize the global bias and RMSE. The inversion carbon variables
+(`nee`/`gpp`/`er`) are masked where the observation is missing (NaN), mirroring
+the ILAMB carbon-variable masks. `lai` uses `ClimaAnalysis.apply_oceanmask`
+instead: MODIS LAI is finite (≈0), not NaN, over ocean, so the `isnan` mask
+would mask nothing.
+"""
+function get_mask_dict(data_loader::FlagshipCarbonMetricsDataLoader)
+    mask_dict = Dict{String, Any}()
+
+    make_mask_fn =
+        (sim_var, obs_var) -> begin
+            return ClimaAnalysis.make_lonlat_mask(
+                ClimaAnalysis.slice(
+                    obs_var,
+                    time = ClimaAnalysis.times(obs_var) |> first,
+                );
+                set_to_val = isnan,
+            )
+        end
+
+    for short_name in available_vars(data_loader)
+        mask_dict[short_name] =
+            short_name == "lai" ?
+            ((sim_var, obs_var) -> ClimaAnalysis.apply_oceanmask) : make_mask_fn
+    end
+
+    @assert keys(mask_dict) == available_vars(data_loader)
+    return mask_dict
+end
+
+"""
+    get_modis_lai_obs_var(; years = 2000:2020)
+
+MODIS LAI (Yuan et al., monthly 1°×1°, per-year files) as a single `OutputVar`
+spanning `years`, keyed `lai`, units `m^2 m^-2` (native, matching the model
+`lai` diagnostic). Latitude is sorted ascending and longitude shifted to
+[-180, 180] via `_preprocess_var`.
+
+The native samples are ~30.4-day spaced and calendar-unaligned, so they are
+linearly interpolated in time onto calendar month-starts to match the
+month-start-dated model `lai` diagnostic. Only interior month-starts are kept
+(endpoints would need extrapolation), so `years` should bracket the window of
+interest by at least one month on each side.
+"""
+function get_modis_lai_obs_var(; years = 2000:2020)
+    paths = [
+        ClimaLand.Artifacts.modis_lai_single_year_path(; year) for year in years
+    ]
+    obs_var = ClimaAnalysis.OutputVar(paths, "lai")
+    obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
+
+    # Resample onto calendar month-starts (interior only) by linear time
+    # interpolation, so seasonal averaging produces the same canonical
+    # month-start season dates as the model's monthly `lai` diagnostic.
+    start_date = Dates.DateTime(obs_var.attributes["start_date"])
+    data_dates = ClimaAnalysis.dates(obs_var)
+    month_starts = filter(
+        d -> first(data_dates) <= d <= last(data_dates),
+        Dates.firstdayofmonth(first(data_dates)):Dates.Month(1):last(
+            data_dates,
+        ),
+    )
+    target_seconds = [
+        Float64(Dates.value(Dates.Second(d - start_date))) for d in month_starts
+    ]
+    obs_var = ClimaAnalysis.resampled_as(obs_var; time = target_seconds)
+
+    obs_var = _preprocess_var(obs_var)
+    obs_var.attributes["short_name"] = "lai"
+    obs_var.attributes["units"] = "m^2 m^-2"
+    return obs_var
 end
 
 """
@@ -452,9 +698,12 @@ end
 
 Return a dictionary mapping short names to `OutputVar` containing preprocessed
 observational data for calibration. This combines ERA5 energy flux variables
-(`lhf`, `shf`, `lwu`, `swu`) with ILAMB variables (`gpp`, `er`, `nee`).
+(`lhf`, `shf`, `lwu`, `swu`), ILAMB variables (`gpp`, `er`, `nee`), the
+inversion-derived carbon targets (`inv_nee`, `sif_gpp`, `res_er`, `inv_hr`)
+from the `inversion_nee` artifact, and the MODIS `lai` target.
 
-If `short_names` is provided, only the requested variables are returned.
+If `short_names` is provided, only the requested variables are returned (and
+the MODIS LAI file load is skipped unless `lai` is requested).
 """
 function get_calibration_obs_var_dict(; short_names = nothing)
     obs_var_dict = Dict{String, Any}()
@@ -470,6 +719,16 @@ function get_calibration_obs_var_dict(; short_names = nothing)
     # Add more variables to obs_var_dict
     for short_name in ("gpp", "er", "nee")
         obs_var_dict[short_name] = get(ilamb_data_loader, short_name)
+    end
+
+    # Inversion-derived carbon targets (CT2022 NEE + GOSIF GPP + residual ER +
+    # Hashimoto Rh), keyed by inv_nee/sif_gpp/res_er/inv_hr.
+    merge!(obs_var_dict, get_inversion_obs_var_dict())
+
+    # MODIS LAI target for optimal-LAI calibration. Loading the 21 per-year
+    # files is comparatively expensive, so only build it when requested.
+    if isnothing(short_names) || "lai" in short_names
+        obs_var_dict["lai"] = get_modis_lai_obs_var()
     end
 
     if !isnothing(short_names)

--- a/ext/land_sim_vis/leaderboard/leaderboard.jl
+++ b/ext/land_sim_vis/leaderboard/leaderboard.jl
@@ -28,40 +28,53 @@ function _percentile_contour_kwargs(
 end
 
 """
-    _monthly_climatology_global_mean(var, mask_fn = ClimaAnalysis.apply_oceanmask)
+    _monthly_climatology_global_means(sim, obs,
+                                      mask_fn = ClimaAnalysis.apply_oceanmask)
 
-Return a 12-element vector of global, lonlat-weighted monthly climatology
-means for `var`. Index `i` corresponds to month `i` (1=Jan ... 12=Dec).
-Months that have no valid samples are filled with `NaN`.
+Return a pair `(sim_monthly, obs_monthly)` of 12-element vectors of global,
+lonlat-weighted monthly climatology means. Index `i` corresponds to month `i`
+(1=Jan ... 12=Dec). Months that have no valid samples are filled with `NaN`.
 
-`mask_fn` is the same per-variable mask used by `global_bias` /  `global_rmse`
-elsewhere in this module (e.g. `apply_oceanmask` for ERA5 vars, the FLUXCOM
-NaN mask for ILAMB vars). Applying it to sim and obs identically guarantees
-that both lines are averaged over the same set of valid pixels, so the gap
-between the lines matches the global bias shown in the ANN column.
+`mask_fn` is the same per-variable mask used by `global_bias`/`global_rmse`
+elsewhere. After applying it, at each time step both sim and obs are restricted
+to the grid cells where *both* have valid (non-`NaN`) data, so the two lines are
+averaged over the same domain even where obs has data gaps that sim does not —
+otherwise the SIM/OBS gap would not match the global bias in the ANN column.
 """
-function _monthly_climatology_global_mean(
-    var,
+function _monthly_climatology_global_means(
+    sim,
+    obs,
     mask_fn = ClimaAnalysis.apply_oceanmask,
 )
-    times = ClimaAnalysis.times(var)
-    isempty(times) && return fill(NaN, 12)
-    start_date = Dates.DateTime(var.attributes["start_date"])
+    times = ClimaAnalysis.times(sim)
+    isempty(times) && return (fill(NaN, 12), fill(NaN, 12))
+    start_date = Dates.DateTime(sim.attributes["start_date"])
     months =
         [Dates.month(start_date + Dates.Second(round(Int, t))) for t in times]
-    global_means = [
-        ClimaAnalysis.weighted_average_lonlat(
-            mask_fn(ClimaAnalysis.slice(var, time = t)),
-        ).data[] for t in times
-    ]
-    out = fill(NaN, 12)
+    sim_global = Float64[]
+    obs_global = Float64[]
+    for t in times
+        sim_t = mask_fn(ClimaAnalysis.slice(sim, time = t))
+        obs_t = mask_fn(ClimaAnalysis.slice(obs, time = t))
+        # Keep only cells where both fields have valid data, so the two
+        # weighted global means are taken over the same domain.
+        nan_either = isnan.(sim_t.data) .| isnan.(obs_t.data)
+        sim_t.data[nan_either] .= NaN
+        obs_t.data[nan_either] .= NaN
+        push!(sim_global, ClimaAnalysis.weighted_average_lonlat(sim_t).data[])
+        push!(obs_global, ClimaAnalysis.weighted_average_lonlat(obs_t).data[])
+    end
+    out_sim = fill(NaN, 12)
+    out_obs = fill(NaN, 12)
     for m in 1:12
         idxs = findall(==(m), months)
         isempty(idxs) && continue
-        vals = filter(isfinite, global_means[idxs])
-        isempty(vals) || (out[m] = sum(vals) / length(vals))
+        sim_vals = filter(isfinite, sim_global[idxs])
+        obs_vals = filter(isfinite, obs_global[idxs])
+        isempty(sim_vals) || (out_sim[m] = sum(sim_vals) / length(sim_vals))
+        isempty(obs_vals) || (out_obs[m] = sum(obs_vals) / length(obs_vals))
     end
-    return out
+    return (out_sim, out_obs)
 end
 
 """
@@ -90,6 +103,61 @@ function _nee_diverging_contour_kwargs(var, q; nlevels = 21)
 end
 
 """
+    _prepare_for_bias(base_mask, sim, obs)
+
+Return `(sim, obs, mask_fn)` so that `ClimaAnalysis.bias` / `global_bias` /
+`global_rmse` / `plot_bias_on_globe!` integrate over the intersection of finite
+cells, matching `_monthly_climatology_global_means`.
+
+Works around a normalization issue in `ClimaAnalysis.bias` when `obs` has
+spatial gaps (e.g. GOSIF-GPP/residual-ER over deserts/ice): its normalization
+`ones_var` doesn't inherit obs's NaN footprint (denominator over all land,
+numerator over land∩finite(obs) — attenuates or flips the bias). `mask_fn`
+combines `base_mask` with the union of the sim/obs NaN footprints so `ones_var`
+and `sim − obs` share one domain.
+
+Gaps are left as `NaN` (not zero-filled) so a NaN-aware `resampled_as`
+(ClimaAnalysis.jl#198) works with them unchanged. Until then `resampled_as`
+erodes cells adjacent to a gap into NaN, leaving a slightly smaller dataset
+there, which is preferable to biasing those edges low with zero-fill.
+"""
+function _prepare_for_bias(base_mask, sim, obs)
+    sim_masked = base_mask(sim)
+    obs_masked = base_mask(obs)
+    extra_nan = isnan.(sim_masked.data) .| isnan.(obs_masked.data)
+    mask_fn = function (var)
+        v = base_mask(var)
+        any(extra_nan) || return v
+        new_data = copy(v.data)
+        new_data[extra_nan] .= NaN
+        return ClimaAnalysis.OutputVar(
+            v.attributes,
+            v.dims,
+            v.dim_attributes,
+            new_data,
+        )
+    end
+    return sim, obs, mask_fn
+end
+
+"""
+    _get_data_loader(data_source)
+
+Return the observational data loader for `data_source` (case-insensitive), one
+of `"ERA5"`, `"FlagshipCarbonMetrics"`, or `"ILAMB"`. Errors on anything else.
+"""
+function _get_data_loader(data_source)
+    source = uppercase(data_source)
+    source == "ERA5" && return ERA5DataLoader()
+    source == "FLAGSHIPCARBONMETRICS" &&
+        return FlagshipCarbonMetricsDataLoader()
+    source == "ILAMB" && return ILAMBDataLoader()
+    return error(
+        "Unknown data_source \"$data_source\"; expected \"ERA5\", \"FlagshipCarbonMetrics\", or \"ILAMB\".",
+    )
+end
+
+"""
     compute_monthly_leaderboard(leaderboard_base_path,
                                 diagnostics_folder_path,
                                 data_source)
@@ -114,8 +182,7 @@ function compute_monthly_leaderboard(
     data_source,
 )
     sim_dir = ClimaAnalysis.SimDir(diagnostics_folder_path)
-    data_loader =
-        uppercase(data_source) == "ERA5" ? ERA5DataLoader() : ILAMBDataLoader()
+    data_loader = _get_data_loader(data_source)
     mask_dict = get_mask_dict(data_loader)
 
     compare_vars_biases_plot_extrema = get_compare_vars_biases_plot_extrema()
@@ -230,12 +297,17 @@ function compute_monthly_leaderboard(
         times = reshape(times, (2, 6))
         for ((indices, t), (month, year)) in zip(pairs(times), months_and_years)
             layout = fig[Tuple(indices)...] = CairoMakie.GridLayout()
-            ClimaAnalysis.Visualize.plot_bias_on_globe!(
-                layout,
+            sim_c, obs_c, mask_c = _prepare_for_bias(
+                mask,
                 ClimaAnalysis.slice(sim_var, time = t),
                 ClimaAnalysis.slice(obs_var, time = t),
+            )
+            ClimaAnalysis.Visualize.plot_bias_on_globe!(
+                layout,
+                sim_c,
+                obs_c,
                 cmap_extrema = compare_vars_biases_plot_extrema[short_name],
-                mask = mask,
+                mask = mask_c,
             )
             CairoMakie.Label(
                 layout[0, 1],
@@ -262,25 +334,34 @@ function compute_monthly_leaderboard(
         mask = mask_dict[short_name](sim_var, obs_var)
 
         sim_vec = [
-            ClimaAnalysis.weighted_average_lonlat(
-                ClimaAnalysis.apply_oceanmask(
+            begin
+                sim_c, _, mask_c = _prepare_for_bias(
+                    mask,
                     ClimaAnalysis.slice(sim_var, time = t),
-                ),
-            ).data[] for t in times
+                    ClimaAnalysis.slice(obs_var, time = t),
+                )
+                ClimaAnalysis.weighted_average_lonlat(mask_c(sim_c)).data[]
+            end for t in times
         ]
         rmse_vec = [
-            ClimaAnalysis.global_rmse(
-                ClimaAnalysis.slice(sim_var, time = t),
-                ClimaAnalysis.slice(obs_var, time = t),
-                mask = mask,
-            ) for t in times
+            begin
+                sim_c, obs_c, mask_c = _prepare_for_bias(
+                    mask,
+                    ClimaAnalysis.slice(sim_var, time = t),
+                    ClimaAnalysis.slice(obs_var, time = t),
+                )
+                ClimaAnalysis.global_rmse(sim_c, obs_c, mask = mask_c)
+            end for t in times
         ]
         bias_vec = [
-            ClimaAnalysis.global_bias(
-                ClimaAnalysis.slice(sim_var, time = t),
-                ClimaAnalysis.slice(obs_var, time = t),
-                mask = mask,
-            ) for t in times
+            begin
+                sim_c, obs_c, mask_c = _prepare_for_bias(
+                    mask,
+                    ClimaAnalysis.slice(sim_var, time = t),
+                    ClimaAnalysis.slice(obs_var, time = t),
+                )
+                ClimaAnalysis.global_bias(sim_c, obs_c, mask = mask_c)
+            end for t in times
         ]
 
         ax_sim = CairoMakie.Axis(
@@ -395,8 +476,7 @@ function compute_seasonal_leaderboard(
 )
     # Get everything we need from data_sources.jl
     sim_dir = ClimaAnalysis.SimDir(diagnostics_folder_path)
-    data_loader =
-        uppercase(data_source) == "ERA5" ? ERA5DataLoader() : ILAMBDataLoader()
+    data_loader = _get_data_loader(data_source)
     short_names = intersect(
         ClimaAnalysis.available_vars(sim_dir),
         available_vars(data_loader),
@@ -526,12 +606,14 @@ function compute_seasonal_leaderboard(
             isempty(sim_var) && break
             layout = fig_bias[row_idx, col_idx] = CairoMakie.GridLayout()
             sim_var.attributes["short_name"] = "mean $(ClimaAnalysis.short_name(sim_var))"
+            sim_c, obs_c, mask_c =
+                _prepare_for_bias(mask_fn_dict[short_name], sim_var, obs_var)
             ClimaAnalysis.Visualize.plot_bias_on_globe!(
                 layout,
-                sim_var,
-                obs_var,
+                sim_c,
+                obs_c,
                 cmap_extrema = compare_vars_biases_plot_extrema[short_name],
-                mask = mask_fn_dict[short_name],
+                mask = mask_c,
             )
         end
     end
@@ -673,10 +755,11 @@ function compute_seasonal_leaderboard(
                 sim_var_full, obs_var_full = sim_obs_full_dict[short_name]
                 isempty(sim_var_full) && break
                 mask_fn = mask_fn_dict[short_name]
-                sim_monthly =
-                    _monthly_climatology_global_mean(sim_var_full, mask_fn)
-                obs_monthly =
-                    _monthly_climatology_global_mean(obs_var_full, mask_fn)
+                sim_monthly, obs_monthly = _monthly_climatology_global_means(
+                    sim_var_full,
+                    obs_var_full,
+                    mask_fn,
+                )
                 units_str = ClimaAnalysis.units(sim_var_full)
                 ax = CairoMakie.Axis(
                     fig_sim_ann[row_idx, col_idx],
@@ -730,12 +813,17 @@ function compute_seasonal_leaderboard(
                     sim_obs_season_comparison_dict[short_name][group]
                 isempty(sim_var) && break
                 layout = fig_sim_ann[row_idx, col_idx] = CairoMakie.GridLayout()
-                ClimaAnalysis.Visualize.plot_bias_on_globe!(
-                    layout,
+                sim_c, obs_c, mask_c = _prepare_for_bias(
+                    mask_fn_dict[short_name],
                     sim_var,
                     obs_var,
+                )
+                ClimaAnalysis.Visualize.plot_bias_on_globe!(
+                    layout,
+                    sim_c,
+                    obs_c,
                     cmap_extrema = annual_compare_vars_biases_plot_extrema[short_name],
-                    mask = mask_fn_dict[short_name],
+                    mask = mask_c,
                 )
             end
         end
@@ -766,17 +854,24 @@ function compute_seasonal_leaderboard(
         # Get season and compute global bias and global rmse
         seasons = [sim_var.attributes["season"] for sim_var in sim_vars]
         sim_vec = [
-            ClimaAnalysis.weighted_average_lonlat(
-                ClimaAnalysis.apply_oceanmask(sim_var),
-            ).data[] for sim_var in sim_vars
+            begin
+                sim_c, _, mask_c = _prepare_for_bias(mask, sim_var, obs_var)
+                ClimaAnalysis.weighted_average_lonlat(mask_c(sim_c)).data[]
+            end for (sim_var, obs_var) in zip(sim_vars, obs_vars)
         ]
         rmse_vec = [
-            ClimaAnalysis.global_rmse(sim_var, obs_var, mask = mask) for
-            (sim_var, obs_var) in zip(sim_vars, obs_vars)
+            begin
+                sim_c, obs_c, mask_c =
+                    _prepare_for_bias(mask, sim_var, obs_var)
+                ClimaAnalysis.global_rmse(sim_c, obs_c, mask = mask_c)
+            end for (sim_var, obs_var) in zip(sim_vars, obs_vars)
         ]
         bias_vec = [
-            ClimaAnalysis.global_bias(sim_var, obs_var, mask = mask) for
-            (sim_var, obs_var) in zip(sim_vars, obs_vars)
+            begin
+                sim_c, obs_c, mask_c =
+                    _prepare_for_bias(mask, sim_var, obs_var)
+                ClimaAnalysis.global_bias(sim_c, obs_c, mask = mask_c)
+            end for (sim_var, obs_var) in zip(sim_vars, obs_vars)
         ]
 
         # Partition by seasons

--- a/toml/default_parameters.toml
+++ b/toml/default_parameters.toml
@@ -107,21 +107,21 @@ description = "Light extinction coefficient (dimensionless)"
 tag = "OptimalLAIModel"
 
 ["optimal_lai_z"]
-value = 12.227
+value = 21.4
 type = "float"
-description = "Unit cost of constructing and maintaining leaves (mol m^-2 yr^-1)"
+description = "Unit cost of constructing and maintaining leaves (mol m^-2 yr^-1). Calibrated against MODIS LAI (Yuan et al. 2017)."
 tag = "OptimalLAIModel"
 
 ["optimal_lai_sigma"]
-value = 1.1
+value = 0.939
 type = "float"
-description = "Dimensionless parameter representing departure from square-wave LAI dynamics (Zhou et al. 2025)"
+description = "Dimensionless parameter representing departure from square-wave LAI dynamics (Zhou et al. 2025). Calibrated against MODIS LAI (Yuan et al. 2017)."
 tag = "OptimalLAIModel"
 
 ["optimal_lai_alpha"]
-value = 0.067
+value = 0.0701
 type = "float"
-description = "Smoothing factor for exponential moving average (dimensionless, 0-1), ~15 days of memory"
+description = "Smoothing factor for exponential moving average (dimensionless, 0-1), ~15 days of memory. Calibrated against MODIS LAI (Yuan et al. 2017)."
 tag = "OptimalLAIModel"
 
 ["optimal_lai_f0"]


### PR DESCRIPTION
## Summary

Adds the calibrated optimal-LAI parameters as model defaults, makes the P-model snowy-land long run able to run with **prognostic (modeled) LAI**, and adds an **inversion-obs leaderboard** to the long run — wired into weekly CI and a new on-demand label.

## Changes

**1. Calibrated optimal-LAI defaults** — `toml/default_parameters.toml`

Calibrated `ZhouOptimalLAIModel` against MODIS LAI (Yuan et al. 2017) with `experiments/calibration/configs/lai.jl` (TransformUnscented, constrained ensemble mean, converged over 4 iterations):

| param | old (prior mean) | new (calibrated) |
|---|---|---|
| `optimal_lai_z` | 12.227 | **21.4** |
| `optimal_lai_sigma` | 1.1 | **0.939** |
| `optimal_lai_alpha` | 0.067 | **0.0701** |

Only affects prognostic-LAI runs; the prescribed-LAI default is unchanged.

**2. Prognostic-LAI option** — `experiments/long_runs/snowy_land_pmodel.jl`

New `PROGNOSTIC_LAI` env-var switch (mirrors `LONGER_RUN` / `UNCALIBRATED`). Unset → prescribed MODIS LAI (unchanged). Set → the canopy computes LAI from the P-model potential GPP via the no-LAI `LandModel` convenience constructor (`ZhouOptimalLAIModel`, #1783). Prognostic output goes to a separate `snowy_land_pmodel_opt_lai_longrun_*` directory.

**3. INVERSION leaderboard** — `ext/land_sim_vis/leaderboard/*`, `ext/LandSimulationVisualizationExt.jl`

- Adds the inversion carbon leaderboard: the long run now compares the model's NEE/GPP/ER against the inversion product (CT2022 NEE, GOSIF GPP, residual ER) from the `inversion_nee` artifact, alongside the ERA5 and ILAMB leaderboards.
- The leaderboard also compares the model `lai` against the MODIS LAI target (Yuan et al. 2017), included for **all** runs: for prescribed-LAI runs the panel is ~1:1 (model `lai` equals the prescribed MODIS obs), and for prognostic-LAI runs it is an independent check. _(The earlier prognostic-only `include_lai` gating was removed in review round #1.)_

**4. CI + labels** — `.buildkite/longruns_gpu/pipeline.yml`

The two labels are now **independent — add just one**:
- `Run long runs` → the prescribed long run (as before).
- `long run opt lai` → the prognostic long run.

The **weekly scheduled build runs both**. (The default group's `if` short-circuits on `build.source == "schedule"` so the weekly run is unaffected by the label logic.)

**5. New GitHub label** — `long run opt lai` (green `#0e8a16`), created via `gh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

