### PR TITLE
Add a restart test for the global land model with the P-model

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,15 @@ ClimaLand.jl Release Notes
 ========================
 main
 ----
+- ![][badge-🐛bugfix] Let `save_checkpoint`/`read_checkpoint` round-trip an `ITime`: the time
+  is written as a number of seconds together with the start date it carries, so a simulation
+  set up from a `start_date` and a `stop_date` can now be checkpointed and restarted (it
+  previously errored when saving). PR [#1836](https://github.com/CliMA/ClimaLand.jl/pull/1836)
+- ![][badge-✨feature] Add a restart test for the global land model with the P-model
+  (`test/integrated/restart.jl`), the configuration of `experiments/long_runs/snowy_land_pmodel.jl`.
+  It checks that the checkpoint round-trips the state exactly, and that restarting from it
+  reproduces an uninterrupted run — bit-for-bit once `p.snow.T_sfc`, the only lagged quantity
+  in the cache, is restored. PR [#1836](https://github.com/CliMA/ClimaLand.jl/pull/1836)
 - ![][badge-✨feature] Add a `TimeIntegratedVariable` utility for prognostic time-integrated
   variables — a running mean/sum or plain time-integral stored in `Y` and advanced by the
   time-stepper (no callback, checkpoint/restart-safe). PR [#1797](https://github.com/CliMA/ClimaLand.jl/pull/1797)

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,12 +5,12 @@ main
 - ![][badge-🐛bugfix] Let `save_checkpoint`/`read_checkpoint` round-trip an `ITime`: the time
   is written as a number of seconds together with the start date it carries, so a simulation
   set up from a `start_date` and a `stop_date` can now be checkpointed and restarted (it
-  previously errored when saving). PR [#1836](https://github.com/CliMA/ClimaLand.jl/pull/1836)
+  previously errored when saving). PR [#1839](https://github.com/CliMA/ClimaLand.jl/pull/1839)
 - ![][badge-✨feature] Add a restart test for the global land model with the P-model
   (`test/integrated/restart.jl`), the configuration of `experiments/long_runs/snowy_land_pmodel.jl`.
   It checks that the checkpoint round-trips the state exactly, and that restarting from it
   reproduces an uninterrupted run — bit-for-bit once `p.snow.T_sfc`, the only lagged quantity
-  in the cache, is restored. PR [#1836](https://github.com/CliMA/ClimaLand.jl/pull/1836)
+  in the cache, is restored. PR [#1839](https://github.com/CliMA/ClimaLand.jl/pull/1839)
 - ![][badge-✨feature] Add a `TimeIntegratedVariable` utility for prognostic time-integrated
   variables — a running mean/sum or plain time-integral stored in `Y` and advanced by the
   time-stepper (no callback, checkpoint/restart-safe). PR [#1797](https://github.com/CliMA/ClimaLand.jl/pull/1797)

--- a/docs/src/restarts.md
+++ b/docs/src/restarts.md
@@ -70,6 +70,24 @@ restart_file = ClimaLand.find_restart(output_dir)
 Y, t = ClimaLand.read_checkpoint(restart_file; model)
 ```
 
+The time is returned as an `ITime` if the checkpoint was saved with one carrying
+a start date, and as a number of seconds otherwise. Simulations built from a
+`start_date` and a `stop_date` use `ITime`s, so restarting one amounts to using
+the date of the checkpoint as the new start date:
+
+```julia
+restart_file = ClimaLand.find_restart(output_dir)
+t = ClimaLand.initial_time_from_checkpoint(restart_file; model)
+simulation = LandSimulation(
+    date(t),
+    stop_date,
+    Δt,
+    model;
+    set_ic! = (Y, p, t, model) ->
+        ClimaLand.set_initial_conditions_from_checkpoint!(Y, restart_file; model),
+)
+```
+
 ## Output Structure
 
 `ClimaLand` utilizes the `OutputPathGenerator` from `ClimaUtilities` to manage
@@ -130,3 +148,16 @@ checkpointing and updating the drivers are compatible.
     The reason why `ClimaLand` does not support these features (at the moment), is that
     updating drivers and diagnostics are implemented as callbacks. Callbacks have some
     internal memory that is not saved in the restart files.
+
+### Checkpoints and the cache
+
+Only the state `Y` is checkpointed; the cache is rebuilt from it when the
+simulation restarts. Nearly every cache variable is a function of the state and
+the time, so rebuilding it is exact, but `p.snow.T_sfc` is not: it is the initial
+guess of the snow surface temperature root find, which takes a single Newton step
+per timestep, and so carries the previous step's value in an uninterrupted run.
+
+A restarted land simulation therefore does not reproduce an uninterrupted one
+bit-for-bit. `test/integrated/restart.jl` measures the difference for a global
+simulation checkpointed three hours in: the states agree to a relative 1e-4, and
+restoring `p.snow.T_sfc` alone recovers bit-for-bit agreement.

--- a/src/shared_utilities/checkpoints.jl
+++ b/src/shared_utilities/checkpoints.jl
@@ -1,5 +1,7 @@
 import ClimaCore: Fields, InputOutput
 import ClimaUtilities
+import ClimaUtilities.TimeManager: ITime
+import Dates
 
 """
     ClimaLand.find_restart(output_dir)
@@ -89,6 +91,15 @@ function _context_from_Y(Y)
 end
 
 """
+    _epoch_attribute(t)
+
+Return the start date of `t` as a string, or `"nothing"` if `t` does not carry
+one. HDF5 attributes cannot hold a `Dates.DateTime` directly.
+"""
+_epoch_attribute(t) = "nothing"
+_epoch_attribute(t::ITime) = isnothing(t.epoch) ? "nothing" : string(t.epoch)
+
+"""
     ClimaLand.save_checkpoint(Y, t, output_dir; model = nothing, context = ClimaComms.context(Y))
 
 Save a simulation checkpoint to an HDF5 file.
@@ -106,6 +117,10 @@ specified output directory.
   to check for consistency.
 - `context` (Optional): The ClimaComms context. This is used for distributed I/O
   operations. Defaults to the context extracted from the state vector `Y` or the `model`.
+
+The time is stored as a number of seconds. If `t` is an `ITime` with a start
+date, that date is stored as well, so that `read_checkpoint` can return an
+`ITime` rather than a bare number of seconds.
 """
 function save_checkpoint(
     Y,
@@ -114,8 +129,9 @@ function save_checkpoint(
     model = nothing,
     context = isnothing(model) ? _context_from_Y(Y) : ClimaComms.context(model),
 )
-    day = floor(Int, t / (60 * 60 * 24))
-    sec = floor(Int, t % (60 * 60 * 24))
+    t_seconds = float(t)
+    day = floor(Int, t_seconds / (60 * 60 * 24))
+    sec = floor(Int, t_seconds % (60 * 60 * 24))
     output_file = joinpath(output_dir, "day$day.$sec.hdf5")
     hdfwriter = InputOutput.HDF5Writer(output_file, context)
     # If model was passed, add its hash, otherwise add nothing
@@ -123,7 +139,11 @@ function save_checkpoint(
     InputOutput.write_attributes!(
         hdfwriter,
         "/",
-        Dict("time" => t, "land_model_hash" => hash_model),
+        Dict(
+            "time" => t_seconds,
+            "epoch" => _epoch_attribute(t),
+            "land_model_hash" => hash_model,
+        ),
     )
     InputOutput.write!(hdfwriter, Y, "Y")
     Base.close(hdfwriter)
@@ -147,7 +167,9 @@ This function loads the simulation state from a previously saved checkpoint file
 
 # Returns
 - `Y`: The state vector loaded from the checkpoint file.
-- `t`: The simulation time loaded from the checkpoint file.
+- `t`: The simulation time loaded from the checkpoint file. This is an `ITime` if
+  the checkpoint was written with one carrying a start date, and a number of
+  seconds otherwise.
 """
 function read_checkpoint(
     file_path;
@@ -164,6 +186,10 @@ function read_checkpoint(
         end
     end
     t = attributes["time"]
+    epoch = get(attributes, "epoch", "nothing")
+    if epoch != "nothing"
+        t = ITime(t; epoch = Dates.DateTime(epoch))
+    end
     Base.close(hdfreader)
     return Y, t
 end

--- a/test/integrated/restart.jl
+++ b/test/integrated/restart.jl
@@ -1,0 +1,197 @@
+using Test
+import ClimaComms
+ClimaComms.@import_required_backends
+import ClimaCore
+import ClimaUtilities
+import ClimaUtilities.TimeManager: ITime, date
+import ClimaLand
+import ClimaLand.Parameters as LP
+import ClimaLand.Simulations: LandSimulation, step!
+using Dates
+
+# Integrate the global land model (soil, snow, soil CO2, inland water, and a
+# canopy which uses the P-model for photosynthesis; this is the configuration of
+# experiments/long_runs/snowy_land_pmodel.jl) for `n_steps`, saving a checkpoint
+# after `n_steps_to_checkpoint`. Then restart from that checkpoint and integrate
+# to the same final time, and compare against the uninterrupted simulation.
+FT = Float64
+context = ClimaComms.context()
+start_date = DateTime(2008, 3, 1)
+Δt = 900.0
+n_steps = 18
+# 3 hours, the interval at which `LandSimulation` updates the drivers by default.
+# The checkpoint is taken on one of those updates so that the restarted
+# simulation, whose update schedule starts at the checkpoint rather than at
+# `start_date`, sees the same forcing as the original run.
+n_steps_to_checkpoint = 12
+stop_date = start_date + Second(n_steps * Δt)
+checkpoint_date = start_date + Second(n_steps_to_checkpoint * Δt)
+t0 = ITime(0, Second(1), start_date)
+
+root_path = "land_pmodel_restart"
+output_dir = ClimaUtilities.OutputPathGenerator.generate_output_path(root_path)
+
+# A coarse version of the long run: the restart machinery does not depend on
+# resolution, and this keeps the solves cheap.
+domain = ClimaLand.Domains.global_domain(
+    FT;
+    nelements = (10, 5),
+    mask_threshold = FT(0.99),
+    context,
+)
+toml_dict = LP.create_toml_dict(FT)
+atmos, radiation = ClimaLand.prescribed_forcing_era5(
+    start_date,
+    stop_date,
+    domain.space.surface,
+    toml_dict,
+    FT;
+    use_lowres_forcing = true,
+    context,
+)
+LAI = ClimaLand.Canopy.prescribed_lai_modis(
+    domain.space.surface,
+    start_date,
+    stop_date,
+)
+model = ClimaLand.LandModel{FT}(
+    (; atmos, radiation),
+    LAI,
+    toml_dict,
+    domain,
+    Δt;
+    prognostic_land_components = (:canopy, :lake, :snow, :soil, :soilco2),
+)
+@test model.canopy.photosynthesis isa ClimaLand.Canopy.PModel
+
+set_ic! = ClimaLand.Simulations.make_set_initial_state_from_file(
+    ClimaLand.Artifacts.soil_ic_2008_50m_path(; context),
+    model;
+    enforce_constraints = true,
+)
+
+simulation = LandSimulation(
+    start_date,
+    stop_date,
+    Δt,
+    model;
+    set_ic!,
+    user_callbacks = (
+        ClimaLand.CheckpointCallback(
+            ITime(n_steps_to_checkpoint * Δt, epoch = start_date),
+            output_dir,
+            t0;
+            model,
+        ),
+    ),
+    diagnostics = nothing,
+)
+for _ in 1:n_steps_to_checkpoint
+    step!(simulation)
+end
+Y_checkpoint = deepcopy(simulation._integrator.u)
+snow_T_sfc_checkpoint = deepcopy(simulation._integrator.p.snow.T_sfc)
+for _ in 1:(n_steps - n_steps_to_checkpoint)
+    step!(simulation)
+end
+@test date(simulation._integrator.t) == stop_date
+
+restart_file = ClimaLand.find_restart(root_path)
+@test !isnothing(restart_file)
+t_restart = ClimaLand.initial_time_from_checkpoint(restart_file; model)
+@test date(t_restart) == checkpoint_date
+
+restarted_simulation() = LandSimulation(
+    date(t_restart),
+    stop_date,
+    Δt,
+    model;
+    set_ic! = (Y, p, t, model) ->
+        ClimaLand.set_initial_conditions_from_checkpoint!(
+            Y,
+            restart_file;
+            model,
+        ),
+    user_callbacks = (),
+    diagnostics = nothing,
+)
+
+"""
+    prognostic_fields(Y, prefix = "")
+
+Return the fields of the state `Y` paired with their names, e.g.
+`"soil.ϑ_l" => Y.soil.ϑ_l`.
+"""
+function prognostic_fields(Y, prefix = "")
+    fields = Pair{String, Any}[]
+    for property_name in propertynames(Y)
+        field = getproperty(Y, property_name)
+        name = isempty(prefix) ? "$property_name" : "$prefix.$property_name"
+        if field isa ClimaCore.Fields.Field
+            push!(fields, name => field)
+        else
+            append!(fields, prognostic_fields(field, name))
+        end
+    end
+    return fields
+end
+
+"""
+    compare_states(expected, actual; rtol = 0)
+
+Test that every field of the state `actual` matches `expected` to a relative
+tolerance of `rtol`, comparing the largest deviation of a field against the
+largest value it takes. With the default `rtol` the states must be identical.
+"""
+function compare_states(expected, actual; rtol = 0)
+    for ((name, expected_field), (_, actual_field)) in
+        zip(prognostic_fields(expected), prognostic_fields(actual))
+        @testset "$name" begin
+            expected_values = Array(parent(expected_field))
+            actual_values = Array(parent(actual_field))
+            @test maximum(abs.(expected_values .- actual_values)) <=
+                  rtol * maximum(abs.(expected_values))
+        end
+    end
+end
+
+restart = restarted_simulation()
+@testset "State read from the checkpoint" begin
+    compare_states(Y_checkpoint, restart._integrator.u)
+end
+
+for _ in 1:(n_steps - n_steps_to_checkpoint)
+    step!(restart)
+end
+@test date(restart._integrator.t) == stop_date
+# The state evolves after the checkpoint, so the comparisons below are not
+# satisfied trivially.
+@test Array(parent(restart._integrator.u.soil.ρe_int)) !=
+      Array(parent(Y_checkpoint.soil.ρe_int))
+
+# Only the state is checkpointed, so the restarted simulation rebuilds its cache
+# from it; the small differences that remain come entirely from the snow surface
+# temperature, see below.
+@testset "Final state after restarting" begin
+    compare_states(simulation._integrator.u, restart._integrator.u; rtol = 1e-3)
+end
+
+# `p.snow.T_sfc` is the initial guess for the snow surface temperature root find,
+# which takes a single Newton step per timestep. It is therefore lagged state
+# rather than a function of `Y` alone, and it is the only quantity in the cache
+# which is: restoring it, and nothing else, makes the restarted simulation
+# identical to the uninterrupted one.
+restart_with_snow_T_sfc = restarted_simulation()
+parent(restart_with_snow_T_sfc._integrator.p.snow.T_sfc) .=
+    parent(snow_T_sfc_checkpoint)
+for _ in 1:(n_steps - n_steps_to_checkpoint)
+    step!(restart_with_snow_T_sfc)
+end
+@testset "Final state after restarting with the snow surface temperature" begin
+    compare_states(
+        simulation._integrator.u,
+        restart_with_snow_T_sfc._integrator.u,
+    )
+end
+
+rm(root_path; recursive = true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,7 @@ end
 @safetestset "Bucket soil tests" begin
     include("standalone/Bucket/soil_bucket_tests.jl")
 end
-@safetestset "Restart tests" begin
+@safetestset "Bucket restart tests" begin
     include("standalone/Bucket/restart.jl")
 end
 
@@ -164,6 +164,9 @@ end
 end
 @safetestset "Full land" begin
     include("integrated/full_land.jl")
+end
+@safetestset "Full land restart tests" begin
+    include("integrated/restart.jl")
 end
 
 # FluxnetSimulations extension tests


### PR DESCRIPTION
We have a restart test for the bucket model, but none for the full land model. This adds one for the configuration of `experiments/long_runs/snowy_land_pmodel.jl` — soil, snow, soil CO2, inland water, and a canopy using the P-model for photosynthesis — on a global domain.

`test/integrated/restart.jl` runs the model for 18 steps at `Δt = 900 s`, checkpointing at 3 hours (a driver-update boundary, so the restarted simulation sees the same forcing), then restarts from that checkpoint and integrates to the same final time. It checks that

- the checkpoint round-trips every prognostic variable exactly, including the P-model's acclimated capacities;
- `find_restart`/`initial_time_from_checkpoint` recover the checkpoint date;
- the restarted simulation reaches the same final state as the uninterrupted one.

### Restarting a dated simulation used to error

`save_checkpoint` computed the output file name with `t / (60 * 60 * 24)`, which is undefined for an `ITime` — so any simulation set up from a `start_date` and a `stop_date` (i.e. every long run) failed at the first checkpoint. The time is now written as a number of seconds together with the start date it carries, and `read_checkpoint` rebuilds the `ITime` from the two. Checkpoints without a start date are read back as before.

### The restart is not bit-for-bit, and why

Only `Y` is checkpointed; the cache is rebuilt from it on restart. That is exact for nearly every cache variable, but not for `p.snow.T_sfc`: it is the initial guess of the snow surface temperature root find, which takes a single Newton step per timestep, so in an uninterrupted run it carries the previous step's value, while a restart reseeds it from the air temperature. Three hours into the run above, the restarted and uninterrupted states differ by a relative `1e-4` at worst (`soil.∫F_e_dt`, `canopy.energy.T`).

`p.snow.T_sfc` is the *only* such quantity: restoring it and nothing else makes the restart bit-for-bit identical. The test asserts both — the `1e-3` tolerance on a plain restart, and exact agreement once `p.snow.T_sfc` is restored — so it will catch any new lagged cache variable. `docs/src/restarts.md` documents this alongside the existing driver and diagnostic caveats.

Making restarts exact would mean checkpointing `p.snow.T_sfc` (or promoting it to prognostic state); happy to do that here or in a follow-up.

### Note on `global_box_domain`

The test uses `global_domain` (cubed sphere) rather than the `global_box_domain` of the long run: ClimaCore's HDF5 reader only understands `XPoint`/`YPoint`/`ZPoint` interval domains, so reading a checkpoint written on a lat/long box fails with `Invalid coord type LatPoint`. Restarts of the long run as currently configured would hit this — it needs a fix in ClimaCore's `InputOutput._scan_coord_type`.

### Testing

`test/integrated/restart.jl` passes (51 tests, ~2 min including compilation); `test/standalone/Bucket/restart.jl` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)