### PR TITLE
Update subseasonal IC to set canopy IC

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@ ClimaLand.jl Release Notes
 ========================
 main
 ----
-
+- ![][badge-✨feature] Change initial condition function name from set_subseasonal to set_from_era5land PR [#1858](https://github.com/CliMA/ClimaLand.jl/pull/1858)
+  
 v1.11.2
 -------
 - ![][badge-✨feature] Add a restart test for the global land model with the P-model

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@ ClimaLand.jl Release Notes
 ========================
 main
 ----
-- ![][badge-✨feature] Change initial condition function name from set_subseasonal to set_from_era5land PR [#1858](https://github.com/CliMA/ClimaLand.jl/pull/1858)
+- ![][badge-✨feature] Change initial condition function name from set_subseasonal to set_from_era5land PR[#1858](https://github.com/CliMA/ClimaLand.jl/pull/1858)
   
 v1.11.2
 -------

--- a/docs/src/APIs/Simulations.md
+++ b/docs/src/APIs/Simulations.md
@@ -9,7 +9,7 @@ ClimaLand.Simulations.LandSimulation
 ClimaLand.Simulations.step!
 ClimaLand.Simulations.solve!
 ClimaLand.Simulations.make_set_initial_state_from_file
-ClimaLand.Simulations.make_set_subseasonal_initial_conditions
+ClimaLand.Simulations. make_set_initial_state_from_era5land
 ClimaLand.Simulations.make_set_initial_state_from_atmos_and_parameters
 ClimaLand.Simulations.set_canopy_component_initial_conditions!
 ```

--- a/docs/src/APIs/Simulations.md
+++ b/docs/src/APIs/Simulations.md
@@ -9,7 +9,7 @@ ClimaLand.Simulations.LandSimulation
 ClimaLand.Simulations.step!
 ClimaLand.Simulations.solve!
 ClimaLand.Simulations.make_set_initial_state_from_file
-ClimaLand.Simulations. make_set_initial_state_from_era5land
+ClimaLand.Simulations.make_set_initial_state_from_era5land
 ClimaLand.Simulations.make_set_initial_state_from_atmos_and_parameters
 ClimaLand.Simulations.set_canopy_component_initial_conditions!
 ```

--- a/src/simulations/initial_conditions.jl
+++ b/src/simulations/initial_conditions.jl
@@ -826,12 +826,11 @@ function make_set_initial_state_from_era5land(
 )
     function set_ic!(Y, p, t, land)
         atmos = ClimaLand.get_drivers(land)[1]
-        earth_param_set = ClimaLand.get_earth_param_set(land.soil)
         if atmos isa ClimaLand.PrescribedAtmosphere
-            evaluate!(p.drivers.T, atmos.T, t0)
-            evaluate!(p.drivers.P, atmos.P, t0)
-            evaluate!(p.drivers.q, atmos.q, t0)
-            evaluate!(p.drivers.c_co2, atmos.c_co2, t0)
+            evaluate!(p.drivers.T, atmos.T, t)
+            evaluate!(p.drivers.P, atmos.P, t)
+            evaluate!(p.drivers.q, atmos.q, t)
+            evaluate!(p.drivers.c_co2, atmos.c_co2, t)
         end
         domain = ClimaLand.get_domain(land)
         surface_space = domain.space.surface

--- a/src/simulations/initial_conditions.jl
+++ b/src/simulations/initial_conditions.jl
@@ -4,7 +4,7 @@ import Interpolations
 using ClimaCore
 
 export make_set_initial_state_from_file,
-    make_set_subseasonal_initial_conditions,
+    make_set_initial_state_from_era5land,
     make_set_initial_state_from_atmos_and_parameters
 
 regridder_type = :InterpolationsRegridder
@@ -798,20 +798,23 @@ function make_set_initial_state_from_file(
 end
 
 """
-    make_set_subseasonal_initial_conditions(ic_path)
+     make_set_initial_state_from_era5land(ic_path)
 
 Creates and returns a function `set_ic!(Y,p,t,model)` which updates `Y` in place with
-the subseasonal initial conditions from the file `ic_path`.
+the initial conditions from the file `ic_path`, which is assumed to be an nc file
+using the naming convention of ERA5 Land.
 These initial conditions are analytical for some variables and read in from file for others.
 
 The input file `ic_path` is expected to contain the following variables:
 - "tsn": snow temperature
 - "swe": snow water equivalent
-- "skt": skin temperature of the land surface
 - "swvl": soil total water content
 - "stl": soil temperature
+
+It is assumed that in CoupledAtmosphere simulations that `p.drivers` has
+been updated already.
 """
-function make_set_subseasonal_initial_conditions(
+function make_set_initial_state_from_era5land(
     ic_path;
     regridder_type = :InterpolationsRegridder,
     extrapolation_bc = (
@@ -822,6 +825,14 @@ function make_set_subseasonal_initial_conditions(
     interpolation_method = Interpolations.Linear(),
 )
     function set_ic!(Y, p, t, land)
+        atmos = ClimaLand.get_drivers(land)[1]
+        earth_param_set = ClimaLand.get_earth_param_set(land.soil)
+        if atmos isa ClimaLand.PrescribedAtmosphere
+            evaluate!(p.drivers.T, atmos.T, t0)
+            evaluate!(p.drivers.P, atmos.P, t0)
+            evaluate!(p.drivers.q, atmos.q, t0)
+            evaluate!(p.drivers.c_co2, atmos.c_co2, t0)
+        end
         domain = ClimaLand.get_domain(land)
         surface_space = domain.space.surface
         subsurface_space = domain.space.subsurface
@@ -841,19 +852,28 @@ function make_set_subseasonal_initial_conditions(
             set_soilco2_SOC_from_soilgrids!(Y.soilco2.SOC)
         end
         Y.canopy.hydraulics.ϑ_l .= land.canopy.hydraulics.parameters.ν
-
+        set_canopy_component_initial_conditions!(
+            Y,
+            p,
+            land.canopy.energy,
+            land.canopy,
+        )
+        set_canopy_component_initial_conditions!(
+            Y,
+            p,
+            land.canopy.biomass,
+            land.canopy,
+        )
+        set_canopy_component_initial_conditions!(
+            Y,
+            p,
+            land.canopy.photosynthesis,
+            land.canopy,
+        )
         # Set snow T first to use in computing snow internal energy from IC file
         p.snow.T .= SpaceVaryingInput(
             ic_path,
             "tsn",
-            surface_space;
-            regridder_type,
-            regridder_kwargs = (; extrapolation_bc, interpolation_method),
-        )
-        # Set canopy temperature to skin temperature
-        Y.canopy.energy.T .= SpaceVaryingInput(
-            ic_path,
-            "skt",
             surface_space;
             regridder_type,
             regridder_kwargs = (; extrapolation_bc, interpolation_method),


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The default land model introduces additional prognostic variables which need initial conditions to be set. In advance of changing to that in the coupler, adjust the seasonal set IC function to accomodate them. Also, rename this to be more clear - set IC using ERA5Land file.

For context: if the land model saves Y, the simulation is restartable (we now have unit tests showing this). However, in many cases, it is convenient to start from a partial state - e.g. ERA5Land does not have the same prognostic variables that we do, or we only save the spun up state for the slowly adjusting variables. In this case, we need to make set IC for some of the prognostic variables. The land functions do this. A good guess for canopy temp is to use e.g. atmospheric Temp as T_canopy. For the additional prognostic Pmodel variables, it is helpful to make a good guess using the actual VPD. so we also use atmos P, q. 


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
