### PR TITLE
Fix C3/C4 blending in SIF

### DIFF
--- a/docs/src/APIs/canopy/SolarInducedFluorescence.md
+++ b/docs/src/APIs/canopy/SolarInducedFluorescence.md
@@ -16,5 +16,4 @@ ClimaLand.Canopy.Lee2015SIFModel{FT}(toml_dict::CP.ParamDict) where {FT}
 
 ```@docs
 ClimaLand.Canopy.update_SIF!
-ClimaLand.Canopy.compute_SIF_at_a_point
 ```

--- a/experiments/ilamb/ilamb_conversion.jl
+++ b/experiments/ilamb/ilamb_conversion.jl
@@ -174,9 +174,9 @@ const ILAMB_VARIABLES = Dict(
     "trans" => ILAMBMapping(
         "tran",
         "Transpiration",
-        1000.0,
+        1.0,
         "kg m-2 s-1",
-        "m s^-1",
+        "kg m^-2 s^-1",
     ),
     "precip" => ILAMBMapping(
         "pr",

--- a/src/standalone/Vegetation/Canopy.jl
+++ b/src/standalone/Vegetation/Canopy.jl
@@ -1224,8 +1224,8 @@ function ClimaLand.make_update_aux(canopy::CanopyModel)
         # Update Rd, An, Vcmax25 (if applicable to model) in place, GPP
         update_photosynthesis!(p, Y, canopy.photosynthesis, canopy)
 
-        # update SIF
-        update_SIF!(p, Y, canopy.sif, canopy)
+        # update SIF (after photosynthesis!)
+        update_SIF!(p, Y, canopy.sif, canopy.photosynthesis, canopy)
 
         # update stomatal conductance
         update_canopy_conductance!(p, Y, canopy.conductance, canopy)

--- a/src/standalone/Vegetation/photosynthesis.jl
+++ b/src/standalone/Vegetation/photosynthesis.jl
@@ -11,7 +11,6 @@ export get_Vcmax25_leaf,
     get_An_leaf,
     get_Rd_canopy,
     get_An_canopy,
-    get_J_over_Jmax,
     get_GPP,
     net_photosynthesis,
     gross_photosynthesis,
@@ -35,12 +34,6 @@ function update_photosynthesis!(
 end
 
 get_Vcmax_leaf(p, photosynthesis_model::AbstractPhotosynthesisModel) = nothing # used by solar induced fluorescence, diagnostics, autotrophic respiration
-get_J_over_Jmax(
-    Y,
-    p,
-    canopy_model,
-    photosynthesis_model::AbstractPhotosynthesisModel,
-) = nothing # used by solar induced fluorescence
 get_Rd_leaf(p, photosynthesis_model::AbstractPhotosynthesisModel) = nothing # used with autotrophic respiration and diagnostics
 get_An_leaf(p, photosynthesis_model::AbstractPhotosynthesisModel) = nothing # used with Medlyn conductance, autotrophic respiration and diagnostics
 # Farquhar photosynthesis computations which are common to multiple Photosynthesis models

--- a/src/standalone/Vegetation/photosynthesis_farquhar.jl
+++ b/src/standalone/Vegetation/photosynthesis_farquhar.jl
@@ -408,13 +408,6 @@ get_An_canopy(p, m::FarquharModel) =
     @. lazy(p.canopy.photosynthesis.An * p.canopy.biomass.area_index.leaf)
 get_GPP(p, m::FarquharModel) = p.canopy.photosynthesis.GPP
 
-function get_J_over_Jmax(Y, p, canopy, m::FarquharModel)
-    Jmax = compute_Jmax_leaf(Y, p, canopy, m) # lazy
-    J = compute_J_leaf(Y, p, canopy, m) # lazy
-    FT = eltype(canopy.earth_param_set)
-    return @. lazy(J / max(Jmax, sqrt(eps(FT))))
-end
-
 function compute_Jmax_leaf(Y, p, canopy, m::FarquharModel) # used internally to farquhar; helper function
     T_canopy = canopy_temperature(canopy.energy, canopy, Y, p)
     (; Vcmax25, ΔHJmax, To) = m.parameters

--- a/src/standalone/Vegetation/pmodel.jl
+++ b/src/standalone/Vegetation/pmodel.jl
@@ -1034,19 +1034,6 @@ get_An_leaf(p, m::PModel) = @. lazy(
 
 get_GPP(p, m::PModel) = p.canopy.photosynthesis.instantaneous.GPP
 
-function get_J_over_Jmax(Y, p, canopy, m::PModel)
-    Jmax_c3, Jmax_c4 = compute_Jmax_canopy(Y, p, canopy, m) # lazy
-    J_c3, J_c4 = compute_J_canopy(Y, p, canopy, m) # lazy
-    FT = eltype(m.constants)
-    return @. lazy(
-        blend(
-            J_c3 / max(Jmax_c3, sqrt(eps(FT))),
-            J_c4 / max(Jmax_c4, sqrt(eps(FT))),
-            m.fractional_c3,
-        ),
-    )
-end
-
 function compute_Jmax_canopy(Y, p, canopy, m::PModel) # used internally to pmodel photosynthesis as a helper function
     T_canopy = canopy_temperature(canopy.energy, canopy, Y, p)
     constants = m.constants

--- a/src/standalone/Vegetation/solar_induced_fluorescence.jl
+++ b/src/standalone/Vegetation/solar_induced_fluorescence.jl
@@ -48,19 +48,24 @@ ClimaLand.auxiliary_vars(model::Lee2015SIFModel) = (:SIF,)
 ClimaLand.auxiliary_types(model::Lee2015SIFModel{FT}) where {FT} = (FT,)
 ClimaLand.auxiliary_domain_names(::Lee2015SIFModel) = (:surface,)
 
-
-# 4 Solar Induced Fluorescence (SIF)
-
-# call function below inside photosynthesis.jl p
+Base.broadcastable(m::SIFParameters) = tuple(m)
 
 """
-    update_SIF!(p, Y, sif_model::Lee2015SIFModel, canopy)
+    update_SIF!(p, Y, sif_model::Lee2015SIFModel, photosynthesis_model::PModel, canopy)
 
-Updates observed SIF at 755 nm in W/m^2. Note that Tc is in Kelvin, and photo
-synthetic rates are in mol/m^2/s, and APAR is in PPFD.
+Updates observed SIF at 755 nm in W/m^2 assuming photosynthesis is modelled using the Pmodel.
+
+Computes a weighted sum of SIF from C4 and C3 plants using the C3 fraction per grid cell.
+
 Lee et al, 2015. Global Change Biology 21, 3469-3477, doi:10.1111/gcb.12948
 """
-function update_SIF!(p, Y, sif_model::Lee2015SIFModel, canopy)
+function update_SIF!(
+    p,
+    Y,
+    sif_model::Lee2015SIFModel,
+    photosynthesis_model::PModel,
+    canopy,
+)
     SIF = p.canopy.sif.SIF
     earth_param_set = canopy.earth_param_set
 
@@ -74,63 +79,247 @@ function update_SIF!(p, Y, sif_model::Lee2015SIFModel, canopy)
     APAR_canopy_moles = @. lazy(
         compute_APAR_canopy_moles(f_abs_par, par_d, λ_γ_PAR, c, planck_h, N_a),
     )
-
-    # Get max photosynthesis rates
     T_canopy = canopy_temperature(canopy.energy, canopy, Y, p)
-    Vcmax25_leaf = get_Vcmax25_leaf(Y, p, canopy.photosynthesis)
-    J_over_Jmax = get_J_over_Jmax(Y, p, canopy, canopy.photosynthesis)
-
     T_freeze = LP.T_freeze(earth_param_set)
     sif_parameters = sif_model.parameters
 
-    @. SIF = compute_SIF_at_a_point(
+    Vcmax25_c3 = Y.canopy.photosynthesis.acclimated.Vcmax25_c3
+    Vcmax25_c4 = Y.canopy.photosynthesis.acclimated.Vcmax25_c4
+    Jmax25_c3 = Y.canopy.photosynthesis.acclimated.Jmax25_c3
+    Jmax25_c4 = Y.canopy.photosynthesis.acclimated.Jmax25_c4
+    LAI = p.canopy.biomass.area_index.leaf;
+    fraction_c3 = photosynthesis_model.fractional_c3
+    @. SIF = compute_SIF_at_a_point_pmodel(
         APAR_canopy_moles,
         T_canopy,
-        Vcmax25_leaf,
-        J_over_Jmax,
+        Vcmax25_c3,
+        Vcmax25_c4,
+        Jmax25_c3,
+        Jmax25_c4,
+        LAI,
+        fraction_c3,
         T_freeze,
         sif_parameters,
+        photosynthesis_model.parameters,
+        photosynthesis_model.constants,
     )
 end
 
-Base.broadcastable(m::SIFParameters) = tuple(m)
+"""
+    update_SIF!(p, Y, sif_model::Lee2015SIFModel, photosynthesis_model::FarquharModel, canopy)
 
+Updates observed SIF at 755 nm in W/m^2 assuming photosynthesis is modelled using the FarquharModel.
+
+Lee et al, 2015. Global Change Biology 21, 3469-3477, doi:10.1111/gcb.12948
+"""
+function update_SIF!(
+    p,
+    Y,
+    sif_model::Lee2015SIFModel,
+    photosynthesis_model::FarquharModel,
+    canopy,
+)
+    SIF = p.canopy.sif.SIF
+    earth_param_set = canopy.earth_param_set
+
+    f_abs_par = p.canopy.radiative_transfer.par.abs
+    par_d = p.canopy.radiative_transfer.par_d
+    (; λ_γ_PAR,) = canopy.radiative_transfer.parameters
+    c = LP.light_speed(earth_param_set)
+    planck_h = LP.planck_constant(earth_param_set)
+    R = LP.gas_constant(earth_param_set)
+    N_a = LP.avogadro_constant(earth_param_set)
+    APAR_canopy_moles = @. lazy(
+        compute_APAR_canopy_moles(f_abs_par, par_d, λ_γ_PAR, c, planck_h, N_a),
+    )
+    T_canopy = canopy_temperature(canopy.energy, canopy, Y, p)
+    T_freeze = LP.T_freeze(earth_param_set)
+    sif_parameters = sif_model.parameters
+
+    Vcmax25_leaf = photosynthesis_model.parameters.Vcmax25
+    LAI = p.canopy.biomass.area_index.leaf
+
+    @. SIF = compute_SIF_at_a_point_farquhar(
+        APAR_canopy_moles,
+        T_canopy,
+        Vcmax25_leaf,
+        LAI,
+        T_freeze,
+        R,
+        sif_parameters,
+        photosynthesis_model.parameters,
+    )
+end
 
 """
-    compute_SIF_at_a_point(
+    compute_SIF_at_a_point_farquhar(
         APAR_canopy_moles::FT,
         Tc::FT,
         Vcmax25_leaf::FT,
-        J_over_Jmax::FT,
+        LAI::FT,
         T_freeze::FT,
-        sif_parameters::SIFParameters{FT},
+        R::FT,
+       sif_parameters::SIFParameters{FT},
+       photo_parameters::FarquharParameters{FT},
     ) where {FT}
     
-Computes the Solar Induced Fluorescence (SIF) at 755 nm in W/m^2 using the Lee et al. 2015 model.
-This takes as parameters `APAR` (absorbed photosynthetically active radiation, mol/m^2/s), `Tc`
-(canopy temperature, K), `Vcmax25` (maximum carboxylation rate at 25 °C, mol/m^2/s), `Jmax`
-(electron transport rate, mol/m^2/s), `J` (electron transport rate, mol/m^2/s), `T_freeze` 
-(freezing temperature, K), `sif_parameters` (SIF parameters). 
+Computes the Solar Induced Fluorescence (SIF) at 755 nm in W/m^2 using the Lee et al. 2015 model,
+assuming photosynthesis is computed using the Farquhar model. The material differences between
+the `_farquhar` and `_pmodel` implementations are that (1) for Farquhar, Vcmax25 leaf is prescribed,
+whereas for the Pmodel, Vcmax25 for the canopy is known, and (2) the PModel implementation allows
+for fractional C3 coverage in a grid cell, whereas the Farquhar parameterization only computes assuming
+a single PFT is present and hence does not need to know a fractional C3/C4 value.
+
+This takes as parameters `APAR` for the canopy (absorbed photosynthetically active radiation, mol/m^2/s), `Tc`
+(canopy temperature, K), `Vcmax25` for the leaf, (maximum carboxylation rate at 25 °C, mol/m^2/s), `LAI`, leaf area
+index, and various parameters: `T_freeze`  and `R`,  `sif_parameters`, and `photo_parameters`.
 """
-function compute_SIF_at_a_point(
+function compute_SIF_at_a_point_farquhar(
     APAR_canopy_moles::FT,
     Tc::FT,
     Vcmax25_leaf::FT,
-    J_over_Jmax::FT,
+    LAI::FT,
+    T_freeze::FT,
+    R::FT,
+    sif_parameters::SIFParameters{FT},
+    photo_parameters::FarquharParameters{FT},
+) where {FT}
+    APAR_leaf_moles = APAR_canopy_moles/max(LAI, eps(FT))
+    (; θj, ϕ, ΔHJmax, To) = photo_parameters
+    Jmax = max_electron_transport_farquhar(Vcmax25_leaf, ΔHJmax, Tc, To, R)
+    J_over_Jmax = electron_transport_farquhar(APAR_leaf_moles, Jmax, θj, ϕ)/Jmax
+    return sif_755_lee_model(
+        sif_parameters,
+        J_over_Jmax,
+        Vcmax25_leaf,
+        APAR_canopy_moles,
+        Tc,
+        T_freeze,
+    )
+end
+
+"""
+    compute_SIF_at_a_point_pmodel(
+        APAR_canopy_moles::FT,
+        Tc::FT,
+        Vcmax25_c3::FT,
+        Vcmax25_c4::FT,
+        Jmax25_c3::FT,
+        Jmax25_c4::FT,
+        LAI::FT,
+        fraction_c3::FT,
+        T_freeze::FT,
+        sif_parameters::SIFParameters{FT},
+        pmodel_parameters::PModelParameters{FT},
+        pmodel_constants::PModelConstants{FT},
+    ) where {FT}
+    
+Computes the Solar Induced Fluorescence (SIF) at 755 nm in W/m^2 using the Lee et al. 2015 model,
+assuming photosynthesis is computed using the Pmodel. The material differences between
+the `_farquhar` and `_pmodel` implementations are that (1) for Farquhar, Vcmax25 leaf is prescribed,
+whereas for the Pmodel, Vcmax25 for the canopy is known, and (2) the PModel implementation allows
+for fractional C3 coverage in a grid cell, whereas the Farquhar parameterization only computes assuming
+a single PFT is present and hence does not need to know a fractional C3/C4 value.
+
+This takes as parameters `APAR` for the canopy (absorbed photosynthetically active radiation, mol/m^2/s), `Tc`
+(canopy temperature, K), `Vcmax25` and `Jmax25` for c3 and c4 plants (canopy level),`LAI`, leaf area
+index, the C3 fraction of the grid cell, and various parameters: `T_freeze`  and `R`,  `sif_parameters`, `photo_parameters`,
+`photo_constants`.
+"""
+function compute_SIF_at_a_point_pmodel(
+    APAR_canopy_moles::FT,
+    Tc::FT,
+    Vcmax25_c3::FT,
+    Vcmax25_c4::FT,
+    Jmax25_c3::FT,
+    Jmax25_c4::FT,
+    LAI::FT,
+    fraction_c3::FT,
     T_freeze::FT,
     sif_parameters::SIFParameters{FT},
+    pmodel_parameters::PModelParameters{FT},
+    pmodel_constants::PModelConstants{FT},
+) where {FT}
+
+    ϕ0_c3 = c3_intrinsic_quantum_yield(Tc, pmodel_parameters)
+    ϕ0_c4 = c4_intrinsic_quantum_yield(Tc, pmodel_parameters)
+    inst_temp_scaling_Jmax_factor = inst_temp_scaling(
+        Tc,
+        Tc,
+        pmodel_constants.To,
+        pmodel_constants.Ha_Jmax,
+        pmodel_constants.Hd_Jmax,
+        pmodel_constants.aS_Jmax,
+        pmodel_constants.bS_Jmax,
+        pmodel_constants.R,
+    )
+    # The following Jmax and Vcmax are canopy level
+    Jmax_c3 = Jmax25_c3 * inst_temp_scaling_Jmax_factor
+    Jmax_c4 = Jmax25_c4 * inst_temp_scaling_Jmax_factor
+    J_over_Jmax_c3 =
+        electron_transport_pmodel(ϕ0_c3, APAR_canopy_moles, Jmax_c3)/max(
+            Jmax_c3,
+            eps(FT),
+        )
+    J_over_Jmax_c4 =
+        electron_transport_pmodel(ϕ0_c4, APAR_canopy_moles, Jmax_c4)/max(
+            Jmax_c4,
+            eps(FT),
+        )
+    # Lee et al 2015 formula uses leaf level Vcmax25
+    Vcmax25_leaf_c4 = Vcmax25_c4/max(LAI, eps(FT))
+    Vcmax25_leaf_c3 = Vcmax25_c3/max(LAI, eps(FT))
+    SIF_755_c3 = sif_755_lee_model(
+        sif_parameters,
+        J_over_Jmax_c3,
+        Vcmax25_leaf_c3,
+        APAR_canopy_moles,
+        Tc,
+        T_freeze,
+    )
+    SIF_755_c4 = sif_755_lee_model(
+        sif_parameters,
+        J_over_Jmax_c4,
+        Vcmax25_leaf_c4,
+        APAR_canopy_moles,
+        Tc,
+        T_freeze,
+    )
+    return SIF_755_c3*fraction_c3+(1-fraction_c3)*SIF_755_c4
+end
+
+"""
+    sif_755_lee_model(
+        sif_parameters,
+        J_over_Jmax::FT,
+        Vcmax25_leaf::FT,
+        APAR_canopy_moles::FT,
+        Tc::FT,
+        T_freeze::FT,
+        ) where {FT}
+
+Computes SIFT at 755nm according to the Lee et al 2015 paper. This employs
+a fit function to convert Vcmax25 at the leaf level to SIF at 755nm at canopy
+level.
+"""
+function sif_755_lee_model(
+    sif_parameters,
+    J_over_Jmax::FT,
+    Vcmax25_leaf::FT,
+    APAR_canopy_moles::FT,
+    Tc::FT,
+    T_freeze::FT,
 ) where {FT}
     (; kf, kd_p1, kd_p2, min_kd, kn_p1, kn_p2, kp, kappa_p1, kappa_p2) =
         sif_parameters
     kd = max(kd_p1 * (Tc - T_freeze) + kd_p2, min_kd)
+
     x = 1 - J_over_Jmax
     kn = (kn_p1 * x - kn_p2) * x
     ϕp0 = kp / max(kf + kp + kn, eps(FT))
     ϕp = J_over_Jmax * ϕp0
     ϕf = kf / max(kf + kd + kn, eps(FT)) * (1 - ϕp)
     κ = kappa_p1 * Vcmax25_leaf * FT(1e6) + kappa_p2 # formula expects Vcmax25 in μmol/m^2/s
-    F = APAR_canopy_moles * ϕf
-    SIF_755 = F / max(κ, eps(FT))
-
+    SIF_755 = APAR_canopy_moles * ϕf / max(κ, eps(FT))
     return SIF_755
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
When computing SIF using the Farquhar model, only one PFT is modelled per cell, so we do not need to worry about averaging the contributions from C3 and C4 plants (because the PFT determines if the plant is C3 or C4). For the Pmodel, this is not the case.

This PR extends how we compute SIF so that we compute the blended contribution of C3 and C4 plants correctly. This means we average SIF, and not Vcmax and J/Jmax.

I also fixed a bug in a unit (unrelated).


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
- dispatch update_SIF!() over the photosynthesis model type, necessarily this creates unique helpers for computing SIF at a point.
- bypass previous get_J_over_Jmax, get_Vcmax_leaf which internally blend quantities between c3 and c4 plants, these are now computed separately; remote J over Jmax function as no longer used
- isolate the lee et al SIF model update



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
