### PR TITLE
Build leaderboard/calibration MODIS LAI obs as a monthly mean

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,12 @@ v1.10.3
 - ![][badge-🐛bugfix] Fix a C4 typo in `compute_chi`: the C4 intercellular CO2 used the C3
   dryness sensitivity `ξ_c3` instead of `ξ_c4`, biasing the blended χ (and hence the
   optimal-LAI water-limitation term) at C4 and mixed C3/C4 cells. PR [#1805](https://github.com/CliMA/ClimaLand.jl/pull/1805)
+- ![][badge-🐛bugfix] Build the leaderboard/calibration MODIS `lai` obs
+  (`get_modis_lai_obs_var`) as a calendar-monthly mean instead of a month-start
+  snapshot, matching the model's monthly-mean `lai` diagnostic. The snapshot led
+  the mean by ~half a month, biasing the seasonal cycle of prescribed-LAI runs.
+  Also shifts the LAI calibration target by up to ~0.2 m² m⁻².
+  PR [#1806](https://github.com/CliMA/ClimaLand.jl/pull/1806)
 
 v1.10.2
 -----

--- a/ext/land_sim_vis/leaderboard/data_sources.jl
+++ b/ext/land_sim_vis/leaderboard/data_sources.jl
@@ -651,18 +651,65 @@ function get_mask_dict(data_loader::FlagshipCarbonMetricsDataLoader)
 end
 
 """
+    _fully_observed_month_starts(dates)
+
+Return the starts of the calendar months that `dates` spans in full.
+"""
+function _fully_observed_month_starts(dates)
+    first_date, last_date = first(dates), last(dates)
+    candidate_starts =
+        Dates.firstdayofmonth(first_date):Dates.Month(1):last_date
+    return filter(
+        month_start ->
+            first_date <= month_start &&
+                month_start + Dates.Month(1) <= last_date,
+        candidate_starts,
+    )
+end
+
+"""
+    _mid_month(month_start)
+
+Return the midpoint of the calendar month beginning at `month_start`.
+"""
+function _mid_month(month_start)
+    @assert month_start == Dates.firstdayofmonth(month_start)
+    month_length = (month_start + Dates.Month(1)) - month_start
+    return month_start + month_length ÷ 2
+end
+
+"""
     get_modis_lai_obs_var(; years = 2000:2020)
 
-MODIS LAI (Yuan et al., monthly 1°×1°, per-year files) as a single `OutputVar`
-spanning `years`, keyed `lai`, units `m^2 m^-2` (native, matching the model
-`lai` diagnostic). Latitude is sorted ascending and longitude shifted to
-[-180, 180] via `_preprocess_var`.
+MODIS LAI (Yuan et al., 1°×1°, per-year files) as a single `OutputVar` spanning
+`years`, keyed `lai`, units `m^2 m^-2`. Latitude is sorted ascending and
+longitude shifted to [-180, 180].
 
-The native samples are ~30.4-day spaced and calendar-unaligned, so they are
-linearly interpolated in time onto calendar month-starts to match the
-month-start-dated model `lai` diagnostic. Only interior month-starts are kept
-(endpoints would need extrapolation), so `years` should bracket the window of
-interest by at least one month on each side.
+The samples are postprocessed to match the convention the leaderboard and
+calibration use: a monthly mean dated on the first day of each month. The native
+samples do not follow it — within each year they run on a 30-day cadence from
+January 1 that drifts against the calendar and resets every January, so a month
+may hold two samples or none. In 2008 they fall on
+
+    01-01, 01-31, 03-01, 03-31, 04-30, 05-30, 06-29, 07-29, 08-28, 09-27, 10-27, 11-26
+
+with February and December empty and January and March doubled, so relabeling
+them to month starts directly would collide the doubled months and leave the
+empty ones unfilled. Three steps produce one first-of-month sample per month,
+traced on 2008:
+
+  - `_fully_observed_month_starts` keeps the months lying fully within the
+    record, so the next step never extrapolates (only the record's first and
+    last partial months are dropped).
+  - `resampled_as` linearly interpolates onto each month's `_mid_month`
+    (01-16, 02-15, 03-16, …), giving every month one value regardless of the
+    native gaps and doublings. For this near-piecewise-linear product the
+    midpoint equals the monthly mean to < 0.002 m^2 m^-2.
+  - `transform_dates(_, firstdayofmonth)` moves each midpoint to its month start
+    (01-01, 02-01, 03-01, …).
+
+`years` should bracket the window of interest by a month on each side, since the
+first step drops the record's partial end months.
 """
 function get_modis_lai_obs_var(; years = 2000:2020)
     paths = [
@@ -671,21 +718,19 @@ function get_modis_lai_obs_var(; years = 2000:2020)
     obs_var = ClimaAnalysis.OutputVar(paths, "lai")
     obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
 
-    # Resample onto calendar month-starts (interior only) by linear time
-    # interpolation, so seasonal averaging produces the same canonical
-    # month-start season dates as the model's monthly `lai` diagnostic.
+    # resampled_as takes its time coordinate as seconds since the reference date,
+    # not DateTime, so the midpoints are converted here.
     start_date = Dates.DateTime(obs_var.attributes["start_date"])
-    data_dates = ClimaAnalysis.dates(obs_var)
-    month_starts = filter(
-        d -> first(data_dates) <= d <= last(data_dates),
-        Dates.firstdayofmonth(first(data_dates)):Dates.Month(1):last(
-            data_dates,
-        ),
+    seconds_since_start(date) =
+        Float64(Dates.value(Dates.Second(date - start_date)))
+
+    month_starts = _fully_observed_month_starts(ClimaAnalysis.dates(obs_var))
+    obs_var = ClimaAnalysis.resampled_as(
+        obs_var;
+        time = seconds_since_start.(_mid_month.(month_starts)),
     )
-    target_seconds = [
-        Float64(Dates.value(Dates.Second(d - start_date))) for d in month_starts
-    ]
-    obs_var = ClimaAnalysis.resampled_as(obs_var; time = target_seconds)
+
+    obs_var = ClimaAnalysis.transform_dates(obs_var, Dates.firstdayofmonth)
 
     obs_var = _preprocess_var(obs_var)
     obs_var.attributes["short_name"] = "lai"


### PR DESCRIPTION
## Now (this PR)

<img width="3600" height="3200" alt="FlagshipCarbonMetrics_sim_annual_time_avg_over_all_years" src="https://github.com/user-attachments/assets/43a8db77-2755-418a-9e59-05a19798b775" />

## Before this PR

<img width="3600" height="3200" alt="image" src="https://github.com/user-attachments/assets/277055e7-4996-43e2-9c8d-6dab9b0bbfb8" />

## Problem

LAI is *prescribed from MODIS*, so the leaderboard's SIM and OBS LAI should be ~1:1 — but the MON lines were visibly offset.

**Root cause (temporal convention mismatch):** the model's `lai` diagnostic is a calendar-monthly **mean** dated at the month start, which effectively represents mid-month. `get_modis_lai_obs_var` built the obs as an instantaneous **month-start snapshot**, which the mean leads by ~half a month — so SIM ran high on the spring green-up and low on the autumn senescence, even though sim and obs come from the same MODIS files. It is **not** a mask issue.

The other leaderboard variables already date their obs at the month start (`transform_dates!(firstdayofmonth)`); LAI was the only snapshot.

## Fix

Sample the linearly-interpolated MODIS at the **middle of each fully observed calendar month** and label it at the **month start**. For this near-piecewise-linear product the mid-month value equals the true monthly mean to **< 0.002 m² m⁻²**, while the month-start snapshot differs by **0.218 m² m⁻²**.

The MON lines now sit on top of each other, and global bias is **−0.0055 m² m⁻²** (≈0, unchanged — the fix is a seasonal-phase correction that cancels in the annual mean).

Per @ph-kev's review, the relabel goes through `ClimaAnalysis.transform_dates` like the other loaders, with the month selection and midpoint split into `_fully_observed_month_starts` and `_mid_month`. That refactor is behavior-preserving (bitwise identical), so the numbers above are unaffected.

## Residual RMSE (~0.34 m² m⁻²) — expected, not reducible

Model and MODIS share the 1°×1° resolution, so there is no resolution loss. But the grids are registered a half-cell apart (model at integer degrees, MODIS centers at half-integer), and the model ingests MODIS **nearest-neighbor** while the leaderboard resamples obs **bilinear**. The residual is a zero-mean dipole hugging sharp LAI boundaries (Amazon/Congo rims, forest–savanna edges, coasts): interior cells agree to ~0.08, top-quartile-gradient cells carry ~0.64, `corr(|SIM−OBS|, |∇LAI|) = 0.76`. Matching the obs to nearest-neighbor makes it **worse** (0.56); reaching ~0 would require passing obs through the model's exact regrid chain, defeating the point of an independent obs.

The same floor exists for other variables, but their RMSE is dominated by genuine physical model-vs-obs differences (ER 1.29, NEE 1.27, GPP 0.83 g m⁻² day⁻¹) — the signal the leaderboard is meant to show. LAI is the only prescribed variable, hence the only one where a non-physical floor matters.

## Note on scope

`get_modis_lai_obs_var` also backs the LAI calibration target, so this shifts that target by up to ~0.2 m² m⁻² in some cells/seasons. Correct direction, but flagging it for in-flight LAI calibrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
