### PR TITLE
Fix C4 dryness sensitivity typo in compute_chi

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@ ClimaLand.jl Release Notes
 ========================
 main
 ----
+- ![][badge-🐛bugfix] Fix a C4 typo in `compute_chi`: the C4 intercellular CO2 used the C3
+  dryness sensitivity `ξ_c3` instead of `ξ_c4`, biasing the blended χ (and hence the
+  optimal-LAI water-limitation term) at C4 and mixed C3/C4 cells. PR [#1805](https://github.com/CliMA/ClimaLand.jl/pull/1805)
 
 v1.10.2
 -----

--- a/src/standalone/Vegetation/pmodel.jl
+++ b/src/standalone/Vegetation/pmodel.jl
@@ -1665,7 +1665,7 @@ function compute_chi(
     # Compute ci and chi
     VPD_safe = max(VPD, eps(FT))
     ci_c3 = intercellular_co2_pmodel(ξ_c3, ca_pp, Γstar, VPD_safe)
-    ci_c4 = intercellular_co2_pmodel(ξ_c3, ca_pp, Γstar, VPD_safe)
+    ci_c4 = intercellular_co2_pmodel(ξ_c4, ca_pp, Γstar, VPD_safe)
     return clamp(blend(ci_c3, ci_c4, fractional_c3) / ca_pp, FT(0), FT(1))
 end
 


### PR DESCRIPTION
## Summary

`compute_chi` computes the optimal `ci/ca` ratio (χ) by blending a C3 and a C4 branch. The C4 intercellular CO₂ was computed with the **C3** dryness sensitivity `ξ_c3` instead of `ξ_c4`:

```julia
ci_c3 = intercellular_co2_pmodel(ξ_c3, ca_pp, Γstar, VPD_safe)
ci_c4 = intercellular_co2_pmodel(ξ_c3, ca_pp, Γstar, VPD_safe)  # <- was ξ_c3
```

Since `ξ_c4 = sqrt(β_c4 * (Kmm + Γstar) / (Drel * ηstar))` uses a much smaller unit-cost ratio (`β_c4` ≈ `β_c3 / 9`), the C4 branch was getting the C3 χ, biasing the blended χ toward C3 behavior at C4 and mixed C3/C4 cells.

## Impact

- `compute_chi` is consumed by the optimal-LAI model (`optimal_lai.jl`) for the water-limitation term, so the bias propagated into optimal LAI at C4/mixed cells.
- The per-timestep GPP path (`compute_blended_pmodel_photosynthesis`) computes `ci_c3`/`ci_c4` correctly with their own ξ and is **not** affected.
- Pure-C3 cells (`fractional_c3 = 1`) are unaffected since the C4 branch is weighted out.

## Change

One-line fix: use `ξ_c4` for the C4 intercellular CO₂. Plus a NEWS entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)