### PR TITLE
Use WorkerBackend for Derecho

### DIFF
--- a/experiments/calibration/README.md
+++ b/experiments/calibration/README.md
@@ -25,6 +25,12 @@ latitude-weighted scalar covariance matrix.
       submission for the forward models.
     - You may want to use `tmux` to keep a persistent session on the cluster.
 
+On Derecho, the calibration uses the `WorkerBackend`: persistent workers are
+submitted once with `ClimaCalibrate.add_workers`, packed 4 per allocation (one
+per GPU), and reused across iterations. Workers are not resubmitted if they
+hit their walltime; to continue a stopped calibration, rerun with the same
+`OUTPUT_DIR`.
+
 For example, launching er.jl on Derecho
 Go into tmux:
 
@@ -52,3 +58,9 @@ are compatible with ClimaCalibrate v0.2.2.
 - `DerechoBackend`: `climacommon/2025_02_25`
 - `CaltechHPCBackend`: `climacommon/2024_10_09`
 - `GCPBackend`: `climacommon` is not supported
+
+On Derecho, if workers repeatedly exit with "Master process (id 1) could not
+connect within 60.0 seconds", the driver could not reach the address the
+workers advertise. See `julia_worker_hsn_bind.sh` and check the logs in
+`OUTPUT_DIR/worker_logs/` (each launch writes to its own timestamped
+subdirectory).

--- a/experiments/calibration/julia_worker_hsn_bind.sh
+++ b/experiments/calibration/julia_worker_hsn_bind.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Start a Julia Distributed worker bound to the node's HSN interface.
+#
+# Why: `julia --worker` binds and advertises `getipaddr()`, which on Derecho
+# compute nodes is the management network (10.169.0.0/16). Login nodes
+# cannot reach that network, so a driver running in tmux on a login node
+# never connects and every worker exits with "Master process (id 1) could
+# not connect within 300.0 seconds". The HSN (10.14.0.0/18) is shared by
+# login and compute nodes, so binding there works for drivers on either.
+set -u
+BIND=$(ip -o -4 addr show | awk '$2 ~ /^hsn/ {print $4; exit}' | cut -d/ -f1)
+if [ -z "$BIND" ]; then
+    echo "julia_worker_hsn_bind.sh: no hsn interface found, binding default" >&2
+    exec julia "$@"
+fi
+exec julia --bind-to "$BIND" "$@"

--- a/experiments/calibration/run_calibration.jl
+++ b/experiments/calibration/run_calibration.jl
@@ -117,8 +117,6 @@ if abspath(PROGRAM_FILE) == @__FILE__
         scheduler = EKP.DataMisfitController(terminate_at = 100),
     )
 
-    # Note: Using this script on Derecho requires changes to addprocs to use
-    # the PBSManager
     curr_backend = ClimaCalibrate.get_backend()
     N_ens = EKP.get_N_ens(ekp)
 
@@ -162,12 +160,39 @@ if abspath(PROGRAM_FILE) == @__FILE__
 
     # Determine which backend to submit job scripts to
     if curr_backend == ClimaCalibrate.DerechoBackend
-        derecho_directives = [:job_priority => "regular"]
-        backend = ClimaCalibrate.DerechoBackend(;
-            directives = vcat(directives, derecho_directives),
-            modules,
-            env_vars,
+        # On Derecho, we use the WorkerBackend to use persistent workers.
+        # Furthermore, we pack 4 workers on a single node since Derecho charges
+        # on a per node basis, so a single worker on a single node costs the
+        # same as four workers on a single node.
+        exename = joinpath(
+            pkgdir(ClimaLand),
+            "experiments",
+            "calibration",
+            "julia_worker_hsn_bind.sh",
         )
+        worker_log_path = joinpath(
+            abspath(CALIBRATE_CONFIG.output_dir),
+            "worker_logs",
+            Dates.format(Dates.now(), "yyyymmdd-HHMMSS"),
+            "worker",
+        )
+        mkpath(dirname(worker_log_path))
+        # 720 minutes is 12 hours
+        walltime = 720
+        ClimaCalibrate.add_workers(
+            N_ens;
+            device = :gpu,
+            time = walltime,
+            workers_per_node = 4,
+            env = env_vars,
+            o = worker_log_path,
+            l_job_priority = "regular",
+            exename,
+        )
+        # Load the model interface on every worker
+        ClimaCalibrate.@worker_setup include($model_interface_filepath)
+        backend =
+            ClimaCalibrate.WorkerBackend(; empty_pool_timeout = walltime * 60)
     elseif curr_backend == ClimaCalibrate.GCPBackend
         gcp_directives = [:partition => "a3mega"]
         backend = ClimaCalibrate.GCPBackend(;


### PR DESCRIPTION
This PR uses the `WorkerBackend` for `Derecho` which allows for the workers to begin work when they are available and pack workers onto a single node to save GPU hours.