### PR TITLE
Partitioning leaderboard, zonal-mean and interannual-spread panels

### DIFF
--- a/.buildkite/Manifest-v1.12.toml
+++ b/.buildkite/Manifest-v1.12.toml
@@ -547,7 +547,7 @@ weakdeps = ["CUDA"]
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "NVTX", "RootSolvers", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.11.2"
+version = "1.12.0"
 weakdeps = ["Adapt", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Downloads", "Flux", "GeoMakie", "InteractiveUtils", "JLD2", "Printf", "Statistics"]
 
     [deps.ClimaLand.extensions]

--- a/.buildkite/Manifest.toml
+++ b/.buildkite/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.11"
+julia_version = "1.10.10"
 manifest_format = "2.0"
 project_hash = "f14f3a09f0af98657689fc9d59c9a94f1b3d9f5f"
 
@@ -544,7 +544,7 @@ weakdeps = ["CUDA"]
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "NVTX", "RootSolvers", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.11.2"
+version = "1.12.0"
 weakdeps = ["Adapt", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Downloads", "Flux", "GeoMakie", "InteractiveUtils", "JLD2", "Printf", "Statistics"]
 
     [deps.ClimaLand.extensions]
@@ -2270,7 +2270,7 @@ version = "2.6.3"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.1010+0"
+version = "2.28.2+1"
 
 [[deps.MicroMamba]]
 deps = ["Pkg", "Scratch", "micromamba_jll"]
@@ -2301,7 +2301,7 @@ version = "0.3.4"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2025.12.2"
+version = "2023.1.10"
 
 [[deps.MuladdMacro]]
 deps = ["PrecompileTools"]
@@ -2510,7 +2510,7 @@ version = "0.3.29+0"
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.23+5"
+version = "0.3.23+4"
 
 [[deps.OpenEXR]]
 deps = ["Colors", "FileIO", "OpenEXR_jll"]
@@ -3816,7 +3816,7 @@ version = "2022.3.0+0"
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.6.1+0"
+version = "17.4.0+2"
 
 [[deps.pixi_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl"]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,7 @@ agents:
 
 env:
   JULIA_NVTX_CALLBACKS: gc
+  SSL_CERT_FILE: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
   OPENBLAS_NUM_THREADS: 1
   SLURM_KILL_BAD_EXIT: 1
   JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/default"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Always read the ClimaLand-specific structure guide before working in this reposi
 - Follow the software design patterns in [docs/dev-guides/code-quality/software_design_patterns.md](docs/dev-guides/code-quality/software_design_patterns.md) for new code and refactor toward them when touching existing code.
 - Run `julia -e 'using JuliaFormatter; format(".")'` before committing code, adhering to the rules in `.JuliaFormatter.toml`.
 - When you `export` a new symbol from `ClimaLand`, add it to a `@docs` block on the matching `docs/src/APIs/*.md` page. The docs build sets `checkdocs = :exports`, so an exported name with a docstring that is not included in the manual fails the docs CI job.
+- Never tag people on GitHub (`@username`) in PR descriptions, issues, or comments you write; an `@` mention notifies a real person on your behalf. Refer to them by name without the `@`, or cite the PR or issue number instead.
 
 ## Self-correction
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@ ClimaLand.jl Release Notes
 ========================
 main
 ----
+
+v1.12.0
+----
+- ![][badge-✨feature] Partitioning leaderboard, zonal-mean, and interannual-spread panels PR[#1836](https://github.com/CliMA/ClimaLand.jl/pull/1836)
 - ![][badge-✨feature] Change initial condition function name from set_subseasonal to set_from_era5land PR[#1858](https://github.com/CliMA/ClimaLand.jl/pull/1858)
   
 v1.11.2
@@ -25,6 +29,18 @@ v1.11.1
   custom initial-condition function must call `set_canopy_biomass_initial_conditions!`.
   Adds the `pra` diagnostic and the `optimal_lai_tau_long_term` parameter.
   PR [#1797](https://github.com/CliMA/ClimaLand.jl/pull/1797)
+- ![][badge-✨feature] Add a leaderboard of the model's energy and water partitioning against
+  ERA5 (`Partitioning_leaderboard.png`), and zonal-mean, seasonal-cycle and
+  interannual-variability panels to the annual leaderboards.
+  PR [#1836](https://github.com/CliMA/ClimaLand.jl/pull/1836)
+- ![][badge-🚀performance] Resolve each leaderboard's land-sea mask once instead of on every
+  masked slice, taking a 19-year run of all leaderboards from ~40 min to ~8 min.
+  PR [#1836](https://github.com/CliMA/ClimaLand.jl/pull/1836)
+- ![][badge-🐛bugfix] Correct the units of the `trans` diagnostic from `m s^-1` to
+  `kg m^-2 s^-1`. PR [#1836](https://github.com/CliMA/ClimaLand.jl/pull/1836)
+- ![][badge-🔥behavioralΔ] Read single-site plotting data through `site_timeseries`, which works
+  with either output writer, and fix the `DictWriter` timestamps across a year boundary.
+  PR [#1836](https://github.com/CliMA/ClimaLand.jl/pull/1836)
 
 v1.11.0
 -----

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ClimaLand"
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.11.2"
+version = "1.12.0"
 authors = ["Clima Land Team"]
 
 [deps]

--- a/docs/Manifest-v1.12.toml
+++ b/docs/Manifest-v1.12.toml
@@ -523,7 +523,7 @@ version = "0.1.1"
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "NVTX", "RootSolvers", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.11.2"
+version = "1.12.0"
 weakdeps = ["Adapt", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Downloads", "Flux", "GeoMakie", "InteractiveUtils", "JLD2", "Printf", "Statistics"]
 
     [deps.ClimaLand.extensions]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.11"
+julia_version = "1.10.10"
 manifest_format = "2.0"
 project_hash = "20891533ed7907c561b93f371bbd822a173e2435"
 
@@ -520,7 +520,7 @@ version = "0.1.1"
 deps = ["ClimaComms", "ClimaCore", "ClimaDiagnostics", "ClimaParams", "ClimaTimeSteppers", "ClimaUtilities", "Dates", "DocStringExtensions", "Insolation", "Interpolations", "LazyArtifacts", "LazyBroadcast", "LinearAlgebra", "NCDatasets", "NVTX", "RootSolvers", "StaticArrays", "SurfaceFluxes", "Thermodynamics"]
 path = ".."
 uuid = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
-version = "1.11.2"
+version = "1.12.0"
 weakdeps = ["Adapt", "CairoMakie", "ClimaAnalysis", "DataFrames", "DelimitedFiles", "Downloads", "Flux", "GeoMakie", "InteractiveUtils", "JLD2", "Printf", "Statistics"]
 
     [deps.ClimaLand.extensions]
@@ -2493,7 +2493,7 @@ version = "1.1.10"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.1010+0"
+version = "2.28.2+1"
 
 [[deps.Measures]]
 git-tree-sha1 = "b513cedd20d9c914783d8ad83d08120702bf2c77"
@@ -2541,7 +2541,7 @@ version = "0.3.12"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2025.12.2"
+version = "2023.1.10"
 
 [[deps.MuladdMacro]]
 deps = ["PrecompileTools"]
@@ -2781,7 +2781,7 @@ version = "0.3.29+0"
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.23+5"
+version = "0.3.23+4"
 
 [[deps.OpenEXR]]
 deps = ["Colors", "FileIO", "OpenEXR_jll"]
@@ -4364,7 +4364,7 @@ version = "2022.3.0+0"
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.6.1+0"
+version = "17.4.0+2"
 
 [[deps.pixi_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -56,7 +56,16 @@ tutorials_jl = flatten_to_array_of_strings(get_second(tutorials))
 println("Building literate tutorials...")
 tutorials_dir = joinpath(@__DIR__, "src", "tutorials")
 tutorials_jl = map(x -> joinpath(tutorials_dir, x), tutorials_jl)
-pmap(t -> generate_tutorial(tutorials_dir, t), tutorials_jl)
+# run serially after the parallel pass since they are too memory heavy
+memory_heavy_tutorials = ["snowy_land.jl", "bucket.jl"]
+is_heavy(t) = basename(t) in memory_heavy_tutorials
+pmap(t -> generate_tutorial(tutorials_dir, t), filter(!is_heavy, tutorials_jl))
+# release worker memory before running remaining tutorials serially
+nworkers() > 1 && rmprocs(workers())
+foreach(
+    t -> generate_tutorial(tutorials_dir, t),
+    filter(is_heavy, tutorials_jl),
+)
 
 # update list of rendered markdown tutorial output for mkdocs
 ext_jl2md(x) = joinpath(basename(GENERATED_DIR), replace(x, ".jl" => ".md"))

--- a/docs/src/leaderboard/leaderboard.md
+++ b/docs/src/leaderboard/leaderboard.md
@@ -123,3 +123,71 @@ compare_vars_biases_plot_extrema = Dict(
     ...
 )
 ```
+
+Note that `get_mask_dict(::ERA5DataLoader)` gives every ERA5 variable the ocean
+mask, so step 3 is only needed for loaders whose observations have gaps over
+land.
+
+## Annual leaderboard columns
+
+`compute_seasonal_leaderboard` draws one row per variable and the columns below.
+The names are the short headings drawn on the figure:
+
+- `SIM` (simulation), the simulated annual mean,
+- `ANN` (annual bias), its bias against observations,
+- `LAT` (zonal mean), the mean along each latitude band of both, banded by the
+  standard deviation along that band,
+- `MON` (seasonal cycle), their global monthly means, banded by the spread
+  across years,
+- `IAV` (interannual variability), the area-weighted global annual mean of one
+  against the other, one point per year, with the 1:1 line, the least squares
+  fit, its slope, r² and `σ_sim / σ_obs`.
+
+Only years covering all twelve months enter `IAV`, since the annual mean of a
+partial year is aliased by whichever part of the seasonal cycle it sampled, and
+the column is drawn only when some variable has more than `_MIN_IAV_YEARS` of
+them.
+
+## Partitioning leaderboard
+
+`partitioning.jl` produces a separate leaderboard of the dimensionless fractions
+describing how the model splits energy and water: the evaporative fraction
+`lhf / (lhf + shf)`, the surface runoff fraction `sr / (sr + ssr)`, the
+evaporative index `et / precip`, and the transpiration fraction `trans / et`.
+Its layout matches the annual leaderboard, with the same `SIM`, `ANN`, `LAT`,
+`MON` and `IAV` columns.
+
+Each row is a `PartitionFraction`, so adding one means appending an entry to
+`PARTITION_FRACTIONS` rather than touching the plotting code:
+
+```julia
+PartitionFraction(
+    "ef",                # short name used in file names
+    "Evaporative Fraction",
+    "LHF/(LHF+SHF)",     # label shown on rows and axes
+    ["lhf"],             # diagnostics summed for the numerator
+    ["lhf", "shf"],      # diagnostics summed for the denominator
+    String[],            # components taken from the simulation on the obs side
+    (-0.2, 0.2),         # bias panel color scale
+    nothing,             # published constraint, when there are no gridded obs
+)
+```
+
+Two things to keep in mind:
+
+**Aggregate, then divide.** Every panel sums the numerator and the denominator
+over its domain or period and divides only at the end. The mean of a ratio is
+not the ratio of the means, and a per-cell `et / precip` diverges wherever
+precipitation approaches zero, so the order matters both physically and
+numerically. Cells whose aggregated denominator falls below
+`_MIN_DENOMINATOR_FRACTION` of its global mean are masked out for the same
+reason.
+
+**Observations are optional.** A row is compared against ERA5 only when every
+component that is not listed as prescribed is available from the loader, which
+is built from the `era5_to_clima_names` keyword argument
+(`ERA5_PARTITION_TO_CLIMA_NAMES` by default). Components that *are* listed as prescribed
+(such as precipitation, which is forcing) are taken from the simulation on both
+sides. A row with no gridded observations, like the transpiration fraction,
+shows the simulation alone next to the published global constraint given in its
+`reference` field.

--- a/docs/src/tutorials/global/snowy_land.jl
+++ b/docs/src/tutorials/global/snowy_land.jl
@@ -47,12 +47,12 @@ start_date = DateTime(2008)
 stop_date = DateTime(2009);
 
 # Create the domain - this is intentionally low resolution,
-# about 4.5 x 4.5 degrees horizontally, to avoid allocating a lot
+# to avoid allocating a lot
 # of memory when building the documentation.
-# By default and for testing runs we use `nelements = (101, 15)`,
-# which is about 0.9 x 0.9 degrees horizontally with 15 layers vertically.
-nelements = (20, 7)
-domain = ClimaLand.Domains.global_domain(FT; context, nelements);
+# By default and for testing runs we use `nelements = (180, 360, 15)`,
+# which is 1 x 1 square degrees horizontally with 15 layers vertically.
+nelements = (18, 36, 7)
+domain = ClimaLand.Domains.global_box_domain(FT; context, nelements);
 
 # Low-resolution forcing data from ERA5 is used here,
 # but high-resolution should be used for production runs.

--- a/experiments/integrated/era5/single_site.jl
+++ b/experiments/integrated/era5/single_site.jl
@@ -82,7 +82,11 @@ model = setup_model(FT, start_date, stop_date, Δt, domain, toml_dict);
 diagnostics = ClimaLand.default_diagnostics(
     model,
     start_date;
-    output_writer = ClimaDiagnostics.Writers.DictWriter(),
+    output_writer = ClimaDiagnostics.Writers.NetCDFWriter(
+        domain.space.subsurface,
+        outdir;
+        start_date,
+    ),
     reduction_period = :monthly,
     reduction_type = :average,
     output_vars = [

--- a/ext/LandSimulationVisualizationExt.jl
+++ b/ext/LandSimulationVisualizationExt.jl
@@ -17,6 +17,7 @@ using Printf
 include("land_sim_vis/leaderboard/data_sources.jl")
 include("land_sim_vis/plotting_utils.jl")
 include("land_sim_vis/leaderboard/leaderboard.jl")
+include("land_sim_vis/leaderboard/partitioning.jl")
 include("land_sim_vis/leaderboard/rmse_boxplots.jl")
 """
     make_leaderboard_plots(sim::ClimaLand.Simulations.LandSimulation; savedir = ".",  leaderboard_data_sources = ["ERA5", "ILAMB"])
@@ -77,7 +78,6 @@ function LandSimVis.make_leaderboard_plots(
     # assert that data spans multiple years and is monthly output?
     # check that the short_names include the appropriate variables for the data source?
     diagdir = first(diagnostics).output_writer.output_dir
-    short_names = [d.variable.short_name for d in diagnostics]
     diagnostics_folder_path = diagdir
     leaderboard_base_path = savedir
     for data_source in leaderboard_data_sources
@@ -93,10 +93,9 @@ function LandSimVis.make_leaderboard_plots(
         )
     end
     compute_rmse_boxplots(leaderboard_base_path, diagnostics_folder_path)
-    create_partitioning_plots(
+    compute_partitioning_leaderboard(
         leaderboard_base_path,
         diagnostics_folder_path,
-        short_names,
     )
 end
 

--- a/ext/land_sim_vis/leaderboard/data_sources.jl
+++ b/ext/land_sim_vis/leaderboard/data_sources.jl
@@ -74,6 +74,51 @@ function _preprocess_sim_var(var, ::Val{:hr})
     return var
 end
 
+"""
+    _water_mass_flux_to_mm_per_day(var)
+
+Convert a simulation water mass flux (`kg m^-2 s^-1`) to `mm / day`.
+"""
+_water_mass_flux_to_mm_per_day(var) =
+    ClimaAnalysis.units(var) != "kg m^-2 s^-1" ? var :
+    ClimaAnalysis.convert_units(
+        var,
+        "mm / day",
+        conversion_function = units -> units * 86400.0,
+    )
+
+"""
+    _water_volume_flux_to_mm_per_day(var)
+
+Convert a simulation water volume flux (`m^3` of water per `m^2` of ground per
+second, i.e. `m s^-1`) to `mm / day` using the density of liquid water.
+"""
+_water_volume_flux_to_mm_per_day(var) =
+    ClimaAnalysis.units(var) != "m s^-1" ? var :
+    ClimaAnalysis.convert_units(
+        var,
+        "mm / day",
+        conversion_function = units -> units * 1000.0 * 86400.0,
+    )
+
+_preprocess_sim_var(var, ::Val{:sr}) = _water_volume_flux_to_mm_per_day(var)
+_preprocess_sim_var(var, ::Val{:ssr}) = _water_volume_flux_to_mm_per_day(var)
+
+# `compute_canopy_transpiration!` returns a mass flux, so `m s^-1` in older
+# output denotes the same quantity as `kg m^-2 s^-1`.
+function _preprocess_sim_var(var, ::Val{:trans})
+    ClimaAnalysis.units(var) == "m s^-1" &&
+        (var = ClimaAnalysis.set_units(var, "kg m^-2 s^-1"))
+    return _water_mass_flux_to_mm_per_day(var)
+end
+
+# Precipitation is reported downward-positive; the partitioning ratios use its
+# magnitude.
+function _preprocess_sim_var(var, ::Val{:precip})
+    var = _water_mass_flux_to_mm_per_day(var)
+    return ClimaAnalysis.remake(var; data = abs.(var.data))
+end
+
 _preprocess_sim_var(var, ::Val{:lwu}) = var
 _preprocess_sim_var(var, ::Val{:lhf}) = var
 _preprocess_sim_var(var, ::Val{:shf}) = var
@@ -149,6 +194,23 @@ const ERA5_TO_CLIMA_NAMES = [
     "msuwlwrf" => "lwu",
     "msuwswrf" => "swu",
 ]
+
+"""
+`ERA5_TO_CLIMA_NAMES` plus the runoff and evaporation the partitioning
+leaderboard needs; the default `era5_to_clima_names` of
+`compute_partitioning_leaderboard` and `create_partitioning_plots`.
+
+These are kept out of `ERA5_TO_CLIMA_NAMES` because the standard ERA5
+leaderboard draws a row per loaded variable the simulation also has, so adding
+them there would add rows to it.
+"""
+const ERA5_PARTITION_TO_CLIMA_NAMES = [
+    ERA5_TO_CLIMA_NAMES
+    "msror" => "sr"
+    "mssror" => "ssr"
+    "mer" => "et"
+]
+
 const STANDARD_UNITS = Dict("W m**-2" => "W m^-2", "W m-2" => "W m^-2")
 
 """
@@ -210,6 +272,28 @@ preprocess(::ERA5DataLoader, var, ::Val{:lhf}) =
     _preprocess_var(var; flip_sign = true)
 preprocess(::ERA5DataLoader, var, ::Val{:lwu}) = _preprocess_var(var)
 preprocess(::ERA5DataLoader, var, ::Val{:swu}) = _preprocess_var(var)
+preprocess(::ERA5DataLoader, var, ::Val{:sr}) =
+    _preprocess_var(_era5_water_flux_to_mm_per_day(var))
+preprocess(::ERA5DataLoader, var, ::Val{:ssr}) =
+    _preprocess_var(_era5_water_flux_to_mm_per_day(var))
+# ERA5 evaporation is negative downward-positive; CliMA reports it positive.
+preprocess(::ERA5DataLoader, var, ::Val{:et}) =
+    _preprocess_var(_era5_water_flux_to_mm_per_day(var); flip_sign = true)
+
+"""
+    _era5_water_flux_to_mm_per_day(var)
+
+Convert an ERA5 water mass flux (`kg m**-2 s**-1`) to `mm / day`, matching the
+units the simulation water fluxes are preprocessed into.
+"""
+function _era5_water_flux_to_mm_per_day(var)
+    ClimaAnalysis.units(var) in ("kg m**-2 s**-1", "kg m^-2 s^-1") || return var
+    return ClimaAnalysis.convert_units(
+        var,
+        "mm / day",
+        conversion_function = units -> units * 86400.0,
+    )
+end
 
 function _preprocess_var(var; flip_sign = false)
     short_name = ClimaAnalysis.short_name(var)
@@ -380,18 +464,16 @@ containing observational data, and returns a masking function. The masking
 function is used to correctly normalize the global bias and global RMSE.
 """
 function get_mask_dict(data_loader::ERA5DataLoader)
-    # Dict for loading in masks
-    mask_dict = Dict{String, Any}()
-
+    # ERA5 is gap-free over land, so every variable uses the same ocean mask.
     make_mask_fn =
         (sim_var, obs_var) -> begin
             return ClimaAnalysis.apply_oceanmask
         end
 
-    mask_dict["shf"] = make_mask_fn
-    mask_dict["lhf"] = make_mask_fn
-    mask_dict["swu"] = make_mask_fn
-    mask_dict["lwu"] = make_mask_fn
+    mask_dict = Dict{String, Any}(
+        short_name => make_mask_fn for
+        short_name in available_vars(data_loader)
+    )
 
     @assert keys(mask_dict) == available_vars(data_loader)
     return mask_dict

--- a/ext/land_sim_vis/leaderboard/leaderboard.jl
+++ b/ext/land_sim_vis/leaderboard/leaderboard.jl
@@ -28,53 +28,314 @@ function _percentile_contour_kwargs(
 end
 
 """
-    _monthly_climatology_global_means(sim, obs,
-                                      mask_fn = ClimaAnalysis.apply_oceanmask)
+    _global_mean_series(sim, obs, mask_fn = ClimaAnalysis.apply_oceanmask)
 
-Return a pair `(sim_monthly, obs_monthly)` of 12-element vectors of global,
-lonlat-weighted monthly climatology means. Index `i` corresponds to month `i`
-(1=Jan ... 12=Dec). Months that have no valid samples are filled with `NaN`.
+Return `(dates, sim_global, obs_global)`: the date of every output time and the
+lonlat-weighted global mean of `sim` and `obs` there.
 
-`mask_fn` is the same per-variable mask used by `global_bias`/`global_rmse`
-elsewhere. After applying it, at each time step both sim and obs are restricted
-to the grid cells where *both* have valid (non-`NaN`) data, so the two lines are
-averaged over the same domain even where obs has data gaps that sim does not —
-otherwise the SIM/OBS gap would not match the global bias in the ANN column.
+Both fields are restricted to the cells where *both* are finite, so the SIM/OBS
+gap here matches the global bias in the ANN column even where obs has gaps that
+sim does not.
 """
-function _monthly_climatology_global_means(
-    sim,
-    obs,
-    mask_fn = ClimaAnalysis.apply_oceanmask,
-)
+function _global_mean_series(sim, obs, mask_fn = ClimaAnalysis.apply_oceanmask)
     times = ClimaAnalysis.times(sim)
-    isempty(times) && return (fill(NaN, 12), fill(NaN, 12))
-    start_date = Dates.DateTime(sim.attributes["start_date"])
-    months =
-        [Dates.month(start_date + Dates.Second(round(Int, t))) for t in times]
+    dates = ClimaAnalysis.dates(sim)
     sim_global = Float64[]
     obs_global = Float64[]
     for t in times
         sim_t = mask_fn(ClimaAnalysis.slice(sim, time = t))
         obs_t = mask_fn(ClimaAnalysis.slice(obs, time = t))
-        # Keep only cells where both fields have valid data, so the two
-        # weighted global means are taken over the same domain.
         nan_either = isnan.(sim_t.data) .| isnan.(obs_t.data)
         sim_t.data[nan_either] .= NaN
         obs_t.data[nan_either] .= NaN
         push!(sim_global, ClimaAnalysis.weighted_average_lonlat(sim_t).data[])
         push!(obs_global, ClimaAnalysis.weighted_average_lonlat(obs_t).data[])
     end
-    out_sim = fill(NaN, 12)
-    out_obs = fill(NaN, 12)
+    return (dates, sim_global, obs_global)
+end
+
+"""
+    _monthly_climatology(dates, sim_global, obs_global)
+
+Return `(sim_monthly, obs_monthly, sim_spread, obs_spread)`, each a 12-element
+vector indexed by calendar month. The first two are the climatology of the
+global means from `_global_mean_series`; the last two their standard deviation
+across years, drawn as the interannual band on the MON panel. Months with no
+valid sample are `NaN`, months sampled in a single year get a spread of zero.
+"""
+function _monthly_climatology(dates, sim_global, obs_global)
+    isempty(dates) && return ntuple(_ -> fill(NaN, 12), 4)
+    months = Dates.month.(dates)
+    out_sim, out_obs = fill(NaN, 12), fill(NaN, 12)
+    spread_sim, spread_obs = fill(NaN, 12), fill(NaN, 12)
     for m in 1:12
         idxs = findall(==(m), months)
         isempty(idxs) && continue
-        sim_vals = filter(isfinite, sim_global[idxs])
-        obs_vals = filter(isfinite, obs_global[idxs])
-        isempty(sim_vals) || (out_sim[m] = sum(sim_vals) / length(sim_vals))
-        isempty(obs_vals) || (out_obs[m] = sum(obs_vals) / length(obs_vals))
+        for (global_vals, means, spreads) in (
+            (sim_global, out_sim, spread_sim),
+            (obs_global, out_obs, spread_obs),
+        )
+            vals = filter(isfinite, global_vals[idxs])
+            isempty(vals) && continue
+            means[m] = sum(vals) / length(vals)
+            spreads[m] = length(vals) > 1 ? Statistics.std(vals) : 0.0
+        end
     end
-    return (out_sim, out_obs)
+    return (out_sim, out_obs, spread_sim, spread_obs)
+end
+
+"""
+    _annual_means(dates, sim_global, obs_global)
+
+Return `(years, sim_annual, obs_annual)`, one entry per calendar year of the
+global means from `_global_mean_series`.
+
+Only years covering all twelve months in both series contribute: a partial
+year's mean is aliased by whichever part of the seasonal cycle it sampled. Each
+month is weighted by its length.
+"""
+function _annual_means(dates, sim_global, obs_global)
+    years, sim_annual, obs_annual = Int[], Float64[], Float64[]
+    for year in sort(unique(Dates.year.(dates)))
+        idxs = findall(d -> Dates.year(d) == year, dates)
+        valid = filter(
+            i -> isfinite(sim_global[i]) && isfinite(obs_global[i]),
+            idxs,
+        )
+        length(unique(Dates.month.(dates[valid]))) == 12 || continue
+        weights = Dates.daysinmonth.(dates[valid])
+        push!(years, year)
+        push!(sim_annual, sum(weights .* sim_global[valid]) / sum(weights))
+        push!(obs_annual, sum(weights .* obs_global[valid]) / sum(weights))
+    end
+    return (years, sim_annual, obs_annual)
+end
+
+"""
+    _band_interannual_spread!(ax, means, spread, color)
+
+Shade `means ± spread` over the 12 calendar months on `ax`. Months whose mean is
+missing stay blank, and a month sampled in a single year contributes no width.
+"""
+function _band_interannual_spread!(ax, means, spread, color)
+    half_width = [isfinite(s) ? s : 0.0 for s in spread]
+    all(iszero, half_width) && return nothing
+    CairoMakie.band!(
+        ax,
+        1:12,
+        means .- half_width,
+        means .+ half_width;
+        color = (color, 0.2),
+    )
+    return nothing
+end
+
+"""
+    _band_zonal_spread!(ax, values, spread, lats, color)
+
+Shade `values ± spread` against latitude on `ax`, whose value axis is the
+horizontal one. Fully masked latitude bands interrupt the shading rather than
+being bridged across.
+"""
+function _band_zonal_spread!(ax, values, spread, lats, color)
+    valid = isfinite.(values) .& isfinite.(spread)
+    i = firstindex(valid)
+    while i <= lastindex(valid)
+        if !valid[i]
+            i += 1
+            continue
+        end
+        j = i
+        while j < lastindex(valid) && valid[j + 1]
+            j += 1
+        end
+        if j > i
+            band = i:j
+            CairoMakie.band!(
+                ax,
+                CairoMakie.Point2f.(values[band] .- spread[band], lats[band]),
+                CairoMakie.Point2f.(values[band] .+ spread[band], lats[band]);
+                color = (color, 0.2),
+            )
+        end
+        i = j + 1
+    end
+    return nothing
+end
+
+"""
+    _zonal_means(var, mask_fn)
+
+Return `(latitudes, values)` for the zonal (longitudinal) mean of the
+time-averaged `var` after applying `mask_fn`. Latitudes whose band is entirely
+masked or missing come back as `NaN`, which `Makie` skips when drawing the line.
+
+All cells in a latitude band subtend the same area, so no area weighting is
+needed.
+"""
+function _zonal_means(var, mask_fn)
+    masked = mask_fn(var)
+    zonal = ClimaAnalysis.average_lon(masked)
+    return (ClimaAnalysis.latitudes(zonal), vec(zonal.data))
+end
+
+"""
+    _zonal_std(var, mask_fn)
+
+Return the standard deviation over longitude of the time-averaged `var` within
+each latitude band, skipping masked cells the way `_zonal_means` does.
+"""
+function _zonal_std(var, mask_fn)
+    # A band holds the whole population of cells at that latitude rather than a
+    # sample of it, so the variance is not Bessel-corrected.
+    variance = ClimaAnalysis.variance_lon(mask_fn(var); corrected = false)
+    return sqrt.(vec(variance.data))
+end
+
+"""
+The IAV column is only drawn when some variable has more than this many complete
+years; below that a scatter of annual means says nothing about year-to-year
+variability.
+"""
+const _MIN_IAV_YEARS = 3
+
+"""
+    _interannual_stats(obs_annual, sim_annual)
+
+Return `(slope, intercept, r2, amplitude_ratio)` for the least squares fit of
+the simulated annual means on the observed ones, and `std(sim) / std(obs)`.
+
+Both are reported because they answer different questions: r² is whether the
+model varies in the right years, the ratio whether it varies by the right
+amount. A model can do the first while damping every anomaly.
+"""
+function _interannual_stats(obs_annual, sim_annual)
+    length(obs_annual) < 3 && return ntuple(_ -> NaN, 4)
+    obs_var = Statistics.var(obs_annual)
+    sim_var = Statistics.var(sim_annual)
+    (obs_var == 0 || sim_var == 0) && return ntuple(_ -> NaN, 4)
+    slope = Statistics.cov(obs_annual, sim_annual) / obs_var
+    intercept =
+        Statistics.mean(sim_annual) - slope * Statistics.mean(obs_annual)
+    r2 = Statistics.cor(obs_annual, sim_annual)^2
+    return (slope, intercept, r2, sqrt(sim_var / obs_var))
+end
+
+"""Ends of the blue → red ramp the IAV points are colored by."""
+const _IAV_FIRST_YEAR_COLOR = :royalblue
+const _IAV_LAST_YEAR_COLOR = :firebrick
+
+"""
+    _label_first_and_last_year!(ax, years, xs, ys)
+
+Write the first and last year beside their own points, in the colors at the ends
+of the ramp those points are drawn with. This does the work of a colorbar
+without spending a strip of the panel on it, and marks where in the cloud the
+run started and ended.
+"""
+function _label_first_and_last_year!(ax, years, xs, ys)
+    x_mid, y_mid = Statistics.mean(xs), Statistics.mean(ys)
+    for (idx, color) in (
+        (firstindex(years), _IAV_FIRST_YEAR_COLOR),
+        (lastindex(years), _IAV_LAST_YEAR_COLOR),
+    )
+        # Grow the label horizontally back towards the middle; endpoints sit in
+        # a corner, where a label growing outwards would be clipped.
+        outward = ys[idx] > y_mid
+        CairoMakie.text!(
+            ax,
+            xs[idx],
+            ys[idx];
+            text = string(years[idx]),
+            offset = (0, outward ? 10 : -10),
+            align = (
+                xs[idx] > x_mid ? :right : :left,
+                outward ? :bottom : :top,
+            ),
+            color,
+            fontsize = 14,
+        )
+    end
+    return nothing
+end
+
+"""
+    _plot_interannual!(position, years, sim_annual, obs_annual;
+                       label, show_title)
+
+Draw the IAV panel: one point per year of the area-weighted global annual mean,
+simulated against observed, with the 1:1 line, the least squares fit and the
+statistics from `_interannual_stats`.
+
+Points run blue to red with the year, so a drift shows up as a march along the
+cloud. The axes share one range, putting the 1:1 line at 45°.
+"""
+function _plot_interannual!(
+    position,
+    years,
+    sim_annual,
+    obs_annual;
+    label,
+    show_title,
+)
+    ax = CairoMakie.Axis(
+        position,
+        xlabel = "OBS $label",
+        ylabel = "SIM $label",
+        aspect = CairoMakie.AxisAspect(1),
+        title = show_title ?
+                "Annual global means, one point per year\n(dashed 1:1, black least squares fit)" :
+                "",
+    )
+    # Leave room above and below the cloud for the year labels.
+    lo, hi = extrema(vcat(sim_annual, obs_annual))
+    pad = hi > lo ? 0.14 * (hi - lo) : 1.0
+    limits = [lo - pad, hi + pad]
+    CairoMakie.limits!(ax, limits..., limits...)
+    CairoMakie.lines!(ax, limits, limits; color = :gray, linestyle = :dash)
+    slope, intercept, r2, amplitude_ratio =
+        _interannual_stats(obs_annual, sim_annual)
+    isfinite(slope) && CairoMakie.lines!(
+        ax,
+        limits,
+        intercept .+ slope .* limits;
+        color = :black,
+        linewidth = 2,
+    )
+    CairoMakie.scatter!(
+        ax,
+        obs_annual,
+        sim_annual;
+        color = years,
+        colormap = CairoMakie.cgrad([
+            _IAV_FIRST_YEAR_COLOR,
+            _IAV_LAST_YEAR_COLOR,
+        ]),
+        colorrange = (first(years), last(years)),
+        markersize = 14,
+        strokewidth = 0.5,
+        strokecolor = :black,
+    )
+    _label_first_and_last_year!(ax, years, obs_annual, sim_annual)
+    # Annotate the corner the cloud leaves free: points above the 1:1 line fill
+    # the upper left, points below it the lower right.
+    above = Statistics.mean(sim_annual .- obs_annual) > 0
+    CairoMakie.text!(
+        ax,
+        above ? 0.97 : 0.03,
+        above ? 0.03 : 0.97;
+        text = Printf.@sprintf(
+            "slope %.2f\nr² %.2f\nσ_sim/σ_obs %.2f\n%d years",
+            slope,
+            r2,
+            amplitude_ratio,
+            length(years),
+        ),
+        space = :relative,
+        align = above ? (:right, :bottom) : (:left, :top),
+        fontsize = 18,
+    )
+    return nothing
 end
 
 """
@@ -103,23 +364,52 @@ function _nee_diverging_contour_kwargs(var, q; nlevels = 21)
 end
 
 """
+    _mask_template(var)
+
+Return a lon-lat field on `var`'s grid whose values are all zero.
+
+`_resolved_mask` needs some field on the grid to find out which cells a mask
+removes. Zeros are used rather than `var`'s own values so that what comes back
+is the mask's footprint alone, with none of `var`'s missing cells in it.
+"""
+function _mask_template(var)
+    lonlat = ClimaAnalysis.slice(var, time = first(ClimaAnalysis.times(var)))
+    return ClimaAnalysis.remake(lonlat; data = zeros(size(lonlat.data)))
+end
+
+"""
+    _resolved_mask(mask_fn, template)
+
+Return a function that masks any field sharing `template`'s grid exactly as
+`mask_fn` does, but that resolves *which* cells are masked only once.
+
+`ClimaAnalysis.apply_oceanmask` and the masks from `make_lonlat_mask` resample
+onto the target grid on every call, which dominates the runtime of a leaderboard
+that masks every monthly slice several times over. The footprint is the same for
+any field on the grid. Fields on another grid fall back to `mask_fn` itself.
+"""
+function _resolved_mask(mask_fn, template)
+    blank = isnan.(mask_fn(template).data)
+    return function (var)
+        size(var.data) == size(blank) || return mask_fn(var)
+        new_data = copy(var.data)
+        new_data[blank] .= NaN
+        return ClimaAnalysis.remake(var; data = new_data)
+    end
+end
+
+"""
     _prepare_for_bias(base_mask, sim, obs)
 
 Return `(sim, obs, mask_fn)` so that `ClimaAnalysis.bias` / `global_bias` /
 `global_rmse` / `plot_bias_on_globe!` integrate over the intersection of finite
-cells, matching `_monthly_climatology_global_means`.
+cells, matching `_global_mean_series`. `mask_fn` drops every cell that is `NaN`
+in either field, so obs with spatial gaps (GOSIF-GPP and residual-ER over
+deserts and ice) are averaged over the same area they are normalized by.
 
-Works around a normalization issue in `ClimaAnalysis.bias` when `obs` has
-spatial gaps (e.g. GOSIF-GPP/residual-ER over deserts/ice): its normalization
-`ones_var` doesn't inherit obs's NaN footprint (denominator over all land,
-numerator over land∩finite(obs) — attenuates or flips the bias). `mask_fn`
-combines `base_mask` with the union of the sim/obs NaN footprints so `ones_var`
-and `sim − obs` share one domain.
-
-Gaps are left as `NaN` (not zero-filled) so a NaN-aware `resampled_as`
-(ClimaAnalysis.jl#198) works with them unchanged. Until then `resampled_as`
-erodes cells adjacent to a gap into NaN, leaving a slightly smaller dataset
-there, which is preferable to biasing those edges low with zero-fill.
+Gaps stay `NaN` rather than zero-filled: `resampled_as` erodes the cells next to
+one into `NaN` until it is NaN-aware (ClimaAnalysis.jl#198), which loses less
+than biasing those edges towards zero.
 """
 function _prepare_for_bias(base_mask, sim, obs)
     sim_masked = base_mask(sim)
@@ -130,12 +420,7 @@ function _prepare_for_bias(base_mask, sim, obs)
         any(extra_nan) || return v
         new_data = copy(v.data)
         new_data[extra_nan] .= NaN
-        return ClimaAnalysis.OutputVar(
-            v.attributes,
-            v.dims,
-            v.dim_attributes,
-            new_data,
-        )
+        return ClimaAnalysis.remake(v; data = new_data)
     end
     return sim, obs, mask_fn
 end
@@ -289,7 +574,10 @@ function compute_monthly_leaderboard(
         )
 
         fig = CairoMakie.Figure(size = (650 * ceil(num_times / 2), 450 * 2))
-        mask = mask_dict[short_name](sim_var, obs_var)
+        mask = _resolved_mask(
+            mask_dict[short_name](sim_var, obs_var),
+            _mask_template(sim_var),
+        )
         times = vcat(
             times,
             Array{Union{Missing, eltype(times)}}(missing, 12 - num_times),
@@ -331,7 +619,10 @@ function compute_monthly_leaderboard(
     for (col, short_name) in enumerate(short_names)
         sim_var, obs_var = sim_obs_comparison_dict[short_name]
         times = ClimaAnalysis.times(sim_var)
-        mask = mask_dict[short_name](sim_var, obs_var)
+        mask = _resolved_mask(
+            mask_dict[short_name](sim_var, obs_var),
+            _mask_template(sim_var),
+        )
 
         sim_vec = [
             begin
@@ -493,9 +784,12 @@ function compute_seasonal_leaderboard(
     sim_obs_season_comparison_dict = Dict()
     # Map short name to time series of time averages for each season
     sim_obs_time_avg_over_seasons_comparison_dict = Dict()
-    # Map short name to (sim_var, obs_var) full windowed time series, used by
-    # the MON column to compute a monthly climatology.
+    # Map short name to the (sim_var, obs_var) full windowed time series, kept
+    # for the metadata that survives collapsing along time below.
     sim_obs_full_dict = Dict()
+    # Map short name to the global mean at each output time. The MON and IAV
+    # columns both reduce it, and the masked slicing behind it is expensive.
+    global_series_dict = Dict()
     seasons = ["ANN", "MAM", "JJA", "SON", "DJF"]
 
     spin_up_months = 12
@@ -508,7 +802,10 @@ function compute_seasonal_leaderboard(
         obs_var = get(data_loader, short_name)
 
         # Make masking function
-        mask_fn_dict[short_name] = mask_dict[short_name](sim_var, obs_var)
+        mask_fn_dict[short_name] = _resolved_mask(
+            mask_dict[short_name](sim_var, obs_var),
+            _mask_template(sim_var),
+        )
 
         # Remove first spin_up_months from simulation if possible
         spinup_cutoff = spin_up_months * 31 * 86400.0
@@ -548,9 +845,10 @@ function compute_seasonal_leaderboard(
 
         # Resample
         obs_var = ClimaAnalysis.resampled_as(obs_var, sim_var)
-        # Stash the full windowed time series so the MON column can compute a
-        # monthly climatology before we collapse along time below.
+        # Reduce along time before collapsing the vars along it below.
         sim_obs_full_dict[short_name] = (sim_var, obs_var)
+        global_series_dict[short_name] =
+            _global_mean_series(sim_var, obs_var, mask_fn_dict[short_name])
         sim_var_seasons = (sim_var, ClimaAnalysis.split_by_season(sim_var)...)
         obs_var_seasons = (obs_var, ClimaAnalysis.split_by_season(obs_var)...)
 
@@ -652,7 +950,15 @@ function compute_seasonal_leaderboard(
     # Cols correspond to "SIM" and "ANN"
     annual_compare_vars_biases_plot_extrema =
         get_compare_vars_biases_plot_extrema(; annual = true)
-    groups = ["SIM", "ANN", "MON"]
+    annual_means_dict = Dict(
+        short_name => _annual_means(global_series_dict[short_name]...) for
+        short_name in short_names
+    )
+    groups = ["SIM", "ANN", "LAT", "MON"]
+    any(
+        years -> length(years) > _MIN_IAV_YEARS,
+        first.(values(annual_means_dict)),
+    ) && push!(groups, "IAV")
     fig_sim_ann = CairoMakie.Figure(;
         size = (600 * length(groups), 400 * length(short_names)),
     )
@@ -695,35 +1001,21 @@ function compute_seasonal_leaderboard(
                 sim_var, _ = sim_obs_season_comparison_dict[short_name]["ANN"]
                 isempty(sim_var) && break
                 layout = fig_sim_ann[row_idx, col_idx] = CairoMakie.GridLayout()
-                # Clip the colorbar to the 5th-95th percentile of the
-                # simulated field so that outliers don't flatten the map;
-                # values outside that range are drawn with the `contourf!`
-                # :auto arrow bounds (same convention as the SIM-OBS bias
-                # plot produced by `plot_bias_on_globe!`).
-                # NEE uses a diverging colormap centered at zero
-                # (green = sink, red = source) since the sign carries
-                # physical meaning.
+                # NEE's sign is physical, so it gets a diverging colormap
+                # centered at zero: green = sink, red = source.
                 more_kwargs =
                     short_name == "nee" ?
                     _nee_diverging_contour_kwargs(sim_var, 0.95) :
                     _percentile_contour_kwargs(sim_var)
-                # Replace the auto-generated panel title (which leaks raw
-                # seconds-since-start_date) with a clean summary that names
-                # the variable, the year range averaged over, and the actual
-                # min/max of the field shown — the colorbar is clipped to
-                # [5%, 95%] so the data range is otherwise invisible.
+                # The auto-generated title leaks seconds-since-start_date, and
+                # the clipped colorbar hides the actual range of the field.
                 sim_var_full, _ = sim_obs_full_dict[short_name]
-                start_date =
-                    Dates.DateTime(sim_var_full.attributes["start_date"])
-                ts = ClimaAnalysis.times(sim_var_full)
-                y0 =
-                    Dates.year(start_date + Dates.Second(round(Int, first(ts))))
-                y1 = Dates.year(start_date + Dates.Second(round(Int, last(ts))))
+                sim_dates = ClimaAnalysis.dates(sim_var_full)
+                y0, y1 =
+                    Dates.year(first(sim_dates)), Dates.year(last(sim_dates))
                 year_str = y0 == y1 ? "$(y0)" : "$(y0)–$(y1)"
-                # Use the un-averaged var's `long_name` and strip the
-                # `, average within …` annotation that ClimaAnalysis appends
-                # for monthly diagnostics — otherwise it leaks into the title
-                # alongside our explicit "mean over <years>" phrase.
+                # Strip the `, average within …` that ClimaAnalysis appends to
+                # `long_name`; the title already says what it averages over.
                 long_name =
                     get(sim_var_full.attributes, "long_name", short_name)
                 long_name = String(split(long_name, ", average")[1])
@@ -750,15 +1042,83 @@ function compute_seasonal_leaderboard(
                     mask = mask_fn_dict[short_name];
                     more_kwargs,
                 )
+            elseif group == "LAT"
+                sim_var, obs_var =
+                    sim_obs_season_comparison_dict[short_name]["ANN"]
+                isempty(sim_var) && break
+                # Average both fields over the same cells, as the bias plots do,
+                # so the two profiles stay comparable where obs has gaps.
+                sim_c, obs_c, mask_c = _prepare_for_bias(
+                    mask_fn_dict[short_name],
+                    sim_var,
+                    obs_var,
+                )
+                sim_lats, sim_zonal = _zonal_means(sim_c, mask_c)
+                _, obs_zonal = _zonal_means(obs_c, mask_c)
+                sim_zonal_std = _zonal_std(sim_c, mask_c)
+                obs_zonal_std = _zonal_std(obs_c, mask_c)
+                ax = CairoMakie.Axis(
+                    fig_sim_ann[row_idx, col_idx],
+                    xlabel = "$short_name ($(ClimaAnalysis.units(sim_var)))",
+                    ylabel = "Latitude (degrees)",
+                    yticks = -90:30:90,
+                    title = row_idx == 1 ? "Zonal mean of the annual mean" : "",
+                )
+                CairoMakie.ylims!(ax, -90, 90)
+                # Bands give the zonal heterogeneity a SIM/OBS gap sits against.
+                _band_zonal_spread!(
+                    ax,
+                    obs_zonal,
+                    obs_zonal_std,
+                    sim_lats,
+                    :black,
+                )
+                _band_zonal_spread!(
+                    ax,
+                    sim_zonal,
+                    sim_zonal_std,
+                    sim_lats,
+                    :firebrick,
+                )
+                # Latitude on the vertical axis, to read alongside the maps.
+                CairoMakie.lines!(
+                    ax,
+                    obs_zonal,
+                    sim_lats;
+                    color = :black,
+                    linewidth = 4,
+                    label = "OBS",
+                )
+                CairoMakie.lines!(
+                    ax,
+                    sim_zonal,
+                    sim_lats;
+                    color = :firebrick,
+                    linewidth = 4,
+                    label = "SIM",
+                )
+                row_idx == 1 && CairoMakie.axislegend(
+                    ax,
+                    position = :rb,
+                    framevisible = false,
+                )
+            elseif group == "IAV"
+                sim_var_full, _ = sim_obs_full_dict[short_name]
+                years, sim_annual, obs_annual = annual_means_dict[short_name]
+                length(years) > _MIN_IAV_YEARS || continue
+                _plot_interannual!(
+                    fig_sim_ann[row_idx, col_idx],
+                    years,
+                    sim_annual,
+                    obs_annual;
+                    label = "$short_name ($(ClimaAnalysis.units(sim_var_full)))",
+                    show_title = row_idx == 1,
+                )
             elseif group == "MON"
                 sim_var_full, obs_var_full = sim_obs_full_dict[short_name]
                 isempty(sim_var_full) && break
-                mask_fn = mask_fn_dict[short_name]
-                sim_monthly, obs_monthly = _monthly_climatology_global_means(
-                    sim_var_full,
-                    obs_var_full,
-                    mask_fn,
-                )
+                sim_monthly, obs_monthly, sim_spread, obs_spread =
+                    _monthly_climatology(global_series_dict[short_name]...)
                 units_str = ClimaAnalysis.units(sim_var_full)
                 ax = CairoMakie.Axis(
                     fig_sim_ann[row_idx, col_idx],
@@ -782,6 +1142,16 @@ function compute_seasonal_leaderboard(
                         ],
                     ),
                 )
+                # Bands show the spread of the global monthly mean across the
+                # simulated years, so the SIM/OBS gap can be read against the
+                # interannual variability rather than in isolation.
+                _band_interannual_spread!(ax, obs_monthly, obs_spread, :black)
+                _band_interannual_spread!(
+                    ax,
+                    sim_monthly,
+                    sim_spread,
+                    :firebrick,
+                )
                 CairoMakie.lines!(
                     ax,
                     1:12,
@@ -798,10 +1168,8 @@ function compute_seasonal_leaderboard(
                     linewidth = 4,
                     label = "SIM",
                 )
-                # Show the legend only on the top-right panel (first row of
-                # MON); per review feedback (kmdeck/AlexisRenchon), repeating
-                # it on every row clutters the figure and on some variables
-                # (e.g. SWU, NEE) the curves intersect the :rt anchor.
+                # First row only: on some variables the curves run through the
+                # :rt anchor, and repeating the legend clutters the figure.
                 row_idx == 1 && CairoMakie.axislegend(
                     ax,
                     position = :rt,
@@ -827,6 +1195,12 @@ function compute_seasonal_leaderboard(
             end
         end
     end
+
+    # The IAV axis is square, so left to a map-sized column it would sit in the
+    # middle of a blank margin.
+    iav_col = findfirst(==("IAV"), groups)
+    isnothing(iav_col) ||
+        CairoMakie.colsize!(fig_sim_ann.layout, iav_col, CairoMakie.Fixed(420))
 
     CairoMakie.save(
         joinpath(

--- a/ext/land_sim_vis/leaderboard/partitioning.jl
+++ b/ext/land_sim_vis/leaderboard/partitioning.jl
@@ -1,0 +1,735 @@
+"""
+    PartitionFraction
+
+One row of the partitioning leaderboard: a ratio between sums of diagnostics,
+such as `lhf / (lhf + shf)`.
+
+All panels aggregate the numerator and the denominator over the domain or period
+of interest and divide only at the end: the mean of a ratio is not the ratio of
+the means, and a per-cell `et / precip` diverges as precipitation approaches
+zero.
+"""
+struct PartitionFraction
+    """Short name of the ratio, used to build file names."""
+    short_name::String
+
+    """Descriptive name shown on the panels."""
+    long_name::String
+
+    """The ratio written out, e.g. `"T/ET"`, used to label rows and axes."""
+    ratio_label::String
+
+    """Diagnostics summed to form the numerator."""
+    numerator::Vector{String}
+
+    """Diagnostics summed to form the denominator."""
+    denominator::Vector{String}
+
+    """Components taken from the simulation when forming the *observed* ratio,
+    because they are prescribed forcing rather than an independent
+    observation."""
+    prescribed::Vector{String}
+
+    """Color scale bounds of the bias panel."""
+    bias_extrema::Tuple{Float64, Float64}
+
+    """Published global constraint drawn on the seasonal panel when no gridded
+    observation exists, as `(value, spread, label)`."""
+    reference::Union{Nothing, Tuple{Float64, Float64, String}}
+end
+
+"""
+The fractions shown in the partitioning leaderboard.
+
+`ef` and `rf` are compared against ERA5. `etp` uses ERA5 evaporation over the
+simulation's own precipitation, which is prescribed forcing and so identical on
+both sides. `tf` has no gridded counterpart in our artifacts and is shown
+against a published global constraint instead.
+"""
+const PARTITION_FRACTIONS = [
+    PartitionFraction(
+        "ef",
+        "Evaporative Fraction",
+        "LHF/(LHF+SHF)",
+        ["lhf"],
+        ["lhf", "shf"],
+        String[],
+        (-0.2, 0.2),
+        nothing,
+    ),
+    PartitionFraction(
+        "rf",
+        "Surface Runoff Fraction",
+        "SR/(SR+SSR)",
+        ["sr"],
+        ["sr", "ssr"],
+        String[],
+        (-0.3, 0.3),
+        nothing,
+    ),
+    PartitionFraction(
+        "etp",
+        "Evaporative Index",
+        "ET/P",
+        ["et"],
+        ["precip"],
+        ["precip"],
+        (-0.3, 0.3),
+        nothing,
+    ),
+    PartitionFraction(
+        "tf",
+        "Transpiration Fraction",
+        "T/ET",
+        ["trans"],
+        ["et"],
+        String[],
+        (-0.3, 0.3),
+        (0.57, 0.07, "Wei et al. (2017), global annual"),
+    ),
+]
+
+"""
+Cells whose aggregated denominator falls below this fraction of its own global
+mean are masked out of the maps: they carry almost no flux, so their ratio is
+numerically unstable while meaning nothing physically.
+"""
+const _MIN_DENOMINATOR_FRACTION = 0.01
+
+"""
+    _sum_vars(vars)
+
+Sum a non-empty collection of `OutputVar`s sharing dimensions, returning an
+`OutputVar` that keeps the first one's metadata.
+"""
+function _sum_vars(vars)
+    first_var = first(vars)
+    length(vars) == 1 && return first_var
+    return ClimaAnalysis.remake(first_var; data = sum(var.data for var in vars))
+end
+
+"""
+    _ratio_var(num, den, fraction)
+
+Build the dimensionless `OutputVar` `num / den`, labelled for `fraction`.
+"""
+function _ratio_var(num, den, fraction)
+    attributes = Dict(
+        # `ClimaAnalysis.bias` rejects an empty units string, so dimensionless
+        # is spelled out the conventional way rather than left blank.
+        "units" => "-",
+        "short_name" => fraction.ratio_label,
+        "long_name" => fraction.long_name,
+    )
+    return ClimaAnalysis.remake(num; attributes, data = num.data ./ den.data)
+end
+
+"""
+    _intersect_mask(base_mask, vars...)
+
+Return a masking function that blanks every cell that `base_mask` removes or
+where any of `vars` is missing, so all panels of a row integrate over one common
+domain.
+
+The footprint is resolved once and then applied by assignment: resampling the
+land-sea mask on every call, as `apply_oceanmask` does, is far too expensive to
+repeat for the hundreds of monthly slices a seasonal cycle averages over.
+"""
+function _intersect_mask(base_mask, vars...)
+    blank =
+        reduce((a, b) -> a .| b, (isnan.(base_mask(var).data) for var in vars))
+    return function (var)
+        new_data = copy(var.data)
+        new_data[blank] .= NaN
+        return ClimaAnalysis.remake(var; data = new_data)
+    end
+end
+
+"""
+    _small_denominator_mask(den, base_mask)
+
+Return a copy of `den` with cells below `_MIN_DENOMINATOR_FRACTION` of the
+global mean (and all non-positive cells) set to `NaN`, so `_intersect_mask`
+propagates the exclusion to the whole row.
+"""
+function _small_denominator_mask(den, base_mask)
+    masked = base_mask(den)
+    global_mean = ClimaAnalysis.weighted_average_lonlat(masked).data[]
+    threshold = _MIN_DENOMINATOR_FRACTION * abs(global_mean)
+    new_data = copy(masked.data)
+    new_data[.!(new_data .> threshold)] .= NaN
+    return ClimaAnalysis.remake(masked; data = new_data)
+end
+
+"""
+    _global_mean_timeseries(var, mask_fn)
+
+Return the lonlat-weighted global mean of `var` at each of its times.
+"""
+function _global_mean_timeseries(var, mask_fn)
+    return [
+        ClimaAnalysis.weighted_average_lonlat(
+            mask_fn(ClimaAnalysis.slice(var, time = t)),
+        ).data[] for t in ClimaAnalysis.times(var)
+    ]
+end
+
+"""
+    _ratio_global_series(diagnostics, fraction, mask_fn)
+
+Return `(dates, num_global, den_global)`: the date of every output time and the
+lonlat-weighted global means of `fraction`'s numerator and denominator there,
+summed from the `diagnostics` of one side of the comparison.
+"""
+function _ratio_global_series(diagnostics, fraction, mask_fn)
+    num = _sum_vars([diagnostics[c] for c in fraction.numerator])
+    den = _sum_vars([diagnostics[c] for c in fraction.denominator])
+    return (
+        ClimaAnalysis.dates(num),
+        _global_mean_timeseries(num, mask_fn),
+        _global_mean_timeseries(den, mask_fn),
+    )
+end
+
+"""
+    _monthly_ratio_climatology(dates, num_global, den_global)
+
+Return `(means, spread)`, 12-element vectors indexed by calendar month, of the
+global ratio and its standard deviation across years.
+
+Each year contributes one ratio per month, formed from that month's global mean
+numerator and denominator; the climatology then averages those ratios over
+years. Months sampled in a single year get a spread of zero.
+"""
+function _monthly_ratio_climatology(dates, num_global, den_global)
+    isempty(dates) && return (fill(NaN, 12), fill(NaN, 12))
+    months = Dates.month.(dates)
+    ratios = num_global ./ den_global
+    means, spread = fill(NaN, 12), fill(NaN, 12)
+    for m in 1:12
+        vals = filter(isfinite, ratios[findall(==(m), months)])
+        isempty(vals) && continue
+        means[m] = sum(vals) / length(vals)
+        spread[m] = length(vals) > 1 ? Statistics.std(vals) : 0.0
+    end
+    return (means, spread)
+end
+
+"""
+    _annual_ratios(dates, sim_num, sim_den, obs_num, obs_den)
+
+Return `(years, sim_annual, obs_annual)`: one global ratio per calendar year for
+the simulation and for the observations, each summing its numerator and
+denominator over the year before dividing, as every other panel does.
+
+Only years where all twelve months are present and finite on both sides
+contribute, since a partial year's ratio is aliased by whichever part of the
+seasonal cycle it sampled. Each month is weighted by its length.
+"""
+function _annual_ratios(dates, sim_num, sim_den, obs_num, obs_den)
+    years, sim_annual, obs_annual = Int[], Float64[], Float64[]
+    series = (sim_num, sim_den, obs_num, obs_den)
+    for year in sort(unique(Dates.year.(dates)))
+        idxs = findall(d -> Dates.year(d) == year, dates)
+        valid = filter(i -> all(isfinite(s[i]) for s in series), idxs)
+        length(unique(Dates.month.(dates[valid]))) == 12 || continue
+        weights = Dates.daysinmonth.(dates[valid])
+        push!(years, year)
+        push!(
+            sim_annual,
+            sum(weights .* sim_num[valid]) / sum(weights .* sim_den[valid]),
+        )
+        push!(
+            obs_annual,
+            sum(weights .* obs_num[valid]) / sum(weights .* obs_den[valid]),
+        )
+    end
+    return (years, sim_annual, obs_annual)
+end
+
+"""
+    _load_partition_sim_var(sim_dir, short_name, spin_up_months)
+
+Load a simulation diagnostic, drop the spin up, and convert it to the units the
+observations use.
+"""
+function _load_partition_sim_var(sim_dir, short_name, spin_up_months)
+    var = get(sim_dir, short_name)
+    spinup_cutoff = spin_up_months * 31 * 86400.0
+    ClimaAnalysis.times(var)[end] >= spinup_cutoff &&
+        (var = ClimaAnalysis.window(var, "time", left = spinup_cutoff))
+    return preprocess_sim_var(var)
+end
+
+"""
+    _prepare_partition_row(sim_dir, data_loader, fraction, spin_up_months)
+
+Assemble everything the four panels of one leaderboard row need, or `nothing`
+when the simulation does not provide every component of `fraction`.
+
+The observed ratio is built only when every component that is not prescribed
+forcing is available from `data_loader`; otherwise the row is model-only.
+"""
+function _prepare_partition_row(sim_dir, data_loader, fraction, spin_up_months)
+    components = union(fraction.numerator, fraction.denominator)
+    available = ClimaAnalysis.available_vars(sim_dir)
+    missing_components = setdiff(components, available)
+    if !isempty(missing_components)
+        @info "Skipping $(fraction.short_name): simulation is missing $(join(sort(collect(missing_components)), ", "))"
+        return nothing
+    end
+
+    # `Any` valued: windowing returns `OutputVar`s backed by views, whose
+    # concrete type differs from the freshly loaded ones stored here first.
+    sim = Dict{String, Any}(
+        c => _load_partition_sim_var(sim_dir, c, spin_up_months) for
+        c in components
+    )
+    start_date = first(values(sim)).attributes["start_date"]
+
+    obs_components = setdiff(components, fraction.prescribed)
+    has_obs = issubset(obs_components, available_vars(data_loader))
+    obs = Dict{String, Any}()
+    if has_obs
+        for c in obs_components
+            obs_var = get(data_loader, c)
+            ClimaAnalysis.set_reference_date!(obs_var, start_date)
+            obs[c] = obs_var
+        end
+        # Window every field to the period all of them cover, then put the
+        # observations on the simulation grid.
+        all_times = ClimaAnalysis.times.(
+            vcat(collect(values(sim)), collect(values(obs))),
+        )
+        min_time = maximum(first.(all_times))
+        max_time = minimum(last.(all_times))
+        for d in (sim, obs), c in keys(d)
+            d[c] = ClimaAnalysis.window(
+                d[c],
+                "time",
+                left = min_time,
+                right = max_time,
+            )
+        end
+        for c in obs_components
+            obs[c] = ClimaAnalysis.resampled_as(obs[c], sim[c])
+        end
+        # Prescribed forcing is identical on both sides by construction.
+        for c in fraction.prescribed
+            obs[c] = sim[c]
+        end
+    end
+
+    annual(d, names) =
+        ClimaAnalysis.average_time(_sum_vars([d[c] for c in names]))
+    sim_num_ann, sim_den_ann =
+        annual(sim, fraction.numerator), annual(sim, fraction.denominator)
+
+    base_mask = ClimaAnalysis.apply_oceanmask
+    guard_vars =
+        Any[sim_num_ann, _small_denominator_mask(sim_den_ann, base_mask)]
+    obs_num_ann = obs_den_ann = nothing
+    if has_obs
+        obs_num_ann, obs_den_ann =
+            annual(obs, fraction.numerator), annual(obs, fraction.denominator)
+        push!(
+            guard_vars,
+            obs_num_ann,
+            _small_denominator_mask(obs_den_ann, base_mask),
+        )
+    end
+    mask_fn = _intersect_mask(base_mask, guard_vars...)
+
+    sim_ratio = _ratio_var(sim_num_ann, sim_den_ann, fraction)
+    obs_ratio =
+        has_obs ? _ratio_var(obs_num_ann, obs_den_ann, fraction) : nothing
+
+    lats, sim_num_zonal = _zonal_means(sim_num_ann, mask_fn)
+    _, sim_den_zonal = _zonal_means(sim_den_ann, mask_fn)
+    # Unlike the mean, the spread has to come from the per-cell ratios: there is
+    # no other sense in which a ratio varies along a latitude band.
+    # `_small_denominator_mask` has already dropped the cells where one blows up.
+    sim_zonal_std = _zonal_std(sim_ratio, mask_fn)
+    obs_zonal = obs_zonal_std = nothing
+    if has_obs
+        _, obs_num_zonal = _zonal_means(obs_num_ann, mask_fn)
+        _, obs_den_zonal = _zonal_means(obs_den_ann, mask_fn)
+        obs_zonal = obs_num_zonal ./ obs_den_zonal
+        obs_zonal_std = _zonal_std(obs_ratio, mask_fn)
+    end
+
+    dates, sim_num_global, sim_den_global =
+        _ratio_global_series(sim, fraction, mask_fn)
+    sim_monthly, sim_spread =
+        _monthly_ratio_climatology(dates, sim_num_global, sim_den_global)
+    obs_monthly, obs_spread = fill(NaN, 12), fill(NaN, 12)
+    years, sim_annual, obs_annual = Int[], Float64[], Float64[]
+    if has_obs
+        _, obs_num_global, obs_den_global =
+            _ratio_global_series(obs, fraction, mask_fn)
+        obs_monthly, obs_spread =
+            _monthly_ratio_climatology(dates, obs_num_global, obs_den_global)
+        years, sim_annual, obs_annual = _annual_ratios(
+            dates,
+            sim_num_global,
+            sim_den_global,
+            obs_num_global,
+            obs_den_global,
+        )
+    end
+
+    return (;
+        fraction,
+        has_obs,
+        mask_fn,
+        sim_ratio,
+        obs_ratio,
+        lats,
+        sim_zonal = sim_num_zonal ./ sim_den_zonal,
+        sim_zonal_std,
+        obs_zonal,
+        obs_zonal_std,
+        sim_monthly,
+        sim_spread,
+        obs_monthly,
+        obs_spread,
+        years,
+        sim_annual,
+        obs_annual,
+        year_range = _year_range(first(values(sim))),
+    )
+end
+
+"""
+    _year_range(var)
+
+Return the years spanned by `var` as a display string, e.g. `"2008-2010"`.
+"""
+function _year_range(var)
+    start_date = Dates.DateTime(var.attributes["start_date"])
+    times = ClimaAnalysis.times(var)
+    y0 = Dates.year(start_date + Dates.Second(round(Int, first(times))))
+    y1 = Dates.year(start_date + Dates.Second(round(Int, last(times))))
+    return y0 == y1 ? "$(y0)" : "$(y0)–$(y1)"
+end
+
+"""
+    _fraction_contour_kwargs(row)
+
+Build `more_kwargs` for the SIM panel: fractions live in `[0, 1]`, so the color
+scale is fixed there rather than following the data, with extend arrows for the
+values (such as an evaporative index above one) that fall outside.
+"""
+function _fraction_contour_kwargs(row)
+    return Dict(
+        :plot => Dict(
+            :levels => collect(range(0, 1; length = 21)),
+            :extendhigh => :auto,
+            :extendlow => :auto,
+        ),
+        :axis => Dict(
+            :title => "$(row.fraction.long_name), mean over $(row.year_range)",
+        ),
+    )
+end
+
+"""
+    _limit_to_fraction_range!(ax, profiles...)
+
+Set the value axis of a zonal-profile panel so that `[0, 1]` is always in view
+and the tails are clipped to the 2nd-98th percentile of the plotted profiles,
+band edges included.
+
+Not every fraction is bounded by one: the evaporative fraction diverges wherever
+the sensible heat flux offsets the latent heat flux, which happens routinely at
+high latitudes and otherwise compresses the whole profile into a sliver of the
+axis.
+"""
+function _limit_to_fraction_range!(ax, profiles...)
+    finite = filter(isfinite, vcat(profiles...))
+    isempty(finite) && return nothing
+    lo = Statistics.quantile(finite, 0.02)
+    hi = Statistics.quantile(finite, 0.98)
+    CairoMakie.xlims!(ax, min(lo, 0.0), max(hi, 1.0))
+    return nothing
+end
+
+"""
+    _no_obs_panel!(position, fraction)
+
+Fill a panel that has no gridded observations to compare against with a note
+saying so.
+
+An empty axis rather than a bare `Label`: a label demands no height, which would
+collapse the whole row next to the map panels.
+"""
+function _no_obs_panel!(position, fraction)
+    ax = CairoMakie.Axis(position)
+    CairoMakie.hidedecorations!(ax)
+    CairoMakie.hidespines!(ax)
+    CairoMakie.text!(
+        ax,
+        0.5,
+        0.5;
+        text = "No gridded observations\nfor $(fraction.long_name)",
+        fontsize = 24,
+        align = (:center, :center),
+    )
+    return nothing
+end
+
+"""
+    compute_partitioning_leaderboard(leaderboard_base_path,
+                                     diagnostics_folder_path;
+                                     spin_up_months = 12,
+                                     fractions = PARTITION_FRACTIONS,
+                                     era5_to_clima_names = ERA5_PARTITION_TO_CLIMA_NAMES)
+
+Plot a leaderboard of the dimensionless fractions that describe how the model
+partitions energy and water: the evaporative fraction, the surface runoff
+fraction, the evaporative index, and the transpiration fraction.
+
+The layout matches the annual leaderboards produced by
+`compute_seasonal_leaderboard`. Rows are fractions and columns are
+
+- `SIM`, the simulated fraction,
+- `ANN`, its bias against observations,
+- `LAT`, zonal means of the simulated and observed fractions, banded by the
+  spread of the per-cell ratios along each latitude band,
+- `MON`, their global seasonal cycle with a band showing the spread across
+  years,
+- `IAV`, the global annual fractions plotted against each other, one point per
+  year.
+
+Observations come from ERA5, loaded under the names `era5_to_clima_names` maps.
+Rows whose components the simulation does not output are skipped, and rows with
+no gridded observations show the simulation alone alongside a published global
+constraint.
+"""
+function compute_partitioning_leaderboard(
+    leaderboard_base_path,
+    diagnostics_folder_path;
+    spin_up_months = 12,
+    fractions = PARTITION_FRACTIONS,
+    era5_to_clima_names = ERA5_PARTITION_TO_CLIMA_NAMES,
+)
+    sim_dir = ClimaAnalysis.SimDir(diagnostics_folder_path)
+    data_loader = ERA5DataLoader(; era5_to_clima_names)
+
+    rows = filter(
+        !isnothing,
+        [
+            _prepare_partition_row(
+                sim_dir,
+                data_loader,
+                fraction,
+                spin_up_months,
+            ) for fraction in fractions
+        ],
+    )
+    if isempty(rows)
+        @info "No partitioning fractions could be computed from $diagnostics_folder_path"
+        return nothing
+    end
+
+    groups = ["SIM", "ANN", "LAT", "MON"]
+    any(row -> length(row.years) > _MIN_IAV_YEARS, rows) && push!(groups, "IAV")
+    fig = CairoMakie.Figure(; size = (600 * length(groups), 400 * length(rows)))
+
+    # The title and the column labels go in before any globe panel: adding a
+    # `Label` to a figure that already holds a `GeoAxis` can send GridLayoutBase
+    # into infinite recursion. See MakieOrg/GeoMakie.jl#330.
+    titlelayout = CairoMakie.GridLayout(
+        fig[-1, 1:length(groups)],
+        halign = :center,
+        tellwidth = false,
+    )
+    CairoMakie.Label(
+        titlelayout[1, 1],
+        "Energy and water partitioning\nexcluding spin up ($spin_up_months months)",
+        fontsize = 40,
+    )
+    for (col_idx, group) in enumerate(groups)
+        CairoMakie.Label(
+            fig[0, col_idx],
+            group,
+            tellwidth = false,
+            fontsize = 30,
+        )
+    end
+
+    for (row_idx, row) in enumerate(rows)
+        CairoMakie.Label(
+            fig[row_idx, 0],
+            row.fraction.ratio_label,
+            tellheight = false,
+            fontsize = 30,
+        )
+        for (col_idx, group) in enumerate(groups)
+            if group == "SIM"
+                layout = fig[row_idx, col_idx] = CairoMakie.GridLayout()
+                ClimaAnalysis.Visualize.contour2D_on_globe!(
+                    layout,
+                    row.sim_ratio,
+                    mask = row.mask_fn;
+                    more_kwargs = _fraction_contour_kwargs(row),
+                )
+            elseif group == "ANN"
+                if !row.has_obs
+                    _no_obs_panel!(fig[row_idx, col_idx], row.fraction)
+                    continue
+                end
+                layout = fig[row_idx, col_idx] = CairoMakie.GridLayout()
+                ClimaAnalysis.Visualize.plot_bias_on_globe!(
+                    layout,
+                    row.sim_ratio,
+                    row.obs_ratio,
+                    cmap_extrema = row.fraction.bias_extrema,
+                    mask = row.mask_fn,
+                )
+            elseif group == "IAV"
+                if length(row.years) <= _MIN_IAV_YEARS
+                    _no_obs_panel!(fig[row_idx, col_idx], row.fraction)
+                    continue
+                end
+                _plot_interannual!(
+                    fig[row_idx, col_idx],
+                    row.years,
+                    row.sim_annual,
+                    row.obs_annual;
+                    label = row.fraction.ratio_label,
+                    show_title = row_idx == 1,
+                )
+            elseif group == "LAT"
+                ax = CairoMakie.Axis(
+                    fig[row_idx, col_idx],
+                    xlabel = row.fraction.ratio_label,
+                    ylabel = "Latitude (degrees)",
+                    yticks = -90:30:90,
+                    title = row_idx == 1 ? "Zonal mean of the annual mean" : "",
+                )
+                CairoMakie.ylims!(ax, -90, 90)
+                _limit_to_fraction_range!(
+                    ax,
+                    row.sim_zonal .- row.sim_zonal_std,
+                    row.sim_zonal .+ row.sim_zonal_std,
+                    row.has_obs ? row.obs_zonal .- row.obs_zonal_std :
+                    Float64[],
+                    row.has_obs ? row.obs_zonal .+ row.obs_zonal_std :
+                    Float64[],
+                )
+                row.has_obs && _band_zonal_spread!(
+                    ax,
+                    row.obs_zonal,
+                    row.obs_zonal_std,
+                    row.lats,
+                    :black,
+                )
+                _band_zonal_spread!(
+                    ax,
+                    row.sim_zonal,
+                    row.sim_zonal_std,
+                    row.lats,
+                    :firebrick,
+                )
+                row.has_obs && CairoMakie.lines!(
+                    ax,
+                    row.obs_zonal,
+                    row.lats;
+                    color = :black,
+                    linewidth = 4,
+                    label = "OBS",
+                )
+                CairoMakie.lines!(
+                    ax,
+                    row.sim_zonal,
+                    row.lats;
+                    color = :firebrick,
+                    linewidth = 4,
+                    label = "SIM",
+                )
+                # Anchored left: the profiles run up against the right edge,
+                # where a legend would sit on top of them.
+                row_idx == 1 && CairoMakie.axislegend(
+                    ax,
+                    position = :lb,
+                    framevisible = false,
+                )
+            else
+                ax = CairoMakie.Axis(
+                    fig[row_idx, col_idx],
+                    xlabel = "Month",
+                    ylabel = row.fraction.ratio_label,
+                    xticks = (1:12, first.(Dates.monthname.(1:12), 1)),
+                    title = row_idx == 1 ? "Global seasonal cycle" : "",
+                )
+                _plot_partition_reference!(ax, row.fraction.reference)
+                if row.has_obs
+                    _band_interannual_spread!(
+                        ax,
+                        row.obs_monthly,
+                        row.obs_spread,
+                        :black,
+                    )
+                end
+                _band_interannual_spread!(
+                    ax,
+                    row.sim_monthly,
+                    row.sim_spread,
+                    :firebrick,
+                )
+                row.has_obs && CairoMakie.lines!(
+                    ax,
+                    1:12,
+                    row.obs_monthly;
+                    color = :black,
+                    linewidth = 4,
+                    label = "OBS",
+                )
+                CairoMakie.lines!(
+                    ax,
+                    1:12,
+                    row.sim_monthly;
+                    color = :firebrick,
+                    linewidth = 4,
+                    label = "SIM",
+                )
+                CairoMakie.axislegend(ax, position = :rt, framevisible = false)
+            end
+        end
+    end
+
+    # The IAV axis is square, so left to a map-sized column it would sit in the
+    # middle of a blank margin.
+    iav_col = findfirst(==("IAV"), groups)
+    isnothing(iav_col) ||
+        CairoMakie.colsize!(fig.layout, iav_col, CairoMakie.Fixed(420))
+
+    CairoMakie.save(
+        joinpath(leaderboard_base_path, "Partitioning_leaderboard.png"),
+        fig,
+    )
+    return nothing
+end
+
+"""
+    _plot_partition_reference!(ax, reference)
+
+Shade a published global constraint `(value, spread, label)` across the seasonal
+panel. The constraint is an annual global number, so it is drawn flat and
+labelled as such rather than implying a month-by-month target.
+"""
+_plot_partition_reference!(ax, ::Nothing) = nothing
+
+function _plot_partition_reference!(ax, reference)
+    value, spread, label = reference
+    CairoMakie.band!(
+        ax,
+        1:12,
+        fill(value - spread, 12),
+        fill(value + spread, 12);
+        color = (:steelblue, 0.15),
+        label = label,
+    )
+    return nothing
+end

--- a/ext/land_sim_vis/plotting_utils.jl
+++ b/ext/land_sim_vis/plotting_utils.jl
@@ -346,6 +346,110 @@ function time_to_date(t::ITime, start_date)
 end
 
 """
+    _reduction_starts(dates, start_date)
+
+Move the timestamps of a reduction (a monthly average, say) from the end of each
+averaging period to its start, so that output kept in memory is dated the way
+output written to disk is.
+
+The two writers disagree on when a reduction happened. A `DictWriter` stores it
+under the time the period closed, while `ClimaDiagnostics` writes the start of
+the period to NetCDF: `init_time` for the first output, the end of the previous
+period after that. Reading the two paths through `site_timeseries` therefore
+needs this on the `DictWriter` side, and only for reductions — an instantaneous
+diagnostic carries no period and is already stamped at its own time.
+"""
+function _reduction_starts(dates, start_date)
+    isempty(dates) && return dates
+    return [start_date; dates[1:(end - 1)]]
+end
+
+"""
+    site_source(diagnostics)
+
+Return what the diagnostics of a single-site simulation are read from: a
+`ClimaAnalysis.SimDir` over the output directory when they were written to disk,
+or the `DictWriter` holding them when they were kept in memory. As everywhere
+else here, the whole list is taken to share one writer.
+
+Build this once and hand it to `site_timeseries` when reading several variables.
+A `SimDir` walks the output tree and then caches every `OutputVar` it reads, so
+rebuilding it per variable does that walk again and throws the cache away.
+"""
+function site_source(diagnostics)
+    writer = first(diagnostics).output_writer
+    writer isa ClimaDiagnostics.Writers.NetCDFWriter || return writer
+    return ClimaAnalysis.SimDir(writer.output_dir)
+end
+
+"""
+    site_timeseries(diagnostics, short_name, start_date;
+                    layer = nothing, source = site_source(diagnostics))
+
+Return `(dates, values, units)` for the single-site diagnostic `short_name`,
+whether the simulation stored its output in memory with a `DictWriter` or on
+disk with a `NetCDFWriter`.
+
+Dates label the start of each reduction period in both cases, so plots do not
+have to know which writer produced them.
+
+For variables resolved in depth, `layer` selects a level counting from `1` at
+the bottom; the default is the top level.
+"""
+function site_timeseries(
+    diagnostics,
+    short_name,
+    start_date;
+    layer = nothing,
+    source = site_source(diagnostics),
+)
+    return _site_timeseries(source, diagnostics, short_name, start_date, layer)
+end
+
+# On disk the SimDir holds everything: it knows the units, and the dates it
+# reports are already the start of each reduction period.
+function _site_timeseries(
+    sim_dir::ClimaAnalysis.SimDir,
+    _,
+    short_name,
+    _,
+    layer,
+)
+    var = get(sim_dir, short_name)
+    if ClimaAnalysis.has_altitude(var)
+        altitudes = ClimaAnalysis.altitudes(var)
+        layer_id = isnothing(layer) ? length(altitudes) : layer
+        var = ClimaAnalysis.slice(var, z = altitudes[layer_id])
+    end
+    return (ClimaAnalysis.dates(var), vec(var.data), ClimaAnalysis.units(var))
+end
+
+# In memory there is no file to describe the output, so the diagnostic itself
+# supplies the name it is stored under, its units, and whether its timestamps
+# need `_reduction_starts`.
+function _site_timeseries(
+    writer::ClimaDiagnostics.Writers.DictWriter,
+    diagnostics,
+    short_name,
+    start_date,
+    layer,
+)
+    matches = filter(d -> d.variable.short_name == short_name, diagnostics)
+    isempty(matches) &&
+        error("$short_name is not available in the saved diagnostics.")
+    diagnostic = first(matches)
+    times, values = ClimaLand.Diagnostics.diagnostic_as_vectors(
+        writer,
+        diagnostic.output_short_name;
+        layer,
+    )
+    dates = time_to_date.(times, start_date)
+    isnothing(diagnostic.reduction_time_func) ||
+        (dates = _reduction_starts(dates, start_date))
+    return (dates, values, diagnostic.variable.units)
+end
+
+"""
     make_diurnal_timeseries(
     savedir,
     diagnostics,
@@ -378,19 +482,11 @@ function LandSimVis.make_diurnal_timeseries(
     comparison_data = nothing,
     spinup_date = start_date,
 )
-    short_names = [d.variable.short_name for d in diagnostics] # short_name_X_average e.g.
-    diag_names = [d.output_short_name for d in diagnostics] # short_name_X_average e.g.
-    diag_units = [d.variable.units for d in diagnostics]
-    for i in 1:length(diag_names)
-        dn = diag_names[i]
-        unit = diag_units[i]
-        sn = short_names[i]
-        model_time, model_output = ClimaLand.Diagnostics.diagnostic_as_vectors(
-            diagnostics[1].output_writer,
-            dn,
-        )
-        save_Δt = model_time[2] - model_time[1] # in seconds since the start_date. if model_time is an Itime, the epoch should be start_date
-        model_dates = time_to_date.(model_time, start_date)
+    source = site_source(diagnostics)
+    for d in diagnostics
+        sn = d.variable.short_name
+        model_dates, model_output, unit =
+            site_timeseries(diagnostics, sn, start_date; source)
         spinup_idx = findfirst(spinup_date .<= model_dates)
         hour_of_day, model_diurnal_cycle = compute_diurnal_cycle(
             model_dates[spinup_idx:end],
@@ -488,25 +584,12 @@ function LandSimVis.make_timeseries(
     comparison_data = nothing,
     spinup_date = start_date,
 )
-    short_names = [d.variable.short_name for d in diagnostics] # short_name
-    diag_names = [d.output_short_name for d in diagnostics] # short_name_X_average e.g.
-    diag_units = [d.variable.units for d in diagnostics]
-    for i in 1:length(diag_names)
-        dn = diag_names[i]
-        unit = diag_units[i]
-        sn = short_names[i]
-        model_time, model_output = ClimaLand.Diagnostics.diagnostic_as_vectors(
-            diagnostics[1].output_writer,
-            dn;
-            layer,
-        )
-        save_Δt = model_time[2] - model_time[1] # in seconds
-        model_dates = time_to_date.(model_time, start_date)
+    source = site_source(diagnostics)
+    for d in diagnostics
+        sn = d.variable.short_name
+        model_dates, model_output, unit =
+            site_timeseries(diagnostics, sn, start_date; layer, source)
         spinup_idx = findfirst(spinup_date .<= model_dates)
-        hour_of_day, model_diurnal_cycle = compute_diurnal_cycle(
-            model_dates[spinup_idx:end],
-            model_output[spinup_idx:end],
-        )
         fig = CairoMakie.Figure(size = (800, 400))
         ax = CairoMakie.Axis(
             fig[1, 1],
@@ -527,10 +610,6 @@ function LandSimVis.make_timeseries(
             data = getproperty(comparison_data, Symbol(sn))
             data_dates = getproperty(comparison_data, :UTC_datetime)
             spinup_idx = findfirst(spinup_date .<= data_dates)
-            hour_of_day, data_diurnal_cycle = compute_diurnal_cycle(
-                data_dates[spinup_idx:end],
-                data[spinup_idx:end],
-            )
             CairoMakie.lines!(
                 ax,
                 data_dates[spinup_idx:end],
@@ -582,19 +661,8 @@ function compare_monthly_fluxes_with_data(
         )
     end
 
-    for i in 1:length(short_names)
-        dn = [
-            d.output_short_name for
-            d in diagnostics if d.variable.short_name == short_names[i]
-        ]
-        @assert length(dn) == 1 ||
-                @error("$(short_names[i]) not available in saved diagnostics.")
-        dn = first(dn)
-        unit = [
-            d.variable.units for
-            d in diagnostics if d.variable.short_name == short_names[i]
-        ][1]
-        sn = short_names[i]
+    source = site_source(diagnostics)
+    for sn in short_names
         global_obs_data = get(data_loader, sn)
         ClimaAnalysis.set_reference_date!(global_obs_data, start_date)
         global_obs_data = ClimaAnalysis.window(
@@ -610,17 +678,8 @@ function compare_monthly_fluxes_with_data(
         )
         obs_times = obs_data.dims["time"]
         obs_values = obs_data.data
-        model_time, model_output = ClimaLand.Diagnostics.diagnostic_as_vectors(
-            diagnostics[1].output_writer,
-            dn;
-        )
-        model_dates = time_to_date.(model_time, start_date)
-        model_dt = Month(model_dates[2]) - Month(model_dates[1])
-        @assert model_dt == Month(1) || @error(
-            "Diagnostic reduction period must be one month to plot partitioning diagnostics."
-        )
-        # DictWriter diagnostics are saved at the end of the reduction period
-        model_dates = model_dates .- model_dt
+        model_dates, model_output, unit =
+            site_timeseries(diagnostics, sn, start_date; source)
         obs_dates = time_to_date.(obs_times, start_date)
         model_spinup_idx = findfirst(spinup_date .<= model_dates)
         obs_spinup_idx = findfirst(spinup_date .<= obs_dates)
@@ -659,497 +718,155 @@ end
         diagnostics,
         start_date,
         stop_date,
-        longlat,
+        longlat;
+        fractions = PARTITION_FRACTIONS,
+        era5_to_clima_names = ERA5_PARTITION_TO_CLIMA_NAMES,
     )
 
-Creates some helper diagnostic plots showing the partition between
-- LHF and SHF (LHF / (LHF+SHF)
-- surface and subsurface runoff (SR / (SSR + SR)
-- transpiration and evaporation (T/ET)
-- ET and runoff (ET/precip)
-for a simulation run at a single site with longitude/latitude pair longlat,
-where the diagnostics were stored using the DictWriter.
+Plot the timeseries of each partitioning fraction in `fractions` for a
+simulation run at the single site with longitude/latitude pair `longlat`,
+saving one png per fraction in `savedir`.
 
-The entire timeseries of the data (and corresponding times from ERA5)
-are used to compute the partitioning.
+The fractions are the same ones the global partitioning leaderboard shows, so a
+site and a global run are described by the same quantities. Every fraction is a
+ratio of diagnostics sharing units, so it is formed directly from the recorded
+values.
 
-For SHF and LHF alone, the comparison to ERA5 is also shown.
+ERA5 is overlaid for the fractions it can supply, loaded under the names
+`era5_to_clima_names` maps. Components flagged as prescribed forcing are taken
+from the simulation on both sides, since they are the same field there by
+construction.
+
+Works with either output writer; see `site_timeseries`.
 """
 function create_partitioning_plots(
     savedir,
     diagnostics,
     start_date,
     stop_date,
-    longlat,
+    longlat;
+    fractions = PARTITION_FRACTIONS,
+    era5_to_clima_names = ERA5_PARTITION_TO_CLIMA_NAMES,
 )
-    data_loader = ERA5DataLoader()
-    diag_short_names = [d.variable.short_name for d in diagnostics]
-    # Evaporative fraction
-    if "shf" ∈ diag_short_names && "lhf" ∈ diag_short_names
-        lhf_dn = [
-            d.output_short_name for
-            d in diagnostics if d.variable.short_name == "lhf"
-        ][1]
-        shf_dn = [
-            d.output_short_name for
-            d in diagnostics if d.variable.short_name == "shf"
-        ][1]
+    data_loader = ERA5DataLoader(; era5_to_clima_names)
+    available = [d.variable.short_name for d in diagnostics]
+    source = site_source(diagnostics)
 
-        model_time, lhf = ClimaLand.Diagnostics.diagnostic_as_vectors(
-            diagnostics[1].output_writer,
-            lhf_dn;
-        )
-        _, shf = ClimaLand.Diagnostics.diagnostic_as_vectors(
-            diagnostics[1].output_writer,
-            shf_dn;
-        )
-        model_dates = time_to_date.(model_time, start_date)
-        # DictWriter diagnostics are saved at the end of the reduction period
-        model_dates = model_dates .- Month(1)
+    for fraction in fractions
+        components = union(fraction.numerator, fraction.denominator)
+        # A ratio needs every one of its components; there is nothing to plot
+        # from a subset of them.
+        issubset(components, available) || continue
 
-        obs_shf = get(data_loader, "shf")
-        ClimaAnalysis.set_reference_date!(obs_shf, start_date)
-        obs_lhf = get(data_loader, "lhf")
-        ClimaAnalysis.set_reference_date!(obs_lhf, start_date)
-        obs_shf = ClimaAnalysis.slice(
-            ClimaAnalysis.window(
-                obs_shf,
-                "time",
-                left = start_date,
-                right = stop_date - Month(1),
-            ),
-            lat = longlat[2],
-            lon = longlat[1],
+        # The one place site diagnostics are put on the leaderboard's scale,
+        # so nothing downstream has to know whether they still need converting.
+        model = Dict(
+            c => _site_component(
+                site_timeseries(diagnostics, c, start_date; source)...,
+                c,
+            ) for c in components
         )
-        obs_lhf = ClimaAnalysis.slice(
-            ClimaAnalysis.window(
-                obs_lhf,
-                "time",
-                left = start_date,
-                right = stop_date - Month(1),
-            ),
-            lat = longlat[2],
-            lon = longlat[1],
-        )
+        model_dates = model[first(components)].dates
+        model_series(names) = sum(model[c].values for c in names)
 
         fig = CairoMakie.Figure(size = (800, 400))
         ax = CairoMakie.Axis(
             fig[1, 1],
             xlabel = "Date (UTC)",
-            ylabel = "LHF/(SHF+LHF)",
+            ylabel = fraction.ratio_label,
+            title = fraction.long_name,
         )
         CairoMakie.lines!(
             ax,
             model_dates,
-            lhf ./ (lhf .+ shf .+ eps(eltype(shf))),
+            model_series(fraction.numerator) ./
+            model_series(fraction.denominator),
             label = "Model",
             color = "blue",
         )
-        CairoMakie.lines!(
-            ax,
-            model_dates,
-            obs_lhf.data ./ (obs_lhf.data .+ obs_shf.data .+ eps(eltype(shf))),
-            label = "ERA5",
-            color = "red",
-        )
-        xlims = extrema(model_dates)
-        xlims!(ax, xlims...)
+
+        obs_components = setdiff(components, fraction.prescribed)
+        # As above: ERA5 supplying part of a ratio is no use, so the overlay is
+        # all or nothing.
+        if issubset(obs_components, available_vars(data_loader))
+            obs = Dict{String, Any}()
+            for c in obs_components
+                obs[c] = _era5_at_site(data_loader, c, longlat, model_dates)
+            end
+            # Prescribed components are the same field on both sides, so the
+            # simulation supplies them; they are already on the loader's scale.
+            for c in fraction.prescribed
+                obs[c] = model[c].values
+            end
+            obs_series(names) = sum(obs[c] for c in names)
+            if all(c -> length(obs[c]) == length(model_dates), components)
+                CairoMakie.lines!(
+                    ax,
+                    model_dates,
+                    obs_series(fraction.numerator) ./
+                    obs_series(fraction.denominator),
+                    label = "ERA5",
+                    color = "red",
+                )
+            else
+                @info "Skipping the ERA5 overlay for $(fraction.short_name): observations do not cover the simulated months"
+            end
+        end
+
+        xlims!(ax, extrema(model_dates)...)
         axislegend(ax, position = :lt)
-        CairoMakie.save(joinpath(savedir, "evap_fraction.png"), fig)
-    end
-
-    # ET partitioning
-    if "et" ∈ diag_short_names && "trans" ∈ diag_short_names
-        lhf_dn = [
-            d.output_short_name for
-            d in diagnostics if d.variable.short_name == "et"
-        ][1]
-        clhf_dn = [
-            d.output_short_name for
-            d in diagnostics if d.variable.short_name == "trans"
-        ][1]
-
-        model_time, lhf = ClimaLand.Diagnostics.diagnostic_as_vectors(
-            diagnostics[1].output_writer,
-            lhf_dn;
+        CairoMakie.save(
+            joinpath(savedir, "$(fraction.short_name)_partition.png"),
+            fig,
         )
-        _, clhf = ClimaLand.Diagnostics.diagnostic_as_vectors(
-            diagnostics[1].output_writer,
-            clhf_dn;
-        )
-        start_date = model_time[1].epoch
-        model_dates = time_to_date.(model_time, start_date)
-        model_dates = model_dates .- Month(1)
-
-        fig = CairoMakie.Figure(size = (800, 400))
-        ax = CairoMakie.Axis(fig[1, 1], xlabel = "Date (UTC)", ylabel = "T/ET")
-        CairoMakie.lines!(
-            ax,
-            model_dates,
-            clhf ./ (lhf .+ eps(eltype(lhf))),
-            label = "Model",
-            color = "blue",
-        )
-        xlims = extrema(model_dates)
-        xlims!(ax, xlims...)
-        axislegend(ax, position = :lt)
-        CairoMakie.save(joinpath(savedir, "et_partition.png"), fig)
-    end
-    # Runoff partitioning
-    if "et" ∈ diag_short_names &&
-       "precip" ∈ diag_short_names &&
-       "sr" ∈ diag_short_names &&
-       "ssr" ∈ diag_short_names
-        et_dn = [
-            d.output_short_name for
-            d in diagnostics if d.variable.short_name == "et"
-        ][1]
-        sr_dn = [
-            d.output_short_name for
-            d in diagnostics if d.variable.short_name == "sr"
-        ][1]
-        ssr_dn = [
-            d.output_short_name for
-            d in diagnostics if d.variable.short_name == "ssr"
-        ][1]
-        precip_dn = [
-            d.output_short_name for
-            d in diagnostics if d.variable.short_name == "precip"
-        ][1]
-        model_time, et = ClimaLand.Diagnostics.diagnostic_as_vectors(
-            diagnostics[1].output_writer,
-            et_dn;
-        )
-        _, precip = ClimaLand.Diagnostics.diagnostic_as_vectors(
-            diagnostics[1].output_writer,
-            precip_dn;
-        )
-        _, sr = ClimaLand.Diagnostics.diagnostic_as_vectors(
-            diagnostics[1].output_writer,
-            sr_dn;
-        )
-        _, ssr = ClimaLand.Diagnostics.diagnostic_as_vectors(
-            diagnostics[1].output_writer,
-            ssr_dn;
-        )
-        start_date = model_time[1].epoch
-        model_dates = time_to_date.(model_time, start_date)
-        model_dates = model_dates .- Month(1)
-
-        fig = CairoMakie.Figure(size = (800, 400))
-        ax = CairoMakie.Axis(fig[1, 1], xlabel = "Date (UTC)", ylabel = "Ratio")
-        CairoMakie.lines!(
-            ax,
-            model_dates,
-            et ./ abs.(precip .+ eps(eltype(precip))),
-            label = "ET/P",
-            color = "blue",
-        )
-        CairoMakie.lines!(
-            ax,
-            model_dates,
-            (ssr .+ sr) .* 1000 ./ abs.(precip .+ eps(eltype(precip))), # convert to mass flux for runoff
-            label = "R/P",
-            color = "red",
-        )
-        xlims = extrema(model_dates)
-        xlims!(ax, xlims...)
-        axislegend(ax, position = :lt)
-        CairoMakie.save(joinpath(savedir, "water_partition.png"), fig)
-
-        fig = CairoMakie.Figure(size = (800, 400))
-        ax = CairoMakie.Axis(fig[1, 1], xlabel = "Date (UTC)", ylabel = "Ratio")
-        CairoMakie.lines!(
-            ax,
-            model_dates,
-            ssr ./ (ssr .+ sr .+ eps(eltype(sr))),
-            label = "SSR/(SSR+SR)",
-            color = "blue",
-        )
-
-        xlims = extrema(model_dates)
-        xlims!(ax, xlims...)
-        axislegend(ax, position = :lt)
-        CairoMakie.save(joinpath(savedir, "runoff_partition.png"), fig)
     end
     return nothing
 end
 
 """
-    create_partitioning_plots(
-        savedir,
-        diagdir,
-        short_names;
-        plot! = viz.heatmap2D_on_globe!,
-        mask = viz.oceanmask(),
-        plot_kwargs = Dict(
-            :mask => ClimaAnalysis.Utils.kwargs(color = :white),
-            :plot => Dict(
-                ClimaAnalysis.Utils.kwargs(rasterize = true)...,
-                :colorrange => (0, 1),
-            ),
-        ),
-    )
-Creates some helper diagnostic plots showing the partition between
-- LHF and SHF (LHF / (LHF+SHF)
-- surface and subsurface runoff (SR / (SSR + SR)
-- transpiration and evaporation (T/ET)
-- ET and runoff (ET/precip)
-for a simulation run globally,
-where the diagnostics were stored using a NetCDFWriter in `diagdir`.
+    _site_component(dates, values, units, short_name)
 
-All ratios are computed using annual means of the numerator and denominator,
-and we restrict to the last complete year of the data and simulation in computing
-them.
+Put a site diagnostic on the same footing as the gridded leaderboard: water
+fluxes in `mm / day`, the units the ERA5 loader reports them in, and
+precipitation as a magnitude. Energy fluxes, and anything already in those
+units, pass through untouched.
 
-For SHF and LHF alone, the comparison to ERA5 is also shown.
+Returns `(; dates, values, units)` with the units the values ended up in, so
+converted output is indistinguishable from output that never needed converting
+and a second pass over it does nothing.
+
+This mirrors the `_preprocess_sim_var` methods, which normalize gridded
+`OutputVar`s rather than the plain vectors a single site produces.
 """
-function create_partitioning_plots(
-    savedir,
-    diagdir,
-    short_names;
-    plot! = viz.heatmap2D_on_globe!,
-    mask = viz.oceanmask(),
-    plot_kwargs = Dict(
-        :mask => ClimaAnalysis.Utils.kwargs(color = :white),
-        :plot => Dict(
-            ClimaAnalysis.Utils.kwargs(rasterize = true)...,
-            :colorrange => (0, 1),
-        ),
-    ),
-)
-    simdir = ClimaAnalysis.SimDir(diagdir)
-    if "shf" ∈ short_names && "lhf" ∈ short_names
-        shf_var = get(simdir; short_name = "shf")
-        lhf_var = get(simdir; short_name = "lhf")
-        # Get the first and last years of the simulation for windowing
-        first_date = first(ClimaAnalysis.dates(shf_var))
-        last_date = last(ClimaAnalysis.dates(shf_var))
-        @assert last_date > first_date + Year(1)
-        shf_var = ClimaAnalysis.average_time(
-            ClimaAnalysis.window(
-                shf_var,
-                "time",
-                left = last_date - Month(11),
-                right = last_date,
-            ),
-        )
-        lhf_var = ClimaAnalysis.average_time(
-            ClimaAnalysis.window(
-                lhf_var,
-                "time",
-                left = last_date - Month(11),
-                right = last_date,
-            ),
-        )
+function _site_component(dates, values, units, short_name)
+    # Precipitation is reported downward-positive; the ratios use its magnitude.
+    short_name == "precip" && (values = abs.(values))
+    units == "kg m^-2 s^-1" &&
+        return (; dates, values = values .* 86400.0, units = "mm / day")
+    units == "m s^-1" && return (;
+        dates,
+        values = values .* 1000.0 .* 86400.0,
+        units = "mm / day",
+    )
+    return (; dates, values, units)
+end
 
-        data_loader = ERA5DataLoader()
-        obs_shf = get(data_loader, "shf")
-        ClimaAnalysis.set_reference_date!(obs_shf, first_date)
-        obs_lhf = get(data_loader, "lhf")
-        ClimaAnalysis.set_reference_date!(obs_lhf, first_date)
-        obs_shf = ClimaAnalysis.average_time(
-            ClimaAnalysis.window(
-                obs_shf,
-                "time",
-                left = last_date - Month(11),
-                right = last_date,
-            ),
-        )
-        obs_lhf = ClimaAnalysis.average_time(
-            ClimaAnalysis.window(
-                obs_lhf,
-                "time",
-                left = last_date - Month(11),
-                right = last_date,
-            ),
-        )
-        fig = CairoMakie.Figure(size = (600, 400))
-        fig2 = CairoMakie.Figure(size = (600, 400))
+"""
+    _era5_at_site(data_loader, short_name, longlat, dates)
 
-        attributes = Dict(
-            "units" => "",
-            "short_name" => "ef",
-            "long_name" => "Evaporative Fraction",
-        )
-        ratio = ClimaAnalysis.Var.remake(
-            lhf_var;
-            attributes,
-            data = lhf_var.data ./ (lhf_var.data .+ shf_var.data),
-        )
-        attributes = Dict(
-            "units" => "",
-            "short_name" => "",
-            "long_name" => "Evaporative Fraction Bias",
-        )
-        bias_ratio = ClimaAnalysis.Var.remake(
-            lhf_var;
-            attributes,
-            data = clamp.(
-                lhf_var.data ./ (lhf_var.data .+ shf_var.data) .-
-                (obs_lhf.data ./ (obs_lhf.data .+ obs_shf.data))[:, 1:180],
-                -0.3,
-                0.3,
-            ),
-        )
-
-        if mask isa Nothing
-            plot!(fig, ratio, more_kwargs = plot_kwargs)
-            plot!(
-                fig2,
-                bias_ratio,
-                more_kwargs = Dict(
-                    :mask => ClimaAnalysis.Utils.kwargs(color = :white),
-                    :plot => Dict(
-                        ClimaAnalysis.Utils.kwargs(rasterize = true)...,
-                        :colorrange => (-0.3, 0.3),
-                    ),
-                ),
-            )
-        else
-            plot!(fig, ratio, more_kwargs = plot_kwargs, mask = mask)
-            plot!(
-                fig2,
-                bias_ratio,
-                more_kwargs = Dict(
-                    :mask => ClimaAnalysis.Utils.kwargs(color = :white),
-                    :plot => Dict(
-                        ClimaAnalysis.Utils.kwargs(rasterize = true)...,
-                        :colorrange => (-0.3, 0.3),
-                    ),
-                ),
-                mask = mask,
-            )
-        end
-
-    end
-    CairoMakie.save(joinpath(savedir, "evaporative_fraction_bias.png"), fig2)
-    CairoMakie.save(joinpath(savedir, "evaporative_fraction.png"), fig)
-
-    if "trans" ∈ short_names && "et" ∈ short_names
-        t_var = get(simdir; short_name = "trans")
-        et_var = get(simdir; short_name = "et")
-        # Get the first and last years of the simulation for windowing
-        first_date = first(ClimaAnalysis.dates(et_var))
-        last_date = last(ClimaAnalysis.dates(et_var))
-        @assert last_date > first_date + Year(1)
-        t_var = ClimaAnalysis.average_time(
-            ClimaAnalysis.window(
-                t_var,
-                "time",
-                left = last_date - Month(11),
-                right = last_date,
-            ),
-        )
-        et_var = ClimaAnalysis.average_time(
-            ClimaAnalysis.window(
-                et_var,
-                "time",
-                left = last_date - Month(11),
-                right = last_date,
-            ),
-        )
-        fig = CairoMakie.Figure(size = (600, 400))
-        attributes = Dict(
-            "units" => "",
-            "short_name" => "tf",
-            "long_name" => "Transpiration Fraction",
-        )
-        ratio = ClimaAnalysis.Var.remake(
-            et_var;
-            attributes,
-            data = t_var.data ./ (et_var.data .+ eps(eltype(et_var.data))),
-        )
-        if mask isa Nothing
-            plot!(fig, ratio, more_kwargs = plot_kwargs)
-        else
-            plot!(fig, ratio, more_kwargs = plot_kwargs, mask = mask)
-        end
-        CairoMakie.save(joinpath(savedir, "et_partition.png"), fig)
-    end
-    if "et" ∈ short_names && "precip" ∈ short_names
-        et_var = get(simdir; short_name = "et")
-        precip_var = get(simdir; short_name = "precip")
-        # Get the first and last years of the simulation for windowing
-        first_date = first(ClimaAnalysis.dates(et_var))
-        last_date = last(ClimaAnalysis.dates(et_var))
-        @assert last_date > first_date + Year(1)
-        et_var = ClimaAnalysis.average_time(
-            ClimaAnalysis.window(
-                et_var,
-                "time",
-                left = last_date - Month(11),
-                right = last_date,
-            ),
-        )
-        precip_var = ClimaAnalysis.average_time(
-            ClimaAnalysis.window(
-                precip_var,
-                "time",
-                left = last_date - Month(11),
-                right = last_date,
-            ),
-        )
-        fig = CairoMakie.Figure(size = (600, 400))
-        attributes = Dict(
-            "units" => "",
-            "short_name" => "etp",
-            "long_name" => "ET Fraction",
-        )
-        ratio = ClimaAnalysis.Var.remake(
-            lhf_var;
-            attributes,
-            data = et_var.data ./ abs.(precip_var.data),
-        )
-        if mask isa Nothing
-            plot!(fig, ratio, more_kwargs = plot_kwargs)
-        else
-            plot!(fig, ratio, more_kwargs = plot_kwargs, mask = mask)
-        end
-        CairoMakie.save(joinpath(savedir, "water_partition.png"), fig)
-    end
-
-    if "sr" ∈ short_names && "ssr" ∈ short_names
-        sr_var = get(simdir; short_name = "sr")
-        ssr_var = get(simdir; short_name = "ssr")
-        # Get the first and last years of the simulation for windowing
-        first_date = first(ClimaAnalysis.dates(sr_var))
-        last_date = last(ClimaAnalysis.dates(sr_var))
-        @assert last_date > first_date + Year(1)
-        sr_var = ClimaAnalysis.average_time(
-            ClimaAnalysis.window(
-                sr_var,
-                "time",
-                left = last_date - Month(11),
-                right = last_date,
-            ),
-        )
-        ssr_var = ClimaAnalysis.average_time(
-            ClimaAnalysis.window(
-                ssr_var,
-                "time",
-                left = last_date - Month(11),
-                right = last_date,
-            ),
-        )
-        fig = CairoMakie.Figure(size = (600, 400))
-        attributes = Dict(
-            "units" => "",
-            "short_name" => "rf",
-            "long_name" => "Surface Runoff Fraction",
-        )
-        ratio = ClimaAnalysis.Var.remake(
-            sr_var;
-            attributes,
-            data = sr_var.data ./ (sr_var.data .+ ssr_var.data),
-        )
-        if mask isa Nothing
-            plot!(fig, ratio, more_kwargs = plot_kwargs)
-        else
-            plot!(fig, ratio, more_kwargs = plot_kwargs, mask = mask)
-        end
-        CairoMakie.save(joinpath(savedir, "runoff_partition.png"), fig)
-    end
-
-    return nothing
+Return the ERA5 timeseries of `short_name` over the months spanned by `dates`,
+taken from the grid cell nearest `longlat`: a site sits within one ERA5 cell,
+and that cell is what the simulated column is being compared against.
+`compare_monthly_fluxes_with_data` reads its observations the same way.
+"""
+function _era5_at_site(data_loader, short_name, longlat, dates)
+    var = get(data_loader, short_name)
+    ClimaAnalysis.set_reference_date!(var, first(dates))
+    var = ClimaAnalysis.window(
+        var,
+        "time",
+        left = first(dates),
+        right = last(dates),
+    )
+    return ClimaAnalysis.slice(var, lat = longlat[2], lon = longlat[1]).data
 end

--- a/src/diagnostics/define_diagnostics.jl
+++ b/src/diagnostics/define_diagnostics.jl
@@ -241,8 +241,8 @@ function define_diagnostics!(land_model, possible_diags)
         short_name = "trans",
         long_name = "Canopy Transpiration",
         standard_name = "canopy_transpiration",
-        units = "m s^-1",
-        comments = "The water evaporated from the canopy due to leaf transpiration (flux of water volume, m^3 of water per m^2 of ground).",
+        units = "kg m^-2 s^-1",
+        comments = "The water evaporated from the canopy due to leaf transpiration (flux of water mass, kg of water per m^2 of ground per second).",
         compute! = (out, Y, p, t) ->
             compute_canopy_transpiration!(out, Y, p, t, land_model),
     )


### PR DESCRIPTION
closes #1833 
closes #1813 

Follows up on #1819: turns the partitioning plots into a leaderboard, adds panels to the annual leaderboards, and makes site and global runs share one plotting path.

## Partitioning leaderboard

A third leaderboard alongside ERA5 and FlagshipCarbonMetrics, with one row per fraction:

| Row | Observations |
|---|---|
| `LHF/(LHF+SHF)` | ERA5 |
| `SR/(SR+SSR)` | ERA5 |
| `ET/P` | ERA5 evaporation over the simulation's own (prescribed) precipitation |
| `T/ET` | none gridded — shown against Wei et al. (2017), 0.57 ± 0.07 |

The ERA5 artifact already contains `msror`, `mssror` and `mer`, so the first three rows get real bias maps; they are registered through a separate name list so the standard ERA5 leaderboard gains no rows. Every panel aggregates numerator and denominator before dividing: the mean of a ratio is not the ratio of the means, and a per-cell `ET/P` diverges wherever precipitation approaches zero. Replaces `create_partitioning_plots` for global runs, whose hardcoded `[:, 1:180]` obs slice only lined up at the default resolution.

## New panels on the leaderboards

All three of these are on the annual leaderboards and on the partitioning one.

- `LAT`: zonal mean of the annual mean, with a band of ±1 standard deviation along each latitude band. For a fraction the mean line still aggregates before dividing, but the band has to come from the per-cell ratios — there is no other sense in which a ratio varies along a band — which is safe because the small-denominator mask has already dropped the cells where a per-cell ratio would blow up.
- `MON`: global seasonal cycle, with a band of the spread across years. Note this is the spread of a *global average*, so a thin band means the global mean is reproducible between years, not that the field is uniform.
- `IAV`: area-weighted global annual mean, SIM vs OBS, one point per year, with the 1:1 line, the least squares fit, slope, r² and σ_sim/σ_obs. Points run blue to red with the year and the first and last are labelled in place, so a drift reads off the plot without spending a strip of the panel on a colorbar. Only years covering all twelve months count — a partial year's mean is aliased by whichever part of the seasonal cycle it sampled — and the column is drawn only for runs with more than three of them. A fraction aggregates its numerator and denominator over the year before dividing, as its other panels do.

r² and the amplitude ratio answer different questions: whether the model varies in the right years, and whether it varies by the right amount. On this run `gpp` gets r² 0.61 with σ_sim/σ_obs 0.41, so it tracks the interannual signal but damps it to 40% of observed; `er` gets 0.14 and 0.17, i.e. almost no interannual variability at all.

`SR/(SR+SSR)` is worse than either: slope −0.47, r² 0.18, amplitude ratio 1.10. The model varies its surface runoff fraction by about the right amount from year to year, but *anticorrelated* with ERA5 — which compounds the mean bias noted at the bottom of this description.

## Single-column output

Following the review suggestion in #1819: site plotting now goes through `site_timeseries`, which reads either a `DictWriter` or a `NetCDFWriter` and reports the start of each reduction period in both cases. `experiments/integrated/era5/single_site.jl` now writes NetCDF.

I did not change the `default_output_writer` default for `Column`/`Point`. In-memory output is deliberate for the site and calibration workflows, and making the plotting writer-agnostic achieves the unification without it. Happy to flip the default separately.

## Bugs fixed along the way

- `trans` was declared `m s^-1`, but `compute_canopy_transpiration!` returns a mass flux. The ratios were fine — both sides were mass fluxes — but anything dispatching on the units string would be misled.
- The `DictWriter` timestamp correction used `Month(dates[2]) - Month(dates[1])`, which returns `Month(-11)` when a run's first two outputs straddle a year boundary. It worked only because `single_site.jl` happens to start in March.
- `create_partitioning_plots` saved `fig`/`fig2` outside the block that defined them, so any run without `shf`/`lhf` hit an `UndefVarError`.
- Site `ET/P` came out negative: `precip` is stored downward-positive and the site path bypassed the `abs` in `_preprocess_sim_var`.

## Performance

`ClimaAnalysis.apply_oceanmask`, and the masks `make_lonlat_mask` builds, rebuild their mask and resample it onto the target grid on *every* call — and a leaderboard masks every monthly slice of every variable several times over (`_prepare_for_bias` alone runs three times per slice, for the sim, RMSE and bias series). Since every one of these masks NaNs cells multiplicatively, which cells are masked is the same for any field on the grid and only needs resolving once. `_resolved_mask` does that against an all-zero template on the sim grid — all-zero rather than the field itself, so a variable's own missing values are not folded into the base mask — and falls back to the original function for a field on another grid.

On 19 years of monthly output:

| Leaderboard | Before | After |
|---|---|---|
| FlagshipCarbonMetrics | 443 s | 126 s |
| ILAMB | 632 s | 121 s |
| ERA5 | 1169 s | 130 s |
| Partitioning | 108 s | 108 s (already hoisted) |
| **Total** | **~40 min** | **~8 min** |

All ten output PNGs are byte-for-byte identical before and after.

## Validation

Run against 19 years of monthly output from a snowy-land long run, across all three seasonal leaderboards plus the partitioning one. That run predates `et` being added to the LandModel short diagnostics (in #1819), so `ET/P` and `T/ET` were exercised with a synthetic `et = lhf/λ`; production long runs will have a real `et`. The single-column path was validated with a 5-month column run.

One result worth a look independently of this PR: `SR/(SR+SSR)` has a global bias of +0.244 (RMSE 0.442), peaking at 0.68 in May against ERA5's 0.41, with the zonal profile at ~0.8 where ERA5 is 0.05–0.2 across 40–70°N. The model routes far too much water to surface rather than subsurface runoff in the northern extratropics, worst at snowmelt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="6000" height="3200" alt="Partitioning_leaderboard" src="https://github.com/user-attachments/assets/38fa8eb4-bad7-477d-a15c-b96434896504" />

<img width="6000" height="3200" alt="ERA5_sim_annual_time_avg_over_all_years" src="https://github.com/user-attachments/assets/13047df6-55ae-4f80-828a-727d125594c6" />

<img width="6000" height="3200" alt="FlagshipCarbonMetrics_sim_annual_time_avg_over_all_years" src="https://github.com/user-attachments/assets/45fb64e9-4fe1-4f33-8c73-5afca959951a" />
