### PR TITLE
Remove GHA tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
           - '1.12'
         os:
           - ubuntu-latest
-          - windows-latest
           # There is a concurrency limit for MacOS runners across the
           # entire organization.
           # (see https://docs.github.com/en/actions/reference/limits#job-concurrency-limits-for-github-hosted-runners)


### PR DESCRIPTION
As of now, there isn't much benefit to testing on Windows.