### PR TITLE
Fix snow melt double counting and snow-free NaNs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@ ClimaLand.jl Release Notes
 ========================
 main
 ----
+- ![][badge-🐛bugfix] Count snow surface melt only once in the liquid-water
+  budget and keep residual melt finite in snow-free columns and zero below freezing.
 - Update compat to ClimaCore v0.16 PR[#1869](https://github.com/CliMA/ClimaLand.jl/pull/1869)
 
 v1.12.0

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -997,11 +997,17 @@ NVTX.@annotate function snow_boundary_fluxes!(
         P_snow * (1 - p.lake_fraction) +
         (P_liq + p.snow.turbulent_fluxes.vapor_flux - p.snow.water_runoff) *
         p.snow.snow_cover_fraction
+    residual_melt_flux = Snow.get_residual_melt_flux(
+        model.parameters.surf_temp,
+        Y,
+        p,
+        model.parameters.earth_param_set,
+    )
 
     @. p.snow.liquid_water_flux =
         (
             P_liq + p.snow.turbulent_fluxes.vapor_flux * p.snow.q_l -
-            p.snow.water_runoff
+            p.snow.water_runoff + residual_melt_flux
         ) * p.snow.snow_cover_fraction
 
     e_flux_falling_snow = Snow.energy_flux_falling_snow(
@@ -1015,13 +1021,10 @@ NVTX.@annotate function snow_boundary_fluxes!(
         model.parameters.earth_param_set,
     )
 
-    residual_surface_flux =
-        Snow.get_residual_surface_flux(model.parameters.surf_temp, Y, p)
     # positive fluxes are TOWARDS atmos, but R_n positive if snow absorbs energy
     @. p.snow.total_energy_flux =
         e_flux_falling_snow * (1 - p.lake_fraction) +
         (
-            residual_surface_flux +
             p.snow.turbulent_fluxes.lhf +
             p.snow.turbulent_fluxes.shf +
             p.snow.R_n - p.snow.energy_runoff - p.ground_heat_flux +

--- a/src/integrated/land.jl
+++ b/src/integrated/land.jl
@@ -997,17 +997,10 @@ NVTX.@annotate function snow_boundary_fluxes!(
         P_snow * (1 - p.lake_fraction) +
         (P_liq + p.snow.turbulent_fluxes.vapor_flux - p.snow.water_runoff) *
         p.snow.snow_cover_fraction
-    residual_melt_flux = Snow.get_residual_melt_flux(
-        model.parameters.surf_temp,
-        Y,
-        p,
-        model.parameters.earth_param_set,
-    )
-
     @. p.snow.liquid_water_flux =
         (
             P_liq + p.snow.turbulent_fluxes.vapor_flux * p.snow.q_l -
-            p.snow.water_runoff + residual_melt_flux
+            p.snow.water_runoff
         ) * p.snow.snow_cover_fraction
 
     e_flux_falling_snow = Snow.energy_flux_falling_snow(

--- a/src/integrated/soil_snow_model.jl
+++ b/src/integrated/soil_snow_model.jl
@@ -384,11 +384,16 @@ NVTX.@annotate function snow_boundary_fluxes!(
         P_snow +
         (P_liq + p.snow.turbulent_fluxes.vapor_flux - p.snow.water_runoff) *
         p.snow.snow_cover_fraction
-
+    residual_melt_flux = Snow.get_residual_melt_flux(
+        model.parameters.surf_temp,
+        Y,
+        p,
+        model.parameters.earth_param_set,
+    )
     @. p.snow.liquid_water_flux =
         (
             P_liq + p.snow.turbulent_fluxes.vapor_flux * p.snow.q_l -
-            p.snow.water_runoff
+            p.snow.water_runoff + residual_melt_flux
         ) * p.snow.snow_cover_fraction
 
     e_flux_falling_snow = Snow.energy_flux_falling_snow(
@@ -406,7 +411,6 @@ NVTX.@annotate function snow_boundary_fluxes!(
     p.snow.total_energy_flux .=
         e_flux_falling_snow .+
         (
-            Snow.get_residual_surface_flux(model.parameters.surf_temp, Y, p) .+
             p.snow.turbulent_fluxes.lhf .+ p.snow.turbulent_fluxes.shf .+
             p.snow.R_n .- p.snow.energy_runoff .- p.ground_heat_flux .+
             e_flux_falling_rain

--- a/src/integrated/soil_snow_model.jl
+++ b/src/integrated/soil_snow_model.jl
@@ -384,16 +384,10 @@ NVTX.@annotate function snow_boundary_fluxes!(
         P_snow +
         (P_liq + p.snow.turbulent_fluxes.vapor_flux - p.snow.water_runoff) *
         p.snow.snow_cover_fraction
-    residual_melt_flux = Snow.get_residual_melt_flux(
-        model.parameters.surf_temp,
-        Y,
-        p,
-        model.parameters.earth_param_set,
-    )
     @. p.snow.liquid_water_flux =
         (
             P_liq + p.snow.turbulent_fluxes.vapor_flux * p.snow.q_l -
-            p.snow.water_runoff + residual_melt_flux
+            p.snow.water_runoff
         ) * p.snow.snow_cover_fraction
 
     e_flux_falling_snow = Snow.energy_flux_falling_snow(

--- a/src/standalone/Snow/Snow.jl
+++ b/src/standalone/Snow/Snow.jl
@@ -932,19 +932,28 @@ function ClimaLand.make_update_boundary_fluxes(model::SnowModel{FT}) where {FT}
             p.snow.total_water_flux,
             model.parameters.Δt,
         )
-        # We now estimate the phase change flux: if the applied energy flux is such that T > T_f on the next step, use the residual after warming to T_f to melt snow
-        # This estimate uses the current S and q_l.
+        earth_param_set = model.parameters.earth_param_set
+        residual_melt_flux = get_residual_melt_flux(
+            model.parameters.surf_temp,
+            Y,
+            p,
+            earth_param_set,
+        )
+        ρL_f = LP.ρ_cloud_liq(earth_param_set) * LP.LH_f0(earth_param_set)
+        # Energy already used for surface melt cannot also melt the bulk snow.
         @. p.snow.phase_change_flux = phase_change_flux(
             Y.snow.U,
             Y.snow.S,
             p.snow.q_l,
-            p.snow.applied_energy_flux,
+            p.snow.applied_energy_flux -
+            ρL_f * residual_melt_flux * p.snow.snow_cover_fraction,
             model.parameters.Δt,
             model.parameters.ΔS,
             model.parameters.earth_param_set,
         )
         @. p.snow.liquid_water_flux +=
-            p.snow.phase_change_flux * p.snow.snow_cover_fraction
+            (residual_melt_flux + p.snow.phase_change_flux) *
+            p.snow.snow_cover_fraction
         @. p.snow.liquid_water_flux = clip_liquid_water_flux(
             Y.snow.S_l,
             Y.snow.S,

--- a/src/standalone/Snow/boundary_fluxes.jl
+++ b/src/standalone/Snow/boundary_fluxes.jl
@@ -127,17 +127,10 @@ function snow_boundary_fluxes!(
         P_snow +
         (P_liq + p.snow.turbulent_fluxes.vapor_flux - p.snow.water_runoff) *
         p.snow.snow_cover_fraction
-    residual_melt_flux = get_residual_melt_flux(
-        model.parameters.surf_temp,
-        Y,
-        p,
-        model.parameters.earth_param_set,
-    )
-
     @. p.snow.liquid_water_flux =
         (
             P_liq + p.snow.turbulent_fluxes.vapor_flux * p.snow.q_l -
-            p.snow.water_runoff + residual_melt_flux
+            p.snow.water_runoff
         ) * p.snow.snow_cover_fraction
 
     e_flux_falling_snow =

--- a/src/standalone/Snow/boundary_fluxes.jl
+++ b/src/standalone/Snow/boundary_fluxes.jl
@@ -127,11 +127,17 @@ function snow_boundary_fluxes!(
         P_snow +
         (P_liq + p.snow.turbulent_fluxes.vapor_flux - p.snow.water_runoff) *
         p.snow.snow_cover_fraction
+    residual_melt_flux = get_residual_melt_flux(
+        model.parameters.surf_temp,
+        Y,
+        p,
+        model.parameters.earth_param_set,
+    )
 
     @. p.snow.liquid_water_flux =
         (
             P_liq + p.snow.turbulent_fluxes.vapor_flux * p.snow.q_l -
-            p.snow.water_runoff
+            p.snow.water_runoff + residual_melt_flux
         ) * p.snow.snow_cover_fraction
 
     e_flux_falling_snow =
@@ -143,7 +149,6 @@ function snow_boundary_fluxes!(
     p.snow.total_energy_flux .=
         e_flux_falling_snow .+
         (
-            get_residual_surface_flux(model.parameters.surf_temp, Y, p) .+
             p.snow.turbulent_fluxes.lhf .+ p.snow.turbulent_fluxes.shf .+
             p.snow.R_n .- p.snow.energy_runoff .+ e_flux_falling_rain
         ) .* p.snow.snow_cover_fraction

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -1051,7 +1051,7 @@ function update_surf_temp!(
 end
 
 """
-    get_residual_melt_flux(surf_temp::BulkSurfaceTemperatureModel, Y, p)
+    get_residual_melt_flux(surf_temp::BulkSurfaceTemperatureModel, Y, p, earth_param_set)
 
 Returns any residual melt flux as defined by the surface temperature parameterization choice.
 """
@@ -1059,22 +1059,23 @@ function get_residual_melt_flux(
     surf_temp::BulkSurfaceTemperatureModel,
     Y,
     p,
-    eps,
+    earth_param_set,
 )
     return FTfromY(Y)(0)
 end
 
 """
-    get_residual_melt_flux(surf_temp::EquilibriumGradientTemperatureModel, Y, p)
+    get_residual_melt_flux(surf_temp::EquilibriumGradientTemperatureModel, Y, p, earth_param_set)
 
 Returns any residual melt flux as defined by the surface temperature parameterization choice;
 The EquilibriumGradientTemperatureModel parameterization solves for `T_sfc` satisfying
-`F_sfc(T_sfc) = (LH + SH + R_n) = -κ(T_sfc - T)/d = 0 `. In the case where the solved T_sfc is larger than
-T_freeze, we use T_freeze, and the residual of `F_sfc(T_sfc) + κ(T_sfc - T)/d` is interpreted as an 
-energy flux that goes phase change, and not changing the temperature. This function computes that 
-additional flux of liquid water.
+`F_sfc(T_sfc) + κ(T_sfc - T)/d = 0`, where `F_sfc = LH + SH + R_n`.
+When the surface temperature is capped at T_freeze, any excess surface heating
+goes to phase change. This function stores the corresponding liquid water flux
+in `p.snow.surf_residual_flux` [m/s], per unit snow-covered area.
 
-A negative value indicates increasing liquid water.
+A negative value indicates increasing liquid water. The flux is zero for
+snow-free columns and surfaces below freezing.
 """
 function get_residual_melt_flux(
     surf_temp::EquilibriumGradientTemperatureModel,
@@ -1082,21 +1083,28 @@ function get_residual_melt_flux(
     p,
     earth_param_set,
 )
+    FT = FTfromY(Y)
     _LH_f0 = LP.LH_f0(earth_param_set)
     _ρ_l = LP.ρ_cloud_liq(earth_param_set)
+    _T_freeze = LP.T_freeze(earth_param_set)
     κ = p.snow.κ
     ρ = p.snow.ρ_snow
     z = p.snow.z_snow
-    @. p.snow.surf_residual_flux =
-        (
-            p.snow.turbulent_fluxes.lhf .+ p.snow.turbulent_fluxes.shf .+
-            p.snow.R_n +
-            κ * (p.snow.T_sfc - p.snow.T)/surface_temp_scaling_length(
-                κ,
-                ρ,
-                z,
-                earth_param_set,
-            )
-        )/(_LH_f0*_ρ_l)
+    @. p.snow.surf_residual_flux = ifelse(
+        (z > 0) & (p.snow.T_sfc >= _T_freeze),
+        min(
+            (
+                p.snow.turbulent_fluxes.lhf +
+                p.snow.turbulent_fluxes.shf +
+                p.snow.R_n +
+                κ * (p.snow.T_sfc - p.snow.T) / max(
+                    surface_temp_scaling_length(κ, ρ, z, earth_param_set),
+                    eps(FT),
+                )
+            ) / (_LH_f0 * _ρ_l),
+            FT(0),
+        ),
+        FT(0),
+    )
     return p.snow.surf_residual_flux
 end

--- a/src/standalone/Snow/snow_parameterizations.jl
+++ b/src/standalone/Snow/snow_parameterizations.jl
@@ -506,7 +506,6 @@ function phase_change_flux(
         energy_from_q_l_and_swe(S_safe, q_l, ΔS, earth_param_set)
     Upred = U - energy_flux * Δt
     energy_excess = Upred - energy_at_T_freeze
-
     _LH_f0 = LP.LH_f0(earth_param_set)
     _ρ_liq = LP.ρ_cloud_liq(earth_param_set)
     _cp_i = LP.cp_i(earth_param_set)
@@ -978,34 +977,9 @@ function solve_for_surface_temp_at_a_point(
 end
 
 """
-    surface_residual_flux(
-        T_sfc_root::FT,
-        κ::FT,
-        ρ::FT,
-        z::FT,
-        earth_param_set
-    )
-
-Determines the residual surface energy flux to dump into the bulk energy whenever the correct surface
-temperature to satisfy Fourier's Law of Conduction at the surface is greater than T_freeze.
-"""
-function surface_residual_flux(
-    T_sfc_root::FT,
-    κ::FT,
-    ρ::FT,
-    z::FT,
-    earth_param_set,
-)::FT where {FT}
-    _T_freeze = FT(LP.T_freeze(earth_param_set))
-    d_safe = max(surface_temp_scaling_length(κ, ρ, z, earth_param_set), eps(FT))
-    return T_sfc_root > _T_freeze ? FT(-κ * (T_sfc_root - _T_freeze) / d_safe) :
-           FT(0)
-end
-
-"""
     update_surf_temp!(model::SnowModel, surf_temp::EquilibriumGradientTemperatureModel, SW_net, LW_down, Y, p, t)
 
-Updates the surface temperature variable, storing residual energy flux in p.snow.surf_residual_flux to be added to the bulk.
+Updates the surface temperature variable.
 """
 function update_surf_temp!(
     model::SnowModel,
@@ -1050,15 +1024,6 @@ function update_surf_temp!(
         surf_temp,
     )
 
-    #set residual flux using values if T_sfc > T_freeze:
-    p.snow.surf_residual_flux .= surface_residual_flux.(
-        p.snow.T_sfc,
-        p.snow.κ,
-        p.snow.ρ_snow,
-        p.snow.z_snow,
-        model.parameters.earth_param_set,
-    )
-
     #reset T_sfc accordingly:
     p.snow.T_sfc .= min.(_T_freeze, p.snow.T_sfc)
     return nothing
@@ -1086,23 +1051,52 @@ function update_surf_temp!(
 end
 
 """
-    get_residual_surface_flux(surf_temp::BulkSurfaceTemperatureModel, Y, p)
+    get_residual_melt_flux(surf_temp::BulkSurfaceTemperatureModel, Y, p)
 
-Returns any residual surface flux as defined by the surface temperature parameterization choice.
+Returns any residual melt flux as defined by the surface temperature parameterization choice.
 """
-function get_residual_surface_flux(surf_temp::BulkSurfaceTemperatureModel, Y, p)
+function get_residual_melt_flux(
+    surf_temp::BulkSurfaceTemperatureModel,
+    Y,
+    p,
+    eps,
+)
     return FTfromY(Y)(0)
 end
 
 """
-    get_residual_surface_flux(surf_temp::EquilibriumGradientTemperatureModel, Y, p)
+    get_residual_melt_flux(surf_temp::EquilibriumGradientTemperatureModel, Y, p)
 
-Returns any residual surface flux as defined by the surface temperature parameterization choice.
+Returns any residual melt flux as defined by the surface temperature parameterization choice;
+The EquilibriumGradientTemperatureModel parameterization solves for `T_sfc` satisfying
+`F_sfc(T_sfc) = (LH + SH + R_n) = -κ(T_sfc - T)/d = 0 `. In the case where the solved T_sfc is larger than
+T_freeze, we use T_freeze, and the residual of `F_sfc(T_sfc) + κ(T_sfc - T)/d` is interpreted as an 
+energy flux that goes phase change, and not changing the temperature. This function computes that 
+additional flux of liquid water.
+
+A negative value indicates increasing liquid water.
 """
-function get_residual_surface_flux(
+function get_residual_melt_flux(
     surf_temp::EquilibriumGradientTemperatureModel,
     Y,
     p,
+    earth_param_set,
 )
+    _LH_f0 = LP.LH_f0(earth_param_set)
+    _ρ_l = LP.ρ_cloud_liq(earth_param_set)
+    κ = p.snow.κ
+    ρ = p.snow.ρ_snow
+    z = p.snow.z_snow
+    @. p.snow.surf_residual_flux =
+        (
+            p.snow.turbulent_fluxes.lhf .+ p.snow.turbulent_fluxes.shf .+
+            p.snow.R_n +
+            κ * (p.snow.T_sfc - p.snow.T)/surface_temp_scaling_length(
+                κ,
+                ρ,
+                z,
+                earth_param_set,
+            )
+        )/(_LH_f0*_ρ_l)
     return p.snow.surf_residual_flux
 end

--- a/test/integrated/soil_snow.jl
+++ b/test/integrated/soil_snow.jl
@@ -94,6 +94,8 @@ using Dates
     # Make sure snow boundary fluxes are zero
     @test all(parent(p.snow.total_energy_flux) .≈ 0)
     @test all(parent(p.snow.total_water_flux) .≈ 0)
+    @test all(iszero, parent(p.snow.surf_residual_flux))
+    @test all(iszero, parent(p.snow.liquid_water_flux))
     # Make sure the boundary conditions match bare soil result
     set_soil_initial_cache! = make_set_initial_cache(land_model.soil)
     p_soil_alone.bare_soil_fraction .=

--- a/test/standalone/Snow/parameterizations.jl
+++ b/test/standalone/Snow/parameterizations.jl
@@ -144,23 +144,6 @@ for FT in (Float32, Float64)
             param_set,
         )
         @test d1 ≈ FT(0.5)
-        resid_flux_1 = Snow.surface_residual_flux(
-            FT(250),
-            κ_surf_test,
-            ρ_surf_test,
-            FT(log(2)),
-            param_set,
-        )
-        @test resid_flux_1 == FT(0)
-        resid_flux_2 = Snow.surface_residual_flux(
-            _T_freeze + FT(2),
-            κ_surf_test,
-            ρ_surf_test,
-            FT(log(2)),
-            param_set,
-        )
-        @test resid_flux_2 ≈ FT(-4 * κ_surf_test)
-
         κ_surf_test = FT(0.08)
         ρ_surf_test = FT(500)
         T_sfc_test = FT(272)

--- a/test/standalone/Snow/snow.jl
+++ b/test/standalone/Snow/snow.jl
@@ -157,13 +157,6 @@ import ClimaLand.Parameters as LP
         model.parameters.surf_temp,
     )
 
-    leftover_flux = Snow.surface_residual_flux.(
-        tsfc_1,
-        p.snow.κ,
-        p.snow.ρ_snow,
-        p.snow.z_snow,
-        model.parameters.earth_param_set,
-    )
     #no update should occur from update_surf_temp!:
     Snow.update_surf_temp!(
         model,
@@ -175,12 +168,20 @@ import ClimaLand.Parameters as LP
         t0,
     )
     @test p.snow.T_sfc == tsfc_original
-    #There is some leftover residual flux, since diagnosed surf temp was forced to T_freeze:
-    @test all(parent(p.snow.surf_residual_flux) .≈ parent(leftover_flux))
-    @test all(
-        parent(Snow.get_residual_surface_flux(surf_temp_choice, Y, p)) .==
-        parent(p.snow.surf_residual_flux),
-    )
+    earth_param_set = model.parameters.earth_param_set
+    _LH_f0 = LP.LH_f0(earth_param_set)
+    @test p.snow.surf_residual_flux ==
+          (
+        p.snow.turbulent_fluxes.lhf .+ p.snow.turbulent_fluxes.shf .+
+        p.snow.R_n .+
+        p.snow.κ .* (p.snow.T_sfc .- p.snow.T) ./
+        ClimaLand.Snow.surface_temp_scaling_length.(
+            p.snow.κ,
+            p.snow.ρ_snow,
+            p.snow.z_snow,
+            earth_param_set,
+        )
+    ) ./ (_LH_f0*_ρ_l)
 
     @test p.snow.snow_cover_fraction == @. min(
         2 * p.snow.z_snow ./ FT(0.1) / (p.snow.z_snow ./ FT(0.1) + 1),
@@ -258,8 +259,7 @@ import ClimaLand.Parameters as LP
     @test dY.snow.S == net_water_fluxes
     @test dY.snow.S_l == @. -Y.snow.S_l / model.parameters.Δt # refreezes
     test_dY_U =
-        -1 .* Snow.get_residual_surface_flux(model.parameters.surf_temp, Y, p) .-
-        p.snow.turbulent_fluxes.shf .- p.snow.turbulent_fluxes.lhf .-
+        -1 .* p.snow.turbulent_fluxes.shf .- p.snow.turbulent_fluxes.lhf .-
         p.snow.R_n .+ p.snow.energy_runoff
     @test all(parent(dY.snow.U) .≈ parent(test_dY_U))
     @test isnothing(
@@ -332,5 +332,5 @@ import ClimaLand.Parameters as LP
     set_initial_cache!(p, Y, t0)
     # Check if aux update occurred correctly
     @test all(parent(p.snow.T_sfc) .== parent(p.snow.T))
-    @test Snow.get_residual_surface_flux(surf_temp_choice, Y, p) == FT(0)
+    @test Snow.get_residual_melt_flux(surf_temp_choice, Y, p) == FT(0)
 end

--- a/test/standalone/Snow/snow.jl
+++ b/test/standalone/Snow/snow.jl
@@ -170,7 +170,7 @@ import ClimaLand.Parameters as LP
     @test p.snow.T_sfc == tsfc_original
     earth_param_set = model.parameters.earth_param_set
     _LH_f0 = LP.LH_f0(earth_param_set)
-    @test p.snow.surf_residual_flux ==
+    @test p.snow.surf_residual_flux ≈
           (
         p.snow.turbulent_fluxes.lhf .+ p.snow.turbulent_fluxes.shf .+
         p.snow.R_n .+
@@ -181,7 +181,7 @@ import ClimaLand.Parameters as LP
             p.snow.z_snow,
             earth_param_set,
         )
-    ) ./ (_LH_f0*_ρ_l)
+    ) ./ (_LH_f0 * _ρ_l)
 
     @test p.snow.snow_cover_fraction == @. min(
         2 * p.snow.z_snow ./ FT(0.1) / (p.snow.z_snow ./ FT(0.1) + 1),
@@ -226,7 +226,8 @@ import ClimaLand.Parameters as LP
         Y.snow.U,
         Y.snow.S,
         p.snow.q_l,
-        p.snow.applied_energy_flux,
+        p.snow.applied_energy_flux -
+        _ρ_l * _LH_f0 * p.snow.surf_residual_flux * p.snow.snow_cover_fraction,
         model.parameters.Δt,
         model.parameters.ΔS,
         model.parameters.earth_param_set,
@@ -257,7 +258,9 @@ import ClimaLand.Parameters as LP
         p.snow.water_runoff
     )
     @test dY.snow.S == net_water_fluxes
-    @test dY.snow.S_l == @. -Y.snow.S_l / model.parameters.Δt # refreezes
+    @test all(parent(p.snow.phase_change_flux) .== 0)
+    @test all(parent(dY.snow.S_l) .> 0)
+    @test dY.snow.S_l ≈ .-p.snow.surf_residual_flux
     test_dY_U =
         -1 .* p.snow.turbulent_fluxes.shf .- p.snow.turbulent_fluxes.lhf .-
         p.snow.R_n .+ p.snow.energy_runoff
@@ -332,5 +335,128 @@ import ClimaLand.Parameters as LP
     set_initial_cache!(p, Y, t0)
     # Check if aux update occurred correctly
     @test all(parent(p.snow.T_sfc) .== parent(p.snow.T))
-    @test Snow.get_residual_melt_flux(surf_temp_choice, Y, p) == FT(0)
+    @test Snow.get_residual_melt_flux(
+        surf_temp_choice,
+        Y,
+        p,
+        model.parameters.earth_param_set,
+    ) == FT(0)
+end
+
+@testset "Surface melt accounting, $FT" for FT in (Float32, Float64)
+    toml_dict = LP.create_toml_dict(FT)
+    Δt = FT(180)
+    parameters = SnowParameters(toml_dict, Δt)
+    earth_param_set = parameters.earth_param_set
+    T_freeze = LP.T_freeze(earth_param_set)
+    ρL_f = LP.ρ_cloud_liq(earth_param_set) * LP.LH_f0(earth_param_set)
+    start_date = DateTime(2005)
+    precip = TimeVaryingInput(t -> FT(0))
+    atmos = ClimaLand.PrescribedAtmosphere(
+        precip,
+        precip,
+        TimeVaryingInput(t -> FT(290)),
+        TimeVaryingInput(t -> FT(10)),
+        TimeVaryingInput(t -> FT(0.003)),
+        TimeVaryingInput(t -> FT(101325)),
+        start_date,
+        FT(3),
+        toml_dict,
+    )
+    rad = ClimaLand.PrescribedRadiativeFluxes(
+        FT,
+        TimeVaryingInput(t -> FT(300)),
+        TimeVaryingInput(t -> FT(350)),
+        start_date,
+    )
+    model = SnowModel(;
+        parameters,
+        domain = Point(; z_sfc = FT(0)),
+        boundary_conditions = Snow.AtmosDrivenSnowBC(atmos, rad),
+    )
+    Y, p, _ = ClimaLand.initialize(model)
+    dY = similar(Y)
+    set_initial_cache! = ClimaLand.make_set_initial_cache(model)
+    exp_tendency! = ClimaLand.make_compute_exp_tendency(model)
+    t = FT(0)
+
+    @testset "Isothermal melt, S=$S, q_l=$q_l" for S in (FT(0.001), FT(0.1)),
+        q_l in (FT(0), FT(0.01))
+
+        Y.snow.S .= S
+        Y.snow.S_l .= S * q_l
+        Y.snow.U .=
+            Snow.energy_from_q_l_and_swe(S, q_l, parameters.ΔS, earth_param_set)
+        set_initial_cache!(p, Y, t)
+        exp_tendency!(dY, Y, p, t)
+        @test all(parent(p.snow.T_sfc) .== T_freeze)
+        @test all(parent(p.snow.water_runoff) .== 0)
+        @test all(parent(p.snow.surf_residual_flux) .< 0)
+        @test all(parent(dY.snow.S_l) .> 0)
+        # Remove evaporation to compare the phase change with its energy supply.
+        melt_energy = @. ρL_f * (
+            dY.snow.S_l +
+            p.snow.turbulent_fluxes.vapor_flux *
+            p.snow.q_l *
+            p.snow.snow_cover_fraction
+        )
+        @test isapprox(melt_energy, dY.snow.U; rtol = FT(1e-4))
+        @test all(
+            abs.(parent(p.snow.phase_change_flux)) .<=
+            FT(1e-4) .* abs.(parent(p.snow.surf_residual_flux)),
+        )
+        S_next = @. Y.snow.S + Δt * dY.snow.S
+        S_l_next = @. Y.snow.S_l + Δt * dY.snow.S_l
+        @test all(0 .<= parent(S_l_next) .<= parent(S_next))
+    end
+
+    @testset "Snow-free column, T=$T" for T in (FT(270), T_freeze)
+        Y.snow.S .= 0
+        Y.snow.S_l .= 0
+        Y.snow.U .=
+            Snow.energy_from_T_and_swe(FT(0), T, parameters.ΔS, earth_param_set)
+        set_initial_cache!(p, Y, t)
+        exp_tendency!(dY, Y, p, t)
+        @test all(iszero, parent(p.snow.surf_residual_flux))
+        @test all(iszero, parent(p.snow.liquid_water_flux))
+        @test all(iszero, parent(dY.snow.S_l))
+        @test all(isfinite, parent(dY))
+    end
+
+    @testset "Residual melt limits" begin
+        p.snow.z_snow .= FT(0.5)
+        p.snow.T .= T_freeze - FT(1)
+        p.snow.T_sfc .= T_freeze - FT(1)
+        p.snow.turbulent_fluxes.lhf .= 0
+        p.snow.turbulent_fluxes.shf .= 0
+        for flux in (FT(-1000), FT(1000))
+            p.snow.R_n .= flux
+            residual = Snow.get_residual_melt_flux(
+                parameters.surf_temp,
+                Y,
+                p,
+                earth_param_set,
+            )
+            @test all(iszero, parent(residual))
+        end
+        p.snow.T_sfc .= T_freeze
+        residual = Snow.get_residual_melt_flux(
+            parameters.surf_temp,
+            Y,
+            p,
+            earth_param_set,
+        )
+        @test all(iszero, parent(residual))
+        p.snow.z_snow .= eps(FT)^2
+        p.snow.T .= T_freeze
+        p.snow.R_n .= FT(-1000)
+        residual = Snow.get_residual_melt_flux(
+            parameters.surf_temp,
+            Y,
+            p,
+            earth_param_set,
+        )
+        @test all(isfinite, parent(residual))
+        @test all(parent(residual) .≈ FT(-1000) / ρL_f)
+    end
 end


### PR DESCRIPTION
## Purpose

Follow-up to #1868, targeting `kd/address_snow_surface_temp_question`. Fix the reproduced melt double counting and snow-free NaNs in the residual surface-melt calculation.

## Fixes

- **Count surface melt once.** The residual surface heating already creates liquid water, but the bulk phase-change estimate also received the full applied energy flux and melted the same ice again. Subtract `rho_l * L_f * residual_melt_flux * snow_cover_fraction` from the energy flux used to estimate bulk phase change. The total energy tendency still receives the applied boundary energy flux.
- **Share the accounting across models.** Compute and apply residual melt in the common snow boundary update, alongside bulk phase change. Remove the separate additions from the standalone, soil-snow, and full-land boundary routines so each path applies surface melt exactly once before liquid-water clipping.
- **Keep snow-free columns finite.** Guard the conductive scaling length against zero and return zero residual melt where snow depth is zero. Previously, the conductive term evaluated as `0/0`, which propagated through the zero snow-cover fraction into the liquid-water tendency.
- **Restrict residual melt to the freezing cap.** Return zero below freezing and clamp the residual to nonpositive values. This prevents surface-solver flux mismatches from producing spurious melting or refreezing at uncapped surfaces.
- **Repair tests and documentation.** Update the bulk-temperature helper call to include its parameter argument, test surface melting in the existing cold-bulk case, use an approximate flux comparison, and document the residual's water-flux units and corrected surface-balance equation.

In the saved isothermal-snow reproducer, surface melt and bulk phase change each contributed about `-2.65e-6 m/s` before this change. Bulk phase change is now zero, while surface melt remains about `-2.65e-6 m/s`. The snow-free reproducer now has zero residual melt and zero liquid-water tendency.

## Validation

Using Julia 1.12.6 and the existing `.buildkite` environment:

- Snow parameterizations and model: 210 checks passed, including new Float32/Float64 regressions for full and partial snow cover, melt-energy accounting, snow-free columns, below-freezing surfaces, and vanishing positive snow depth.
- Snow integrated energy/water content: 8 checks passed.
- Snow parameter constructors: 2 checks passed.
- Coupled soil-snow: 26 checks passed, including new snow-free residual and liquid-water checks.
- Full land: 406 checks passed, including global tendencies, Jacobian updates, an integration step, and inland-water configurations.
- Reran the saved review reproducers.
- JuliaFormatter 2.10.1 passed for all changed Julia files; whitespace check passed with the existing CRLF file treated as CRLF.

The full repository test suite, GPU execution, and the long SnowMIP experiment were not run. The cold-pack melt/percolation/refreezing behavior introduced by #1868 still warrants evaluation in SnowMIP.
