### PR TITLE
Fix snow residual flux

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -233,7 +233,7 @@ steps:
 
       - label: "Snow Col de Porte GPU"
         command: "julia --color=yes --project=.buildkite experiments/standalone/Snow/snowmip_simulation.jl cdp"
-        artifact_paths: "experiments/standalone/Snow/gpu/cdp/output_active/*png"
+        artifact_paths: "experiments/standalone/Snow/gpu/cdp_default_gradtemp/output_active/*png"
         agents:
           slurm_ntasks: 1
           slurm_gpus: 1

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -997,7 +997,6 @@ NVTX.@annotate function snow_boundary_fluxes!(
         P_snow * (1 - p.lake_fraction) +
         (P_liq + p.snow.turbulent_fluxes.vapor_flux - p.snow.water_runoff) *
         p.snow.snow_cover_fraction
-
     @. p.snow.liquid_water_flux =
         (
             P_liq + p.snow.turbulent_fluxes.vapor_flux * p.snow.q_l -
@@ -1015,13 +1014,10 @@ NVTX.@annotate function snow_boundary_fluxes!(
         model.parameters.earth_param_set,
     )
 
-    residual_surface_flux =
-        Snow.get_residual_surface_flux(model.parameters.surf_temp, Y, p)
     # positive fluxes are TOWARDS atmos, but R_n positive if snow absorbs energy
     @. p.snow.total_energy_flux =
         e_flux_falling_snow * (1 - p.lake_fraction) +
         (
-            residual_surface_flux +
             p.snow.turbulent_fluxes.lhf +
             p.snow.turbulent_fluxes.shf +
             p.snow.R_n - p.snow.energy_runoff - p.ground_heat_flux +

--- a/src/integrated/soil_snow_model.jl
+++ b/src/integrated/soil_snow_model.jl
@@ -384,7 +384,6 @@ NVTX.@annotate function snow_boundary_fluxes!(
         P_snow +
         (P_liq + p.snow.turbulent_fluxes.vapor_flux - p.snow.water_runoff) *
         p.snow.snow_cover_fraction
-
     @. p.snow.liquid_water_flux =
         (
             P_liq + p.snow.turbulent_fluxes.vapor_flux * p.snow.q_l -
@@ -406,7 +405,6 @@ NVTX.@annotate function snow_boundary_fluxes!(
     p.snow.total_energy_flux .=
         e_flux_falling_snow .+
         (
-            Snow.get_residual_surface_flux(model.parameters.surf_temp, Y, p) .+
             p.snow.turbulent_fluxes.lhf .+ p.snow.turbulent_fluxes.shf .+
             p.snow.R_n .- p.snow.energy_runoff .- p.ground_heat_flux .+
             e_flux_falling_rain

--- a/src/standalone/Snow/Snow.jl
+++ b/src/standalone/Snow/Snow.jl
@@ -955,8 +955,8 @@ function ClimaLand.make_update_boundary_fluxes(model::SnowModel{FT}) where {FT}
             earth_param_set,
         )
         @. p.snow.liquid_water_flux +=
-            (residual_melt_flux+p.snow.phase_change_flux) *
-            p.snow.snow_cover_fraction
+            p.snow.phase_change_flux +
+            residual_melt_flux * p.snow.snow_cover_fraction
         @. p.snow.liquid_water_flux = clip_liquid_water_flux(
             Y.snow.S_l,
             Y.snow.S,

--- a/src/standalone/Snow/Snow.jl
+++ b/src/standalone/Snow/Snow.jl
@@ -941,12 +941,15 @@ function ClimaLand.make_update_boundary_fluxes(model::SnowModel{FT}) where {FT}
             p,
             earth_param_set,
         )
-
+        _ρ_l = LP.ρ_cloud_liq(earth_param_set)
+        _LH_f0 = LP.LH_f0(earth_param_set)
+        # Energy already used for surface melt cannot also melt the bulk snow.
         @. p.snow.phase_change_flux = phase_change_flux(
             Y.snow.U,
             Y.snow.S,
             p.snow.q_l,
-            p.snow.applied_energy_flux,
+            p.snow.applied_energy_flux -
+            _ρ_l * _LH_f0 * residual_melt_flux * p.snow.snow_cover_fraction,
             model.parameters.Δt,
             model.parameters.ΔS,
             earth_param_set,

--- a/src/standalone/Snow/Snow.jl
+++ b/src/standalone/Snow/Snow.jl
@@ -934,6 +934,14 @@ function ClimaLand.make_update_boundary_fluxes(model::SnowModel{FT}) where {FT}
         )
         # We now estimate the phase change flux: if the applied energy flux is such that T > T_f on the next step, use the residual after warming to T_f to melt snow
         # This estimate uses the current S and q_l.
+        earth_param_set = model.parameters.earth_param_set
+        residual_melt_flux = get_residual_melt_flux(
+            model.parameters.surf_temp,
+            Y,
+            p,
+            earth_param_set,
+        )
+
         @. p.snow.phase_change_flux = phase_change_flux(
             Y.snow.U,
             Y.snow.S,
@@ -941,10 +949,11 @@ function ClimaLand.make_update_boundary_fluxes(model::SnowModel{FT}) where {FT}
             p.snow.applied_energy_flux,
             model.parameters.Δt,
             model.parameters.ΔS,
-            model.parameters.earth_param_set,
+            earth_param_set,
         )
         @. p.snow.liquid_water_flux +=
-            p.snow.phase_change_flux * p.snow.snow_cover_fraction
+            (residual_melt_flux+p.snow.phase_change_flux) *
+            p.snow.snow_cover_fraction
         @. p.snow.liquid_water_flux = clip_liquid_water_flux(
             Y.snow.S_l,
             Y.snow.S,

--- a/src/standalone/Snow/boundary_fluxes.jl
+++ b/src/standalone/Snow/boundary_fluxes.jl
@@ -127,7 +127,6 @@ function snow_boundary_fluxes!(
         P_snow +
         (P_liq + p.snow.turbulent_fluxes.vapor_flux - p.snow.water_runoff) *
         p.snow.snow_cover_fraction
-
     @. p.snow.liquid_water_flux =
         (
             P_liq + p.snow.turbulent_fluxes.vapor_flux * p.snow.q_l -
@@ -143,7 +142,6 @@ function snow_boundary_fluxes!(
     p.snow.total_energy_flux .=
         e_flux_falling_snow .+
         (
-            get_residual_surface_flux(model.parameters.surf_temp, Y, p) .+
             p.snow.turbulent_fluxes.lhf .+ p.snow.turbulent_fluxes.shf .+
             p.snow.R_n .- p.snow.energy_runoff .+ e_flux_falling_rain
         ) .* p.snow.snow_cover_fraction

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -506,7 +506,6 @@ function phase_change_flux(
         energy_from_q_l_and_swe(S_safe, q_l, ΔS, earth_param_set)
     Upred = U - energy_flux * Δt
     energy_excess = Upred - energy_at_T_freeze
-
     _LH_f0 = LP.LH_f0(earth_param_set)
     _ρ_liq = LP.ρ_cloud_liq(earth_param_set)
     _cp_i = LP.cp_i(earth_param_set)
@@ -978,34 +977,9 @@ function solve_for_surface_temp_at_a_point(
 end
 
 """
-    surface_residual_flux(
-        T_sfc_root::FT,
-        κ::FT,
-        ρ::FT,
-        z::FT,
-        earth_param_set
-    )
-
-Determines the residual surface energy flux to dump into the bulk energy whenever the correct surface
-temperature to satisfy Fourier's Law of Conduction at the surface is greater than T_freeze.
-"""
-function surface_residual_flux(
-    T_sfc_root::FT,
-    κ::FT,
-    ρ::FT,
-    z::FT,
-    earth_param_set,
-)::FT where {FT}
-    _T_freeze = FT(LP.T_freeze(earth_param_set))
-    d_safe = max(surface_temp_scaling_length(κ, ρ, z, earth_param_set), eps(FT))
-    return T_sfc_root > _T_freeze ? FT(-κ * (T_sfc_root - _T_freeze) / d_safe) :
-           FT(0)
-end
-
-"""
     update_surf_temp!(model::SnowModel, surf_temp::EquilibriumGradientTemperatureModel, SW_net, LW_down, Y, p, t)
 
-Updates the surface temperature variable, storing residual energy flux in p.snow.surf_residual_flux to be added to the bulk.
+Updates the surface temperature variable.
 """
 function update_surf_temp!(
     model::SnowModel,
@@ -1050,15 +1024,6 @@ function update_surf_temp!(
         surf_temp,
     )
 
-    #set residual flux using values if T_sfc > T_freeze:
-    p.snow.surf_residual_flux .= surface_residual_flux.(
-        p.snow.T_sfc,
-        p.snow.κ,
-        p.snow.ρ_snow,
-        p.snow.z_snow,
-        model.parameters.earth_param_set,
-    )
-
     #reset T_sfc accordingly:
     p.snow.T_sfc .= min.(_T_freeze, p.snow.T_sfc)
     return nothing
@@ -1086,23 +1051,50 @@ function update_surf_temp!(
 end
 
 """
-    get_residual_surface_flux(surf_temp::BulkSurfaceTemperatureModel, Y, p)
+    get_residual_melt_flux(surf_temp::BulkSurfaceTemperatureModel, Y, p)
 
-Returns any residual surface flux as defined by the surface temperature parameterization choice.
+Returns any residual melt flux as defined by the surface temperature parameterization choice.
 """
-function get_residual_surface_flux(surf_temp::BulkSurfaceTemperatureModel, Y, p)
+function get_residual_melt_flux(
+    surf_temp::BulkSurfaceTemperatureModel,
+    Y,
+    p,
+    eps,
+)
     return FTfromY(Y)(0)
 end
 
 """
-    get_residual_surface_flux(surf_temp::EquilibriumGradientTemperatureModel, Y, p)
+    get_residual_melt_flux(surf_temp::EquilibriumGradientTemperatureModel, Y, p)
 
-Returns any residual surface flux as defined by the surface temperature parameterization choice.
+Returns any residual melt flux as defined by the surface temperature parameterization choice;
+The EquilibriumGradientTemperatureModel parameterization solves for `T_sfc` satisfying
+`F_sfc(T_sfc) = (LH + SH + R_n) = -κ(T_sfc - T)/d = 0 `. In the case where the solved T_sfc is larger than
+T_freeze, we use T_freeze, and the residual of `F_sfc(T_sfc) + κ(T_sfc - T)/d` is interpreted as an 
+energy flux that goes phase change, and not changing the temperature. This function computes that 
+additional flux of liquid water.
+
+A negative value indicates increasing liquid water.
 """
-function get_residual_surface_flux(
-    surf_temp::EquilibriumGradientTemperatureModel,
+function get_residual_melt_flux(
+    surf_temp::EquilibriumGradientTemperatureModel{FT},
     Y,
     p,
-)
+    earth_param_set,
+) where {FT}
+    _LH_f0 = LP.LH_f0(earth_param_set)
+    _ρ_l = LP.ρ_cloud_liq(earth_param_set)
+    κ = p.snow.κ
+    ρ = p.snow.ρ_snow
+    z = p.snow.z_snow
+    @. p.snow.surf_residual_flux =
+        (
+            p.snow.turbulent_fluxes.lhf .+ p.snow.turbulent_fluxes.shf .+
+            p.snow.R_n +
+            κ * (p.snow.T_sfc - p.snow.T)/max(
+                surface_temp_scaling_length(κ, ρ, z, earth_param_set),
+                eps(FT),
+            )
+        )/(_LH_f0*_ρ_l)
     return p.snow.surf_residual_flux
 end

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -512,7 +512,7 @@ function phase_change_flux(
     _cp_l = LP.cp_l(earth_param_set)
     _T_ref = LP.T_0(earth_param_set)
     _T_freeze = LP.T_freeze(earth_param_set)
-    if energy_excess > 0 || (energy_excess < 0 && q_l > 0)
+    if energy_excess > 0 || (energy_excess < 0 && q_l > sqrt(eps(FT)))
         return -energy_excess / Δt / _ρ_liq /
                ((_cp_l - _cp_i) * (_T_freeze - _T_ref) + _LH_f0)
     else

--- a/test/integrated/soil_snow.jl
+++ b/test/integrated/soil_snow.jl
@@ -94,6 +94,8 @@ using Dates
     # Make sure snow boundary fluxes are zero
     @test all(parent(p.snow.total_energy_flux) .≈ 0)
     @test all(parent(p.snow.total_water_flux) .≈ 0)
+    @test all(iszero, parent(p.snow.surf_residual_flux))
+    @test all(iszero, parent(p.snow.liquid_water_flux))
     # Make sure the boundary conditions match bare soil result
     set_soil_initial_cache! = make_set_initial_cache(land_model.soil)
     p_soil_alone.bare_soil_fraction .=

--- a/test/integrated/soil_snow.jl
+++ b/test/integrated/soil_snow.jl
@@ -94,7 +94,6 @@ using Dates
     # Make sure snow boundary fluxes are zero
     @test all(parent(p.snow.total_energy_flux) .≈ 0)
     @test all(parent(p.snow.total_water_flux) .≈ 0)
-    @test all(iszero, parent(p.snow.surf_residual_flux))
     @test all(iszero, parent(p.snow.liquid_water_flux))
     # Make sure the boundary conditions match bare soil result
     set_soil_initial_cache! = make_set_initial_cache(land_model.soil)

--- a/test/standalone/Snow/parameterizations.jl
+++ b/test/standalone/Snow/parameterizations.jl
@@ -144,23 +144,6 @@ for FT in (Float32, Float64)
             param_set,
         )
         @test d1 ≈ FT(0.5)
-        resid_flux_1 = Snow.surface_residual_flux(
-            FT(250),
-            κ_surf_test,
-            ρ_surf_test,
-            FT(log(2)),
-            param_set,
-        )
-        @test resid_flux_1 == FT(0)
-        resid_flux_2 = Snow.surface_residual_flux(
-            _T_freeze + FT(2),
-            κ_surf_test,
-            ρ_surf_test,
-            FT(log(2)),
-            param_set,
-        )
-        @test resid_flux_2 ≈ FT(-4 * κ_surf_test)
-
         κ_surf_test = FT(0.08)
         ρ_surf_test = FT(500)
         T_sfc_test = FT(272)

--- a/test/standalone/Snow/snow.jl
+++ b/test/standalone/Snow/snow.jl
@@ -170,7 +170,7 @@ import ClimaLand.Parameters as LP
     @test p.snow.T_sfc == tsfc_original
     earth_param_set = model.parameters.earth_param_set
     _LH_f0 = LP.LH_f0(earth_param_set)
-    @test p.snow.surf_residual_flux ==
+    @test p.snow.surf_residual_flux ≈
           (
         p.snow.turbulent_fluxes.lhf .+ p.snow.turbulent_fluxes.shf .+
         p.snow.R_n .+
@@ -181,7 +181,7 @@ import ClimaLand.Parameters as LP
             p.snow.z_snow,
             earth_param_set,
         )
-    ) ./ (_LH_f0*_ρ_l)
+    ) ./ (_LH_f0 * _ρ_l)
 
     @test p.snow.snow_cover_fraction == @. min(
         2 * p.snow.z_snow ./ FT(0.1) / (p.snow.z_snow ./ FT(0.1) + 1),
@@ -226,7 +226,8 @@ import ClimaLand.Parameters as LP
         Y.snow.U,
         Y.snow.S,
         p.snow.q_l,
-        p.snow.applied_energy_flux,
+        p.snow.applied_energy_flux -
+        _ρ_l * _LH_f0 * p.snow.surf_residual_flux * p.snow.snow_cover_fraction,
         model.parameters.Δt,
         model.parameters.ΔS,
         model.parameters.earth_param_set,
@@ -257,7 +258,9 @@ import ClimaLand.Parameters as LP
         p.snow.water_runoff
     )
     @test dY.snow.S == net_water_fluxes
-    @test dY.snow.S_l == @. -1 * p.snow.surf_residual_flux
+    @test all(parent(p.snow.phase_change_flux) .== 0)
+    @test all(parent(dY.snow.S_l) .> 0)
+    @test dY.snow.S_l ≈ .-p.snow.surf_residual_flux
     test_dY_U =
         -1 .* p.snow.turbulent_fluxes.shf .- p.snow.turbulent_fluxes.lhf .-
         p.snow.R_n .+ p.snow.energy_runoff
@@ -336,6 +339,104 @@ import ClimaLand.Parameters as LP
         surf_temp_choice,
         Y,
         p,
-        earth_param_set,
+        model.parameters.earth_param_set,
     ) == FT(0)
+end
+
+@testset "Surface melt accounting, $FT" for FT in (Float32, Float64)
+    toml_dict = LP.create_toml_dict(FT)
+    Δt = FT(180)
+    parameters = SnowParameters(toml_dict, Δt)
+    earth_param_set = parameters.earth_param_set
+    T_freeze = LP.T_freeze(earth_param_set)
+    ρL_f = LP.ρ_cloud_liq(earth_param_set) * LP.LH_f0(earth_param_set)
+    start_date = DateTime(2005)
+    precip = TimeVaryingInput(t -> FT(0))
+    atmos = ClimaLand.PrescribedAtmosphere(
+        precip,
+        precip,
+        TimeVaryingInput(t -> FT(290)),
+        TimeVaryingInput(t -> FT(10)),
+        TimeVaryingInput(t -> FT(0.003)),
+        TimeVaryingInput(t -> FT(101325)),
+        start_date,
+        FT(3),
+        toml_dict,
+    )
+    rad = ClimaLand.PrescribedRadiativeFluxes(
+        FT,
+        TimeVaryingInput(t -> FT(300)),
+        TimeVaryingInput(t -> FT(350)),
+        start_date,
+    )
+    model = SnowModel(;
+        parameters,
+        domain = Point(; z_sfc = FT(0)),
+        boundary_conditions = Snow.AtmosDrivenSnowBC(atmos, rad),
+    )
+    Y, p, _ = ClimaLand.initialize(model)
+    dY = similar(Y)
+    set_initial_cache! = ClimaLand.make_set_initial_cache(model)
+    exp_tendency! = ClimaLand.make_compute_exp_tendency(model)
+    t = FT(0)
+
+    @testset "Isothermal melt, S=$S, q_l=$q_l" for S in (FT(0.001), FT(0.1)),
+        q_l in (FT(0), FT(0.01))
+
+        Y.snow.S .= S
+        Y.snow.S_l .= S * q_l
+        Y.snow.U .=
+            Snow.energy_from_q_l_and_swe(S, q_l, parameters.ΔS, earth_param_set)
+        set_initial_cache!(p, Y, t)
+        exp_tendency!(dY, Y, p, t)
+        @test all(parent(p.snow.T_sfc) .== T_freeze)
+        @test all(parent(p.snow.water_runoff) .== 0)
+        @test all(parent(p.snow.surf_residual_flux) .< 0)
+        @test all(parent(dY.snow.S_l) .> 0)
+        # Remove evaporation to compare the phase change with its energy supply.
+        melt_energy = @. ρL_f * (
+            dY.snow.S_l +
+            p.snow.turbulent_fluxes.vapor_flux *
+            p.snow.q_l *
+            p.snow.snow_cover_fraction
+        )
+        @test isapprox(melt_energy, dY.snow.U; rtol = FT(1e-4))
+        @test all(
+            abs.(parent(p.snow.phase_change_flux)) .<=
+            FT(1e-4) .* abs.(parent(p.snow.surf_residual_flux)),
+        )
+        S_next = @. Y.snow.S + Δt * dY.snow.S
+        S_l_next = @. Y.snow.S_l + Δt * dY.snow.S_l
+        @test all(0 .<= parent(S_l_next) .<= parent(S_next))
+    end
+
+    @testset "Snow-free column, T=$T" for T in (FT(270), T_freeze)
+        Y.snow.S .= 0
+        Y.snow.S_l .= 0
+        Y.snow.U .=
+            Snow.energy_from_T_and_swe(FT(0), T, parameters.ΔS, earth_param_set)
+        set_initial_cache!(p, Y, t)
+        exp_tendency!(dY, Y, p, t)
+        @test all(iszero, parent(dY.snow.S))
+        @test all(iszero, parent(dY.snow.U))
+        @test all(iszero, parent(dY.snow.S_l))
+        @test all(isfinite, parent(dY))
+    end
+
+    @testset "Residual melt limits" begin
+        p.snow.T_sfc .= T_freeze
+        p.snow.turbulent_fluxes.lhf .= 0
+        p.snow.turbulent_fluxes.shf .= 0
+        p.snow.z_snow .= eps(FT)^2
+        p.snow.T .= T_freeze
+        p.snow.R_n .= FT(-1000)
+        residual = Snow.get_residual_melt_flux(
+            parameters.surf_temp,
+            Y,
+            p,
+            earth_param_set,
+        )
+        @test all(isfinite, parent(residual))
+        @test all(parent(residual) .≈ FT(-1000) / ρL_f)
+    end
 end

--- a/test/standalone/Snow/snow.jl
+++ b/test/standalone/Snow/snow.jl
@@ -157,13 +157,6 @@ import ClimaLand.Parameters as LP
         model.parameters.surf_temp,
     )
 
-    leftover_flux = Snow.surface_residual_flux.(
-        tsfc_1,
-        p.snow.κ,
-        p.snow.ρ_snow,
-        p.snow.z_snow,
-        model.parameters.earth_param_set,
-    )
     #no update should occur from update_surf_temp!:
     Snow.update_surf_temp!(
         model,
@@ -175,12 +168,20 @@ import ClimaLand.Parameters as LP
         t0,
     )
     @test p.snow.T_sfc == tsfc_original
-    #There is some leftover residual flux, since diagnosed surf temp was forced to T_freeze:
-    @test all(parent(p.snow.surf_residual_flux) .≈ parent(leftover_flux))
-    @test all(
-        parent(Snow.get_residual_surface_flux(surf_temp_choice, Y, p)) .==
-        parent(p.snow.surf_residual_flux),
-    )
+    earth_param_set = model.parameters.earth_param_set
+    _LH_f0 = LP.LH_f0(earth_param_set)
+    @test p.snow.surf_residual_flux ==
+          (
+        p.snow.turbulent_fluxes.lhf .+ p.snow.turbulent_fluxes.shf .+
+        p.snow.R_n .+
+        p.snow.κ .* (p.snow.T_sfc .- p.snow.T) ./
+        ClimaLand.Snow.surface_temp_scaling_length.(
+            p.snow.κ,
+            p.snow.ρ_snow,
+            p.snow.z_snow,
+            earth_param_set,
+        )
+    ) ./ (_LH_f0*_ρ_l)
 
     @test p.snow.snow_cover_fraction == @. min(
         2 * p.snow.z_snow ./ FT(0.1) / (p.snow.z_snow ./ FT(0.1) + 1),
@@ -256,10 +257,9 @@ import ClimaLand.Parameters as LP
         p.snow.water_runoff
     )
     @test dY.snow.S == net_water_fluxes
-    @test dY.snow.S_l == @. -Y.snow.S_l / model.parameters.Δt # refreezes
+    @test dY.snow.S_l == @. -1 * p.snow.surf_residual_flux
     test_dY_U =
-        -1 .* Snow.get_residual_surface_flux(model.parameters.surf_temp, Y, p) .-
-        p.snow.turbulent_fluxes.shf .- p.snow.turbulent_fluxes.lhf .-
+        -1 .* p.snow.turbulent_fluxes.shf .- p.snow.turbulent_fluxes.lhf .-
         p.snow.R_n .+ p.snow.energy_runoff
     @test all(parent(dY.snow.U) .≈ parent(test_dY_U))
     @test isnothing(
@@ -332,5 +332,10 @@ import ClimaLand.Parameters as LP
     set_initial_cache!(p, Y, t0)
     # Check if aux update occurred correctly
     @test all(parent(p.snow.T_sfc) .== parent(p.snow.T))
-    @test Snow.get_residual_surface_flux(surf_temp_choice, Y, p) == FT(0)
+    @test Snow.get_residual_melt_flux(
+        surf_temp_choice,
+        Y,
+        p,
+        earth_param_set,
+    ) == FT(0)
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
I realized when revamping the conservation PR that the "residual" snow energy flux had been implemented incorrectly, and this PR fixes it (I think). Previously, we had solved for T_sfc as the root of the flux balance equation
`F(T) - G(T) = 0`, where `F = LH + SH + R_n`, and `G` is a conductive flux between the surface and the bulk temp. 
If the root was T >T_freeze, we clipped T_sfc = T_freeze. We then computed an additional energy flux which accounts for this as `FT(-κ * (T_sfc_root - _T_freeze) / d)` which would be the energy required to bring a layer of temperature T_sfc_root and layer thickness `d` back to `T_freeze`. 

This views the surface warming as first bringing the temp to T_sfc_root (to satisfy the equation) and then "cooling" it back to T_freeze, where the additional cooling flux has to come from the bulk snowpack.

But this odd because that makes the BC for the bulk snow:
`F(T_freeze) -κ * (T_sfc_root - _T_freeze) / d`

but where does this extra energy come from? the atmosphere does not see this flux. I think what actually happens is that our thin layer has a temperature at T_freeze (maximum) and any excess warming goes towards melting water. I tried to explain this below...

Long run: https://buildkite.com/clima/climaland-long-runs/builds/4997


## Content
To recap, we parameterize the snow surface temperature by solving for the root of the equation:
F(T) - G(T) = 0, where F = LH + SH + R_n, and G is a conductive flux between the surface and the bulk temp. This approaches arises from considering a two layer snow model, where the top layer is very thin. then for the two prognostic energy equations, we have:
(1) `d(U_top)/dt = (F(T) - G(T))`
(2) `d(U_bottom)/dt = (G(T)- G_soil)`
where `G_soil` is the ground heat flux. `U_top` and `U_bottom` are the energy per unit (horizontal) area of the top and bottom layers, i.e. the thickness has already been factored in, so the total energy is `U = U_top +U_bottom`. In total, then, we have
(3) `dU/dt = (F(T)- G_soil)`, which is what we solve.

Assuming the thermal inertia of the top layer is very small, it equilibrates quickly (on timescales shorter than our timestep), so we advance `U_top(t+dt) = U_top(T(t+dt), q_l)` where `q_l` is the liquid fraction of the top layer, and `T(t+dt)` is the root of the flux balance equation above. (U_top still changes each step, even though equation (1) looks like the tendency would be zero).

The issue is when the solved root is larger than `T_freeze`. this is not physical. In reality, the temperature would stay at `T_freeze` while the top layer melted. In this case, we set `T(t+dt) = T_freeze`. And we should get `U_top(t+dt) = U_top(T_freeze, q_l(t+dt))`, now the snow water in the top layer has melted so q_l increases. The amount of water melting as a flux is given by `(F(T_freeze) - G(T_freeze))/LH`, where `LH` is the latent heat of fusion. This can be used to increase the liquid water of the entire snowpack:
(4) `dq_l/dt = (F(T_freeze) - G(T_freeze))/LH*S`, where S is the snow water equivalent.
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
