### PR TITLE
Kd/lai climatology fix

### DIFF
--- a/src/standalone/Vegetation/biomass.jl
+++ b/src/standalone/Vegetation/biomass.jl
@@ -1,5 +1,6 @@
 import ClimaUtilities.TimeVaryingInputs:
     TimeVaryingInput, LinearInterpolation, PeriodicCalendar
+using Dates
 import ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
 import Interpolations: Constant
 import ClimaUtilities.Regridders: InterpolationsRegridder
@@ -117,7 +118,7 @@ end
 
 """
      prescribed_climatological_lai_modis(surface_space,
-                                         time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
+                                         time_interpolation_method = LinearInterpolation(PeriodicCalendar(Year(1), DateTime(2000))),
                                          regridder_type = :InterpolationsRegridder,
                                          interpolation_method = Interpolations.Constant(),
                                          context = ClimaComms.context(surface_space))
@@ -132,7 +133,9 @@ by passing interpolation_method = Interpolations.Linear().
 """
 function prescribed_climatological_lai_modis(
     surface_space,
-    time_interpolation_method = LinearInterpolation(PeriodicCalendar()),
+    time_interpolation_method = LinearInterpolation(
+        PeriodicCalendar(Year(1), DateTime(2000)),
+    ),
     regridder_type = :InterpolationsRegridder,
     interpolation_method = Interpolations.Constant(),
     context = ClimaComms.context(surface_space),


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
There is a bug in how we repeat the climatological data for LAI, found through some of @nicobartolomeo 's calibration efforts. We currently use: 
`time_interpolation_method = LinearInterpolation(PeriodicCalendar())`.

But with dates in the data of:
 2000-01-01T00:00:00
 2000-01-31T00:00:00
 2000-03-01T00:00:00
 2000-03-31T00:00:00
 2000-04-30T00:00:00
 2000-05-30T00:00:00
 2000-06-29T00:00:00
 2000-07-29T00:00:00
 2000-08-28T00:00:00
 2000-09-27T00:00:00
 2000-10-27T00:00:00
 2000-11-26T00:00:00
, i.e. a 30 day interval, the Periodic Calendar [with no arguments will equate 11/26+30 days = 12/26 as Jan 1](https://github.com/CliMA/ClimaUtilities.jl/blob/eeafbaf6df05c1cf20dfaf767fea7aacf23b7779/src/TimeVaryingInputs.jl#L105-L110). This apparently causes a shift of ~5 days per year. 

Passing in:
`time_interpolation_method = LinearInterpolation(PeriodicCalendar(Year(1), DateTime(2000)))`

seems to mostly fix the problem,though there is a still a shift each curve (2000, 2005, 2010). Is this because 2000 is a leap year?

See the plot below. Each curve should lie on top of each other (I thought) because I am evaluating the time varying object at the same ITime relative to the start of the year, and we should be repeating the 2000 data each year. Ignore the year on the x-axis. the values plotted are `0:Int(86400*365/12):365*86400` + year, where year = 2000, 2005, or 2010. 

I think I need to remake this evaluating at the same days of the year, and then the modified TVI should yield the same curve for each year - I hope!
<img width="1800" height="1800" alt="lai_tvi_bug" src="https://github.com/user-attachments/assets/d8f6fa4b-a3e5-4f8a-bedd-0beade2fe433" />



## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
