### PR TITLE
Decouple ILAMB leaderboard from soil long run

### DIFF
--- a/.buildkite/longruns_gpu/pipeline.yml
+++ b/.buildkite/longruns_gpu/pipeline.yml
@@ -140,6 +140,7 @@ steps:
     if: build.env("LONGER_RUN") != null
     steps:
       - label: "Snowy Land, 19 years"
+        key: "snowy_land_19yr_run"
         command:
           - julia --color=yes --project=.buildkite experiments/long_runs/snowy_land_pmodel.jl
         artifact_paths:
@@ -162,8 +163,6 @@ steps:
           CLIMACOMMS_DEVICE: "CUDA"
           LONGER_RUN: ""
 
-  - wait
-
   # To check if the ILAMB leaderboard should be generated or not, we check for
   # the existence of `LONGER_RUN` and `ILAMB_RUN`. If both environment variables
   # exist, then this group step is ran and otherwise, this group step does not
@@ -173,6 +172,7 @@ steps:
 
   - group: "ILAMB leaderboard"
     if: build.env("LONGER_RUN") != null && build.env("ILAMB_RUN") != null
+    depends_on: "snowy_land_19yr_run"
     steps:
     - label: "Set up ILAMB leaderboard"
       command:


### PR DESCRIPTION
Before this change, the ILAMB leaderboard requires both the snowy land long run and the soil long run to complete. With this change, the ILAMB leaderboard should only require the snowy land long run to complete.