### PR TITLE
Use ClimaCalibrate v0.4.0 and ClimaAnalysis v0.5.23

### DIFF
--- a/.buildkite/Manifest-v1.12.toml
+++ b/.buildkite/Manifest-v1.12.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.5"
 manifest_format = "2.0"
-project_hash = "6ae0cd45ad2cb0a0b08a5c132eef50cb784c1c71"
+project_hash = "0ea2920b7d8e270eb765c22f105b4aa0709bb20f"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "ec6be48a85c93d995563b84bff8a86bc98df45ce"
@@ -479,9 +479,9 @@ version = "3.2.0"
 
 [[deps.ClimaAnalysis]]
 deps = ["Artifacts", "Dates", "Interpolations", "NCDatasets", "NaNStatistics", "OrderedCollections", "Reexport", "Statistics", "Unitful"]
-git-tree-sha1 = "611225df08ea210d8c7a8f17063cc4ad4de745d3"
+git-tree-sha1 = "111ecb3fdc40344be32e5c2453392dfc18861e2f"
 uuid = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
-version = "0.5.22"
+version = "0.5.23"
 weakdeps = ["GeoMakie", "Makie"]
 
     [deps.ClimaAnalysis.extensions]
@@ -489,14 +489,15 @@ weakdeps = ["GeoMakie", "Makie"]
     ClimaAnalysisMakieExt = "Makie"
 
 [[deps.ClimaCalibrate]]
-deps = ["ArnoldiMethod", "Dates", "Distributed", "EnsembleKalmanProcesses", "JLD2", "LinearAlgebra", "LinearMaps", "Logging", "OrderedCollections", "Random", "Reexport", "Statistics", "TOML", "YAML"]
-git-tree-sha1 = "70961a24ff7d6ecb527d4989ed5b267935ccb0cd"
+deps = ["ArnoldiMethod", "Dates", "Distributed", "EnsembleKalmanProcesses", "JLD2", "LinearAlgebra", "LinearMaps", "Logging", "OrderedCollections", "Reexport", "Statistics", "TOML", "YAML"]
+git-tree-sha1 = "27ced647f790d43ace5e0c7df20efad5ffb05f77"
 uuid = "4347a170-ebd6-470c-89d3-5c705c0cacc2"
-version = "0.3.1"
-weakdeps = ["ClimaAnalysis", "NaNStatistics"]
+version = "0.4.0"
+weakdeps = ["ClimaAnalysis", "Makie", "NaNStatistics"]
 
     [deps.ClimaCalibrate.extensions]
     ClimaCalibrateClimaAnalysisExt = ["ClimaAnalysis", "NaNStatistics"]
+    ClimaCalibrateMakieExt = ["Makie"]
 
 [[deps.ClimaComms]]
 deps = ["Adapt", "Logging", "LoggingExtras"]

--- a/.buildkite/Manifest.toml
+++ b/.buildkite/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.11"
 manifest_format = "2.0"
-project_hash = "9b766056b18b285771c75bda5afebf77bcb3e9e2"
+project_hash = "f14f3a09f0af98657689fc9d59c9a94f1b3d9f5f"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "ec6be48a85c93d995563b84bff8a86bc98df45ce"
@@ -476,9 +476,9 @@ version = "3.2.0"
 
 [[deps.ClimaAnalysis]]
 deps = ["Artifacts", "Dates", "Interpolations", "NCDatasets", "NaNStatistics", "OrderedCollections", "Reexport", "Statistics", "Unitful"]
-git-tree-sha1 = "611225df08ea210d8c7a8f17063cc4ad4de745d3"
+git-tree-sha1 = "111ecb3fdc40344be32e5c2453392dfc18861e2f"
 uuid = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
-version = "0.5.22"
+version = "0.5.23"
 weakdeps = ["GeoMakie", "Makie"]
 
     [deps.ClimaAnalysis.extensions]
@@ -486,14 +486,15 @@ weakdeps = ["GeoMakie", "Makie"]
     ClimaAnalysisMakieExt = "Makie"
 
 [[deps.ClimaCalibrate]]
-deps = ["ArnoldiMethod", "Dates", "Distributed", "EnsembleKalmanProcesses", "JLD2", "LinearAlgebra", "LinearMaps", "Logging", "OrderedCollections", "Random", "Reexport", "Statistics", "TOML", "YAML"]
-git-tree-sha1 = "70961a24ff7d6ecb527d4989ed5b267935ccb0cd"
+deps = ["ArnoldiMethod", "Dates", "Distributed", "EnsembleKalmanProcesses", "JLD2", "LinearAlgebra", "LinearMaps", "Logging", "OrderedCollections", "Reexport", "Statistics", "TOML", "YAML"]
+git-tree-sha1 = "27ced647f790d43ace5e0c7df20efad5ffb05f77"
 uuid = "4347a170-ebd6-470c-89d3-5c705c0cacc2"
-version = "0.3.1"
-weakdeps = ["ClimaAnalysis", "NaNStatistics"]
+version = "0.4.0"
+weakdeps = ["ClimaAnalysis", "Makie", "NaNStatistics"]
 
     [deps.ClimaCalibrate.extensions]
     ClimaCalibrateClimaAnalysisExt = ["ClimaAnalysis", "NaNStatistics"]
+    ClimaCalibrateMakieExt = ["Makie"]
 
 [[deps.ClimaComms]]
 deps = ["Adapt", "Logging", "LoggingExtras"]

--- a/.buildkite/Project.toml
+++ b/.buildkite/Project.toml
@@ -46,8 +46,8 @@ Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 
 [compat]
 CalibrateEmulateSample = "1"
-ClimaAnalysis = "0.5.22"
-ClimaCalibrate = "0.3"
+ClimaAnalysis = "0.5.23"
+ClimaCalibrate = "0.4"
 ClimaDiagnostics = "0.3.4"
 ClimaTimeSteppers = ">= 0.8.11"
 EnsembleKalmanProcesses = "2.5.0, 2.6.0, 2.7.0"

--- a/experiments/calibration/generate_observations.jl
+++ b/experiments/calibration/generate_observations.jl
@@ -65,39 +65,37 @@ function make_observation_vector(
     start_date = first(first(sample_date_ranges))
     obs_vars = preprocess_obs_vars(short_names, start_date, nelements)
 
+    # Flatten each variable into a `SampleCollection` with one sample (column)
+    # per date range. Each variable is built separately so that it can be
+    # given its own covariance scaling below.
+    sample_collections = map(obs_vars) do var
+        ClimaCalibrate.SampleBuilder.build_samples_by_times(
+            var,
+            sample_date_ranges;
+            FT = Float32,
+        )
+    end
+
     # Build per-variable covariance estimators
-    covar_estimators = Dict(
-        name => ClimaCalibrate.ObservationRecipe.ScalarCovariance(;
+    covar_estimators = map(short_names) do name
+        ClimaCalibrate.ObservationRecipe.ScalarCovariance(;
             scalar = noise_scalars[name],
             use_latitude_weights = true,
             min_cosd_lat = 0.1,
-        ) for name in short_names
-    )
-
-    observation_vector = map(sample_date_ranges) do (start_date, stop_date)
-        # Create a separate observation for each variable with its own scalar
-        per_var_obs = map(zip(short_names, obs_vars)) do (name, var)
-            ClimaCalibrate.ObservationRecipe.observation(
-                covar_estimators[name],
-                [var],
-                start_date,
-                stop_date,
-            )
-        end
-        # Combine into a single observation with block-diagonal covariance.
-        # EKP.combine_observations leaves metadata as Vector{Any}; re-type it
-        # so ClimaCalibrate's GEnsembleBuilder accepts it.
-        combined = EKP.combine_observations(per_var_obs)
-        typed_md =
-            Vector{ClimaAnalysis.Var.Metadata}(EKP.get_metadata(combined))
-        EKP.Observation(
-            EKP.get_samples(combined),
-            EKP.get_covs(combined),
-            EKP.get_inv_covs(combined),
-            EKP.get_names(combined),
-            EKP.get_indices(combined),
-            typed_md,
         )
+    end
+
+    observation_vector = map(eachindex(sample_date_ranges)) do i
+        # Create a separate observation for each variable with its own scalar,
+        # using the ith sample of each variable as the observation
+        per_var_obs = map(
+            covar_estimators,
+            sample_collections,
+        ) do estimator, collection
+            ClimaCalibrate.ObservationRecipe.observation(estimator, collection, i)
+        end
+        # Combine into a single observation with block-diagonal covariance
+        EKP.combine_observations(per_var_obs)
     end
     return observation_vector
 end
@@ -204,7 +202,6 @@ function preprocess_single_obs_var(var::OutputVar, short_name, nelements)
         by = ClimaAnalysis.Index(),
     )
 
-    var = ClimaCalibrate.ObservationRecipe.change_data_type(var, Float32)
     var.attributes["short_name"] = short_name
     return var
 end


### PR DESCRIPTION
This PR updates the calibration pipeline to use the latest release of ClimaCalibrate and ClimaAnalysis. The most notable change is to pipeline for generating observations. To generate observations, we first create a `SampleCollection` which is a matrix of samples with metadata, construct a covariance estimator, and combine all of that with an index of the samples to create an `EKP.Observation` using `ClimaCalibrate.ObservationRecipe.observation`.

See the NEWS.md of [ClimaCalibrate.jl](https://github.com/CliMA/ClimaCalibrate.jl) and [ClimaAnalysis.jl](github.com/CliMA/ClimaAnalysis.jl) for all changes.