### PR TITLE
Release v1.10.3

### DIFF
--- a/.buildkite/Manifest-v1.12.toml
+++ b/.buildkite/Manifest-v1.12.toml
@@ -546,7 +546,7 @@ weakdeps = ["CUDA"]
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "NVTX", "RootSolvers", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.10.2"
+version = "1.10.3"
 weakdeps = ["Adapt", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Downloads", "Flux", "GeoMakie", "InteractiveUtils", "JLD2", "Printf", "Statistics"]
 
     [deps.ClimaLand.extensions]

--- a/.buildkite/Manifest.toml
+++ b/.buildkite/Manifest.toml
@@ -543,7 +543,7 @@ weakdeps = ["CUDA"]
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "NVTX", "RootSolvers", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.10.2"
+version = "1.10.3"
 weakdeps = ["Adapt", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Downloads", "Flux", "GeoMakie", "InteractiveUtils", "JLD2", "Printf", "Statistics"]
 
     [deps.ClimaLand.extensions]

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,15 @@ ClimaLand.jl Release Notes
 ========================
 main
 ----
+
+v1.10.3
+-----
+- ![][badge-🐛bugfix] Fix the P-model intercellular CO2 (`ci`): guard the water-stress factor
+  `ξ` so `ci` no longer returns a `NaN` when `ξ = 0` (recovering the `ci = Γ*` limit), which
+  previously propagated through GPP, `An`, stomatal conductance, and the canopy turbulent
+  fluxes. PR [#1811](https://github.com/CliMA/ClimaLand.jl/pull/1811)
+- ![][badge-🔥behavioralΔ] Update the SIF `kd_p2` parameter (0.0273 → 0.0773, Tol et al. 2014)
+  and correct the `sif` diagnostic units to `W m^-2 sr^-1 μm^-1`. PR [#1812](https://github.com/CliMA/ClimaLand.jl/pull/1812)
 - ![][badge-🐛bugfix] Fix a C4 typo in `compute_chi`: the C4 intercellular CO2 used the C3
   dryness sensitivity `ξ_c3` instead of `ξ_c4`, biasing the blended χ (and hence the
   optimal-LAI water-limitation term) at C4 and mixed C3/C4 cells. PR [#1805](https://github.com/CliMA/ClimaLand.jl/pull/1805)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ClimaLand"
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.10.2"
+version = "1.10.3"
 authors = ["Clima Land Team"]
 
 [deps]

--- a/docs/Manifest-v1.12.toml
+++ b/docs/Manifest-v1.12.toml
@@ -517,7 +517,7 @@ version = "0.1.1"
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "NVTX", "RootSolvers", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.10.2"
+version = "1.10.3"
 weakdeps = ["Adapt", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Downloads", "Flux", "GeoMakie", "InteractiveUtils", "JLD2", "Printf", "Statistics"]
 
     [deps.ClimaLand.extensions]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -514,7 +514,7 @@ version = "0.1.1"
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "NVTX", "RootSolvers", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.10.2"
+version = "1.10.3"
 weakdeps = ["Adapt", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Downloads", "Flux", "GeoMakie", "InteractiveUtils", "JLD2", "Printf", "Statistics"]
 
     [deps.ClimaLand.extensions]


### PR DESCRIPTION
Patch release **v1.10.3** (1.10.2 → 1.10.3). No breaking changes, so the patch slot is bumped (per repo convention, the minor slot is reserved for `💥breaking` API changes).

## Contents (per the release-PR checklist)
- **`Project.toml`**: `version` 1.10.2 → 1.10.3.
- **`NEWS.md`**: froze the `main` section as `v1.10.3` and opened a fresh empty `main`.
- **Manifests**: bumped the recorded ClimaLand version to 1.10.3 in the four tracked Manifests (`.buildkite` and `docs`, Julia 1.10 and 1.12). Dependency versions are unchanged — #1811 refreshed them earlier today, so a `Pkg.resolve()` touched only the ClimaLand version line in each.

## NEWS entries added
Two changes merged since v1.10.2 had no `NEWS.md` entry; this release documents them alongside the already-logged #1805:
- 🐛 P-model `ci` `NaN` guard when `ξ = 0` — PR #1811
- 🔥 SIF `kd_p2` update (0.0273 → 0.0773) and `sif` diagnostic units correction to `W m^-2 sr^-1 μm^-1` — PR #1812
- 🐛 C4 typo in `compute_chi` — PR #1805 (already logged)

## After merge
Comment `@JuliaRegistrator register` on the merge commit; TagBot creates the `v1.10.3` tag automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)